### PR TITLE
ci(quality): features.json generated at commit time — CI verifies and blocks, never commits

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -173,12 +173,12 @@ on:
         type: boolean
         default: false
       enable-sbom:
-        description: "Generate CycloneDX SBOM, validate (CVE + license), and commit to repo"
+        description: "Generate CycloneDX SBOM and validate it (Grype CVE scan + composer/npm audit — hard failures). Published as a run artifact and release asset; intentionally never committed to the repo."
         required: false
         type: boolean
         default: true
       enable-features-extract:
-        description: "Scan openspec/specs/ and (re)generate docs/features.json — auto-commits on feature branches, warns on protected branches"
+        description: "Verify docs/features.json is in sync with openspec/specs/ — READ-ONLY, hard-fails when stale (features-check on PRs, features-extract on pushes; both gate the Quality Report). Generation happens at commit time via the repo's .githooks/pre-commit — see CONVENTIONS.md."
         required: false
         type: boolean
         default: true
@@ -2503,7 +2503,7 @@ jobs:
           files: sbom.cdx.json
 
   # ╔══════════════════════════════════════════════╗
-  # ║  STAGE 5 — Features extract & commit          ║
+  # ║  STAGE 5 — Features verification (read-only)  ║
   # ║                                               ║
   # ║  Scans openspec/specs/*/spec.md for           ║
   # ║  capabilities whose YAML frontmatter declares  ║
@@ -2512,10 +2512,12 @@ jobs:
   # ║  Features & Roadmap surface consumes via       ║
   # ║  initial-state injection.                      ║
   # ║                                               ║
-  # ║  Branch policy mirrors update-baseline:        ║
-  # ║  feature branches → auto-commit + push;        ║
-  # ║  protected branches → warn only (see           ║
-  # ║  ConductionNL/.github#61).                     ║
+  # ║  CI never commits: generation happens at       ║
+  # ║  COMMIT TIME via each repo's committed          ║
+  # ║  .githooks/pre-commit (CONVENTIONS.md). Both    ║
+  # ║  jobs below only verify and HARD-FAIL when     ║
+  # ║  stale — via the Quality Report gate that      ║
+  # ║  blocks the merge.                             ║
   # ╚══════════════════════════════════════════════╝
 
   # On pull_request events, run the extractor in `--check` mode only — fail

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2550,18 +2550,24 @@ jobs:
       - name: Verify docs/features.json is up to date
         run: python .conduction-shared/scripts/extract-features.py --app-root . --check
 
+  # READ-ONLY by design. This job used to auto-commit + push the regenerated
+  # docs/features.json back to the branch — a quality pipeline mutating the
+  # branch it is judging. That moved the PR head from under the checks
+  # (with [skip ci] it stripped ALL checks from the PR), dismissed reviewer
+  # approvals via the org ruleset's dismiss-stale-on-push, and on protected
+  # branches the bot push bounced anyway (#61). Generation now happens at
+  # COMMIT TIME in each repo via the committed .githooks/pre-commit hook
+  # (see CONVENTIONS.md § features.json is generated at commit time); CI
+  # only verifies and hands back the regenerated file as an artifact.
   features-extract:
     if: ${{ inputs.enable-features-extract && !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     name: "Features Extract"
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          token: ${{ github.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -2581,16 +2587,19 @@ jobs:
       - name: Regenerate docs/features.json
         run: python .conduction-shared/scripts/extract-features.py --app-root .
 
-      - name: Commit if changed
+      - name: Fail if stale
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet docs/features.json 2>/dev/null && ! git status --porcelain docs/features.json | grep -q '^??'; then
-            echo "docs/features.json unchanged, nothing to commit."
+            echo "docs/features.json is up to date."
           else
-            git add docs/features.json
-            git commit -m "ci: regenerate docs/features.json from openspec/specs/ [skip ci]"
-            # Non-blocking on protected branches: branch-protection rulesets reject
-            # the bot push on main/beta/development. Tracked in ConductionNL/.github#61.
-            git push || echo "::warning::Could not push the regenerated docs/features.json — branch protection rejected the bot push (see ConductionNL/.github#61). Run scripts/extract-features.py locally and commit manually."
+            echo "::error::docs/features.json is out of date with openspec/specs/. Regenerate it locally (the committed .githooks/pre-commit hook does this automatically — see CONVENTIONS.md) and commit it. The regenerated file is attached as the 'features-json' artifact of this run."
+            exit 1
           fi
+
+      - name: Upload regenerated file
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: features-json
+          path: docs/features.json
+          retention-days: 7

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2590,6 +2590,7 @@ jobs:
         run: python .conduction-shared/scripts/extract-features.py --app-root .
 
       - name: Fail if stale
+        id: fail-if-stale
         run: |
           if git diff --quiet docs/features.json 2>/dev/null && ! git status --porcelain docs/features.json | grep -q '^??'; then
             echo "docs/features.json is up to date."
@@ -2599,7 +2600,14 @@ jobs:
           fi
 
       - name: Upload regenerated file
-        if: failure()
+        # Gate on the staleness step SPECIFICALLY, not `failure()` alone: if the
+        # Regenerate step itself crashed, the file on disk is the stale committed
+        # copy (or absent), and uploading it under the 'features-json' label would
+        # invite committing exactly what CI just rejected. Only when fail-if-stale
+        # failed is the on-disk file guaranteed to be the fresh regeneration.
+        # (`failure() &&` is required — without a status-check function GitHub
+        # implies `success()`, and the step would never run after a failure.)
+        if: failure() && steps.fail-if-stale.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: features-json

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -140,7 +140,7 @@ A `.npmrc` containing `legacy-peer-deps=true` without a dated explanation and a 
 - `features-check` (PRs) and `features-extract` (pushes) are both **read-only gates** — they regenerate in memory, fail if the committed file is stale, and attach the regenerated file as a run artifact. Neither ever commits or pushes.
 - The pipeline previously auto-committed the regenerated file back to the branch. That is forbidden now and must not come back: a CI push moves the PR head out from under its checks (with `[skip ci]` it stripped **all** checks from the PR), dismisses reviewer approvals via the org ruleset's dismiss-stale-on-push, and bounced off branch protection on protected branches anyway (#61). A quality pipeline must never mutate the branch it is judging.
 
-Repo setup (reference implementation: `openregister`):
+Repo setup (the verbatim hook below is the canonical source — copy it, don't reinvent it):
 
 1. Commit `.githooks/pre-commit` — regenerates `docs/features.json` whenever staged changes touch `openspec/specs/` or `openspec/features.overlay.json`, fetching the canonical `scripts/extract-features.py` from this repo (cached fallback when offline). Best-effort: it warns and never blocks the commit; the CI gate is the enforcement backstop.
 2. Activate it automatically for every contributor — use **whichever manifests the repo has** (either one suffices; wire both when both exist):
@@ -175,11 +175,14 @@ if git diff --cached --name-only | grep -qE "^openspec/(specs/|features\.overlay
     elif command -v py >/dev/null 2>&1; then PY="py -3";
     else PY="python"; fi
 
-    if $PY "$CACHE" --app-root . >/dev/null 2>&1; then
+    # stdout is silenced for a quiet happy path, but stderr must reach the
+    # terminal: a spec file with broken YAML frontmatter should show the real
+    # parse error, not get mis-diagnosed as a missing-python problem.
+    if $PY "$CACHE" --app-root . >/dev/null; then
       git add docs/features.json
       echo "pre-commit: docs/features.json regenerated from openspec/specs/."
     else
-      echo "pre-commit: WARNING — could not regenerate docs/features.json (python or pyyaml missing?). CI features-check will verify." >&2
+      echo "pre-commit: WARNING — could not regenerate docs/features.json (see error above; missing python/pyyaml also lands here). CI features-check will verify." >&2
     fi
   else
     echo "pre-commit: WARNING — could not fetch extract-features.py (offline?). CI features-check will verify." >&2
@@ -188,6 +191,8 @@ fi
 
 exit 0
 ```
+
+**Trust boundary — know what you're inheriting.** The hook downloads and executes `scripts/extract-features.py` from this repo's `main` at commit time. That is the same trust model the reusable workflow already uses (its `Checkout shared scripts` step checks out `ConductionNL/.github@main`), but the blast radius differs: the workflow runs on an ephemeral CI runner, the hook runs on every contributor's machine — anyone with write access to `.github`'s `main` can execute code there on the next openspec-touching commit. This is accepted for now because it matches existing CI practice and keeps the script in one canonical place. If that ever stops being acceptable, harden by pinning the fetch to a tag (`.../refs/tags/quality-vN/...`) or verifying a committed SHA-256 checksum of the script before executing (fail closed on mismatch).
 
 ##### Per-repo rollout checklist
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -152,6 +152,54 @@ Repo setup (reference implementation: `openregister`):
 
 **Repos with no package.json or composer.json** (e.g. `hydra`): no auto-activation path exists — but such repos currently have `enable-features-extract: false`, so no hook is needed. If features are ever enabled there, document the manual `git config` line in the repo README.
 
+##### Enforcement: staleness is a merge blocker
+
+The commit hook is convenience, not the safety net — CI is. `features-check` (PR events) and `features-extract` (push events) both **hard-fail** when `docs/features.json` is out of sync with `openspec/specs/`, and both feed the `Quality Report` gate. Since `quality / Quality Report` is (to become) the org-wide required check, **a stale features.json blocks the merge** even if the hook was skipped, broken, or not activated. The failed run attaches the regenerated file as an artifact so recovery is one download + commit away.
+
+##### The hook, verbatim (`.githooks/pre-commit`)
+
+```sh
+#!/bin/sh
+# Regenerates docs/features.json whenever staged changes touch openspec/specs/
+# or the features overlay. Best-effort: warns but never blocks the commit —
+# the CI gate (features-check/features-extract → Quality Report) enforces.
+
+if git diff --cached --name-only | grep -qE "^openspec/(specs/|features\.overlay\.json)"; then
+  CACHE=".git/extract-features.py"
+  curl -sf --max-time 10 \
+    https://raw.githubusercontent.com/ConductionNL/.github/main/scripts/extract-features.py \
+    -o "$CACHE" 2>/dev/null || true
+
+  if [ -f "$CACHE" ]; then
+    if command -v python3 >/dev/null 2>&1; then PY="python3";
+    elif command -v py >/dev/null 2>&1; then PY="py -3";
+    else PY="python"; fi
+
+    if $PY "$CACHE" --app-root . >/dev/null 2>&1; then
+      git add docs/features.json
+      echo "pre-commit: docs/features.json regenerated from openspec/specs/."
+    else
+      echo "pre-commit: WARNING — could not regenerate docs/features.json (python or pyyaml missing?). CI features-check will verify." >&2
+    fi
+  else
+    echo "pre-commit: WARNING — could not fetch extract-features.py (offline?). CI features-check will verify." >&2
+  fi
+fi
+
+exit 0
+```
+
+##### Per-repo rollout checklist
+
+1. Copy `.githooks/pre-commit` (above) into the repo and mark it executable (`git add --chmod=+x .githooks/pre-commit` on Windows).
+2. Wire the activation one-liner into every manifest the repo has (`package.json` `prepare`, `composer.json` `post-install-cmd`); husky repos put the snippet in `.husky/pre-commit` instead.
+3. Run `git config core.hooksPath .githooks` once in your own clone (installs only cover future clones/installs).
+4. Regenerate once (`commit anything touching openspec/`, or run the script manually) so the repo enters the enforced state green.
+
+##### SBOM: nothing to set up per repo
+
+The SBOM never had this problem and needs no hook: the `sbom` job generates the CycloneDX SBOM in CI, hard-fails on validation (Grype CVE scan, composer/npm audit), and publishes it as a run artifact + release asset. It is **intentionally never committed to the repo** (SBOMs embed timestamps/serial numbers, so a committed copy would be perpetually "stale" and pollute every diff). Its failures block merges through the same Quality Report gate. PR-time dependency gating is covered separately by the `Security (composer)`/`Security (npm)` legs, which run on every PR.
+
 ## SBOM (Software Bill of Materials)
 
 Each app's SBOM is published exclusively as a **release asset** via the central Quality workflow's SBOM job. Per-app `sbom.yml` workflows are not allowed — they were removed in [`ConductionNL/.github#34`](https://github.com/ConductionNL/.github/pull/34).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -133,6 +133,25 @@ A release or critical merge is blocked **right now**, the real fix (aligning the
 
 A `.npmrc` containing `legacy-peer-deps=true` without a dated explanation and a linked issue should be treated as a bug and flagged in review.
 
+#### features.json is generated at commit time, never by CI
+
+`docs/features.json` (the commercial capability list derived from `openspec/specs/`) is regenerated **on the developer's machine at commit time**, by a committed pre-commit hook. CI only verifies:
+
+- `features-check` (PRs) and `features-extract` (pushes) are both **read-only gates** — they regenerate in memory, fail if the committed file is stale, and attach the regenerated file as a run artifact. Neither ever commits or pushes.
+- The pipeline previously auto-committed the regenerated file back to the branch. That is forbidden now and must not come back: a CI push moves the PR head out from under its checks (with `[skip ci]` it stripped **all** checks from the PR), dismisses reviewer approvals via the org ruleset's dismiss-stale-on-push, and bounced off branch protection on protected branches anyway (#61). A quality pipeline must never mutate the branch it is judging.
+
+Repo setup (reference implementation: `openregister`):
+
+1. Commit `.githooks/pre-commit` — regenerates `docs/features.json` whenever staged changes touch `openspec/specs/` or `openspec/features.overlay.json`, fetching the canonical `scripts/extract-features.py` from this repo (cached fallback when offline). Best-effort: it warns and never blocks the commit; the CI gate is the enforcement backstop.
+2. Activate it automatically for every contributor — use **whichever manifests the repo has** (either one suffices; wire both when both exist):
+   - `package.json`: `"prepare": "git config core.hooksPath .githooks || true"`
+   - `composer.json`: add `"git config core.hooksPath .githooks || true"` to `post-install-cmd`
+   - Existing clones activate once manually: `git config core.hooksPath .githooks`
+
+**Husky repos (e.g. `nextcloud-vue`):** husky already owns `core.hooksPath` (`.husky`) — do NOT add `.githooks/` there, it would silently disable the existing husky hooks. Put the regeneration snippet inside the existing `.husky/pre-commit` instead.
+
+**Repos with no package.json or composer.json** (e.g. `hydra`): no auto-activation path exists — but such repos currently have `enable-features-extract: false`, so no hook is needed. If features are ever enabled there, document the manual `git config` line in the repo README.
+
 ## SBOM (Software Bill of Materials)
 
 Each app's SBOM is published exclusively as a **release asset** via the central Quality workflow's SBOM job. Per-app `sbom.yml` workflows are not allowed — they were removed in [`ConductionNL/.github#34`](https://github.com/ConductionNL/.github/pull/34).


### PR DESCRIPTION
## What

The quality pipeline no longer commits to the branches it checks. `docs/features.json`
is now generated **at commit time** by a committed git hook; CI only verifies — and
verification failures are merge blockers.

- **`features-extract`** (push events) rewritten: read-only. Regenerates in memory,
  **hard-fails** when `docs/features.json` is stale, and attaches the regenerated file
  as a run artifact. No more `git commit`/`git push` from CI.
- **`features-check`** (PR events) unchanged — already a read-only `--check` gate.
- Both jobs feed the `Quality Report` gate (`needs:` + fail step, already on main), so a
  stale features.json fails `quality / Quality Report` and **cannot be merged** —
  hook or no hook.
- Comments and input descriptions updated to match; CONVENTIONS.md gains the full
  per-repo rollout guide (verbatim hook, activation via npm `prepare` /
  composer `post-install-cmd`, husky + manifest-less variants, enforcement semantics).

## Why

The auto-commit was well-intentioned (devs forgot to regenerate) but self-defeating:

1. The bot commit carried `[skip ci]` and became the PR head → **zero workflows ran
   for the head SHA**, the PR lost all its checks (observed on nextcloud-vue#569).
2. Every bot push **dismissed reviewer approvals** (org ruleset dismisses stale
   reviews on push).
3. On protected branches the push bounced off branch protection anyway (#61 — now
   obsolete, can be closed).

A quality pipeline must never mutate the branch it is judging. Generation belongs in
the developer's commit, before the checks run; CI enforces.

## SBOM

Already correct and needs no per-repo setup: generated in CI, hard-failing validation
(Grype CVE scan + composer/npm audit), published as run artifact + release asset, and
**intentionally never committed** (SBOMs embed timestamps/serial numbers — a committed
copy would be perpetually stale). Failures block through the same Quality Report gate.
Input description updated accordingly (it still claimed "commit to repo").

## Rollout (per spec-bearing repo, we do this ourselves)

1. Copy `.githooks/pre-commit` from CONVENTIONS.md (reference implementation: openregister).
2. Wire activation into every manifest the repo has (`package.json` "prepare" /
   composer `post-install-cmd`); husky repos embed the snippet in `.husky/pre-commit`.
3. `git config core.hooksPath .githooks` once per existing clone.
4. Regenerate once so the repo enters the enforced state green.

Repos without `openspec/specs` keep `enable-features-extract: false` — nothing to do.