### PR TITLE
chore(docs): bump preset to ^3.12.0 + proper hero header

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,7 +8,7 @@
       "name": "conduction-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.10.2",
+        "@conduction/docusaurus-preset": "^3.12.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@docusaurus/theme-mermaid": "^3.10.1",
@@ -2013,10 +2013,13 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.2.tgz",
-      "integrity": "sha512-qbQ6htlDq8a6oVlZ7Bxo7Vhely0gSsD23FtL9KfNBJOugIScIGA1I/2ocAZP54u6zto/twzQtsnlSn5wBIXfsg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.12.0.tgz",
+      "integrity": "sha512-aTaGpAfMCLZEeGx4cZxAeHX9iyHGA1besQe5E6GyyAvZ8c5c8iSt8OH5A1WFCJreJgvNsnpQqgTS8GRh3Z+5Bg==",
       "license": "EUPL-1.2",
+      "bin": {
+        "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
+      },
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^2.10.2",
+    "@conduction/docusaurus-preset": "^3.12.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@docusaurus/theme-mermaid": "^3.10.1",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -88,7 +88,6 @@ const sidebars = {
             'claude/getting-started',
             'claude/walkthrough',
             'claude/agents',
-            'claude/rad-platform',
 
             {
               type: 'category',

--- a/website/src/diagrams/index.js
+++ b/website/src/diagrams/index.js
@@ -6,6 +6,16 @@
  * directly now that 2.10.2 ships them as published subpath exports.
  * The local copy that previously lived next to this file was a stopgap
  * during the preset version bump and has been removed.
+ *
+ * SSR guard: clientModules are imported on both server and client by
+ * Docusaurus; cn-arch-flow uses `class extends HTMLElement` at module
+ * top-level which is undefined in Node. Gate on canUseDOM so the import
+ * only fires in the browser.
  */
 
-import '@conduction/docusaurus-preset/diagrams/cn-arch-flow';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  // eslint-disable-next-line global-require
+  require('@conduction/docusaurus-preset/diagrams/cn-arch-flow');
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -90,6 +90,14 @@ export default function Home() {
         background="cobalt"
         title="How We Work"
         tagline="How Conduction operates — culture, roles, expectations, and the way our (digital) employees act."
+        iconColor="var(--c-blue-cobalt)"
+        icon={
+          <svg viewBox="0 0 24 24">
+            <path d="M4 4h11l4 4v13a1 1 0 0 1-1 1H4z" />
+            <path d="M15 4v4h4" />
+            <path d="M8 12h8M8 16h8M8 20h5" />
+          </svg>
+        }
         primaryCta={{ label: 'Explore our identity', href: 'https://identity.conduction.nl/' }}
         secondaryCta={{ label: 'View on GitHub', href: 'https://github.com/ConductionNL/.github/tree/main/docs' }}
       />


### PR DESCRIPTION
## Summary

- Bumps **@conduction/docusaurus-preset** from `2.10.2` to `^3.12.0` (the version released today, ships the new DetailHero `intro` prop + all the AI-baseline / branding work that landed in 3.x).
- Adds an **icon hex to DetailHero** on the homepage so the header matches the per-app sites (`openregister.conduction.nl`) and `conduction.nl/apps/*`. Cobalt hex with a document-style glyph, leading the H1.
- **Fixes the broken deploy** that started 2026-05-14: drops `claude/rad-platform` from `sidebars.js`. The file was deleted in `fcb6efb Delete docs/claude/rad-platform.md` but the sidebar reference stayed behind, causing every `Deploy docs.conduction.nl` run since then to fail at `checkSidebarsDocIds`. Live site has been stuck on the 2026-05-13 build for a week.
- **Adds an SSR guard** to the cn-arch-flow client module. Preset 3.x ships the web component as a `class extends HTMLElement` at module top-level; clientModules are evaluated during SSR (where `HTMLElement` is undefined), which broke the build until I gated the import behind `ExecutionEnvironment.canUseDOM`. Browser-side registration still fires on hydration so `<cn-arch-flow>` diagrams in `docs/WayOfWork/spec-driven-development.md` and `docs/hydra/README.md` keep working.

## Test plan

- [x] Local `npm run build` passes (only advisory broken-link/anchor warnings, no blockers)
- [x] Homepage renders with icon hex + cobalt panel, verified at localhost:3057
- [ ] CI build passes
- [ ] Deploy run succeeds (first green deploy since 2026-05-13)