### PR TITLE
fix(docs): pipeline diagram nodes all same size

### DIFF
--- a/docs/WayOfWork/spec-driven-development.md
+++ b/docs/WayOfWork/spec-driven-development.md
@@ -18,7 +18,7 @@ All development follows four stages. Each stage feeds the next: discovery become
 flowchart LR
   A["<b>1 · Obtain</b><br/>Discover requirements"]
   B["<b>2 · Specify</b><br/>Write structured specs"]
-  C["<b>3 · Build</b>"]:::accent
+  C["<b>3 · Build</b><br/>Implement by assembly"]:::accent
   D["<b>4 · Validate</b><br/>Verify against specs"]
   A --> B --> C --> D
   classDef accent fill:#F36C21,stroke:#F36C21,color:#fff;


### PR DESCRIPTION
## Summary

The Pipeline diagram on **Spec-Driven Development** had four nodes of three different widths because `3 · Build` was the only single-line label. Mermaid auto-sizes nodes to label content, so Build came out narrower than the rest. Adding the matching subtitle (\"Implement by assembly\") brings all four nodes to the same width without any CSS hack.

## Why this fix and not CSS

A `min-width` override in `conduction-mermaid.css` would affect every Mermaid node on every page site-wide — riskier and less honest. Content-side parity matches what every other node already does and the bullet list below the diagram already covers the same idea, so the new subtitle stays accurate.

## Test plan

- [ ] After merge, check https://docs.conduction.nl/WayOfWork/spec-driven-development and confirm the four pipeline nodes are equal-width