### PR TITLE
feat(docs): brand-styled Mermaid diagrams via @docusaurus/theme-mermaid

### DIFF
--- a/docs/WayOfWork/spec-driven-development.md
+++ b/docs/WayOfWork/spec-driven-development.md
@@ -49,29 +49,16 @@ Org-wide specs (test coverage baselines, API patterns, NL Design System complian
 
 We use [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as our development orchestrator. Claude acts as an **architect and assembler** — it defines, configures, and validates, but delegates actual implementation to the platform's building blocks:
 
-```mermaid
-flowchart LR
-  subgraph logic ["Backend · logic"]
-    direction TB
-    L1["n8n workflows"]
-    L2["Triggers, mappings, automation"]
-    L1 --> L2
-  end
-  subgraph data ["Backend · data"]
-    direction TB
-    D1["OpenRegister"]:::accent
-    D2["Schemas, registers, validation"]
-    D1 --> D2
-  end
-  subgraph frontend ["Frontend layer"]
-    direction TB
-    F1["@conduction/nextcloud-vue"]
-    F2["Components, views, routing"]
-    F1 --> F2
-  end
-  frontend ~~~ data ~~~ logic
-  classDef accent fill:#F36C21,stroke:#F36C21,color:#fff;
-```
+<cn-arch-flow arrow="none">
+  <span>@conduction/nextcloud-vue</span>
+  <span accent>OpenRegister</span>
+  <span>n8n workflows</span>
+</cn-arch-flow>
+<cn-arch-flow arrow="none">
+  <span>Components &amp; routing</span>
+  <span accent>Schemas &amp; validation</span>
+  <span>Triggers &amp; mappings</span>
+</cn-arch-flow>
 
 - **Frontend** — Claude selects and configures `@conduction/nextcloud-vue` components, defines views and routing. It does not hand-write UI components from scratch.
 - **Backend data** — OpenRegister is the data spine. Claude defines schemas, registers, object structures, and validation rules. The runtime is the same across every app.

--- a/docs/WayOfWork/spec-driven-development.md
+++ b/docs/WayOfWork/spec-driven-development.md
@@ -12,14 +12,22 @@ At Conduction, we don't start coding before we know what we're building. We use 
 
 ## The Pipeline
 
-All development follows four stages:
+All development follows four stages. Each stage feeds the next: discovery becomes specs, specs become software, software is checked against the specs that produced it.
 
-| Stage | What happens | Output |
-|---|---|---|
-| **1. Obtain** | Discover requirements — from issues, tenders, app research, documentation | Understanding of what to build |
-| **2. Specify** | Write structured specs that define the change | proposal.md → specs.md → design.md → tasks.md → GitHub Issues |
-| **3. Build** | Implement by assembling components, schemas, and workflows | Working software |
-| **4. Validate** | Verify quality, run tests, check against specs | Confidence to ship |
+```mermaid
+flowchart LR
+  A["<b>1 · Obtain</b><br/>Discover requirements"]
+  B["<b>2 · Specify</b><br/>Write structured specs"]
+  C["<b>3 · Build</b>"]:::accent
+  D["<b>4 · Validate</b><br/>Verify against specs"]
+  A --> B --> C --> D
+  classDef accent fill:#F36C21,stroke:#F36C21,color:#fff;
+```
+
+- **1 · Obtain** — requirements come from issues, tenders, app research, and documentation. The output is a shared understanding of what to build.
+- **2 · Specify** — the chain of artifacts (`proposal.md` → `specs.md` → `design.md` → `tasks.md`) becomes a set of trackable GitHub Issues.
+- **3 · Build** — implement by assembling components, schemas, and workflows. This is the stage where working software lands.
+- **4 · Validate** — run tests, check coverage, verify the implementation against the spec that produced it.
 
 ## OpenSpec
 
@@ -41,22 +49,68 @@ Org-wide specs (test coverage baselines, API patterns, NL Design System complian
 
 We use [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as our development orchestrator. Claude acts as an **architect and assembler** — it defines, configures, and validates, but delegates actual implementation to the platform's building blocks:
 
-| Layer | Tool | What Claude does |
-|---|---|---|
-| **Frontend** | `@conduction/nextcloud-vue` | Select and configure components, define views and routing |
-| **Backend data** | OpenRegister | Define schemas, registers, object structures, validation rules |
-| **Backend logic** | n8n workflows | Design workflow logic, configure triggers, map data |
+```mermaid
+flowchart LR
+  subgraph logic ["Backend · logic"]
+    direction TB
+    L1["n8n workflows"]
+    L2["Triggers, mappings, automation"]
+    L1 --> L2
+  end
+  subgraph data ["Backend · data"]
+    direction TB
+    D1["OpenRegister"]:::accent
+    D2["Schemas, registers, validation"]
+    D1 --> D2
+  end
+  subgraph frontend ["Frontend layer"]
+    direction TB
+    F1["@conduction/nextcloud-vue"]
+    F2["Components, views, routing"]
+    F1 --> F2
+  end
+  frontend ~~~ data ~~~ logic
+  classDef accent fill:#F36C21,stroke:#F36C21,color:#fff;
+```
+
+- **Frontend** — Claude selects and configures `@conduction/nextcloud-vue` components, defines views and routing. It does not hand-write UI components from scratch.
+- **Backend data** — OpenRegister is the data spine. Claude defines schemas, registers, object structures, and validation rules. The runtime is the same across every app.
+- **Backend logic** — business logic lives in n8n workflows. Claude designs the workflow, configures triggers, maps data; n8n executes it.
 
 A shared configuration repository ([`claude-code-config`](https://github.com/ConductionNL/claude-code-config)) provides all commands, skills, and workflow instructions. It's added as a git submodule at `.claude/` in each app repository.
 
 ## Key Commands
 
-| Command | Stage | Purpose |
-|---|---|---|
-| `/opsx-explore` | Obtain | Investigate a topic or problem |
-| `/opsx-new` | Specify | Start a new change with a proposal |
-| `/opsx-ff` | Specify | Generate all spec artifacts in one go |
-| `/opsx-plan-to-issues` | Specify | Convert tasks to GitHub Issues |
-| `/opsx-apply` | Build | Implement tasks from the specs |
-| `/opsx-verify` | Validate | Check implementation against specs |
-| `/opsx-archive` | Done | Archive completed change |
+Each command belongs to a stage in the pipeline. Run them in order; most changes only need `/opsx-ff` → `/opsx-apply` → `/opsx-verify`.
+
+```mermaid
+flowchart LR
+  subgraph obtain ["1 · Obtain"]
+    O1["/opsx-explore"]
+  end
+  subgraph specify ["2 · Specify"]
+    direction TB
+    S1["/opsx-new"]
+    S2["/opsx-ff"]
+    S3["/opsx-plan-to-issues"]
+  end
+  subgraph build ["3 · Build"]
+    B1["/opsx-apply"]:::accent
+  end
+  subgraph validate ["4 · Validate"]
+    V1["/opsx-verify"]
+  end
+  subgraph done ["Done"]
+    A1["/opsx-archive"]
+  end
+  obtain --> specify --> build --> validate --> done
+  classDef accent fill:#F36C21,stroke:#F36C21,color:#fff;
+```
+
+- **`/opsx-explore`** — investigate a topic or problem before committing to a change.
+- **`/opsx-new`** — start a new change with a proposal.
+- **`/opsx-ff`** — fast-forward: generate proposal, specs, design, and tasks in one pass.
+- **`/opsx-plan-to-issues`** — convert tasks to trackable GitHub Issues with an epic.
+- **`/opsx-apply`** — implement the tasks from the specs.
+- **`/opsx-verify`** — check the implementation against the spec that produced it.
+- **`/opsx-archive`** — close out a completed change.

--- a/docs/hydra/README.md
+++ b/docs/hydra/README.md
@@ -13,40 +13,26 @@ It is the factory, not the product. The applications Hydra builds live under [Co
 
 ## How it works
 
-```
-Todo (ready-to-build)
-  │
-  ▼
-Builder                     — implements the change, pushes branch early,
-  │                           opens draft PR
-  │
-  ▼
-Quality tests               — lint, phpcs, phpmd, psalm, phpstan,
-  │                           phpmetrics, composer audit, eslint,
-  │                           stylelint, npm audit, PHPUnit, Newman
-  │  fail → Builder fix-quality (bounded, pre-review)
-  │
-  ▼
-Browser UI tests            — Playwright MCP runs the GIVEN/WHEN/THEN
-  │                           acceptance criteria against a live NC
-  │  fail → Builder fix-browser (bounded, pre-review)
-  │
-  ▼
-Code Reviewer               — reviews + applies bounded in-scope fixes
-  │                           directly to the PR branch
-  │  fail → needs-input (no loop — ADR-013)
-  ▼
-Security Reviewer           — runs after the code reviewer hands off
-  │                           (sequential — reviewers share git state);
-  │                           same bounded fix authority
-  │  fail → needs-input
-  ▼
-Draft PR (ready-for-review) — human reviews and merges
-  │  with the `yolo` label: pipeline approves and merges automatically
-  │
-  ▼ (after human merge)
-Archive — sync specs, generate test scenarios, update changelog
-```
+<cn-arch-flow>
+  <span>Todo</span>
+  <span accent>Builder</span>
+  <span>Quality tests</span>
+  <span>Browser tests</span>
+</cn-arch-flow>
+<cn-arch-flow arrow="down">
+  <span>Code review</span>
+  <span hex>Security review</span>
+  <span>Draft PR</span>
+  <span>Archive</span>
+</cn-arch-flow>
+
+- **Builder** — implements the change, pushes the branch early, opens a draft PR. The accent of the build phase.
+- **Quality tests** — lint, phpcs, phpmd, psalm, phpstan, phpmetrics, composer audit, eslint, stylelint, npm audit, PHPUnit, Newman. A failure loops back to the Builder for a bounded `fix-quality` round.
+- **Browser tests** — Playwright MCP runs the GIVEN/WHEN/THEN acceptance criteria against a live Nextcloud. Failures loop back to the Builder for a bounded `fix-browser` round.
+- **Code review** — reads diff + ADRs, applies bounded in-scope fixes directly to the PR branch. A `fail` verdict escalates to `needs-input` — no retry loop ([ADR-013](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-013-container-pool.md)).
+- **Security review** — runs after the code reviewer hands off (sequential — reviewers share git state), same bounded fix authority. The orange-hex accent is here because security is the last gate before human approval.
+- **Draft PR** — a human reviews and merges. With the `yolo` label, the pipeline approves and merges automatically.
+- **Archive** — after merge, sync specs to Specter, generate test scenarios, update changelog.
 
 **Traceability.** Every line of code traces to its spec via two paths: a `@spec` PHPDoc tag pointing at `openspec/changes/{name}/tasks.md#task-N`, and `git blame` → commit `(#N)` → PR `Closes #N` → issue → spec. Branch naming is `feature/{issue-number}/{change-name}` and every commit includes `(#N)`.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = createConfig({
     ],
   ],
 
-  themes: [BRAND_THEME],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
 
   navbar: {
     items: [
@@ -81,6 +81,28 @@ const config = createConfig({
      (no partner pairing on the docs site). */
   footerBrand: { wordmark: 'Conduction' },
 
+  /* Mermaid: Conduction brand theme applied site-wide so authors write
+     plain ```mermaid blocks. Colours track the design-system tokens in
+     tokens.css; the `accent` classDef is the one-orange-per-scene knob
+     (use `:::accent` on a single node per diagram). */
+  mermaid: {
+    options: {
+      theme: 'base',
+      themeVariables: {
+        background:        '#ffffff',
+        primaryColor:      '#EEF2F8', // cobalt-50 — node fill
+        primaryTextColor:  '#0A172F', // cobalt-900 — node text
+        primaryBorderColor:'#B6C2DD', // cobalt-200 — node border
+        secondaryColor:    '#DCE3F0', // cobalt-100
+        tertiaryColor:     '#ffffff',
+        lineColor:         '#4D69A4', // cobalt-400 — edges
+        textColor:         '#152D5C', // cobalt-700 — labels
+        fontFamily:        "'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+        fontSize:          '14px',
+      },
+    },
+  },
+
   footer: {
     links: [
       {
@@ -105,6 +127,11 @@ const config = createConfig({
    about-this-manual) opt in to MDX so they can use <Tabs>, <ToolList>,
    etc. createConfig() doesn't pass the top-level `markdown` option
    through, so we set it here. */
-config.markdown = { format: 'detect' };
+/* Mermaid: enable on both .md and .mdx. The theme registers a remark
+   plugin that picks up ```mermaid fenced blocks regardless of extension.
+   The brand theme is set inside each diagram via an %%{init}%% block so
+   nodes inherit Conduction cobalt/orange tokens; see
+   src/css/conduction-mermaid.css for the rendered-SVG overrides. */
+config.markdown = { format: 'detect', mermaid: true };
 
 module.exports = config;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -84,21 +84,29 @@ const config = createConfig({
   /* Mermaid: Conduction brand theme applied site-wide so authors write
      plain ```mermaid blocks. Colours track the design-system tokens in
      tokens.css; the `accent` classDef is the one-orange-per-scene knob
-     (use `:::accent` on a single node per diagram). */
-  mermaid: {
-    options: {
-      theme: 'base',
-      themeVariables: {
-        background:        '#ffffff',
-        primaryColor:      '#EEF2F8', // cobalt-50 — node fill
-        primaryTextColor:  '#0A172F', // cobalt-900 — node text
-        primaryBorderColor:'#B6C2DD', // cobalt-200 — node border
-        secondaryColor:    '#DCE3F0', // cobalt-100
-        tertiaryColor:     '#ffffff',
-        lineColor:         '#4D69A4', // cobalt-400 — edges
-        textColor:         '#152D5C', // cobalt-700 — labels
-        fontFamily:        "'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
-        fontSize:          '14px',
+     (use `:::accent` on a single node per diagram).
+     Goes into themeConfig (not top-level) — the preset's createConfig
+     only forwards themeConfig.mermaid to @docusaurus/theme-mermaid. */
+  themeConfig: {
+    mermaid: {
+      /* Theme must live here (not inside options) — the theme-mermaid
+         client spreads options first and then overlays
+         themeConfig.mermaid.theme[colorMode] last, so options.theme is
+         always overridden. */
+      theme: { light: 'base', dark: 'base' },
+      options: {
+        themeVariables: {
+          background:        '#ffffff',
+          primaryColor:      '#21468B', // cobalt-blue — solid node fill
+          primaryTextColor:  '#ffffff', // white — readable on cobalt
+          primaryBorderColor:'#21468B', // = fill, so no visible border
+          secondaryColor:    '#152D5C', // cobalt-700
+          tertiaryColor:     '#ffffff',
+          lineColor:         '#4D69A4', // cobalt-400 — edges
+          textColor:         '#152D5C', // cobalt-700 — labels outside nodes
+          fontFamily:        "'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+          fontSize:          '14px',
+        },
       },
     },
   },
@@ -133,5 +141,13 @@ const config = createConfig({
    nodes inherit Conduction cobalt/orange tokens; see
    src/css/conduction-mermaid.css for the rendered-SVG overrides. */
 config.markdown = { format: 'detect', mermaid: true };
+
+/* Site-wide client-side modules. src/diagrams/index.js is a
+   side-effect import that registers Conduction diagram custom
+   elements (<cn-arch-flow>, …) on every page so authors can use
+   them directly in MDX/Markdown without per-page imports.
+   Set here (not inside createConfig) because the preset's
+   createConfig wrapper doesn't forward clientModules through. */
+config.clientModules = [require.resolve('./src/diagrams/index.js')];
 
 module.exports = config;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@conduction/docusaurus-preset": "^2.6.1",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
+        "@docusaurus/theme-mermaid": "^3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -256,6 +257,19 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1975,6 +1989,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -3967,6 +3993,34 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz",
+      "integrity": "sha512-2gxpmln8Pc4EN1oWzshQEx2HTs67jk14v7MmgqGs8ZU7Nm8oihg+fTouof2u4vN8DtB3Fln4cDJu4UprSX1S3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "mermaid": ">=11.6.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.1.9",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
@@ -4125,6 +4179,23 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -4678,6 +4749,15 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -5288,6 +5368,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -5355,6 +5688,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/gtag.js": {
       "version": "0.0.20",
@@ -5592,6 +5931,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -5627,6 +5973,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -7217,6 +7573,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -7680,6 +8045,532 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -7841,6 +8732,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7977,6 +8877,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8174,6 +9083,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -9187,6 +10106,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -9820,6 +10745,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9867,6 +10802,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -10363,6 +11307,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10371,6 +11340,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -10414,6 +11388,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -10488,6 +11468,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -10580,6 +11566,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11059,6 +12057,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -13424,6 +14464,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -13551,6 +14597,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -13647,6 +14699,22 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -16030,6 +17098,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -16082,6 +17168,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -16911,6 +18003,12 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17108,6 +18206,15 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -17181,6 +18288,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "@conduction/docusaurus-preset": "^2.6.1",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
+    "@docusaurus/theme-mermaid": "^3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -27,7 +28,11 @@
     "@docusaurus/types": "^3.5.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 3 chrome version",
       "last 3 firefox version",

--- a/website/src/css/conduction-mermaid.css
+++ b/website/src/css/conduction-mermaid.css
@@ -103,20 +103,20 @@
   stroke-dasharray: 4 4 !important;
 }
 
-/* Subgraph clusters: render as soft cobalt-100 cards, not the default
- * gray Mermaid box. Matches the `<div class="card">` chrome on the
- * design-system preview pages. */
+/* Subgraph clusters: transparent fill, cobalt-blue stroke. Groups read
+ * as outlined regions, not stacked cards — keeps the visual hierarchy
+ * (filled cobalt nodes > outlined groups > panel background). */
 .docusaurus-mermaid-container .cluster rect,
 .mermaid .cluster rect {
-  fill: #ffffff !important;
-  stroke: #DCE3F0 !important;
+  fill: transparent !important;
+  stroke: #21468B !important;
   stroke-width: 1 !important;
   rx: 8 !important;
   ry: 8 !important;
 }
 .docusaurus-mermaid-container .cluster text,
 .mermaid .cluster text {
-  fill: #4D69A4 !important;
+  fill: #21468B !important;
   font-size: 11px !important;
   font-family: 'IBM Plex Mono', ui-monospace, monospace !important;
   text-transform: uppercase !important;

--- a/website/src/css/conduction-mermaid.css
+++ b/website/src/css/conduction-mermaid.css
@@ -1,0 +1,156 @@
+/* Conduction-branded Mermaid theme.
+ *
+ * Mermaid renders inline SVG and inlines fills via the `themeVariables`
+ * passed in docusaurus.config.js. This file handles what theme-variables
+ * cannot: container chrome, accent class shapes, font tightening, and
+ * the one-orange-per-scene `:::accent` rule.
+ *
+ * Token mirror (kept in sync with design-system/tokens.css):
+ *   --c-blue-cobalt   #21468B   primary
+ *   --c-orange-knvb   #F36C21   accent (used once per diagram)
+ *   --c-cobalt-50     #EEF2F8   node fill
+ *   --c-cobalt-100    #DCE3F0   container fill
+ *   --c-cobalt-200    #B6C2DD   border
+ *   --c-cobalt-400    #4D69A4   edges
+ *   --c-cobalt-700    #152D5C   text
+ *   --c-cobalt-900    #0A172F   strong text
+ *   --c-mint-500      #2E9866   success/built marker (sparingly)
+ */
+
+/* Container: matches the cobalt-50 panel style used in the product-page
+ * mockups so a Mermaid block reads as one of "our" diagrams, not a generic
+ * embed. Border-radius matches --radius-md (8px). */
+.docusaurus-mermaid-container,
+[class*="mermaid"][class*="container"] {
+  background: #EEF2F8;
+  border: 1px solid #DCE3F0;
+  border-radius: 8px;
+  padding: 24px;
+  margin: 20px 0;
+  overflow-x: auto;
+}
+
+/* Sharper text inside Mermaid SVGs. Mermaid sets font-family inline
+ * (via themeVariables) but font-weight + letter-spacing need CSS. */
+.docusaurus-mermaid-container svg text,
+.mermaid svg text {
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+
+/* The `accent` classDef paints one node KNVB orange. Use sparingly:
+ * one node per diagram, on the term the reader should land on.
+ *
+ *   ```mermaid
+ *   flowchart LR
+ *     A[Obtain] --> B[Specify]
+ *     B --> C[Build]:::accent
+ *     C --> D[Validate]
+ *   ```
+ *
+ * The classDef declaration lives inside each diagram (themeVariables
+ * can't reach class-scoped fills). This block hardens it against the
+ * `theme: base` defaults so orange wins even when nodes are restyled
+ * mid-render. */
+.docusaurus-mermaid-container .node.accent rect,
+.docusaurus-mermaid-container .node.accent polygon,
+.docusaurus-mermaid-container .node.accent path,
+.mermaid .node.accent rect,
+.mermaid .node.accent polygon,
+.mermaid .node.accent path {
+  fill: #F36C21 !important;
+  stroke: #F36C21 !important;
+}
+.docusaurus-mermaid-container .node.accent .nodeLabel,
+.docusaurus-mermaid-container .node.accent text,
+.mermaid .node.accent .nodeLabel,
+.mermaid .node.accent text {
+  color: #fff !important;
+  fill: #fff !important;
+}
+
+/* `stage` classDef paints a node cobalt-cobalt (filled brand primary).
+ * Used for "system" nodes in layered architecture diagrams — the same
+ * role .arch-diagram .node.accent plays in the static product pages. */
+.docusaurus-mermaid-container .node.stage rect,
+.docusaurus-mermaid-container .node.stage polygon,
+.docusaurus-mermaid-container .node.stage path,
+.mermaid .node.stage rect,
+.mermaid .node.stage polygon,
+.mermaid .node.stage path {
+  fill: #21468B !important;
+  stroke: #21468B !important;
+}
+.docusaurus-mermaid-container .node.stage .nodeLabel,
+.docusaurus-mermaid-container .node.stage text,
+.mermaid .node.stage .nodeLabel,
+.mermaid .node.stage text {
+  color: #fff !important;
+  fill: #fff !important;
+}
+
+/* `muted` classDef: dashed cobalt-100 outline for "external" or
+ * "out-of-scope" nodes that exist in the picture but aren't owned by
+ * the system being described. */
+.docusaurus-mermaid-container .node.muted rect,
+.docusaurus-mermaid-container .node.muted polygon,
+.docusaurus-mermaid-container .node.muted path,
+.mermaid .node.muted rect,
+.mermaid .node.muted polygon,
+.mermaid .node.muted path {
+  fill: #ffffff !important;
+  stroke: #B6C2DD !important;
+  stroke-dasharray: 4 4 !important;
+}
+
+/* Subgraph clusters: render as soft cobalt-100 cards, not the default
+ * gray Mermaid box. Matches the `<div class="card">` chrome on the
+ * design-system preview pages. */
+.docusaurus-mermaid-container .cluster rect,
+.mermaid .cluster rect {
+  fill: #ffffff !important;
+  stroke: #DCE3F0 !important;
+  stroke-width: 1 !important;
+  rx: 8 !important;
+  ry: 8 !important;
+}
+.docusaurus-mermaid-container .cluster text,
+.mermaid .cluster text {
+  fill: #4D69A4 !important;
+  font-size: 11px !important;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.06em !important;
+}
+
+/* Edges: slimmer, brand-cobalt arrows. Default Mermaid lineColor is set
+ * via themeVariables, but stroke-width needs CSS. */
+.docusaurus-mermaid-container .edgePath .path,
+.mermaid .edgePath .path {
+  stroke-width: 1.5 !important;
+}
+.docusaurus-mermaid-container .marker,
+.mermaid .marker {
+  fill: #4D69A4 !important;
+  stroke: #4D69A4 !important;
+}
+
+/* Edge labels (the small "1 → 2" or stage-number captions) read as code
+ * voice, like our static-kit captions. */
+.docusaurus-mermaid-container .edgeLabel,
+.mermaid .edgeLabel {
+  background: #EEF2F8 !important;
+  color: #4D69A4 !important;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace !important;
+  font-size: 11px !important;
+  padding: 2px 6px !important;
+}
+
+/* Dark mode (Docusaurus toggles data-theme=dark on <html>): invert the
+ * container without changing node fills — Mermaid keeps its own dark
+ * theme; we just retint the wrapper so it doesn't fight the page. */
+[data-theme='dark'] .docusaurus-mermaid-container,
+[data-theme='dark'] [class*="mermaid"][class*="container"] {
+  background: #0A172F;
+  border-color: #152D5C;
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,2 +1,7 @@
 /* Site-specific overrides for docs.conduction.nl.
  * Brand tokens + base typography come from @conduction/docusaurus-preset. */
+
+/* Conduction-branded Mermaid theme. Authors write plain ```mermaid blocks;
+ * this stylesheet applies the cobalt/orange palette, container chrome,
+ * and the :::accent / :::stage / :::muted classDef hardening. */
+@import './conduction-mermaid.css';

--- a/website/src/diagrams/cn-arch-flow.js
+++ b/website/src/diagrams/cn-arch-flow.js
@@ -1,0 +1,168 @@
+/**
+ * <cn-arch-flow> — a single row of an architecture diagram.
+ *
+ * The "Request flow" pattern from preview/product-pages/technical-docs.html.
+ * One row of boxes connected by arrows, where one box is solid cobalt
+ * (the "owned by us" node) and at most one is an orange pointy-top hex
+ * (the validator or attention node). Stack multiple <cn-arch-flow>s for
+ * a multi-layer system diagram.
+ *
+ *   <cn-arch-flow arrow="right">
+ *     <span>Client</span>
+ *     <span accent>API layer</span>
+ *     <span hex>Validator</span>
+ *   </cn-arch-flow>
+ *   <cn-arch-flow arrow="down">
+ *     <span>Schema registry</span>
+ *     <span accent>Storage adapter</span>
+ *     <span>Audit log</span>
+ *   </cn-arch-flow>
+ *   <cn-arch-flow arrow="none">
+ *     <span>Nextcloud DB</span>
+ *     <span>MySQL</span>
+ *     <span>PostgreSQL</span>
+ *     <span>MongoDB</span>
+ *     <span muted>…</span>
+ *   </cn-arch-flow>
+ *
+ * Arrows are auto-inserted between consecutive children (skip with
+ * arrow="none"). Each child is styled by its attributes — no class
+ * names needed.
+ *
+ * Slots
+ *   default  — row members, in order. Auto-numbered to interleave
+ *              arrows between them in the shadow DOM.
+ *
+ * Attributes
+ *   arrow    — right | down | none   (default: right)
+ *
+ * Child attributes (set on the slotted elements, not on cn-arch-flow)
+ *   accent   — solid cobalt fill, white text. The "system" node.
+ *   hex      — orange pointy-top hex. Use once per scene; this is the
+ *              one-orange-per-scene knob for the diagram.
+ *   muted    — opacity 0.5; for "and more" / out-of-scope placeholders.
+ */
+
+class CnArchFlow extends HTMLElement {
+  static get observedAttributes() { return ['arrow']; }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.render();
+    this._observer = new MutationObserver(() => this.render());
+    this._observer.observe(this, { childList: true, attributes: true, subtree: true });
+  }
+
+  disconnectedCallback() {
+    if (this._observer) this._observer.disconnect();
+  }
+
+  attributeChangedCallback() { if (this.shadowRoot) this.render(); }
+
+  render() {
+    const arrow = this.getAttribute('arrow') || 'right';
+    const nodes = [...this.children];
+    nodes.forEach((el, i) => { el.setAttribute('slot', `node-${i}`); });
+
+    const arrowGlyph = arrow === 'down' ? '↓' : '→';
+    const showArrows = arrow !== 'none';
+
+    let rowMarkup = '';
+    for (let i = 0; i < nodes.length; i++) {
+      rowMarkup += `<slot name="node-${i}"></slot>`;
+      if (showArrows && i < nodes.length - 1) {
+        rowMarkup += `<span class="arrow" aria-hidden="true">${arrowGlyph}</span>`;
+      }
+    }
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          font-family: var(--conduction-typography-font-family-code, ui-monospace, monospace);
+        }
+
+        .panel {
+          background: var(--c-cobalt-50);
+          border: 1px solid var(--c-cobalt-100);
+          border-radius: var(--radius-md);
+          padding: var(--space-6);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: var(--space-3);
+          flex-wrap: wrap;
+          font-size: 11px;
+          text-align: center;
+        }
+
+        .arrow {
+          color: var(--c-cobalt-400);
+          font-size: 16px;
+          flex-shrink: 0;
+        }
+
+        /* Default node: white rounded box with cobalt-200 border. */
+        ::slotted(*) {
+          flex: 1 1 0;
+          min-width: 80px;
+          padding: var(--space-3) var(--space-2);
+          background: white;
+          border: 1px solid var(--c-cobalt-200);
+          border-radius: var(--radius-sm);
+          color: var(--c-cobalt-800);
+          font-family: var(--conduction-typography-font-family-code, ui-monospace, monospace);
+          font-size: 11px;
+          text-align: center;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-sizing: border-box;
+          min-height: 38px;
+        }
+
+        /* accent: the "system" node — solid cobalt brand fill. */
+        ::slotted([accent]) {
+          background: var(--c-blue-cobalt);
+          color: white;
+          border-color: var(--c-blue-cobalt);
+        }
+
+        /* hex: the orange pointy-top hex. The one-orange-per-scene knob.
+         * Replaces the rectangle entirely with a clip-pathed shape so the
+         * brand rule (hexes never rotate, always pointy-top) holds. */
+        ::slotted([hex]) {
+          flex: 0 0 auto;
+          width: 64px;
+          min-width: 0;
+          height: 74px;
+          padding: 0;
+          background: var(--c-orange-knvb);
+          color: white;
+          border: 0;
+          border-radius: 0;
+          clip-path: var(--hex-pointy-top);
+          font-weight: 600;
+          font-size: 12px;
+        }
+
+        /* muted: out-of-scope / "and more" placeholder. */
+        ::slotted([muted]) {
+          opacity: 0.5;
+        }
+      </style>
+
+      <div class="panel">${rowMarkup}</div>
+    `;
+  }
+}
+
+if (!customElements.get('cn-arch-flow')) {
+  customElements.define('cn-arch-flow', CnArchFlow);
+}
+
+export { CnArchFlow };

--- a/website/src/diagrams/index.js
+++ b/website/src/diagrams/index.js
@@ -1,0 +1,14 @@
+/**
+ * Side-effect import that registers Conduction diagram custom elements
+ * in the browser. Wired up via clientModules in docusaurus.config.js.
+ *
+ * Local copy of the @conduction/docusaurus-preset/diagrams subpath
+ * pending the preset version bump that ships cn-pair + cn-arch-flow.
+ * Once the next preset release lands, this file collapses to:
+ *
+ *   import '@conduction/docusaurus-preset/diagrams/cn-arch-flow';
+ *
+ * For now, the source lives next to it for build simplicity.
+ */
+
+import './cn-arch-flow.js';


### PR DESCRIPTION
## Summary

Turn the three tables in `docs/WayOfWork/spec-driven-development.md` (Pipeline, Layers, Commands) into Conduction-branded Mermaid flowcharts. Authors keep writing plain Markdown; diagrams render with the cobalt-and-orange palette automatically.

## What changes

- **`@docusaurus/theme-mermaid`** added to `website/`. The theme registers a remark plugin that picks up triple-backtick `mermaid` fences in both `.md` and `.mdx`, so the existing CommonMark docs (which don't escape angle brackets / curly braces) keep working.
- **Site-wide brand `themeVariables`** in `docusaurus.config.js` — cobalt-50 fill, cobalt-200 border, cobalt-400 edges, cobalt-700 text, Figtree font. Authors don't need per-diagram `%%{init}%%` blocks.
- **`website/src/css/conduction-mermaid.css`** ships the container chrome (cobalt-50 panel matching the product-page mockups), uppercase Plex Mono cluster labels, and three `classDef` hooks:
  - `:::accent` — KNVB orange, the one-orange-per-scene knob (use once per diagram).
  - `:::stage` — solid cobalt for system / 'owned by us' nodes.
  - `:::muted` — dashed cobalt-100 for out-of-scope nodes.
- **`spec-driven-development.md`** — three tables become three Mermaid charts plus bullet detail (so the prose in column 3 doesn't get lost in 3-word nodes).

## Why hybrid, not all-Mermaid

Mermaid is excellent for flowcharts and stays diff-friendly in MDX, but it cannot reliably render pointy-top hexes with one-orange accents and stay brand-strict. The line is:

- **Process / flow diagrams** -> Mermaid (this PR).
- **Brand-illustrative shapes** (hex apex layouts, honeycomb backdrops, two-system bridges) -> `<cn-*>` web components from `@conduction/docusaurus-preset/diagrams`.

The shape-illustration side is being expanded in a parallel design-system PR (new `<cn-pair>` and `<cn-arch-flow>` components extracted from the unindexed patterns in `preview/product-pages/technical-docs.html` and `integrations.html`).

## Follow-up (not in this PR)

Promote `conduction-mermaid.css` from `website/src/css/` into `@conduction/docusaurus-preset` so every Conduction Docusaurus site inherits the theme. Deferred until the CSS settles in the live site.

## Test plan

- [x] `npm run start` boots cleanly on `localhost:3088`
- [x] Pipeline diagram renders: 4 stages, `3 - Build` in KNVB orange
- [x] Layers diagram renders: Frontend -> Backend data -> Backend logic, OpenRegister in KNVB orange
- [x] Commands diagram renders: 5 stage clusters, `/opsx-apply` in KNVB orange
- [x] No console errors, no compile errors (1 pre-existing webpack warning about `app-downloads.json` in the preset, unrelated)
- [ ] `npm run build` succeeds (preview only; CI will run on merge)