### PR TITLE
ci(quality): install app deps before enabling app (phpunit job)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1898,7 +1898,12 @@ jobs:
         # peer/version mismatches in transitive deps, a hard dependency declared
         # by a lib but deduped away, etc. — which has nothing to do with the SBOM.
         # The lockfile is the deterministic source of truth for what gets installed.
-        run: npx @cyclonedx/cyclonedx-npm --package-lock-only --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
+        # --ignore-npm-errors: cyclonedx-npm still shells out to `npm ls` internally
+        # even with --package-lock-only, and aborts on those same benign
+        # ELSPROBLEMS (e.g. a transitive @vueuse/core pulled by @nextcloud/dialogs
+        # that mismatches a peer range). The tree quirk does not affect the SBOM,
+        # so tolerate it rather than red the whole quality run.
+        run: npx @cyclonedx/cyclonedx-npm --package-lock-only --ignore-npm-errors --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
 
       - name: Merge PHP + npm SBOMs
         if: ${{ inputs.enable-frontend }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -758,13 +758,20 @@ jobs:
               php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
             done
           fi
-          php occ app:enable ${{ inputs.app-name }}
           chmod -R a+w config
 
-      - name: Install app dependencies
+      # Install the app's own dependencies BEFORE enabling it. Enabling triggers
+      # install-scope repair steps that autowire services with eager constructors
+      # (e.g. SaveObject does `new Twig\Environment(...)`); without vendor present
+      # that fatals with an uncaught \Error (NC core only catches \Exception),
+      # killing the step. Matches the newman/playwright/journeydoc jobs, which
+      # already composer-install before enabling the app.
+      - name: Install app dependencies and enable app
         run: |
           cd server/apps/${{ inputs.app-name }}
           composer install --no-progress --prefer-dist --optimize-autoloader
+          cd ../../
+          php occ app:enable ${{ inputs.app-name }}
 
       - name: Validate test infrastructure
         run: |


### PR DESCRIPTION
The phpunit matrix job enabled the app before composer install, so enable-time repair steps autowiring eager constructors (e.g. OpenRegister SaveObject `new Twig\Environment`) fatal with an uncaught `Error` when vendor is absent (`Class Twig\Extension\AbstractExtension not found`). Reorder to composer-install-then-enable, matching the newman/playwright/journeydoc jobs. Mirrors Codeberg Conduction/.github#71. Fixes OpenRegister's PHPUnit (NC stable32) CI.