### PR TITLE
fix(quality.yml): add --legacy-peer-deps to all npm ci invocations

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -277,7 +277,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run ${{ matrix.tool }}
         run: |
@@ -341,7 +341,7 @@ jobs:
               composer audit --format=plain --abandoned=report
               ;;
             npm)
-              npm ci
+              npm ci --legacy-peer-deps
               npm audit --audit-level=critical --omit=dev
               ;;
           esac
@@ -435,7 +435,7 @@ jobs:
           if [ "${{ matrix.ecosystem }}" = "composer" ]; then
             composer install --no-progress --prefer-dist --optimize-autoloader
           else
-            npm ci
+            npm ci --legacy-peer-deps
             npm install -g license-checker
           fi
 
@@ -1060,7 +1060,7 @@ jobs:
         run: |
           cd server/apps/${{ inputs.app-name }}
           if [ -f "package.json" ]; then
-            npm ci
+            npm ci --legacy-peer-deps
           fi
 
       - name: Install Playwright
@@ -1568,7 +1568,7 @@ jobs:
 
       - name: Install npm dependencies
         if: ${{ inputs.enable-frontend }}
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Generate npm SBOM
         if: ${{ inputs.enable-frontend }}


### PR DESCRIPTION
## Summary
Adds \`--legacy-peer-deps\` to all 5 \`npm ci\` invocations in \`quality.yml\` (the reusable Code Quality workflow):
- Vue Quality matrix (eslint, stylelint)
- Security (npm)
- License (npm)
- E2E Tests (Playwright) — app-side npm ci
- SBOM generation

## Why
\`@conduction/nextcloud-vue@^1.0.0-beta.61\` brings in a transitive package that requires \`pinia ^3.0.4\` as a peer dep, while root \`package.json\` across the fleet currently pins \`pinia ^2.1.7\`. Without \`--legacy-peer-deps\`, every npm-side job fails with EUSAGE at the install step before its actual check runs. Apps already operate under \`legacy-peer-deps=true\` in production (\`.npmrc\`); CI just hadn't caught up.

Surfaced fleet-wide via [openbuilt#121](https://github.com/ConductionNL/openbuilt/pull/121) and [#122](https://github.com/ConductionNL/openbuilt/pull/122). Same pattern as the per-app \`pull-request-lint-check.yaml\` workflows that already use \`--legacy-peer-deps\`.

## Test plan
- [ ] After merge, openbuilt#121/#122 npm-side jobs (License, Security, eslint, stylelint) go green on next CI run.
- [ ] No regressions on other apps' Code Quality runs.