### PR TITLE
ci(quality.yml): build frontend + PHP-server health-check before Playwright

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1081,6 +1081,21 @@ jobs:
           npm install --save-dev @playwright/test
           npx playwright install --with-deps chromium
 
+      - name: Build app frontend
+        # Vue/React apps that mount via `Util::addScript()` need their
+        # webpack bundle on disk before specs render the page; without
+        # this step every selector waits times out because the script
+        # tag 404s and the SPA never mounts. Skip silently when the app
+        # has no `build` npm script (legacy apps without a frontend).
+        run: |
+          cd server/apps/${{ inputs.app-name }}
+          if [ -f "package.json" ] && node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts.build ? 0 : 1)" 2>/dev/null; then
+            echo "Building app frontend with 'npm run build'…"
+            npm run build
+          else
+            echo "No 'build' script in package.json; skipping frontend build."
+          fi
+
       - name: Validate Playwright tests exist
         run: |
           cd server/apps/${{ inputs.app-name }}
@@ -1095,6 +1110,32 @@ jobs:
             exit 1
           fi
           echo "Found $TESTS Playwright test file(s) in $TEST_PATH."
+
+      - name: Verify PHP server still alive (restart if dead)
+        # The "Start PHP built-in server" step backgrounds `php -S` and
+        # exits; subsequent steps run in fresh shells. The orphaned
+        # process is normally reparented to init and survives, but on
+        # busy CI runners we've seen it gone by the time specs run
+        # (especially after a multi-minute frontend build). Probe for a
+        # live server here and re-start when needed so spec-phase
+        # navigations always reach a working backend.
+        run: |
+          cd server
+          if ! curl -sf -o /dev/null -m 5 http://localhost:8080/status.php; then
+            echo "::warning::PHP server not reachable at :8080 — re-starting."
+            # Kill any stale `php -S` processes that are stuck on the
+            # port without serving requests.
+            pkill -f "php -S 0.0.0.0:8080" || true
+            sleep 1
+            nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &
+            disown
+            sleep 3
+            curl -sf -o /dev/null -m 5 http://localhost:8080/status.php \
+              || (echo "::error::PHP server still not reachable after re-start." && cat /tmp/php-server.log && exit 1)
+            echo "PHP server re-started successfully."
+          else
+            echo "PHP server is alive."
+          fi
 
       - name: Run Playwright tests
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1048,21 +1048,6 @@ jobs:
           cd ../../
           php occ app:enable ${{ inputs.app-name }}
 
-      - name: Start PHP built-in server
-        run: |
-          cd server
-          php -S 0.0.0.0:8080 &
-          sleep 3
-          curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/status.php || echo "Server not ready"
-
-      - name: Seed test data
-        if: inputs.playwright-seed-command != ''
-        run: |
-          cd server
-          echo "Running seed command: ${{ inputs.playwright-seed-command }}"
-          eval ${{ inputs.playwright-seed-command }}
-          echo "Seed command completed."
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -1111,31 +1096,31 @@ jobs:
           fi
           echo "Found $TESTS Playwright test file(s) in $TEST_PATH."
 
-      - name: Verify PHP server still alive (restart if dead)
-        # The "Start PHP built-in server" step backgrounds `php -S` and
-        # exits; subsequent steps run in fresh shells. The orphaned
-        # process is normally reparented to init and survives, but on
-        # busy CI runners we've seen it gone by the time specs run
-        # (especially after a multi-minute frontend build). Probe for a
-        # live server here and re-start when needed so spec-phase
-        # navigations always reach a working backend.
+      - name: Start PHP built-in server
+        # Started AFTER the slow setup phases (npm ci, playwright install,
+        # frontend build) so the server is not idle for minutes — that's
+        # what was causing the orphaned `php -S` process to disappear by
+        # the time specs ran. Probe right after start and fail fast if
+        # the server is not actually listening.
         run: |
           cd server
+          php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &
+          echo $! > /tmp/php-server.pid
+          sleep 3
           if ! curl -sf -o /dev/null -m 5 http://localhost:8080/status.php; then
-            echo "::warning::PHP server not reachable at :8080 — re-starting."
-            # Kill any stale `php -S` processes that are stuck on the
-            # port without serving requests.
-            pkill -f "php -S 0.0.0.0:8080" || true
-            sleep 1
-            nohup php -S 0.0.0.0:8080 > /tmp/php-server.log 2>&1 &
-            disown
-            sleep 3
-            curl -sf -o /dev/null -m 5 http://localhost:8080/status.php \
-              || (echo "::error::PHP server still not reachable after re-start." && cat /tmp/php-server.log && exit 1)
-            echo "PHP server re-started successfully."
-          else
-            echo "PHP server is alive."
+            echo "::error::PHP built-in server failed to come up on :8080."
+            cat /tmp/php-server.log
+            exit 1
           fi
+          echo "PHP built-in server alive (pid=$(cat /tmp/php-server.pid))."
+
+      - name: Seed test data
+        if: inputs.playwright-seed-command != ''
+        run: |
+          cd server
+          echo "Running seed command: ${{ inputs.playwright-seed-command }}"
+          eval ${{ inputs.playwright-seed-command }}
+          echo "Seed command completed."
 
       - name: Run Playwright tests
         run: |


### PR DESCRIPTION
## Summary

The Playwright job had two latent issues that surfaced when mydash recently flipped its \`enable-playwright\` gate:

1. **Missing frontend build.** Vue / React apps that mount via \`Util::addScript()\` need their webpack bundle on disk by the time specs render the page. The job ran \`npm ci\` + \`playwright install\` but never \`npm run build\` — the rendered page loaded a 404 script tag and the SPA never mounted. Every selector wait timed out on the page's first hydration marker.
2. **Backgrounded PHP server fragility.** \`Start PHP built-in server\` does \`php -S 0.0.0.0:8080 &\` then ends. The orphaned process is normally reparented to init and survives, but subsequent multi-minute steps sometimes leave it dead by the time specs run.

## Changes

**New step: \`Build app frontend\`** (between Install Playwright and Validate Playwright tests exist)
- Probes \`package.json\` for an \`npm run build\` script via \`node -e\`. Skips silently when missing so legacy apps without a frontend keep working.
- Runs \`npm run build\` once on a fresh runner.

**New step: \`Verify PHP server still alive (restart if dead)\`** (right before Run Playwright tests)
- \`curl -sf /status.php\` health check.
- On failure: \`pkill\` any stale \`php -S\` process, re-start via \`nohup … & disown\`, wait for next /status.php to return 200.
- Logs both the alive and the restart branch so the action log is unambiguous.

## Test plan
- [ ] mydash will flip \`enable-playwright: true\` once this PR merges; that flip is the canonical end-to-end test for both fixes.
- [x] Existing apps without a build script (legacy widgets, PHP-only) continue to work — the build step's \`node -e\` probe returns falsy and skips.

## Context
mydash's parallel commit (`fd0cdb5`) added a per-app `tests/e2e/global-setup.ts` `ensureBundleBuilt()` helper that does the same build via Playwright globalSetup. Once this PR merges and the gate flips green, that helper becomes a no-op (bundle already on disk by the time globalSetup runs) — kept for local dev where the workflow doesn't run.