### PR TITLE
sync: port four Codeberg-only commits to GitHub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,25 @@ services:
       - ../larpingapp:/var/www/html/custom_apps/larpingapp
       - ../scholiq:/var/www/html/custom_apps/scholiq
       - ../hermiq:/var/www/html/custom_apps/hermiq
+      # These five used to be mounted from ../openregister/custom_apps/<app>,
+      # which is NOT their checkout. Those directories are a stale second copy:
+      # `decidesk` and `openbuild` are not git repositories at all, `petstore`
+      # points at nextcloud-app-template, and `shillinq` sat five patch versions
+      # behind. Every one of the ConductionNL/<app> checkouts that work happens
+      # in is a sibling of .github, so the container was running code nobody was
+      # editing — proven 2026-08-01 by a marker round-trip, and it silently
+      # invalidated any live verification done against these apps.
+      # ⚠️ shillinq's checkout is ahead of the copy (0.9.18 -> 0.9.23), so the
+      # first container recreate after this change registers an app upgrade.
+      - ../decidesk:/var/www/html/custom_apps/decidesk
+      - ../hrmq:/var/www/html/custom_apps/hrmq
+      - ../openbuild:/var/www/html/custom_apps/openbuild
+      - ../petstore:/var/www/html/custom_apps/petstore
+      - ../shillinq:/var/www/html/custom_apps/shillinq
+      # planix had no mount at all, so nothing about it could ever be verified
+      # against this instance. Mounting it does not enable it — run
+      # `occ app:enable planix` once after the next recreate.
+      - ../planix:/var/www/html/custom_apps/planix
       # Pre-installed apps — mounted INDIVIDUALLY, not via a single recursive base
       # mount. The old `../openregister/custom_apps:/var/www/html/custom_apps`
       # mount overlapped the 16 child mounts above and, on Docker Desktop/WSL2,
@@ -149,19 +168,14 @@ services:
       - ../openregister/custom_apps/collectives:/var/www/html/custom_apps/collectives
       - ../openregister/custom_apps/contacts:/var/www/html/custom_apps/contacts
       - ../openregister/custom_apps/cospend:/var/www/html/custom_apps/cospend
-      - ../openregister/custom_apps/decidesk:/var/www/html/custom_apps/decidesk
       - ../openregister/custom_apps/deck:/var/www/html/custom_apps/deck
       - ../openregister/custom_apps/doriath:/var/www/html/custom_apps/doriath
       - ../openregister/custom_apps/forms:/var/www/html/custom_apps/forms
-      - ../openregister/custom_apps/hrmq:/var/www/html/custom_apps/hrmq
       - ../openregister/custom_apps/mail:/var/www/html/custom_apps/mail
       - ../openregister/custom_apps/maps:/var/www/html/custom_apps/maps
-      - ../openregister/custom_apps/openbuild:/var/www/html/custom_apps/openbuild
       - ../openregister/custom_apps/openconnector:/var/www/html/custom_apps/openconnector
-      - ../openregister/custom_apps/petstore:/var/www/html/custom_apps/petstore
       - ../openregister/custom_apps/polls:/var/www/html/custom_apps/polls
       - ../openregister/custom_apps/portaliq:/var/www/html/custom_apps/portaliq
-      - ../openregister/custom_apps/shillinq:/var/www/html/custom_apps/shillinq
       - ../openregister/custom_apps/spreed:/var/www/html/custom_apps/spreed
       - ../openregister/custom_apps/tasks:/var/www/html/custom_apps/tasks
       - ../openregister/custom_apps/timemanager:/var/www/html/custom_apps/timemanager
@@ -342,6 +356,13 @@ services:
       - ../larpingapp:/var/www/html/custom_apps/larpingapp
       - ../scholiq:/var/www/html/custom_apps/scholiq
       - ../hermiq:/var/www/html/custom_apps/hermiq
+      # See the note on the postgres `nextcloud` service: these five are the real
+      # ConductionNL checkouts, not the stale ../openregister/custom_apps copies.
+      - ../decidesk:/var/www/html/custom_apps/decidesk
+      - ../hrmq:/var/www/html/custom_apps/hrmq
+      - ../openbuild:/var/www/html/custom_apps/openbuild
+      - ../petstore:/var/www/html/custom_apps/petstore
+      - ../shillinq:/var/www/html/custom_apps/shillinq
       - ../openregister/custom_apps/analytics:/var/www/html/custom_apps/analytics
       - ../openregister/custom_apps/app_versions:/var/www/html/custom_apps/app_versions
       - ../openregister/custom_apps/bookmarks:/var/www/html/custom_apps/bookmarks
@@ -349,19 +370,14 @@ services:
       - ../openregister/custom_apps/collectives:/var/www/html/custom_apps/collectives
       - ../openregister/custom_apps/contacts:/var/www/html/custom_apps/contacts
       - ../openregister/custom_apps/cospend:/var/www/html/custom_apps/cospend
-      - ../openregister/custom_apps/decidesk:/var/www/html/custom_apps/decidesk
       - ../openregister/custom_apps/deck:/var/www/html/custom_apps/deck
       - ../openregister/custom_apps/doriath:/var/www/html/custom_apps/doriath
       - ../openregister/custom_apps/forms:/var/www/html/custom_apps/forms
-      - ../openregister/custom_apps/hrmq:/var/www/html/custom_apps/hrmq
       - ../openregister/custom_apps/mail:/var/www/html/custom_apps/mail
       - ../openregister/custom_apps/maps:/var/www/html/custom_apps/maps
-      - ../openregister/custom_apps/openbuild:/var/www/html/custom_apps/openbuild
       - ../openregister/custom_apps/openconnector:/var/www/html/custom_apps/openconnector
-      - ../openregister/custom_apps/petstore:/var/www/html/custom_apps/petstore
       - ../openregister/custom_apps/polls:/var/www/html/custom_apps/polls
       - ../openregister/custom_apps/portaliq:/var/www/html/custom_apps/portaliq
-      - ../openregister/custom_apps/shillinq:/var/www/html/custom_apps/shillinq
       - ../openregister/custom_apps/spreed:/var/www/html/custom_apps/spreed
       - ../openregister/custom_apps/tasks:/var/www/html/custom_apps/tasks
       - ../openregister/custom_apps/timemanager:/var/www/html/custom_apps/timemanager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,10 @@ services:
       - db
     volumes:
       - nextcloud:/var/www/html:rw
+      # PHP tuning overlay — sorts last in conf.d so it wins over the image's
+      # opcache-recommended.ini. Disables JIT, which costs ~140ms per request
+      # on this workload; see the file for the measurement.
+      - ./docker/php/zz-conduction-opcache.ini:/usr/local/etc/php/conf.d/zz-conduction-opcache.ini:ro
       # App mounts — each app directory is a sibling of .github in the workspace
       - ../openregister:/var/www/html/custom_apps/openregister
       - ../opencatalogi:/var/www/html/custom_apps/opencatalogi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,18 @@
 # Quick start:
 #   docker compose -f .github/docker-compose.yml up -d
 #
+# ⚠️ ALWAYS pass `-p openregister`. The running stack was created under the
+# compose project name `openregister`, but compose derives the project name from
+# the working directory — so running this file from inside `.github/` silently
+# targets a project called `github` instead. That project is NOT empty: other
+# worktrees run their own CI-local stacks from their own `.github/` directories,
+# so their containers carry `project=github` too. On 2026-08-01 a bare
+#   `docker compose up -d --force-recreate nextcloud`
+# run from this directory matched a *procest* CI container as its `nextcloud`
+# service and stopped it, then failed on a name clash with `conduction-postgres`
+# after creating two empty stray volumes. Correct form:
+#   docker compose -p openregister up -d --force-recreate --no-deps nextcloud
+#
 # With profiles:
 #   docker compose -f .github/docker-compose.yml --profile mail up -d
 #   docker compose -f .github/docker-compose.yml --profile ai --profile mail up -d

--- a/docker/php/zz-conduction-opcache.ini
+++ b/docker/php/zz-conduction-opcache.ini
@@ -1,0 +1,37 @@
+; Conduction PHP tuning overlay for the development Nextcloud container.
+;
+; Loaded after the image's own opcache-recommended.ini (conf.d is read in
+; alphabetical order and this file sorts last), so the settings here win.
+;
+; ---------------------------------------------------------------------------
+; JIT: disabled deliberately.
+;
+; The nextcloud:34-apache image ships opcache.jit=1255 with an 8M buffer. That
+; combination costs time on this workload rather than saving it. Measured
+; 2026-07-29 on the dev instance, /ocs/v2.php/cloud/capabilities (an
+; authenticated request that boots all 92 enabled apps and does no other work):
+;
+;   opcache.jit=1255   min 939ms   median 1065ms   max 1241ms
+;   opcache.jit=disable min 794ms  median  922ms   max 1034ms
+;
+; ~140ms, about 13%, on EVERY request. Two reasons it does not pay here:
+;
+;   1. mod_php under Apache prefork gives each worker process its own JIT
+;      buffer, so the compilation cost is repaid per process rather than
+;      amortised across the fleet of requests one process serves.
+;   2. An 8M buffer is small for a codebase this size (92 apps). A buffer that
+;      fills stops helping but keeps costing — tracing JIT continues to profile
+;      and attempt compilation.
+;
+; If you want to revisit this, raise opcache.jit_buffer_size to 128M+ and
+; re-measure rather than simply re-enabling: the 8M default is the part that
+; makes it a loss.
+; ---------------------------------------------------------------------------
+opcache.jit=disable
+
+; Deliberately NOT set here: opcache.validate_timestamps=0.
+;
+; It would remove the per-request stat() of every included file and is standard
+; in production, but on a shared development instance it means an edit does not
+; take effect until opcache is reset — which silently breaks everyone else's
+; iteration loop. The right place for it is a production image, not this one.

--- a/docs/claude/README.md
+++ b/docs/claude/README.md
@@ -60,6 +60,10 @@ Proven L3 building blocks for skills — description writing, subfolder layout (
 
 Detailed L5 reference for evaluating, measuring, and improving skills with data — `evals.json` format, baseline scoring, trigger tests, and the iteration workflow.
 
+### [Skill Level Sources](./skill-level-sources.md)
+
+Annotated external sources behind the L1–L7 maturity framework — direct ancestry, human-competence frameworks (SFIA 9, Dreyfus, e-CF/KWIV), maturity models (CMMI), L5 eval methodology, user AI-fluency frameworks (Anthropic 4Ds, EU AI Act Article 4), and sources assessed-and-excluded.
+
 ### [Writing ADRs](./writing-adrs.md)
 
 How to write Architectural Decision Records: structure, format, when to create one, and how ADRs feed into the OpenSpec workflow.
@@ -472,6 +476,7 @@ This repo contains **documentation**, **global settings**, and **project templat
 │       ├── skill-checklist.md           # Pre-add / review checklist by maturity level
 │       ├── skill-patterns.md            # Reusable L3 skill patterns and subfolder guide
 │       ├── skill-evals.md               # Skill evaluation & measurement (L5 reference)
+│       ├── skill-level-sources.md       # Annotated external sources for the L1–L7 framework
 │       ├── writing-adrs.md              # How to write ADRs
 │       ├── writing-docs.md              # Documentation standards
 │       ├── app-lifecycle.md             # Nextcloud app lifecycle

--- a/docs/claude/skill-level-sources.md
+++ b/docs/claude/skill-level-sources.md
@@ -1,0 +1,212 @@
+# Skill Level Sources
+
+External sources grounding the L1–L7 skill maturity framework defined in
+[writing-skills.md](./writing-skills.md). The framework is **not** our
+invention — it adapts a community framing, is validated against Anthropic's
+official guidance, and echoes the shape of long-established human-competence
+and process-maturity models. This page records where each idea comes from,
+what each source is good for, and — just as important — which
+frequently-suggested sources we assessed and deliberately **excluded**.
+
+All links verified 2026-07-26.
+
+---
+
+## 1. Direct ancestry — agent skills and their levels
+
+The sources the L1–L7 framework is actually built from.
+
+| Source | What it is | Grounds |
+| --- | --- | --- |
+| Simon Scrapes, ["Every Level of Claude Code Skills in 27 mins"](https://www.youtube.com/watch?v=-u_igSQHAIo) (YouTube, 19 Mar 2026) | The direct ancestor of our 7-level framing | The L1–L7 ladder itself |
+| Anthropic, ["Skill authoring best practices"](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) | Official authoring guidance: conciseness, degrees of freedom, descriptions/triggering, progressive disclosure, "build evaluations first" | L1, L2, L3, L5 |
+| [Agent Skills open standard](https://agentskills.io/specification) — published by Anthropic (18 Dec 2025), aligned with the Agentic AI Foundation (Linux Foundation; long-term governance not yet formally settled); adopted by Microsoft, OpenAI, Atlassian, Figma, Cursor, GitHub | The specification of what a skill *is* (SKILL.md format, frontmatter, progressive disclosure tiers, `skills-ref validate`) | L1 |
+| Barry Zhang & Mahesh Murag (Anthropic), ["Don't Build Agents, Build Skills Instead"](https://www.youtube.com/watch?v=CEvIs9y1uog) (AI Engineer, late 2025) | The thesis: agents lack expertise; skills are composable procedural knowledge loaded at runtime | The overall premise |
+| Anthropic, ["Improving skill-creator: Test, measure, and refine Agent Skills"](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills) | skill-creator's Create/Eval/Improve/Benchmark modes; with-skill vs without-skill A/B benchmarking; pass-rate/latency/token metrics | L5 (see [skill-evals.md](./skill-evals.md)) |
+| MindStudio, ["How to Build a Learnings Loop for Claude Code Skills That Self-Improve"](https://mindstudio.ai/blog/how-to-build-learnings-loop-claude-code-skills) (19 Mar 2026) | The persistent `learnings.md` feedback mechanism | L6 |
+| Community implementations: [claude-reflect-system](https://github.com/haddock-development/claude-reflect-system), [claude-meta](https://github.com/aviadr1/claude-meta), [turbo](https://github.com/tobihagemann/turbo), [self-learning-skills](https://github.com/Kulaxyz/self-learning-skills) | Working learnings-loop variants (correction capture, confidence tracking, golden-path persistence) | L6 |
+
+> **Key fact:** there is **no official Anthropic concept of "skill levels"** —
+> neither the Claude Code docs nor the Agent Skills standard define maturity
+> tiers. Anthropic provides the *machinery* (eval tooling, hooks, dynamic
+> context injection); the leveling is a community/Conduction construct.
+
+---
+
+## 2. Human skill-level frameworks — the ladder's ancestry
+
+Established frameworks that grade **people**. They legitimize the "numbered
+levels of skill" shape and give us shared vocabulary with clients, but none
+of them grades an *artifact* the way L1–L7 does.
+
+| Source | Levels | Mapping onto L1–L7 |
+| --- | --- | --- |
+| [SFIA 9](https://sfia-online.org/en/sfia-9/sfia-9) (SFIA Foundation, Oct 2024) — Skills Framework for the Information Age | 7 levels of responsibility: 1 Follow → 7 Set strategy | Same ladder shape and count, but measures human autonomy/influence. SFIA 9 explicitly covers AI skills and even offers [guidance on using its levels to decide which tasks to assign to AI](https://sfia-online.org/en/sfia-9/sfia-9-release-notes/ai-skills-framework/using-sfia-levels-of-responsibility-to-analyse-what-tasks-responsibilities-to-assign-to-ai) |
+| [Dreyfus model of skill acquisition](https://apps.dtic.mil/sti/tr/pdf/ADA084551.pdf) — Dreyfus & Dreyfus, UC Berkeley ORC-80-2 (1980) | 5 stages, canonically Novice → Advanced Beginner → Competent → Proficient → Expert (the 1980 paper uses novice → competence → proficiency → expertise → mastery) | Rule-following → intuition in a learner ≈ L1 (follow anatomy) → L6 (self-improvement), for human cognition |
+| [European e-Competence Framework (e-CF)](https://itprofessionalism.org/professionalism/e-competence-framework/), EN 16234-1:2019 (CEN TC 428) | 41 competences × 5 proficiency levels e-1…e-5, aligned to EQF 3–8 | Closest human analogue to "one skill, graded levels" — a proficiency-per-competence matrix |
+| [KWIV — Kwaliteitsraamwerk Informatievoorziening](https://www.functiegebouwrijksoverheid.nl/kwaliteitsraamwerken/kwaliteitsraamwerk-informatievoorziening) 4.0 (Rijksoverheid, Dec 2023) | ~61 kwaliteitenprofielen for government IV/IT roles, [explicitly built on e-CF](https://www.nen.nl/nieuws/ict/rijksoverheid-implementeert-e-competence-framework-via-eigen-kwaliteitsraamwerk-/) | **The Dutch-government hook**: the Rijksoverheid already runs its IT workforce on e-CF levels — a skill ladder that name-checks e-CF/KWIV speaks our clients' language |
+| Bloom's taxonomy (revised) — Anderson & Krathwohl (2001), *A Taxonomy for Learning, Teaching, and Assessing* | 6 cognitive levels: Remember → … → Evaluate → Create, plus a knowledge dimension | Evaluate → Create maps onto L5 → L6/L7; "metacognitive knowledge" is a good frame for the L6 learnings loop |
+
+---
+
+## 3. Maturity models — levels applied to capability, not people
+
+The conceptually closest ancestry: maturity of a **process or capability**,
+which is what L1–L7 grades for a skill artifact + its improvement process.
+
+| Source | Levels | Mapping onto L1–L7 |
+| --- | --- | --- |
+| [CMMI V3.0](https://www.isaca.org/resources/reference-guide/cmmi-model-quick-reference-guide) (ISACA, Apr 2023) | 1 Initial → 2 Managed → 3 Defined → 4 Quantitatively Managed → 5 Optimizing | The canonical "maturity level" ancestry. Elegant parallel: CMMI L4 (quantitative measurement) ≈ our L5 (evals); CMMI L5 (optimizing) ≈ our L6 (learnings loops). Our L7 extends beyond CMMI's scope |
+| [Microsoft, Agentic AI adoption maturity model](https://learn.microsoft.com/en-us/agents/adoption-maturity-model/) | Level 100 (Initial) → agent-first optimized | Grades an *organisation's adoption*, not a skill artifact — a complementary axis |
+| Gartner, "Agentic AI Maturity Roadmap" (Aug 2025; paywalled, [reseller summary](https://www.skan.ai/analyst-reports/2025-gartner-agentic-ai-maturity-roadmap)) | 5 levels, task automation → expert autonomous systems | Secondary citation only (paywalled); same organisational axis as Microsoft's |
+
+---
+
+## 4. Measurement methodology — what L5 borrows from
+
+Model benchmarks do **not** measure skill maturity (they grade models), but
+their *methodology* is exactly what skill evals borrow. Cite these for the
+technique, not the leaderboard.
+
+| Source | Technique we borrow |
+| --- | --- |
+| [SWE-bench](https://arxiv.org/abs/2310.06770) (Jimenez et al., ICLR 2024) + SWE-bench Verified | Task-based, end-to-end verifiable agentic evaluation — the template shape for skill evals |
+| [τ-bench](https://arxiv.org/abs/2406.12045) (Yao et al., Sierra) + [τ²-bench](https://github.com/sierra-research/tau2-bench) | Tool-agent-user interaction evals; the **pass^k** reliability metric (run the same case k times — consistency is part of quality) |
+| [Terminal-Bench](https://www.tbench.ai/) (Stanford + Laude Institute) | Containerized task + programmatic verifier suite per case |
+| [Berkeley Function-Calling Leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) (UC Berkeley Gorilla) | Tool-call correctness grading |
+| [LiveBench](https://arxiv.org/abs/2406.19314) (Abacus.AI + NYU et al.) | Contamination-free rolling refresh — keep eval cases fresh so skills don't overfit to them |
+| [MathArena](https://matharena.ai) (ETH Zurich SRI Lab + INSAIT) | Evaluate on genuinely unseen problems (fresh competitions) with objective ground truth |
+| LMArena / Chatbot Arena (ex-LMSYS) | Pairwise-preference + Elo/Bradley-Terry for comparing two skill *variants* when no objective ground truth exists. **Caveats:** now commercial; known critiques (vote gaming, style bias, "Leaderboard Illusion") |
+| Zheng et al. 2023, ["Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena"](https://arxiv.org/abs/2306.05685) (NeurIPS 2023) | LLM-as-judge — and its documented biases (position, verbosity, self-preference). Required reading before grading skill output with a model |
+| [OpenAI Evals](https://github.com/openai/evals) | Open-source eval framework/registry; useful reference implementation |
+| [Prompt Engineering Guide](https://www.promptingguide.ai/) (DAIR.AI) + Anthropic Cookbook | Authoring patterns (L3) and practical eval notebooks incl. LLM-as-judge caveats (L5) |
+
+---
+
+## 5. Assessed and excluded — do not re-add without new evidence
+
+These come up in every "top LLM resources" list (a 20-item list of them was
+vetted on 2026-07-26). They were excluded deliberately:
+
+**Category error — human upskilling, not agent-skill maturity.** Hugging Face
+LLM Course, DataCamp, DeepLearning.AI courses, Karpathy's videos/nanoGPT,
+Cohere LLM University, Sebastian Raschka's books, mlabonne/llm-course,
+KDnuggets roadmaps, Awesome-LLM link dumps, Towards Data Science / Ahead of AI
+newsletters. All fine for *humans learning about LLMs*; none says anything
+about the maturity of a skill artifact. (If we ever write a personal-development
+learning path, that's a different document.)
+
+**Category error — model capability, not skill maturity.** Artificial
+Analysis Intelligence Index, GPQA Diamond, MMLU-Pro, Humanity's Last Exam.
+They rank *models*; a skill's maturity is independent of which model runs it.
+
+**Dead.** Hugging Face Open LLM Leaderboard — officially **retired March
+2025** (v1 and v2), archive-only. Useful only as a historical lesson in
+benchmark saturation.
+
+**Unverifiable provenance.** benchmarklist.com and llm-benchs.com — anonymous
+aggregators with no identifiable operator, no methodology page, no
+independent coverage. Opacity is the disqualifier.
+
+**Single-firm content marketing.** benchmarkingagents.com (Digital Signet) —
+decent editorial roundup, but it aggregates the primary sources cited in §4;
+cite those directly. ai-radar.aoe.com (AOE GmbH) — an honest
+ThoughtWorks-style tech radar for AI tooling, but one agency's opinion; at
+most a tooling-discovery pointer.
+
+**Attribution traps** (errors found in circulating lists — don't reproduce
+them): LiveBench is **Abacus.AI + NYU et al., not ETH Zurich** (MathArena is
+the ETH one — they are unrelated projects); the Agent Skills standard is
+*published by Anthropic and aligned with* the Agentic AI Foundation, which
+does not (yet) formally own it.
+
+---
+
+## 6. User AI-fluency frameworks — the *other* ladder
+
+Skill maturity (L1–L7) grades the **artifact**. A separate, adjacent question
+is how proficient the **human using the AI** is. These frameworks grade
+users/practitioners, and matter for product decisions (progressive UI,
+guided modes, tutorials) in AI products like hermiq. Vetted 2026-07-26.
+
+**The five citable ones, ranked:**
+
+| Source | Shape | Why cite it |
+| --- | --- | --- |
+| [Anthropic AI Fluency: Framework & Foundations](https://anthropic.skilljar.com/ai-fluency-framework-foundations) — Anthropic Academy course co-developed with Rick Dakan (Ringling College) & Joseph Feller (University College Cork); CC BY-NC-SA; also on [Coursera](https://www.coursera.org/learn/ai-fluency-framework-foundations) and [aifluencyframework.org](https://aifluencyframework.org/) | **The 4Ds: Delegation, Description, Discernment, Diligence** — competency *dimensions*, not levels | The anchor. For a Claude-based product, Anthropic's own academically co-authored framework is the coherent choice; use the 4Ds as the dimensions each level is measured on |
+| [EU AI Act Article 4 — AI literacy](https://www.traverssmith.com/knowledge/knowledge-container/the-eu-ai-acts-ai-literacy-requirement-key-considerations/) | Legal obligation, applies since **2 Feb 2025**; national enforcement + penalties from **3 Aug 2026**. Providers *and deployers* must ensure staff AI literacy **calibrated to role, knowledge, and context**; documentation expected (EU AI Office Living Repository) | **The compliance driver, not a framework.** Proficiency-aware features (guided modes, tracked tutorial completion, role-calibrated UI) map directly onto a deployer's Article 4 documentation duty — acutely relevant to Dutch government clients |
+| [UNESCO AI competency frameworks](https://www.unesco.org/en/articles/what-you-need-know-about-unescos-new-ai-competency-frameworks-students-and-teachers) (Sept 2024) | Teachers: 15 competencies × 5 dimensions × 3 progression levels (acquire/deepen/create); students: 12 competencies × 4 dimensions × 3 levels (understand/apply/create) | UN-level authority for the *shape*: competencies × 3 progression levels is exactly the pattern for progressive UI tiers |
+| [OECD/EC AILit Framework](https://ailiteracyframework.org/) (final June 2026, with Code.org; feeds PISA 2029) | 4 domains: Engage with AI, Create with AI, Manage AI, Shape AI | EU-institutional reinforcement; the domains map well onto consumer → builder → administrator → governance personas. Caveat: scoped to primary/secondary education |
+| Microsoft — [Agentic AI adoption maturity model](https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/maturity-model-overview) (Levels 100–500, organisational) + [Work Trend Index](https://www.microsoft.com/en-us/worklab/work-trend-index/agents-human-agency-and-the-opportunity-for-every-organization) user segmentation (skeptics → novices → explorers → power users) | Org maturity ladder + the only large-N empirical *user* segmentation | Concrete enterprise example; vendor-research caveat applies |
+
+**Honorable mention:** [Alex Ewerlöf, "AI Fluency Leveling"](https://blog.alexewerlof.com/p/ai-fluency-leveling) (Jan 2026) — 7 levels, Casual Consumer → Prompt Coder → Context Developer → AI Engineer → AI System Architect → AI Platformizer → AI Pioneer. The best practitioner-authored consumer→builder ladder; cite as "one practitioner formulation", not authority.
+
+**The common shape** across every credible framework: 3–7 levels; the same
+recurring dimensions (prompting/description sophistication, delegation
+judgment, discernment/oversight, building/orchestration,
+governance/responsibility); and the universal arc
+**consume → direct → verify → compose → govern**. A 4–5 level user model
+scored against the Anthropic 4Ds, with UNESCO/OECD's
+understand → apply → create progression as the leveling logic and Article 4
+as the compliance rationale, sits squarely inside all of them.
+
+**Assessed and excluded from this category** (vetted 2026-07-26): Larridin's
+AI Proficiency Model (real a16z-backed startup, but SEO funnel content for
+their SaaS); "5 Layers of AI Engineering" (aibuilderclub.com — a system
+architecture layering, not human proficiency; paid-community marketing);
+"Levels of AI Engineering Proficiency" LinkedIn posts (anonymous-grade, no
+citations); the "12-level Prompt Engineering Mastery" progression (**could
+not be located at all — treat as apocryphal**); aimlinsights.com and Pertama
+Partners (content-farm / regional vendor marketing); KDnuggets roadmaps,
+StrataScratch, To Data & Beyond, outcomeschool (legitimate *developer
+curricula* or monetized roadmaps — wrong axis for user proficiency; the same
+goes for mlabonne/llm-course and the *LLM Engineer's Handbook*, both
+excellent for engineer upskilling). The InformationWeek "101–401" agentic
+learning model is a real op-ed by Dan Mitchell (Digital Wave Technology, Jul
+2026) — citable as illustrative pedagogy only, attributed to Mitchell.
+
+---
+
+## 7. Agent-platform maturity & autonomy (mid-2026 wave)
+
+A third axis next to skill maturity (§1–5) and user fluency (§6): how mature
+the **platform/organisation running agents** is, and how much **autonomy** an
+agent is granted. Vetted 2026-07-27; four sources survive.
+
+| Source | Shape | What we take from it |
+| --- | --- | --- |
+| [Pydantic, "A maturity model for applied generative AI"](https://pydantic.dev/articles/applied-generative-ai-maturity-model) (Alex Che, 25 Jun 2026) | 5 levels (Experimenting → Adopted → Observed → Governed → Optimized) × 5 dimensions: visibility/observability, evaluation & quality, cost governance, access & identity, audit & incident response | The eval-coverage ratchet (ad-hoc → suites for critical agents → evals as CI gates → continuous online evals) and cost ladder (dashboards → alerts → server-side caps → per-run unit economics). Advice: fix "the gap currently bleeding", don't chase L5 everywhere |
+| [Addy Osmani, "Agentic Autonomy Levels"](https://addyosmani.com/blog/agentic-autonomy-levels/) (2 Jul 2026) | 6 levels L0–L5: Assist → Supervised Action → Scoped Task Delegation → Goal-Driven Autonomy → Parallel Delegation → Managed-by-Exception Orchestration | Graduated per-agent autonomy; the **per-run contract** (goal, scope, non-goals, tool permissions, stopping condition, evidence, escalation, budget); risk-calibrated autonomy (risk × reversibility × available verification); KPIs: mean time between interventions, longest unattended run, auto-approval rate, token cost per accepted change |
+| [Arize, "How to write effective AI agent skills: 6 data-backed practices"](https://arize.com/blog/) (Laurie Voss, 24 Jul 2026) | Six practices backed by SkillsBench data | Human-curated beats self-generated (+18–25 pts vs −8–12); compact & procedural wins (comprehensive docs +0.7 pt only); route a **minimal skill set** (1–3 skills ≈ +18–19 pts; all-196 loaded = worse and +23% tokens); test per model×harness ("portable as files, not as behavior"); target gaps the base model can't fill; **every skill change is a paired experiment** against a frozen baseline. "The eval is the skill" |
+| CMMI AI Maturity ([CMMI AIM](https://www.isaca.org/), ISACA, launched Jun 2026) | AI content across all 31 CMMI Practice Areas, 8 domains (Data, Development, People, Safety, Security, Services, Suppliers, Virtual collaboration) | Institutional weight for AI-capability maturity; People domain = workforce-readiness as a first-class axis. **Caveat:** model body is behind CMMI licensing — cite only the public structure, under the correct name "CMMI AIM" |
+
+**Assessed and excluded** (2026-07-27): the widely-shared "Hakkoda AI
+maturity ladder (LLM velocity → build skills → chain skills → agents →
+agents-talk-to-agents)" **could not be located on hakkoda.io as cited** —
+their real publications say different things; treat the ladder as
+misattributed and back agent-to-agent rungs with Osmani L4–L5 instead.
+AgentPatterns.ai's 7-phase adoption model is thoughtful but authorless;
+HiBob's "AI Skills Framework" is a press release; The Neuron's 5-level stack
+(Projects → Prompting → Skills → Automations → Agents) is consumer
+up-skilling content — citable only as a footnote that even consumer guidance
+converges on skills → automations → agents; AgenticCareers' career ladder is
+job-board content marketing.
+
+**Convergent spine across the four citable sources:** autonomy is granted
+per-run against verification capability (Osmani); quality is enforced by
+evals-as-gates (Pydantic + Arize); cost, access, and audit are server-side
+controls, not dashboards (Pydantic + CMMI).
+
+---
+
+## How the levels map to their strongest sources
+
+| Level | Strongest external grounding |
+| --- | --- |
+| L1 Anatomy | Agent Skills open standard; Anthropic best practices |
+| L2 Triggering | Anthropic best practices (descriptions, progressive disclosure) |
+| L3 Patterns | Anthropic best practices; Prompt Engineering Guide; Anthropic Cookbook |
+| L4 Personalization | (inherently internal — no external source can supply your business context; e-CF's "competence in context" framing is the analogue) |
+| L5 Measurement | Anthropic skill-creator blog; SWE-bench / τ-bench / Terminal-Bench / BFCL methodology; Zheng 2023 for LLM-as-judge caveats |
+| L6 Self-Improvement | MindStudio learnings loop; community implementations; CMMI L5 "Optimizing" as ancestry |
+| L7 AI Workforce | Zhang & Murag talk; Claude Code Agent Teams / Agent SDK docs; Microsoft agentic maturity model as the organisational mirror |

--- a/docs/claude/writing-skills.md
+++ b/docs/claude/writing-skills.md
@@ -18,7 +18,7 @@ Skills live in `.claude/skills/<skill-name>/` and are invoked with `/<skill-name
 
 Skills evolve through 7 maturity levels. Each level builds on the previous — a skill is at the highest level where **all** criteria are met. Use these levels to assess existing skills, plan improvements, and set quality targets.
 
-> **Source:** This framework is based on Simon Scrapes' "Every Level of Claude Code Skills" (March 2026), validated against Anthropic's official skill authoring best practices ([platform.claude.com](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)), the Barry Zhang & Mahesh Murag talk "Don't Build Agents, Build Skills Instead" (AI Engineer Summit, November 2025), and the Agent Skills Open Standard ([agentskills.io](https://agentskills.io/specification)).
+> **Source:** This framework is based on Simon Scrapes' "Every Level of Claude Code Skills" (March 2026), validated against Anthropic's official skill authoring best practices ([platform.claude.com](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)), the Barry Zhang & Mahesh Murag talk "Don't Build Agents, Build Skills Instead" (AI Engineer Summit, November 2025), and the Agent Skills Open Standard ([agentskills.io](https://agentskills.io/specification)). The full annotated source list — including the human-competence ancestry (SFIA 9, Dreyfus, e-CF/KWIV), maturity-model ancestry (CMMI), L5 measurement methodology, and sources we assessed and deliberately excluded — lives in [skill-level-sources.md](./skill-level-sources.md).
 
 ### Levels Are Cumulative but Not Always Sequential
 


### PR DESCRIPTION
Codeberg is a **backup mirror**; GitHub is primary. Four commits landed only on Codeberg and are ported here.

## What was genuinely missing

| commit | brings |
|---|---|
| `8651b05` | `docs/claude/skill-level-sources.md` (+212), README + writing-skills updates |
| `a67bb4a` | `docker/php/zz-conduction-opcache.ini` (+37) — PHP JIT disabled, ~140 ms off every request |
| `481acff` | compose mounts decidesk/openbuild/petstore/hrmq/shillinq from their real checkouts |
| `3f3f37c` | compose warning that the file needs `-p openregister` |

Net: **+297 lines**, all additive.

## What was deliberately NOT ported

Four Codeberg `ci(quality)` commits (#70-#73) mirror GitHub's own (#110-#114) — same subjects, same work. Cherry-picking them would have **regressed** `quality.yml`, which has since gained the enable-php switch, custom frontend checks and the report gate.

Verified by content rather than by commit subject:

| | GitHub | Codeberg |
|---|---|---|
| `quality.yml` lines | **2209** | 2091 |
| `omit=dev` | 5 | 4 |
| `audit` | 18 | 16 |

GitHub is a strict superset, so those four are already here.

## Verification

- `quality.yml` still **2209 lines** after the port — not regressed
- `CONVENTIONS.md` still present (Codeberg's branch lacks it; a blind overwrite would have deleted it)
- All four cherry-picks applied without conflict

Found while auditing why a fix of mine went to Codeberg instead of GitHub — `git remote -v | head -2` truncated the output and hid `origin`.
