### PR TITLE
fix: only generate SBOM on protected branches, only commit on main

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1195,7 +1195,7 @@ jobs:
   # ╚══════════════════════════════════════════════╝
 
   sbom:
-    if: ${{ inputs.enable-sbom && !cancelled() }}
+    if: ${{ inputs.enable-sbom && !cancelled() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/development') }}
     runs-on: ubuntu-latest
     name: "SBOM"
     needs: [security]
@@ -1283,6 +1283,7 @@ jobs:
       # ── Commit validated SBOM ──
 
       - name: Commit SBOM
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- SBOM generation now only runs on `main`, `beta`, and `development` branches (was running on every push to any branch)
- The SBOM commit/push step now only runs on `main` — on `beta` and `development` the SBOM is generated and validated but not committed back
- This prevents the bot from creating "chore: update SBOM" commits on every feature branch push

## Context
The standalone `sbom.yml` workflows in individual app repos (opencatalogi, openconnector, softwarecatalog, mydash, docudesk) are being replaced with `enable-sbom: true` in the reusable quality workflow to avoid duplication.

## Test plan
- [ ] Verify SBOM job runs on push to `main`
- [ ] Verify SBOM job runs on push to `beta` and `development` (generate + validate only, no commit)
- [ ] Verify SBOM job does NOT run on push to `feature/**` branches