### PR TITLE
feat(workflows): pass GITHUB_TOKEN to build, allow schedule + dispatch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,10 @@ jobs:
   deploy:
     name: Deploy Documentation
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # Deploy on direct pushes, scheduled rebuilds (cron-driven data
+    # refresh on conduction-website), and manual workflow_dispatch.
+    # PR runs still build but don't deploy.
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
@@ -37,7 +40,14 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies and build
-        timeout-minutes: 5
+        timeout-minutes: 10
+        env:
+          # Pass the run-scoped token through so npm prebuild scripts
+          # that hit the GitHub API (e.g. conduction-website's nightly
+          # app-downloads fetch) authenticate and avoid 60-req/hr rate
+          # limits. Token is auto-scoped to the run, expires when the
+          # job ends.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ${{ inputs.source-folder }}
           rm -rf node_modules/.cache .docusaurus build


### PR DESCRIPTION
Two related tweaks to the centralized documentation deploy reusable workflow:

- **Build step now sees `GITHUB_TOKEN`.** Lets npm prebuild scripts hit the GitHub API authenticated. Conduction-website is about to use this for nightly app-downloads enumeration (331 ConductionNL repos); unauthenticated would hit the 60 req/hr ceiling on every build. Token is auto-scoped to the run.
- **Drop the 'push only' guard** so `schedule` and `workflow_dispatch` also deploy. Currently `workflow_dispatch` is a no-op on every product repo, which is confusing. Lets conduction-website add a nightly cron that triggers a fresh build with refreshed data, without a bot push to a protected branch.

Used by every product subdomain (`mydash`, `opencatalogi`, `docs.conduction.nl`, etc.) so the changes apply org-wide. PR runs still build but don't deploy (the `pull_request` event isn't in the new `if:` list).