### PR TITLE
fix(docs): correct ADR reference for i18n from 005 to 007

### DIFF
--- a/docs/claude/writing-specs.md
+++ b/docs/claude/writing-specs.md
@@ -37,7 +37,7 @@ Every spec file at `openspec/specs/{domain}/spec.md` follows this structure:
 
 - **Performance:** <measurable performance requirement>
 - **Accessibility:** <WCAG or usability requirement>
-- **Internationalization:** Dutch and English MUST be supported (ADR-005)
+- **Internationalization:** Dutch and English MUST be supported (ADR-007)
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

One-character fix in [docs/claude/writing-specs.md:40](docs/claude/writing-specs.md#L40) — the bullet about Dutch + English i18n cited (ADR-005), but ADR-005 is the Security ADR. i18n lives in [ADR-007](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-007-i18n.md).

Spotted while auditing the hydra ADR set for cross-references (see ConductionNL/hydra#341 thread).

## Test plan

- [x] Render `docs/claude/writing-specs.md` on GitHub — bullet reads "(ADR-007)" and the parenthetical still parses as a single capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order

This work is split across four PRs. Merge in this order to avoid base-rebase churn:

1. **[hydra#341](https://github.com/ConductionNL/hydra/pull/341)** — ADR renumber + ADR-018→017 merge + adr-039 status backfill. Base: `development`.
2. **[hydra#342](https://github.com/ConductionNL/hydra/pull/342)** — fleet-wide Prettier formatting on all `*.md`. Base: `chore/adr-renumber-033-duplicates` (auto-retargets to `development` once #341 merges).
3. **[hydra#312](https://github.com/ConductionNL/hydra/pull/312)** — credentials 401 detection fix. Independent — can merge any time, but easiest after #341/#342 to avoid the small ADR-formatting overlap.
4. **[.github#103](https://github.com/ConductionNL/.github/pull/103)** — one-character ADR-005→007 typo fix in `writing-specs.md`. Fully standalone, separate repo.

