### PR TITLE
ci(quality): --omit=dev on SBOM npm audit

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1898,7 +1898,12 @@ jobs:
         # peer/version mismatches in transitive deps, a hard dependency declared
         # by a lib but deduped away, etc. — which has nothing to do with the SBOM.
         # The lockfile is the deterministic source of truth for what gets installed.
-        run: npx @cyclonedx/cyclonedx-npm --package-lock-only --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
+        # --ignore-npm-errors: cyclonedx-npm still shells out to `npm ls` internally
+        # even with --package-lock-only, and aborts on those same benign
+        # ELSPROBLEMS (e.g. a transitive @vueuse/core pulled by @nextcloud/dialogs
+        # that mismatches a peer range). The tree quirk does not affect the SBOM,
+        # so tolerate it rather than red the whole quality run.
+        run: npx @cyclonedx/cyclonedx-npm --package-lock-only --ignore-npm-errors --output-file bom-npm.cdx.json --spec-version 1.5 --omit dev
 
       - name: Merge PHP + npm SBOMs
         if: ${{ inputs.enable-frontend }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -758,13 +758,20 @@ jobs:
               php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
             done
           fi
-          php occ app:enable ${{ inputs.app-name }}
           chmod -R a+w config
 
-      - name: Install app dependencies
+      # Install the app's own dependencies BEFORE enabling it. Enabling triggers
+      # install-scope repair steps that autowire services with eager constructors
+      # (e.g. SaveObject does `new Twig\Environment(...)`); without vendor present
+      # that fatals with an uncaught \Error (NC core only catches \Exception),
+      # killing the step. Matches the newman/playwright/journeydoc jobs, which
+      # already composer-install before enabling the app.
+      - name: Install app dependencies and enable app
         run: |
           cd server/apps/${{ inputs.app-name }}
           composer install --no-progress --prefer-dist --optimize-autoloader
+          cd ../../
+          php occ app:enable ${{ inputs.app-name }}
 
       - name: Validate test infrastructure
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1949,7 +1949,12 @@ jobs:
 
       - name: npm audit
         if: ${{ inputs.enable-frontend }}
-        run: npm audit --audit-level=critical
+        # --omit=dev: gate only on production-dependency criticals. Dev-only
+        # build tooling (node-gyp/cacache → tar, cyclonedx, babel, …) is never
+        # shipped in the app bundle, and its frequent advisories would otherwise
+        # red every run. Matches the dedicated `Security (npm)` job, which
+        # already runs `--audit-level=critical --omit=dev`.
+        run: npm audit --audit-level=critical --omit=dev
 
       # ── Publish validated SBOM ──
       # The SBOM is intentionally NOT committed back to the repo.


### PR DESCRIPTION
The SBOM job's `npm audit --audit-level=critical` gated on dev-only build-tool criticals (tar via node-gyp/cacache) that never ship. Match the `Security (npm)` job's `--omit=dev` so both gate on production criticals only. Mirrors Codeberg Conduction/.github#72. Fixes OpenRegister's Code Quality SBOM/npm-audit red.