### PR TITLE
fix(ci): bound the Playwright job — a hang burned a runner for six hours

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1308,6 +1308,14 @@ jobs:
     runs-on: ubuntu-latest
     name: "E2E Tests (Playwright)"
     needs: [php-quality, security]
+    # No job in this file declared a timeout, so a hung suite ran to GitHub's
+    # 6-hour default. Observed durations once the suite is healthy: 4-10 min
+    # (planix 0.8, doriath 4.2, zaakafhandelapp 5.3, softwarecatalog 6.1,
+    # openconnector 7.7, opencatalogi 10.0). Unhealthy runs measured 1.1h and
+    # 1.6h before the `visual`/`docs-capture` projects were excluded. 45
+    # minutes leaves a wide margin over every healthy run while turning a hang
+    # into a failure in under an hour instead of burning a runner for six.
+    timeout-minutes: 45
 
     services:
       postgres:


### PR DESCRIPTION
`quality.yml` declared **no `timeout-minutes` on any job**, so a hung Playwright suite ran to GitHub's **6-hour** default.

Measured durations once a suite is healthy:

| repo | duration |
|---|---|
| planix | 0.8 min |
| doriath | 4.2 min |
| zaakafhandelapp | 5.3 min |
| softwarecatalog | 6.1 min |
| openconnector | 7.7 min |
| opencatalogi | 10.0 min |

Unhealthy runs measured **1.1h** and **1.6h** before the `visual` and `docs-capture` projects were excluded from CI — the workflow passes no `--project`, so every project in the chosen config runs.

**45 minutes** clears every healthy run by a wide margin while turning a hang into a failure inside the hour rather than after six.

Verified: YAML re-parses, 16 jobs, `playwright.timeout-minutes = 45`; negative control confirms no other job gains one.