### PR TITLE
fix(quality): a missing composer gate script must fail, not pass vacuously

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -234,8 +234,31 @@ jobs:
 
       - name: Run ${{ matrix.tool }}
         run: |
+          # `composer <script>` exits 1 for BOTH "the script ran and returned 1"
+          # and "Command \"<script>\" is not defined." Any leg that interprets
+          # exit 1 (the phpcs warnings-are-non-blocking rule below) therefore
+          # reads a MISSING gate as a PASSING gate — a gate's absence and a
+          # gate's success become indistinguishable. See ConductionNL/.github#121.
+          #
+          # So: assert the script is declared BEFORE running it, and read the
+          # declaration from composer.json rather than from the exit code.
+          # Deliberately NOT an `[ -f vendor/bin/<tool> ]` guard — a file-presence
+          # guard that skips is the same silent-pass defect in a new costume.
+          require_script() {
+            tool="$1"
+            hint="$2"
+            if [ ! -f composer.json ]; then
+              echo "::error::The '$tool' gate is enabled but there is no composer.json in the repository root."
+              exit 1
+            fi
+            if ! jq -e --arg s "$tool" '(.scripts // {}) | has($s)' composer.json > /dev/null 2>&1; then
+              echo "::error::The '$tool' gate is enabled but composer.json declares no '$tool' script. Add it under \"scripts\", or turn the gate off with $hint."
+              exit 1
+            fi
+          }
           case "${{ matrix.tool }}" in
             lint)
+              require_script lint "the enable-php input"
               composer lint
               ;;
             phpcs)
@@ -243,8 +266,10 @@ jobs:
                 echo "PHPCS is disabled — skipping."
                 exit 0
               fi
+              require_script phpcs "the enable-phpcs input"
               # Exit code 0 = clean, 1 = warnings only, 2 = errors found.
-              # We treat warnings as non-blocking (exit 1 → success).
+              # We treat warnings as non-blocking (exit 1 → success). This is only
+              # safe because require_script has already proven the script exists.
               # NB: capture via `|| RC=$?` — a bare `composer phpcs; RC=$?`
               # is killed by `set -e` before RC is ever assigned.
               RC=0
@@ -260,6 +285,7 @@ jobs:
                 echo "PHPMD is disabled — skipping."
                 exit 0
               fi
+              require_script phpmd "the enable-phpmd input"
               composer phpmd
               ;;
             psalm)
@@ -267,6 +293,7 @@ jobs:
                 echo "Psalm is disabled — skipping."
                 exit 0
               fi
+              require_script psalm "the enable-psalm input"
               composer psalm
               ;;
             phpstan)
@@ -274,6 +301,7 @@ jobs:
                 echo "PHPStan is disabled — skipping."
                 exit 0
               fi
+              require_script phpstan "the enable-phpstan input"
               composer phpstan
               ;;
             phpmetrics)
@@ -281,6 +309,7 @@ jobs:
                 echo "phpmetrics is disabled — skipping."
                 exit 0
               fi
+              require_script phpmetrics "the enable-phpmetrics input"
               composer phpmetrics
               ;;
           esac


### PR DESCRIPTION
Closes #121.

## The hole

`composer <script>` exits **1** for two very different things:

- the script ran and returned 1, and
- `Command "phpcs" is not defined.` — there is no such script.

The `phpcs` leg maps exit 1 to success (PHPCS warnings are non-blocking by
policy), so **any repo with no `phpcs` composer script got a permanently green
`PHP Quality (phpcs)` tick**. A gate's absence and a gate's success were
indistinguishable in the checks list.

## Before

```bash
phpcs)
  if [ "${{ inputs.enable-phpcs }}" != "true" ]; then
    echo "PHPCS is disabled — skipping."
    exit 0
  fi
  # Exit code 0 = clean, 1 = warnings only, 2 = errors found.
  # We treat warnings as non-blocking (exit 1 → success).
  RC=0
  composer phpcs || RC=$?
  if [ "$RC" -eq 1 ]; then
    echo "::warning::PHPCS found warnings but no errors — passing."
    exit 0
  fi
  exit $RC
  ;;
```

The comment describes **phpcs's** exit codes; `RC` holds **composer's**.

## After

A `require_script` helper reads the declaration from `composer.json` (via `jq`,
already used 46× in this workflow) *before* the script is run, on every PHP
quality leg:

```bash
require_script() {
  tool="$1"
  hint="$2"
  if [ ! -f composer.json ]; then
    echo "::error::The '$tool' gate is enabled but there is no composer.json in the repository root."
    exit 1
  fi
  if ! jq -e --arg s "$tool" '(.scripts // {}) | has($s)' composer.json > /dev/null 2>&1; then
    echo "::error::The '$tool' gate is enabled but composer.json declares no '$tool' script. Add it under \"scripts\", or turn the gate off with $hint."
    exit 1
  fi
}
```

Deliberately **not** an `if [ -f vendor/bin/<tool> ]` guard — a file-presence
guard that *skips* is the same silent-pass defect in a new costume. (Also, a
bare `phpmd`/`psalm` in a composer script resolves fine without `vendor/bin/`,
because Composer prepends `vendor/bin` to `PATH`.)

`lint`, `phpmd`, `psalm`, `phpstan` and `phpmetrics` already went red on a
missing script — but with the opaque `Command "phpmd" is not defined.` They now
get an actionable message naming the input that turns the gate off. **Their
red/green verdict is unchanged.**

## Proof — three live CI cells on `ConductionNL/petstore`

Throwaway branch `feature/dotgithub-121-proof`. One variable changes per cell.

| Cell | composer.json | reusable ref | `PHP Quality (phpcs)` | Run |
|---|---|---|---|---|
| A | has `phpcs` | this branch (fixed) | ✅ **success** | [30766494556](https://github.com/ConductionNL/petstore/actions/runs/30766494556) |
| B | **no** `phpcs` | this branch (fixed) | ❌ **failure** | [30766612959](https://github.com/ConductionNL/petstore/actions/runs/30766612959) |
| C | **no** `phpcs` | `@main` (unfixed) | ✅ **success** — the bug | [30766687154](https://github.com/ConductionNL/petstore/actions/runs/30766687154) |

**Cell C**, `@main`, verbatim — the vacuous pass reproduced live:

```
Did you mean one of these?
    phpcs-DELIBERATELY-RENAMED-FOR-ISSUE-121-PROOF Runs the phpcs-DELIB...
    phpcs:fix                                      Runs the phpcs:fix s...
    phpcs:output                                   Runs the phpcs:outpu....
##[warning]PHPCS found warnings but no errors — passing.
##[group]Run mkdir -p quality-results
echo "success" > quality-results/phpcs.txt
```

**Cell B**, this branch, same repo state — now red with an actionable message:

```
##[error]The 'phpcs' gate is enabled but composer.json declares no 'phpcs' script. Add it under "scripts", or turn the gate off with the enable-phpcs input.
##[error]Process completed with exit code 1.
```

**Cell A**, this branch, real script present — still green:

```
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
...
Time: 634ms; Memory: 10MB
```
→ job conclusion `success`, `echo "success" > quality-results/phpcs.txt`.

C→B is the discriminator: identical repo state, only the reusable-workflow ref
differs, and the verdict flips. A→B holds the ref fixed and flips only the
script's existence.

## Blast radius — exactly one repo, one leg

All 19 consumers of this workflow in the org were swept for the six gate scripts
in their default-branch `composer.json`:

| Repo | Effect |
|---|---|
| openregister, hermiq, openbuild, openbuilt, pipelinq, doriath, opencatalogi, decidesk, zaakafhandelapp, scholiq, portaliq, planix, nextcloud-app-template, larpingapp, petstore, shillinq, deskdesk, mydash | all six scripts declared — **no change** |
| **app-versions** | **`PHP Quality (phpcs)` flips green → red** |

`app-versions` uses php-cs-fixer, not phpcs, and declares no `phpcs`, `phpmd`,
`phpstan` or `phpmetrics` script while leaving `enable-phpcs` at its `true`
default. Its `phpmd` / `phpstan` / `phpmetrics` legs are **already red** for
exactly this reason; only `phpcs` was being swallowed. Turning that tick red is
the point of this change — but it is the one CI status in the fleet that moves.
Fix on that side is one line: `enable-phpcs: false` in
`app-versions/.github/workflows/code-quality.yml` (see ConductionNL/app-versions#118).

## Not touched

`global-settings/` is unmodified, so no `VERSION` bump is required.
