### PR TITLE
fix(ci): give every shared job a measured timeout-minutes

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    # Observed across 123 executions: median and max both 0.1 min. A single
+    # bash branch-name comparison with no checkout and no network.
+    timeout-minutes: 10
     steps:
       - name: Validate source branch
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -90,6 +90,9 @@ jobs:
     name: Deploy Documentation
     needs: build
     runs-on: ubuntu-latest
+    # Observed across 9 executions: median 0.2 min, max 1.8 min (.github,
+    # docs.conduction.nl). Downloads the built artifact and pushes gh-pages.
+    timeout-minutes: 20
     # Deploy only on direct pushes, scheduled rebuilds, and manual
     # workflow_dispatch. PR runs stop after the build job, so the
     # AI-baseline gate runs but no gh-pages push happens.
@@ -134,6 +137,11 @@ jobs:
   image:
     name: Build fallback site image
     needs: build
+    # UNMEASURED: no executed run of this job appears in the fleet history
+    # sampled (0 executions). It is a docker buildx build-and-push to GHCR of a
+    # static Apache site, so 30 min is a wide bound for an image build plus a
+    # registry push. Revisit once it has run a few times.
+    timeout-minutes: 30
     # Build the portable Apache image on the same events that deploy to
     # gh-pages, so the GHCR :latest tag always matches what is live. The
     # build job only uploads the artifact on these events, so the

--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # A checkout plus a single bash test script over global-settings/. Runs
+    # only when global-settings/** changes; sub-minute in every run observed.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -36,6 +36,9 @@ jobs:
   triage-single:
     name: Triage New Issue
     runs-on: ubuntu-latest
+    # Observed across 8 executions: 0.1 min. A single actions/github-script
+    # step labelling one issue; 15 min covers a slow GitHub API.
+    timeout-minutes: 15
     permissions:
       issues: write
       contents: read
@@ -195,6 +198,9 @@ jobs:
   triage-decision:
     name: Handle Triage Decision
     runs-on: ubuntu-latest
+    # Same shape as triage-single: one actions/github-script step acting on a
+    # single issue. No executed run was sampled, so this mirrors that bound.
+    timeout-minutes: 15
     permissions:
       issues: write
       contents: read
@@ -331,6 +337,11 @@ jobs:
   backlog-triage:
     name: Backlog Triage Existing Issues
     runs-on: ubuntu-latest
+    # UNMEASURED: 6 skipped records, 0 executions in the fleet history sampled.
+    # Unlike the two single-issue jobs it walks EVERY untriaged open issue and
+    # writes labels, so its runtime scales with backlog size and with GitHub
+    # API rate limiting. Bounded well above the single-issue jobs at 30 min.
+    timeout-minutes: 30
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -26,6 +26,10 @@ jobs:
   sync:
     name: Sync OpenSpec to GitHub Issues
     runs-on: ubuntu-latest
+    # Observed: 1.6 min (larpingapp, the only executed run found). Walks
+    # openspec/changes and creates or updates one issue per change, so runtime
+    # scales with the number of changes and with GitHub API rate limiting.
+    timeout-minutes: 20
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -221,6 +221,10 @@ jobs:
     if: ${{ inputs.enable-php }}
     runs-on: ubuntu-latest
     name: "PHP Quality (${{ matrix.tool }})"
+    # Observed across 1497 executions fleet-wide: median 0.5 min, p95 1.5 min,
+    # max 4.0 min (launchpad). 20 min is a wide margin over the worst leg while
+    # still turning a hang into a failure instead of a 6-hour runner burn.
+    timeout-minutes: 20
     strategy:
       matrix:
         tool: [lint, phpcs, phpmd, psalm, phpstan, phpmetrics]
@@ -346,6 +350,9 @@ jobs:
     if: ${{ inputs.enable-frontend }}
     runs-on: ubuntu-latest
     name: "Vue Quality (${{ matrix.tool }})"
+    # Observed across 494 executions: median 0.6 min, p95 1.2 min, max 2.1 min
+    # (opencatalogi). 20 min absorbs npm-install contention with ~10x headroom.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ${{ inputs.frontend-path }}
@@ -410,6 +417,10 @@ jobs:
     if: ${{ inputs.enable-frontend && inputs.frontend-checks != '[]' }}
     runs-on: ubuntu-latest
     name: "Frontend Check (${{ matrix.script }})"
+    # Observed across 102 executions: median 0.6 min, p95 1.4 min, max 2.1 min
+    # (nextcloud-vue). These legs include `npm run build`, which has been
+    # measured at 211 s under heavy load, so the bound is deliberately loose.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ${{ inputs.frontend-path }}
@@ -491,6 +502,9 @@ jobs:
     if: ${{ inputs.enable-frontend }}
     runs-on: ubuntu-latest
     name: "Frontend Tests (unit)"
+    # Observed across 232 executions: median 0.6 min, p95 1.5 min, max 2.0 min
+    # (openbuild). Unit runs are load-sensitive, so 20 min, not 5.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -567,6 +581,9 @@ jobs:
   security:
     runs-on: ubuntu-latest
     name: "Security (${{ matrix.ecosystem }})"
+    # Observed across 505 executions: median 0.4 min, p95 1.0 min, max 5.7 min
+    # (docudesk). Advisory-database fetches can stall, hence 20 min.
+    timeout-minutes: 20
     strategy:
       matrix:
         ecosystem: [composer, npm]
@@ -688,6 +705,9 @@ jobs:
     if: ${{ inputs.enable-license-check }}
     runs-on: ubuntu-latest
     name: "License (${{ matrix.ecosystem }})"
+    # Observed across 497 executions: median 0.7 min, p95 1.4 min, max 1.9 min
+    # (planix). 20 min covers a slow registry without ever firing on a good run.
+    timeout-minutes: 20
     strategy:
       matrix:
         ecosystem: [composer, npm]
@@ -954,6 +974,12 @@ jobs:
     runs-on: ubuntu-latest
     name: "PHPUnit (PHP ${{ matrix.php-version }}, NC ${{ matrix.nextcloud-ref }})"
     needs: [php-quality, security]
+    # Observed across 337 SUCCESSFUL executions: median 1.7 min, p95 13.6 min,
+    # max 18.9 min (shillinq, green). The spread is huge because each leg
+    # installs a full Nextcloud server before the suite runs, so a tight bound
+    # would newly fail shillinq's already-green runs. 45 min is ~2.4x the worst
+    # observed green run and still cuts a hang from 6 hours to 45 minutes.
+    timeout-minutes: 45
 
     services:
       postgres:
@@ -1099,6 +1125,9 @@ jobs:
     runs-on: ubuntu-latest
     name: "Integration Tests (Newman)"
     needs: [php-quality, security]
+    # Observed across 39 executions: median 1.9 min, max 7.5 min (launchpad).
+    # Also installs a full Nextcloud server first, so 30 min — 4x the worst run.
+    timeout-minutes: 30
 
     services:
       postgres:
@@ -1831,6 +1860,14 @@ jobs:
     runs-on: ubuntu-latest
     name: "Journeydoc Capture (screenshots)"
     needs: [security]
+    # UNMEASURED: no caller in the fleet currently sets
+    # `enable-journeydoc-capture: true`, so this job has never executed (312
+    # skipped records, 0 executions, across 15 repos). Its step list is a
+    # superset of the Playwright job's — full Nextcloud install, frontend build,
+    # a Playwright project, plus a commit and a workflow dispatch — so it is
+    # bounded above the Playwright job's 45 min rather than at it. Revisit with
+    # real numbers once a caller enables it.
+    timeout-minutes: 60
     permissions:
       contents: write
       actions: write
@@ -2129,6 +2166,8 @@ jobs:
     if: ${{ inputs.enable-coverage-guard && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     name: "Coverage Baseline Protection"
+    # Observed across 8 executions: median 0.3 min, max 1.0 min (procest).
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -2147,6 +2186,9 @@ jobs:
     runs-on: ubuntu-latest
     name: "Update Coverage Baseline"
     needs: phpunit
+    # Observed across 3 executions: max 0.3 min (openregister). Downloads an
+    # artifact and commits; 15 min is generous for a push+commit round trip.
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -2186,6 +2228,15 @@ jobs:
     name: "Quality Report"
     needs: [php-quality, vue-quality, frontend-checks, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection, sbom, features-check, features-extract]
     if: always()
+    # Observed across 266 executions: median 0.6 min — but 2% of runs sit at
+    # ~30 min because the `Install PDF tools` apt-get step stalls on the Ubuntu
+    # mirror. That stall is currently intermittent-but-live fleet-wide
+    # (nldesign, opencatalogi, pipelinq, planix, softwarecatalog) and it still
+    # SUCCEEDS: pipelinq run 30799846661 spent 09:34:30 -> 10:04:52 in that one
+    # step and went green. Anything under ~45 min would newly fail runs that
+    # pass today, so this is bounded at 60 min. The apt stall is a separate
+    # defect worth fixing on its own; this bound only stops the 6-hour case.
+    timeout-minutes: 60
 
     steps:
       - name: Download all result artifacts
@@ -2433,6 +2484,10 @@ jobs:
     runs-on: ubuntu-latest
     name: "SBOM"
     needs: [security]
+    # Observed across 54 executions: median 1.1 min, max 1.9 min
+    # (nextcloud-app-template). Does composer install + npm install + a Grype
+    # download + a CVE scan, all network-bound, so 30 min rather than 10.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -2640,6 +2695,9 @@ jobs:
     if: ${{ inputs.enable-features-extract && !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     name: "Features Check"
+    # Observed across 174 executions: median 0.2 min, max 3.1 min
+    # (zaakafhandelapp).
+    timeout-minutes: 20
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -2668,6 +2726,9 @@ jobs:
     if: ${{ inputs.enable-features-extract && !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     name: "Features Extract"
+    # Observed across 76 executions: median 0.2 min, max 2.5 min
+    # (nextcloud-app-template).
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -38,6 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Observed across 73 executions of the shared release jobs: median 1.3 min,
+    # p95 3.0 min, max 4.0 min (nextcloud-vue). A release is expensive to fail
+    # spuriously — it builds the frontend (measured at 211 s under load),
+    # installs composer deps, packages and signs a tarball and uploads it — so
+    # this is bounded at 45 min, ~11x the worst run, purely as a hang stop.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout code

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -38,6 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Observed across 73 executions of the shared release jobs: median 1.3 min,
+    # p95 3.0 min, max 4.0 min (nextcloud-vue). A release is expensive to fail
+    # spuriously — it builds the frontend (measured at 211 s under load),
+    # installs composer deps, packages and signs a tarball and uploads it — so
+    # this is bounded at 45 min, ~11x the worst run, purely as a hang stop.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Observed across 73 executions of the shared release jobs: median 1.3 min,
+    # p95 3.0 min, max 4.0 min (nextcloud-vue). A release is expensive to fail
+    # spuriously — it builds the frontend (measured at 211 s under load),
+    # installs composer deps, packages and signs a tarball and uploads it — so
+    # this is bounded at 45 min, ~11x the worst run, purely as a hang stop.
+    timeout-minutes: 45
     steps:
 
       - name: Validate release type

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,9 @@ jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    # Observed: 0.5 min (hydra, the only executed run found). Checkout plus a
+    # containerised ShellCheck action.
+    timeout-minutes: 10
     permissions:
       contents: read
 

--- a/.github/workflows/sync-to-beta.yml
+++ b/.github/workflows/sync-to-beta.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   create-pr:
     runs-on: ubuntu-latest
+    # Observed across 152 executions: median 0.1 min, p95 1.1 min, max 5.6 min
+    # (openregister — a full-depth checkout of a large repo). 20 min covers a
+    # slow `fetch-depth: 0` clone with a wide margin.
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## What

Adds `timeout-minutes` to the **28 shared jobs that had none**. Before this, only `playwright` (#129) and documentation's `build` were bounded — every other job in every other shared workflow ran to GitHub's **6-hour default** on a hang.

After: **30 of 31 jobs bounded**, 1 deliberately not (see below).

## How the values were chosen — measured, not guessed

Sample: **12,465 unique job records across 34 fleet repos**, filtered to real executions (`success`/`failure`). Skipped records were excluded — they otherwise drag every median to zero and make short jobs look instantaneous.

| workflow | job | observed (executed runs) | timeout | rationale |
|---|---|---|---|---|
| quality | php-quality | n=1497, med 0.5m, max **4.0m** | 20 | 5x worst leg |
| quality | vue-quality | n=494, med 0.6m, max **2.1m** | 20 | npm-install contention headroom |
| quality | frontend-checks | n=102, med 0.6m, max **2.1m** | 20 | includes `npm run build` (211 s under load) |
| quality | frontend-tests | n=232, med 0.6m, max **2.0m** | 20 | unit runs are load-sensitive |
| quality | security | n=505, med 0.4m, max **5.7m** | 20 | advisory-DB fetch can stall |
| quality | license | n=497, med 0.7m, max **1.9m** | 20 | slow registry headroom |
| quality | **phpunit** | n=337, med 1.7m, p95 13.6m, max **18.9m green** | **45** | see below |
| quality | newman | n=39, med 1.9m, max **7.5m** | 30 | installs a full NC server first |
| quality | playwright | success max 12.8m | 45 | unchanged (#129) |
| quality | journeydoc-capture | **never executed** | 60 | UNMEASURED — superset of playwright's work |
| quality | baseline-protection | n=8, max **1.0m** | 15 | |
| quality | update-baseline | n=3, max **0.3m** | 15 | |
| quality | **report** | n=266, med 0.6m, max **31.0m** | **60** | see below |
| quality | sbom | n=54, max **1.9m** | 30 | composer+npm+Grype, all network-bound |
| quality | features-check | n=174, max **3.1m** | 20 | |
| quality | features-extract | n=76, max **2.5m** | 20 | |
| documentation | build | n=8, max 2.8m | 15 | unchanged |
| documentation | deploy | n=9, max **1.8m** | 20 | |
| documentation | image | **never executed** | 30 | UNMEASURED — docker build + GHCR push |
| branch-protection | check-branch | n=123, max **0.1m** | 10 | one bash comparison, no network |
| hook-tests | test | sub-minute | 15 | one bash script |
| issue-triage | triage-single | n=8, **0.1m** | 15 | one github-script step |
| issue-triage | triage-decision | same shape | 15 | |
| issue-triage | backlog-triage | **never executed** | 30 | UNMEASURED — walks the whole backlog |
| openspec-sync | sync | n=1, **1.6m** | 20 | scales with change count + rate limits |
| release-beta / release-stable / release | release | n=73, med 1.3m, max **4.0m** | 45 | ~11x worst; a spurious release failure is expensive |
| shellcheck | shellcheck | n=1, **0.5m** | 10 | |
| sync-to-beta | create-pr | n=152, max **5.6m** | 20 | slow `fetch-depth: 0` clone |

## Bounds are deliberately loose

A timeout that fires under normal contention is **worse than no timeout** — it turns a slow run into a phantom defect. Two measurements forced the loosest values:

- **PHPUnit reaches 18.9 min while SUCCEEDING** (shillinq). Each leg installs a full Nextcloud server before the suite runs. A 20-minute bound would have newly failed shillinq's already-green runs. 45 min is ~2.4x the worst green run.
- **Quality Report sits at ~30 min in 2% of runs** across nldesign, opencatalogi, pipelinq, planix and softwarecatalog, because the `Install PDF tools` `apt-get` step stalls on the Ubuntu mirror — and it still goes green. pipelinq run `30799846661` spent `09:34:30 → 10:04:52` in that one step. Anything under ~45 min would newly fail runs that pass today. **That apt stall is a separate defect worth fixing on its own**; this PR only stops the 6-hour case.

## One job left unbounded, on purpose

`deploy-docs.yml` → `deploy` is a **reusable-workflow call** (`uses:`). GitHub does not accept `timeout-minutes` on a calling job. Its actual work is bounded inside `documentation.yml`, where all three jobs now carry a timeout — so nothing is left unprotected.

## What this change cannot break

It **only adds a `timeout-minutes` key** to job definitions. The diff is **115 insertions, 0 deletions, workflow files only**. No step, condition, matrix, permission, input, output or job dependency is touched. It cannot change which jobs run, in what order, or whether they pass — a timeout has no effect unless a job exceeds it, and no observed green run does.

Verified by re-parsing all 12 files with `yaml.safe_load` after editing and asserting the **job set is unchanged (31 jobs)** and each job carries its **exact expected value** — plus that no `uses:` job carries a timeout.

Follow-on to #129.