### PR TITLE
fix(quality): make PHPCS warnings non-blocking under set -e

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -204,7 +204,10 @@ jobs:
               fi
               # Exit code 0 = clean, 1 = warnings only, 2 = errors found.
               # We treat warnings as non-blocking (exit 1 → success).
-              composer phpcs; RC=$?
+              # NB: capture via `|| RC=$?` — a bare `composer phpcs; RC=$?`
+              # is killed by `set -e` before RC is ever assigned.
+              RC=0
+              composer phpcs || RC=$?
               if [ "$RC" -eq 1 ]; then
                 echo "::warning::PHPCS found warnings but no errors — passing."
                 exit 0


### PR DESCRIPTION
## Problem

The reusable `quality.yml` workflow's `phpcs` job runs under bash `set -e` (the GitHub Actions default shell is `bash --noprofile --norc -eo pipefail {0}`).

```bash
composer phpcs; RC=$?
if [ "$RC" -eq 1 ]; then
  echo "::warning::PHPCS found warnings but no errors — passing."
  exit 0
fi
exit $RC
```

Under `set -e`, the step terminates at `composer phpcs` the instant PHPCS exits `1` (warnings-only) — `RC=$?` never runs, so the "warnings → pass" branch is dead code. Any app with PHPCS *warnings* (e.g. the `@spec` PHPDoc sniff) fails the `phpcs` check even though the intent is that only *errors* (exit `2`) block.

Repro:
```
$ bash -e -c 'false; RC=$?; echo "reached RC=$RC"'; echo "outer=$?"
outer=1          # "reached" never prints
```

## Fix

Capture the exit code with `|| RC=$?`, which is exempt from `errexit`:

```bash
RC=0
composer phpcs || RC=$?
if [ "$RC" -eq 1 ]; then ...
```

Behaviour after this change:
- exit `0` (clean) → pass
- exit `1` (warnings only) → pass (as the comment always intended)
- exit `2` (errors) → fail

No app that currently passes can regress (clean stays clean); apps that were red purely from PHPCS warnings go green.

## Surfaced by

`ConductionNL/procest` PR #421 — phpcs job red despite `lib/` having 0 PHPCS errors (only ~700 `@spec` warnings).