### PR TITLE
ci(documentation): run build/validate on PRs, deploy only on push

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,16 +18,22 @@ on:
         type: string
         default: "20"
 
+# Two jobs so the AI-baseline validation gate runs on every event,
+# including pull_request, while the actual gh-pages deploy stays
+# gated to push / schedule / workflow_dispatch. Sites that ship the
+# postbuild validator from @conduction/docusaurus-preset (robots.txt,
+# llms.txt, sitemaps, JSON-LD, FAQPage, og:image, etc.) get PR-time
+# enforcement of the contract automatically.
+
 jobs:
-  deploy:
-    name: Deploy Documentation
+  build:
+    name: Build and validate
     runs-on: ubuntu-latest
-    # Deploy on direct pushes, scheduled rebuilds (cron-driven data
-    # refresh on conduction-website), and manual workflow_dispatch.
-    # PR runs still build but don't deploy.
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      built: ${{ steps.flag.outputs.built }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,6 +65,39 @@ jobs:
             echo "ERROR: index.html not found in build directory!"
             exit 1
           fi
+
+      - name: Upload build artifact for deploy job
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docusaurus-build
+          path: ${{ inputs.source-folder }}/build
+          retention-days: 1
+
+      - id: flag
+        run: echo "built=true" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Deploy Documentation
+    needs: build
+    runs-on: ubuntu-latest
+    # Deploy only on direct pushes, scheduled rebuilds, and manual
+    # workflow_dispatch. PR runs stop after the build job, so the
+    # AI-baseline gate runs but no gh-pages push happens.
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: docusaurus-build
+          path: ${{ inputs.source-folder }}/build
 
       - name: Create .nojekyll and CNAME files
         run: |


### PR DESCRIPTION
## Summary

Split the shared documentation workflow into a `build` job that runs on every event (including pull_request) and a `deploy` job that runs only on push / schedule / workflow_dispatch. Net effect: every docs site that uses this workflow now gets PR-time CI on the build, including the AI-baseline validator that ships postbuild from @conduction/docusaurus-preset.

## Why

Today the workflow has:

```yaml
if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
```

at the top of the only job. PRs match none of those, so the whole job is SKIPPED. A PR can:
- drop `static/robots.txt`
- empty `static/llms.txt`
- delete the SoftwareApplication JSON-LD emission from `<DetailHero>` (via a preset version pin downgrade)
- remove the FAQ block from `/support`
- break the sitemap

...and CI gives a green check anyway. The bad code lands. The nightly cron rebuilds, sees the regression, fails the deploy. By then production is already broken.

This PR shifts detection left. PRs now run the same `npm run ci` (build + validate) that production runs. Sites that ship the AI-baseline gate (robots.txt, llms.txt, sitemap shape, JSON-LD on the homepage and `/apps/<slug>` pages, FAQPage on `/support` `/install` `/iso`, og:image, twitter meta) get fleet-wide PR-time enforcement of the contract without each repo needing its own `validate-ai-baseline.yml` workflow.

## What changed

- `build` job: runs on every event. Checks out, installs, runs `npm run ci`. Uploads the `build/` tree as an artifact on the events that go on to deploy.
- `deploy` job: needs the `build` job. Only fires on push / schedule / workflow_dispatch. Downloads the artifact, adds `.nojekyll` + `CNAME`, pushes to gh-pages.

## Compatibility

- **No input contract changes.** Sites that already call this workflow with `cname: ...; source-folder: ...` keep working unchanged.
- **PRs that previously got no CI signal** now get a green or red check from the new `build` job.
- **Sites without a postbuild validator** (most of the fleet today) see the build job run a vanilla `npm run ci` and pass. The gate only fires for sites that have wired it locally (conduction-website is the first; the rest of the fleet follows in separate PRs).

## Test plan

- [ ] CI runs on this PR; the `build` job exists and runs
- [ ] After merge, the next PR opened against any consuming docs site triggers the workflow and runs `build` only (no deploy)
- [ ] After merge, the next push to `development` on any consuming docs site triggers `build` then `deploy`
- [ ] Spot-check that a docs site without a validator still builds successfully through the new flow (e.g. docudesk, mydash)