### PR TITLE
chore(website): bump preset to ^2.6.1 + add i18n/nl skeleton

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,9 +17,19 @@ const config = createConfig({
   organizationName: 'ConductionNL',
   projectName: '.github',
 
+  /* Two locales, English default. Dutch translations live under
+     i18n/nl/ and are seeded as a skeleton — Docusaurus falls back to
+     EN for any string that isn't yet translated, so /nl/ routes are
+     safe to expose even before a full translation pass. URL shape:
+       /         → English (canonical)
+       /nl/      → Nederlands */
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'nl'],
+    localeConfigs: {
+      en: { label: 'English',    htmlLang: 'en-GB', direction: 'ltr' },
+      nl: { label: 'Nederlands', htmlLang: 'nl-NL', direction: 'ltr' },
+    },
   },
 
   presets: [
@@ -54,6 +64,7 @@ const config = createConfig({
       { to: '/iso/', label: 'ISO', position: 'left' },
       { href: 'https://www.conduction.nl/support/', label: 'Support', position: 'left' },
       { href: 'https://www.conduction.nl/apps/', label: 'Products', position: 'left' },
+      { type: 'localeDropdown', position: 'right' },
       {
         href: 'https://github.com/ConductionNL/.github',
         label: 'GitHub',

--- a/website/i18n/nl/README.md
+++ b/website/i18n/nl/README.md
@@ -1,0 +1,32 @@
+# Dutch (nl) translation skeleton
+
+Skeleton for the Nederlandse vertaling of `docs.conduction.nl`. Docusaurus
+falls back to English for any string not yet translated, so this directory
+can be expanded incrementally without breaking the live site.
+
+## What's here
+
+- `code.json` — theme-level UI strings (back-to-top button, 404 page,
+  breadcrumbs, sidebar collapse/expand, last-updated, edit-this-page, …).
+- `docusaurus-theme-classic/navbar.json` — navbar item labels.
+- `docusaurus-theme-classic/footer.json` — footer link column titles and labels.
+- `docusaurus-plugin-content-docs/current.json` — sidebar category labels.
+
+## What's still missing (intentionally)
+
+Per-page Dutch translations of the markdown under `.github/docs/` —
+each `docs/<path>.md` would get a sibling at
+`i18n/nl/docusaurus-plugin-content-docs/current/<path>.md`. Adding the
+files is incremental: untranslated routes fall back to the English source.
+
+## Refreshing the keys
+
+If the English navbar/footer/sidebar labels change, regenerate the JSON
+key shape with:
+
+```sh
+npm run docusaurus -- write-translations --locale nl
+```
+
+Then re-add the Dutch `message` values (write-translations seeds the key
+with the English text by default).

--- a/website/i18n/nl/code.json
+++ b/website/i18n/nl/code.json
@@ -1,0 +1,98 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "Deze pagina is gecrasht.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Terug naar boven",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.NotFound.title": {
+    "message": "Pagina niet gevonden",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We konden de pagina die je zoekt niet vinden.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Neem contact op met de eigenaar van de site die je naar de oorspronkelijke URL heeft verwezen en laat hem weten dat zijn link kapot is.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Bekijk alle tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Hoofdpagina",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Broodkruimels",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Documentatiepagina's",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Vorige",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Volgende",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Zijbalk inklappen",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Zijbalk inklappen",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Zijbalk uitklappen",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Zijbalk uitklappen",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.label": {
+    "message": "Zoeken",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Schakel tussen donkere en lichte modus (huidige modus: {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " op {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " door {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Laatst bijgewerkt{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.common.editThisPage": {
+    "message": "Deze pagina bewerken",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Directe link naar {heading}",
+    "description": "Title for link to heading"
+  }
+}

--- a/website/i18n/nl/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/nl/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,18 @@
+{
+  "sidebar.tutorialSidebar.category.Working at Conduction": {
+    "message": "Werken bij Conduction",
+    "description": "The label for category Working at Conduction in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Building Software": {
+    "message": "Software bouwen",
+    "description": "The label for category Building Software in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Support & Safety": {
+    "message": "Ondersteuning & Veiligheid",
+    "description": "The label for category Support & Safety in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Claude workflow": {
+    "message": "Claude-workflow",
+    "description": "The label for category Claude workflow in sidebar tutorialSidebar"
+  }
+}

--- a/website/i18n/nl/docusaurus-theme-classic/footer.json
+++ b/website/i18n/nl/docusaurus-theme-classic/footer.json
@@ -1,0 +1,18 @@
+{
+  "link.title.Documentation": {
+    "message": "Documentatie",
+    "description": "The title of the footer links column with title=Documentation in the footer"
+  },
+  "link.item.label.Roadmap": {
+    "message": "Roadmap",
+    "description": "The label of footer link with label=Roadmap"
+  },
+  "link.item.label.Claude workflow": {
+    "message": "Claude-workflow",
+    "description": "The label of footer link with label=Claude workflow"
+  },
+  "link.item.label.ISO compliance": {
+    "message": "ISO-compliance",
+    "description": "The label of footer link with label=ISO compliance"
+  }
+}

--- a/website/i18n/nl/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/nl/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,34 @@
+{
+  "item.label.Way of Work": {
+    "message": "Manier van Werken",
+    "description": "Navbar item with label Way of Work"
+  },
+  "item.label.Roadmap": {
+    "message": "Roadmap",
+    "description": "Navbar item with label Roadmap"
+  },
+  "item.label.Claude workflow": {
+    "message": "Claude-workflow",
+    "description": "Navbar item with label Claude workflow"
+  },
+  "item.label.Hydra": {
+    "message": "Hydra",
+    "description": "Navbar item with label Hydra"
+  },
+  "item.label.ISO": {
+    "message": "ISO",
+    "description": "Navbar item with label ISO"
+  },
+  "item.label.Support": {
+    "message": "Ondersteuning",
+    "description": "Navbar item with label Support"
+  },
+  "item.label.Products": {
+    "message": "Producten",
+    "description": "Navbar item with label Products"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,7 +8,7 @@
       "name": "conduction-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.7.0",
+        "@conduction/docusaurus-preset": "^2.6.1",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.7.0.tgz",
-      "integrity": "sha512-JH7aXaRGZCvkHZTLTLRh3gDWhj/2zAc8S4eBGS67hCfDIwzP5SK+Uj5BidoqbSi0FEEnekEoya2AVVLXbNv/OQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.6.1.tgz",
+      "integrity": "sha512-hOkS2XAj3p1wfaZWjvIqKzwC5cbTSLUPm+DJxUp7TePbnU37kaHGegjLjfVOnQ312G8an+0M5VWIhmg/YhRVyA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.7.0",
+    "@conduction/docusaurus-preset": "^2.6.1",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
## Phase 2 of the `.github` consolidation

Replaces the closed PR #30 with the actually-correct move. The `website/` folder is **not** redundant — it's the `conduction-docs` Docusaurus build that renders `docs.conduction.nl`. PR #30's premise was that the site had migrated to `conduction-website`, but `conduction-website` serves a different domain (`www.conduction.nl`) with different content. See the close comment on #30 for details.

## What this PR does

### 1. `@conduction/docusaurus-preset` ^1.7.0 → ^2.6.1
Aligns with the rest of the fleet (per the memory note `project_journeydoc-rollout` — *whole fleet now on preset `^2.6.1`*). Other apps using 2.x: `conduction-website` (2.1.0), and the upcoming `hydra.conduction.nl` build (Phase 3).

### 2. Dutch (`nl`) locale skeleton
Adds `i18n/nl/` so `docs.conduction.nl` can grow bilingual incrementally:

| File | Translates |
|------|-----------|
| `code.json` | 24 theme strings — back-to-top, 404, breadcrumbs, sidebar collapse, last-updated, edit-this-page, … |
| `docusaurus-theme-classic/navbar.json` | 8 navbar items |
| `docusaurus-theme-classic/footer.json` | Documentation footer column |
| `docusaurus-plugin-content-docs/current.json` | 4 sidebar category labels |
| `README.md` | What's translated, what isn't, how to regenerate keys |

Docusaurus falls back to English for any string not yet translated, so `/nl/` routes are safe to expose immediately — visiting `docs.conduction.nl/nl/` today renders chrome+sidebar in Dutch and content in English. Per-page markdown translations follow as a separate content task.

### 3. Navbar locale dropdown
`{ type: 'localeDropdown', position: 'right' }` next to the GitHub link.

## What's intentionally NOT in this PR

- **Per-page Dutch markdown translations** under `i18n/nl/docusaurus-plugin-content-docs/current/` — follow as a content task.
- **`docs/claude/` content move to hydra** — that's Phase 3 of the consolidation. After that lands, `sidebars.js` will drop the `{ type: 'autogenerated', dirName: 'claude' }` entry and the navbar's *Claude workflow* link will redirect to `hydra.conduction.nl/setup` or similar.
- **Broken-link warnings in the build output** — pre-existing on `main`; markdown references to cross-repo paths (`/hydra/...`, `/concurrentie-analyse/...`, `/.claude/...`) that GitHub's markdown renderer resolves but Docusaurus can't. Out of scope for an i18n/preset PR; worth a separate cleanup pass.

## Test plan

- [x] `npm install --legacy-peer-deps` — succeeds, preset 2.6.1 resolves
- [x] `npm run build` — succeeds; `build/` (EN, 17 entries) and `build/nl/` (159 files) both generated
- [x] `build/index.html` (EN, 34 281 bytes) and `build/nl/index.html` (NL, 34 347 bytes) both exist
- [ ] Visual check post-merge on `docs.conduction.nl` (preset 2.6.1 may have subtle theme differences vs 1.7.0)

## Phase status

| Phase | Status |
|-------|--------|
| 1. PR triage + cleanup | ✅ Complete |
| 2. website preset + i18n skeleton | this PR |
| 3. Move `docs/claude/` → `hydra/docs/` + set up `hydra.conduction.nl` | Next |