### PR TITLE
Publish website/ at docs.conduction.nl

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,19 @@
+name: Deploy docs.conduction.nl
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-docs.yml'
+      - '.github/workflows/documentation.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/documentation.yml
+    with:
+      cname: docs.conduction.nl
+      source-folder: website

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "ci": "npm ci && npm run build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Summary
- Add `deploy-docs.yml` caller that invokes the existing reusable `documentation.yml` with `cname: docs.conduction.nl` and `source-folder: website`. Triggers on push to `main` when `website/**` changes.
- Add `ci` script to `website/package.json` (`npm ci && npm run build`) — required by the reusable workflow's build step.

After this merges, the workflow will publish to the `gh-pages` branch and we'll set the Pages custom domain to `docs.conduction.nl`. DNS for `docs.conduction.nl` will need a CNAME → `conductionnl.github.io`.

## Test plan
- [ ] PR build of `Deploy docs.conduction.nl` shows up (job will skip on PR — push-only)
- [ ] After merge, workflow run succeeds and `gh-pages` branch is created/updated with `index.html` + `CNAME`
- [ ] `https://docs.conduction.nl/` serves the Docusaurus site once Pages CNAME + DNS are wired