### PR TITLE
ci(quality): enable-php switch, custom frontend checks, strict npm ci, and a real Quality Report gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: '["stable31", "stable32"]'
+      enable-php:
+        description: "Master switch for the PHP toolchain (php-quality, PHPUnit, composer security/license legs). Set false for JS-only repos without composer.json."
+        required: false
+        type: boolean
+        default: true
       enable-psalm:
         description: "Run Psalm static analysis"
         required: false
@@ -57,6 +62,21 @@ on:
         required: false
         type: boolean
         default: true
+      node-version:
+        description: "Node.js version for all frontend/npm steps"
+        required: false
+        type: string
+        default: "20"
+      frontend-setup-command:
+        description: "Optional extra install command run after `npm ci` in the frontend-checks job (e.g. 'cd docusaurus && npm ci')"
+        required: false
+        type: string
+        default: ""
+      frontend-checks:
+        description: "JSON array of npm scripts to run as individual 'Frontend Check (<script>)' jobs (e.g. '[\"test\", \"check:docs\"]'). Requires enable-frontend."
+        required: false
+        type: string
+        default: "[]"
       enable-license-check:
         description: "Run dependency license compliance check (composer + npm)"
         required: false
@@ -183,6 +203,7 @@ jobs:
 
   # ── Group 1: PHP Quality ────────────────────────
   php-quality:
+    if: ${{ inputs.enable-php }}
     runs-on: ubuntu-latest
     name: "PHP Quality (${{ matrix.tool }})"
     strategy:
@@ -293,7 +314,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
           cache: "npm"
 
       - name: Install dependencies
@@ -326,6 +347,55 @@ jobs:
           name: result-vue-quality-${{ matrix.tool }}
           path: quality-results/
 
+  # ── Group 2b: Custom frontend checks ───────────
+  #
+  # Repo-defined npm scripts run as individual matrix legs, e.g.
+  #   frontend-checks: '["test", "check:build", "check:docs"]'
+  # Each leg gets a fresh checkout + npm ci, so scripts must be
+  # self-contained (bundle ordering deps into one script, e.g.
+  # "check:build": "npm run build && npm run check:css-entry").
+  frontend-checks:
+    if: ${{ inputs.enable-frontend && inputs.frontend-checks != '[]' }}
+    runs-on: ubuntu-latest
+    name: "Frontend Check (${{ matrix.script }})"
+    strategy:
+      matrix:
+        script: ${{ fromJSON(inputs.frontend-checks) }}
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ inputs.node-version }}"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Extra setup
+        if: ${{ inputs.frontend-setup-command != '' }}
+        run: ${{ inputs.frontend-setup-command }}
+
+      - name: Run ${{ matrix.script }}
+        run: npm run "${{ matrix.script }}"
+
+      - name: Record result
+        if: always()
+        run: |
+          mkdir -p quality-results
+          # ':' is invalid in artifact file paths — sanitize the script name
+          echo "${{ job.status }}" > "quality-results/$(echo '${{ matrix.script }}' | tr ':/' '--').txt"
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-frontend-check-${{ strategy.job-index }}
+          path: quality-results/
+
   # ── Group 3: Security ──────────────────────────
   security:
     runs-on: ubuntu-latest
@@ -350,13 +420,17 @@ jobs:
         if: matrix.ecosystem == 'npm'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
           cache: "npm"
 
       - name: Run ${{ matrix.ecosystem }} audit
         run: |
           case "${{ matrix.ecosystem }}" in
             composer)
+              if [ "${{ inputs.enable-php }}" != "true" ]; then
+                echo "PHP toolchain is disabled — skipping composer audit."
+                exit 0
+              fi
               composer install --no-progress --prefer-dist --optimize-autoloader
               composer audit --format=plain --abandoned=report
               ;;
@@ -459,12 +533,16 @@ jobs:
         if: matrix.ecosystem == 'npm'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
           cache: "npm"
 
       - name: Install dependencies
         run: |
           if [ "${{ matrix.ecosystem }}" = "composer" ]; then
+            if [ "${{ inputs.enable-php }}" != "true" ]; then
+              echo "PHP toolchain is disabled — skipping composer install."
+              exit 0
+            fi
             composer install --no-progress --prefer-dist --optimize-autoloader
           else
             npm ci --legacy-peer-deps
@@ -474,6 +552,11 @@ jobs:
       - name: Check ${{ matrix.ecosystem }} licenses
         run: |
           set -euo pipefail
+
+          if [ "${{ matrix.ecosystem }}" = "composer" ] && [ "${{ inputs.enable-php }}" != "true" ]; then
+            echo "PHP toolchain is disabled — skipping composer license check."
+            exit 0
+          fi
 
           # ── Default allowlist (EUPL-1.2 / AGPL-3.0 compatible) ──
           DEFAULT_ALLOWLIST='[
@@ -677,7 +760,7 @@ jobs:
   # ╚══════════════════════════════════════════════╝
 
   phpunit:
-    if: ${{ inputs.enable-phpunit && !cancelled() && needs.php-quality.result != 'failure' && needs.security.result != 'failure' }}
+    if: ${{ inputs.enable-php && inputs.enable-phpunit && !cancelled() && needs.php-quality.result != 'failure' && needs.security.result != 'failure' }}
     runs-on: ubuntu-latest
     name: "PHPUnit (PHP ${{ matrix.php-version }}, NC ${{ matrix.nextcloud-ref }})"
     needs: [php-quality, security]
@@ -937,7 +1020,7 @@ jobs:
       - name: Setup Node.js and Newman
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
 
       - name: Install Newman
         run: npm install -g newman
@@ -1093,7 +1176,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
 
       - name: Install app npm dependencies
         run: |
@@ -1427,7 +1510,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "${{ inputs.node-version }}"
 
       - name: Install app npm dependencies
         run: |
@@ -1649,7 +1732,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     name: "Quality Report"
-    needs: [php-quality, vue-quality, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection]
+    needs: [php-quality, vue-quality, frontend-checks, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection]
     if: always()
 
     steps:
@@ -1751,6 +1834,13 @@ jobs:
             for tool in eslint stylelint; do
               result=$(read_result "results/result-vue-quality-$tool/$tool.txt")
               echo "| $tool | | $(icon "$result") | | | |"
+            done
+
+            # Custom frontend checks (if any)
+            for f in results/result-frontend-check-*/*.txt; do
+              [ -f "$f" ] || continue
+              tool=$(basename "$f" .txt)
+              echo "| $tool | | $(icon "$(read_result "$f")") | | | |"
             done
 
             # Composer: security + license in one row
@@ -1859,6 +1949,15 @@ jobs:
               body
             });
 
+      # Makes "quality / Quality Report" a usable required check: without
+      # this the job always succeeded (if: always() + report-only steps),
+      # so requiring it in branch protection would gate nothing.
+      - name: Gate — fail when any upstream job failed
+        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        run: |
+          echo "::error::One or more quality jobs failed — see the report above."
+          exit 1
+
   # ╔══════════════════════════════════════════════╗
   # ║  STAGE 4 — SBOM Generation & Validation      ║
   # ║                                               ║
@@ -1891,7 +1990,7 @@ jobs:
         if: ${{ inputs.enable-frontend }}
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "${{ inputs.node-version }}"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: '["stable31", "stable32"]'
       enable-php:
-        description: "Master switch for the PHP toolchain (php-quality, PHPUnit, composer security/license legs). Set false for JS-only repos without composer.json."
+        description: "Master switch for the PHP toolchain (php-quality, PHPUnit, composer security/license legs, SBOM). Set false for JS-only repos without composer.json."
         required: false
         type: boolean
         default: true
@@ -68,12 +68,12 @@ on:
         type: string
         default: "20"
       frontend-setup-command:
-        description: "Optional ADDITIONAL setup command for the frontend-checks job. The standard root `npm ci` always runs first; this command runs after it and does NOT replace it. Use it to prepare things the root install doesn't cover, e.g. installing a nested package's dependencies: 'cd docusaurus && npm ci'."
+        description: "Optional ADDITIONAL setup command for the frontend-checks job. The standard root `npm ci` always runs first; this command runs after it and does NOT replace it. Use it to prepare things the root install doesn't cover, e.g. installing a nested package's dependencies: 'cd docusaurus && npm ci' (the nested directory then needs its own package.json + package-lock.json)."
         required: false
         type: string
         default: ""
       frontend-checks:
-        description: "JSON array of npm scripts to run as individual 'Frontend Check (<script>)' jobs (e.g. '[\"test\", \"check:docs\"]'). Requires enable-frontend. Every listed script MUST exist in the repo's package.json and MUST be self-contained — each leg is a fresh job (own checkout + npm ci), so bundle order-dependent steps into one script (e.g. \"check:build\": \"npm run build && npm run check:css-entry\"). See CONVENTIONS.md § Custom frontend checks."
+        description: "JSON array of npm scripts to run as individual 'Frontend Check (<script>)' jobs (e.g. '[\"test\", \"check:docs\"]'). Requires enable-frontend and a repo with package.json + package-lock.json (each leg runs `npm ci`). Every listed script MUST exist in the repo's package.json and MUST be self-contained — each leg is a fresh job (own checkout + npm ci), so bundle order-dependent steps into one script (e.g. \"check:build\": \"npm run build && npm run check:css-entry\"). See CONVENTIONS.md § Custom frontend checks."
         required: false
         type: string
         default: "[]"
@@ -373,10 +373,15 @@ jobs:
           node-version: "${{ inputs.node-version }}"
           cache: "npm"
 
+      # Caller-supplied values are passed via env and referenced as "$VAR"
+      # (never inlined into the script) so special characters cannot break
+      # out of the intended shell context.
       - name: Verify script exists in package.json
+        env:
+          SCRIPT: ${{ matrix.script }}
         run: |
-          if ! node -e "const s = require('./package.json').scripts || {}; process.exit(s['${{ matrix.script }}'] ? 0 : 1)"; then
-            echo "::error::npm script '${{ matrix.script }}' is listed in this repo's frontend-checks input but does not exist in package.json. Add the script (see CONVENTIONS.md § Custom frontend checks in ConductionNL/.github) or remove it from the frontend-checks list in .github/workflows/code-quality.yml."
+          if ! node -e "const s = require('./package.json').scripts || {}; process.exit(s[process.env.SCRIPT] ? 0 : 1)"; then
+            echo "::error::npm script '$SCRIPT' is listed in this repo's frontend-checks input but does not exist in package.json. Add the script (see CONVENTIONS.md § Custom frontend checks in ConductionNL/.github) or remove it from the frontend-checks list in .github/workflows/code-quality.yml."
             exit 1
           fi
 
@@ -385,17 +390,23 @@ jobs:
 
       - name: Extra setup (runs after npm ci, does not replace it)
         if: ${{ inputs.frontend-setup-command != '' }}
-        run: ${{ inputs.frontend-setup-command }}
+        env:
+          SETUP_CMD: ${{ inputs.frontend-setup-command }}
+        run: bash -c "$SETUP_CMD"
 
       - name: Run ${{ matrix.script }}
-        run: npm run "${{ matrix.script }}"
+        env:
+          SCRIPT: ${{ matrix.script }}
+        run: npm run "$SCRIPT"
 
       - name: Record result
         if: always()
+        env:
+          SCRIPT: ${{ matrix.script }}
         run: |
           mkdir -p quality-results
           # ':' is invalid in artifact file paths — sanitize the script name
-          echo "${{ job.status }}" > "quality-results/$(echo '${{ matrix.script }}' | tr ':/' '--').txt"
+          echo "${{ job.status }}" > "quality-results/$(echo "$SCRIPT" | tr ':/' '--').txt"
       - name: Upload result
         if: always()
         uses: actions/upload-artifact@v4
@@ -1739,7 +1750,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     name: "Quality Report"
-    needs: [php-quality, vue-quality, frontend-checks, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection]
+    needs: [php-quality, vue-quality, frontend-checks, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection, sbom, features-check, features-extract]
     if: always()
 
     steps:
@@ -1975,7 +1986,7 @@ jobs:
   # ╚══════════════════════════════════════════════╝
 
   sbom:
-    if: ${{ inputs.enable-sbom && !cancelled() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/development') }}
+    if: ${{ inputs.enable-php && inputs.enable-sbom && !cancelled() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/development') }}
     runs-on: ubuntu-latest
     name: "SBOM"
     needs: [security]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -68,12 +68,12 @@ on:
         type: string
         default: "20"
       frontend-setup-command:
-        description: "Optional extra install command run after `npm ci` in the frontend-checks job (e.g. 'cd docusaurus && npm ci')"
+        description: "Optional ADDITIONAL setup command for the frontend-checks job. The standard root `npm ci` always runs first; this command runs after it and does NOT replace it. Use it to prepare things the root install doesn't cover, e.g. installing a nested package's dependencies: 'cd docusaurus && npm ci'."
         required: false
         type: string
         default: ""
       frontend-checks:
-        description: "JSON array of npm scripts to run as individual 'Frontend Check (<script>)' jobs (e.g. '[\"test\", \"check:docs\"]'). Requires enable-frontend."
+        description: "JSON array of npm scripts to run as individual 'Frontend Check (<script>)' jobs (e.g. '[\"test\", \"check:docs\"]'). Requires enable-frontend. Every listed script MUST exist in the repo's package.json and MUST be self-contained — each leg is a fresh job (own checkout + npm ci), so bundle order-dependent steps into one script (e.g. \"check:build\": \"npm run build && npm run check:css-entry\"). See CONVENTIONS.md § Custom frontend checks."
         required: false
         type: string
         default: "[]"
@@ -318,7 +318,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Run ${{ matrix.tool }}
         run: |
@@ -373,10 +373,17 @@ jobs:
           node-version: "${{ inputs.node-version }}"
           cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+      - name: Verify script exists in package.json
+        run: |
+          if ! node -e "const s = require('./package.json').scripts || {}; process.exit(s['${{ matrix.script }}'] ? 0 : 1)"; then
+            echo "::error::npm script '${{ matrix.script }}' is listed in this repo's frontend-checks input but does not exist in package.json. Add the script (see CONVENTIONS.md § Custom frontend checks in ConductionNL/.github) or remove it from the frontend-checks list in .github/workflows/code-quality.yml."
+            exit 1
+          fi
 
-      - name: Extra setup
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extra setup (runs after npm ci, does not replace it)
         if: ${{ inputs.frontend-setup-command != '' }}
         run: ${{ inputs.frontend-setup-command }}
 
@@ -435,7 +442,7 @@ jobs:
               composer audit --format=plain --abandoned=report
               ;;
             npm)
-              npm ci --legacy-peer-deps
+              npm ci
               # Tolerate an unavailable npm advisory endpoint: npm is retiring
               # the audits/quick endpoint and it intermittently 400s ("audit
               # endpoint returned an error" / "Invalid package tree"). That is an
@@ -545,7 +552,7 @@ jobs:
             fi
             composer install --no-progress --prefer-dist --optimize-autoloader
           else
-            npm ci --legacy-peer-deps
+            npm ci
             npm install -g license-checker
           fi
 
@@ -1182,7 +1189,7 @@ jobs:
         run: |
           cd server/apps/${{ inputs.app-name }}
           if [ -f "package.json" ]; then
-            npm ci --legacy-peer-deps
+            npm ci
           fi
 
       - name: Install Playwright
@@ -1516,7 +1523,7 @@ jobs:
         run: |
           cd server/apps/${{ inputs.app-name }}
           if [ -f "package.json" ]; then
-            npm ci --legacy-peer-deps
+            npm ci
           fi
 
       - name: Install Playwright
@@ -2007,7 +2014,7 @@ jobs:
 
       - name: Install npm dependencies
         if: ${{ inputs.enable-frontend }}
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Generate npm SBOM
         if: ${{ inputs.enable-frontend }}

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -56,6 +56,76 @@ jobs:
 - ❌ Inline quality jobs (PHPCS / Psalm / etc.) defined directly in app repos rather than via the central reusable workflow.
 - ❌ Renaming the wrapper to anything other than `code-quality.yml`. Filename consistency lets contributors and tools find the wrapper without per-repo guesswork.
 
+#### JS-only repos (`enable-php: false`)
+
+Repos without a `composer.json` (component libraries, themes — e.g. `nextcloud-vue`, `conduction-theme`) use the same wrapper with the PHP toolchain switched off:
+
+```yaml
+    with:
+      app-name: <repo-name>
+      enable-php: false        # skips php-quality, PHPUnit and the composer legs of security/license
+      enable-frontend: true
+      enable-eslint: true
+      node-version: "24"       # optional, defaults to "20"
+```
+
+The skipped PHP checks still report (as "skipped"), which satisfies required status checks — so the same org-wide required contexts work for PHP apps and JS-only repos alike.
+
+#### Custom frontend checks (`frontend-checks`)
+
+Repo-specific quality gates (unit tests, build verification, docs coverage, …) run through the `frontend-checks` input — a JSON array of **npm script names**. Each entry becomes its own `quality / Frontend Check (<script>)` job.
+
+```yaml
+    with:
+      frontend-setup-command: "cd docusaurus && npm ci"   # optional, runs AFTER the root npm ci (never replaces it)
+      frontend-checks: '["test", "check:build", "check:docs"]'
+```
+
+**Requirements for every script you list:**
+
+1. **It must exist in the repo's `package.json` `scripts`** — the leg fails fast with an explicit annotation (`npm script '<name>' is listed in this repo's frontend-checks input but does not exist in package.json`) before anything is installed.
+2. **It must be self-contained.** Every leg is an independent job with a fresh checkout + `npm ci`; nothing from another leg (like `dist/`) is available. Bundle order-dependent steps into one script:
+   ```json
+   "check:build": "npm run build && npm run check:css-entry"
+   ```
+   (`check:css-entry` needs `dist/`, so it must live in the same script as the build.)
+3. **Multi-command checks become named scripts.** Inline shell sequences can't be expressed in the JSON list — wrap them, e.g.:
+   ```json
+   "check:docs-fresh": "cd docusaurus && npm run prebuild:docs && cd .. && git diff --exit-code docs/components/_generated/"
+   ```
+
+All `frontend-checks` legs feed into the `Quality Report` gate, so a failing custom check fails the org-required `quality / Quality Report` context.
+
+#### Peer-dependency policy (`.npmrc`, not CLI flags)
+
+The central workflow runs plain `npm ci` — it does **not** pass `--legacy-peer-deps`, and it never will. Peer-resolution behaviour is owned by each repo via its committed `.npmrc`, so CI behaves exactly like every local and production install, and real conflicts surface in CI instead of being masked org-wide.
+
+Do not ask for the flag to be re-hardcoded in `quality.yml`; that silently disables peer checking for every repo in the fleet at once.
+
+##### `legacy-peer-deps` is an emergency brake, not a setting
+
+**The default is: never use it.** Not on the command line, not in `.npmrc`, not "just to get CI green".
+
+What the flag actually does: it reverts npm to its pre-v7 behaviour where peer dependencies are *advisory* — npm stops checking whether the packages in your tree are compatible with each other and simply installs whatever the lockfile says. The error you silenced does not describe a problem with npm; it describes a real incompatibility between two libraries you ship.
+
+Why that always comes back to bite you:
+
+- **It moves the failure from install-time to runtime.** A strict `npm ci` failure is loud, early, and points at the exact packages in conflict. With the flag, the same conflict ships — and resurfaces as `export 'X' was not found`, a second copy of Vue with broken reactivity, or a component that silently renders nothing. Those bugs cost days instead of minutes and are found by users instead of CI.
+- **It compounds silently.** Every `npm install` run under the flag can bake further unresolvable combinations into the lockfile. The longer it stays on, the bigger the eventual cleanup — you are not deferring one conflict, you are accumulating them.
+- **It hides the fix.** The moment the error is gone, the pressure to actually align the versions is gone with it. Flags like this have a way of becoming permanent; the openconnector `.npmrc` exists since the vue2/vue3 migration and is still there.
+- **It desynchronises the fleet.** A repo running legacy resolution produces lockfiles that strict repos can't reproduce, so the same dependency bump behaves differently across apps — the exact drift the central quality workflow exists to prevent.
+
+##### The only acceptable use
+
+A release or critical merge is blocked **right now**, the real fix (aligning the conflicting versions, upgrading the offending dependency, or removing it) is genuinely not achievable on that timeline, and shipping matters more than waiting. Under those circumstances — and only those:
+
+1. Set `legacy-peer-deps=true` in the repo's **`.npmrc`** (never as an ad-hoc CLI flag, so at least the behaviour is committed, visible, and identical everywhere).
+2. Add a comment directly above it stating **why** it is needed, **which packages** conflict, **who** set it and **when**.
+3. Open a tracking issue for the real fix and link it in that comment.
+4. Remove the flag as soon as the conflict is resolved. Treat it like a `TODO` with interest: every week it survives makes the eventual removal harder.
+
+A `.npmrc` containing `legacy-peer-deps=true` without a dated explanation and a linked issue should be treated as a bug and flagged in review.
+
 ## SBOM (Software Bill of Materials)
 
 Each app's SBOM is published exclusively as a **release asset** via the central Quality workflow's SBOM job. Per-app `sbom.yml` workflows are not allowed — they were removed in [`ConductionNL/.github#34`](https://github.com/ConductionNL/.github/pull/34).


### PR DESCRIPTION
## What

Four improvements to the shared quality workflow, aimed at making `quality / Quality Report` usable as the single org-wide required status check and letting every repo — PHP app or JS-only — adopt the same wrapper.

### 1. `enable-php` master switch
New boolean input (default `true`) that gates the entire PHP toolchain: `php-quality`, PHPUnit, the composer legs of security/license, and SBOM generation. JS-only repos (`nextcloud-vue`, `conduction-theme`) can now adopt the shared workflow with `enable-php: false` — the skipped PHP checks still report as "skipped", which satisfies required status checks, so the same org-wide required contexts work for every repo.

### 2. Custom frontend checks
- **`frontend-checks`** — JSON array of npm scripts, each running as its own `Frontend Check (<script>)` matrix job (fresh checkout + `npm ci` per leg).
- **`frontend-setup-command`** — optional additional setup that runs *after* the root `npm ci` (never replaces it), e.g. installing a nested package's dependencies.
- **`node-version`** — replaces the 7 hardcoded Node `"20"` pins (default unchanged).
- Listed scripts are validated against `package.json` **before** install — a missing script fails fast with an actionable error annotation pointing to CONVENTIONS.md.

### 3. Quality Report becomes a real gate
The `report` job previously always succeeded (`if: always()` + report-only steps), so requiring it in branch protection gated nothing. It now:
- fails when any upstream job failed (new gate step), and
- covers the complete job set — `needs:` extended with `frontend-checks`, `sbom`, `features-check`, `features-extract`, so e.g. a stale `docs/features.json` on a PR trips the gate.

### 4. Strict `npm ci` (removal of `--legacy-peer-deps`)
The hardcoded `--legacy-peer-deps` on all `npm ci` invocations is removed. Peer-resolution behaviour is now **repo-owned** via a committed `.npmrc` (the pattern openconnector already uses), so CI behaves exactly like local/production installs and real peer conflicts surface instead of being masked fleet-wide. CONVENTIONS.md documents the policy: the flag is an emergency brake for blocked releases only — committed in `.npmrc` with a dated why-comment and a linked tracking issue, removed ASAP.

> ⚠️ Rollout note: repos whose lockfiles require legacy resolution but lack the `.npmrc` line will fail their npm jobs on the first run after this merges — that's the conflict surfacing, not a workflow bug. openregister was verified to pass strict `npm ci` cleanly.

## Security hardening

All caller-supplied values used by the new `frontend-checks` job (`matrix.script`, `frontend-setup-command`) are passed through `env:` and referenced as `"$VAR"` instead of being inlined into `run:` scripts, per GitHub's security-hardening guidance.

## Documentation

`CONVENTIONS.md` gains three sections under the Central Quality workflow: **JS-only repos (`enable-php: false`)**, **Custom frontend checks** (script requirements: must exist, must be self-contained, bundle order-dependent steps), and the **peer-dependency policy**.

## Review

All four change requests from @WilcoLouwerse are addressed: `sbom` gated via `enable-php` (option 1), report `needs:` completed, env-var interpolation hardening, and input descriptions now state the `package.json` + `package-lock.json` prerequisites. The suggested hardening pass for the pre-existing `newman-seed-command` / `playwright-seed-command` / `journeydoc-*` inputs is left as a follow-up.

## Compatibility

All new inputs default to current behaviour (`enable-php: true`, Node 20, empty checks list). The two intentional behavioural changes for existing adopters: Quality Report can now be red, and `npm ci` is strict.