### PR TITLE
copy(feature-request): explain why the auto-filled context is visible

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -70,7 +70,10 @@ body:
 
         The fields below are auto-filled when you suggest a feature from inside
         the app. They capture where you were when the idea hit so we can scope
-        the spec without a second round of questions. Leave them blank if
+        the spec without a second round of questions.
+
+        **We show them to you here on purpose**: you can see exactly what we
+        send and edit or clear any field before you submit. Leave them blank if
         you're filing directly from GitHub — we'll still triage it.
 
   - type: input


### PR DESCRIPTION
## Summary

- Adds an explicit transparency sentence to the **Context** section of the org-level Feature Issue Form
- Tells submitters that the auto-captured fields (app/page/surface/object/spec-ref) are shown on purpose so they can review what we send and edit or clear anything before submitting
- No structural changes to the form fields

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/feature-request.yml'))"\` — valid
- [ ] Open a new feature request to visually confirm the new Context blurb renders