### PR TITLE
fix(quality): SBOM via package-lock; non-blocking coverage-baseline push

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1299,7 +1299,11 @@ jobs:
           else
             git add .coverage-baseline
             git commit -m "ci: update coverage baseline [skip ci]"
-            git push
+            # Non-blocking: branch-protection rulesets reject the bot push on
+            # repos with a protected development/main. Surface a warning instead
+            # of failing the whole workflow over an auto-committed convenience
+            # file. Tracked in ConductionNL/.github#61 (add bot as a bypass actor).
+            git push || echo "::warning::Could not push the updated coverage baseline — branch protection rejected the bot push (see ConductionNL/.github#61). Commit .coverage-baseline manually."
           fi
 
   report:
@@ -1568,7 +1572,12 @@ jobs:
 
       - name: Generate npm SBOM
         if: ${{ inputs.enable-frontend }}
-        run: npx @cyclonedx/cyclonedx-npm --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
+        # --package-lock-only: build the SBOM from package-lock.json rather than
+        # `npm ls`. `npm ls` exits non-zero (ELSPROBLEMS) on benign tree quirks —
+        # peer/version mismatches in transitive deps, a hard dependency declared
+        # by a lib but deduped away, etc. — which has nothing to do with the SBOM.
+        # The lockfile is the deterministic source of truth for what gets installed.
+        run: npx @cyclonedx/cyclonedx-npm --package-lock-only --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
 
       - name: Merge PHP + npm SBOMs
         if: ${{ inputs.enable-frontend }}


### PR DESCRIPTION
Two `quality.yml` jobs fail on repos that opt into the SBOM / coverage-guard features (e.g. `ConductionNL/procest`), even when every actual quality gate passed:

### 1. `SBOM` — `Generate npm SBOM` step

`npx @cyclonedx/cyclonedx-npm … --omit dev` invokes `npm ls` internally; `npm ls` exits `ELSPROBLEMS` on benign dependency-tree quirks (peer/version mismatches in transitive deps, a hard dependency declared by a lib but deduped away — e.g. `@conduction/nextcloud-vue` lists `bootstrap-vue` as a hard `dependency`, `apexcharts`/`pinia` come out "invalid" against its peer ranges, `rehype-react` wants `@types/react`). None of that affects the SBOM.

→ pass `--package-lock-only` so the SBOM is built from `package-lock.json` (the deterministic source of truth for what gets installed). A real fix, not `--ignore-npm-errors`. The underlying dep-declaration noise should still be cleaned up at the library level (separate.)

### 2. `Update Coverage Baseline` — `git push`

The job regenerates `.coverage-baseline`, commits it as `github-actions[bot]`, and pushes — which the org branch-protection rulesets reject on repos with a protected `development`/`main` (`GH013`), failing the whole workflow.

→ make the `git push` non-blocking (log a `::warning::` instead of failing). The proper fix — adding the CI bot as a path-scoped ruleset bypass actor — is tracked in #61.

Surfaced while getting `ConductionNL/procest`'s CI green.