### PR TITLE
fix(quality): a cosmetic PR comment must not fail the Quality Report gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1953,6 +1953,15 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request'
+        # Posting the summary comment needs `pull-requests: write`. A reusable
+        # workflow inherits the CALLER's permissions, and most callers declare
+        # only `contents: read` + `packages: read` — so this step 403s with
+        # "Resource not accessible by integration" and failed the whole Quality
+        # Report job. A cosmetic comment must never fail a quality gate: the
+        # gate's verdict comes from the jobs it aggregates, not from whether it
+        # could comment. Callers that want the comment should add
+        # `pull-requests: write` to their own `permissions:` block.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem

`Quality Report` is red on pull requests across the fleet **for a reason unrelated to quality**.

The `Comment PR with results` step calls `issues.createComment`, which requires `pull-requests: write`. A reusable workflow inherits the **caller's** permissions, and the callers declare only:

```yaml
permissions:
  contents: read
  packages: read
```

`quality.yml` declares no `permissions:` block of its own, so the step gets a **403**:

```
POST /repos/<org>/<repo>/issues/<n>/comments  ->  403
RequestError [HttpError]: Resource not accessible by integration
```

and that failure sinks the whole aggregating job.

## Evidence

opencatalogi #783: **22 of 24 jobs green** (eslint, stylelint, all 6 PHP Quality legs, both PHPUnit legs, licences, security) — `Quality Report` red *solely* because it could not post a comment. The same job fails identically on that repo's `development` branch, so this has been masking real signal rather than reporting it.

⚠️ Note the misleading first error in the log: `Unable to download artifact(s): Artifact not found for name: playwright-report`. That step already has `continue-on-error: true` and is **not** the cause — it is a red herring that makes this look like an artifact problem.

## Fix

Mark the comment step `continue-on-error: true`.

The gate's verdict comes from the jobs it aggregates, not from whether it managed to post a comment. This changes no security posture and grants no new permission.

## Follow-up (deliberately not done here)

Callers that want the comment to actually appear should add `pull-requests: write` to their own `permissions:` block. That is a per-repo decision, so it is left to each repo rather than bundled into a shared-workflow change.

## Verification

- YAML re-parsed after the edit: 15 jobs, step found, `continue-on-error: true`.
- Negative control: total steps carrying `continue-on-error` is 4 — the 3 pre-existing ones are untouched.
- Diff is additive only: **+9 lines, 0 removed.**