### PR TITLE
feat(quality): run JS unit tests in CI — they never have

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -414,6 +414,99 @@ jobs:
           name: result-frontend-check-${{ strategy.job-index }}
           path: quality-results/
 
+  # Auto-detected JS unit tests.
+  #
+  # `frontend-checks` above is an opt-in LIST that defaults to "[]", so a repo
+  # only runs its JS suite if someone remembered to name the script. Nobody
+  # did: across the fleet this job's matrix resolved empty and reported
+  # "skipping" with the expression unexpanded, so vitest/jest suites had NEVER
+  # run in CI. Real failures sat invisible for months (openbuild carries one;
+  # procest's harness is broken outright — `tests/vitest/setup.js` does
+  # `import Vue from 'vue'`, which vue@3 does not publish).
+  #
+  # This job needs no opt-in: it runs the repo's own `test` script when one
+  # exists and is not a placeholder, and it BLOCKS on failure. A repo with no
+  # test script skips cleanly.
+  #
+  # Note it invokes `npm run test`, never `npx vitest` — a bare `npx vitest`
+  # exits 0 with no output when it finds no matching config, which is how
+  # doriath's "passing" unit gate was running nothing at all.
+  frontend-tests:
+    if: ${{ inputs.enable-frontend }}
+    runs-on: ubuntu-latest
+    name: "Frontend Tests (unit)"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ inputs.node-version }}"
+          cache: "npm"
+
+      - name: Detect a runnable test script
+        id: detect
+        run: |
+          if [ ! -f package.json ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No package.json — nothing to test."
+            exit 0
+          fi
+          # Prefer `test`, fall back to `test:unit` — several repos declare
+          # their suite only under the latter (decidesk has 282 passing tests
+          # that a `test`-only probe would have skipped entirely).
+          #
+          # Skip the conventional npm placeholder, which "passes" while
+          # running nothing: "Error: no test specified" && exit 1.
+          node -e "
+            const s = (require('./package.json').scripts) || {};
+            const placeholder = v => !v || /no test specified/i.test(v);
+            const name = !placeholder(s.test) ? 'test'
+                       : !placeholder(s['test:unit']) ? 'test:unit'
+                       : '';
+            console.log('run=' + (name ? 'true' : 'false'));
+            console.log('script=' + name);
+          " >> "$GITHUB_OUTPUT"
+          node -e "
+            const s = (require('./package.json').scripts) || {};
+            const placeholder = v => !v || /no test specified/i.test(v);
+            const name = !placeholder(s.test) ? 'test'
+                       : !placeholder(s['test:unit']) ? 'test:unit'
+                       : '';
+            console.log(name
+              ? 'Detected \'' + name + '\' script: ' + s[name]
+              : 'No runnable test script (checked: test, test:unit).');
+          "
+
+      - name: Install dependencies
+        if: steps.detect.outputs.run == 'true'
+        run: npm ci
+
+      - name: Run unit tests
+        if: steps.detect.outputs.run == 'true'
+        env:
+          SCRIPT: ${{ steps.detect.outputs.script }}
+        run: npm run "$SCRIPT"
+
+      - name: Record result
+        if: always()
+        run: |
+          mkdir -p quality-results
+          if [ "${{ steps.detect.outputs.run }}" != "true" ]; then
+            echo "skipped" > quality-results/frontend-tests.txt
+          else
+            echo "${{ job.status }}" > quality-results/frontend-tests.txt
+          fi
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-frontend-tests
+          path: quality-results/
+
   # ── Group 3: Security ──────────────────────────
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The gap

`frontend-checks` is an opt-in JSON list of npm script names defaulting to `"[]"`, and the job is guarded by `frontend-checks != '[]'`. **Nobody populated it.** Across the fleet the matrix resolved empty and the job reported `skipping` with the expression literally unexpanded:

```
quality / Frontend Check (${{ matrix.script }})   skipping
```

So **no app's vitest/jest suite has ever run in CI.**

Positive control on this file: `phpunit` 10 hits, `playwright` 50, `eslint` 6, `stylelint` 5 — against `vitest`/`jest`/`npm test`: **0**.

## What it hid

- **procest's harness was broken outright** — `tests/vitest/setup.js` did `import Vue from 'vue'`, which vue@3 does not publish. Vitest runs `setupFiles` before every spec, so **all 32 files failed collection and 0 tests ran** — through the entire Vue 3 migration.
- **openbuild carried 2 real failing tests** (not 1), both pinning contracts a later correct fix had removed.
- **doriath's gate ran nothing**: a bare `npx vitest` exits **0 with no output** when it finds no matching config.

## The change

A job that needs no opt-in: it runs the repo's own test script when one exists and is not the npm placeholder, and **blocks** on failure. Repos without one skip cleanly. The existing `frontend-checks` matrix is untouched for custom scripts.

Deliberate choices:
- invokes `npm run <script>`, **never `npx vitest`** — see doriath above;
- prefers `test`, falls back to `test:unit` — decidesk has **282 passing tests** a `test`-only probe would have skipped;
- rejects the `"no test specified"` placeholder, which passes while running nothing;
- **not** `continue-on-error`. A non-blocking gate is the same shape as the `|| echo skipping` that once let a PR show green while breaking 191 tests.

## Blast radius — measured, not assumed

**11 of 20 repos run it, 9 skip cleanly.** Every repo that will run has been measured green first:

openconnector 97 · planix 98 · launchpad 638 · docudesk 45 · zaakafhandelapp 21 · decidesk 282 · openregister 298 · opencatalogi 66 · softwarecatalog 120 · **procest 330** (fixed in procest#700) · **openbuild 1364** (fixed in openbuild#100) · doriath 425.

procest and openbuild were repaired **before** this merged, specifically so the gate would not block them on arrival.

## Known risk

**doriath is the load-sensitivity canary.** Its `import.spec.js` is slow-not-flaky — real PBKDF2 at 600k iterations (OWASP), slowest test 1081ms against vitest's default 5000ms, so ~4.6× headroom. Measured n=3 at low load: 3/3 pass. Under contended runners it is the first thing that will flake, and the right response is runner capacity or crypto-test isolation — **not** a raised timeout.

## Verification

- YAML re-parsed: 16 jobs, step present, no `continue-on-error`.
- Detector positive-controlled across 5 shapes: `test` present → runs; placeholder → skips; only `test:unit` → runs it; placeholder + `test:unit` → runs `test:unit`; no scripts → skips.