### PR TITLE
fix(quality): Newman job — single-worker php -S deadlocks on self-referential fixtures; seed env; env-file path

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1261,9 +1261,49 @@ jobs:
           php -S 0.0.0.0:8080 ci-router.php &
           sleep 3
           curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/status.php || echo "Server not ready"
+        env:
+          # PHP_CLI_SERVER_WORKERS: `php -S` is SINGLE-WORKER by default, so it
+          # can only ever have one request in flight. That is fatal — not slow,
+          # FATAL — for any API collection in which the app under test calls
+          # BACK into this same instance while serving a request: the one
+          # worker is blocked inside the outer request, so the nested request
+          # can never be accepted, and both hang until the job's timeout kills
+          # them.
+          #
+          # Measured on openconnector (run 30821823343, job 91713730053): the
+          # collection creates a "self-pointing source" whose `location` is
+          # this very server, then calls
+          # `POST /api/synchronizations/<uuid>/test`. That request never
+          # returned. The job sat in "Run Newman tests" for ~30 minutes and was
+          # cancelled by timeout-minutes, having completed J2.2 and printed
+          # nothing after J2.3. Self-referential fixtures like this are normal
+          # in an integration suite — pointing a Source at the instance's own
+          # OpenRegister API is the cheapest way to get a real, reachable
+          # upstream — so the runner has to be able to serve them.
+          #
+          # The Playwright job's identical `php -S` step already sets this (for
+          # a different symptom: SPA boot requests serialising behind each
+          # other). Callers cannot set it — the `php -S` invocation lives in
+          # this workflow — so, exactly as noted there, it has to be fixed here.
+          PHP_CLI_SERVER_WORKERS: 8
 
       - name: Seed test data
         if: inputs.newman-seed-command != ''
+        # Same rationale as the Playwright job's seed step: a seed script is
+        # usually driving the app's own admin API and has to be told WHICH
+        # instance and with what credentials. This step declared no `env:` at
+        # all, so a script here saw neither BASE_URL nor ADMIN_USER and had to
+        # hardcode `http://localhost:8080` — a literal that means the SHARED
+        # dev container on a developer box, which makes the same script unsafe
+        # to run anywhere else.
+        env:
+          BASE_URL: http://localhost:8080
+          NEXTCLOUD_URL: http://localhost:8080
+          NC_BASE_URL: http://localhost:8080
+          ADMIN_USER: admin
+          ADMIN_PASSWORD: admin
+          NC_ADMIN_USER: admin
+          NC_ADMIN_PASS: admin
         run: |
           cd server
           echo "Running seed command: ${{ inputs.newman-seed-command }}"
@@ -1302,7 +1342,20 @@ jobs:
           # Build environment args: use --environment file if provided, otherwise ad-hoc vars
           ENV_ARGS=""
           if [ -n "${{ inputs.newman-environment-path }}" ]; then
-            ENV_FILE="../../../apps/${{ inputs.app-name }}/${{ inputs.newman-environment-path }}"
+            # Absolute, so it does not depend on how deep
+            # `newman-collection-path` happens to be. The previous value,
+            # "../../../apps/<app>/<env-path>", was hand-rolled relative to the
+            # cwd set above and was off by one level: from
+            # `server/apps/<app>/tests/postman`, `../../..` is `server/apps`,
+            # so it resolved to `server/apps/apps/<app>/...` and never existed.
+            # Every run took the fallback branch and emitted a "not found"
+            # warning about a file that is committed and present (measured on
+            # openconnector, which ships tests/postman/*.postman_environment.json).
+            # The fallback happens to set the same three variables, so this was
+            # invisible — until a collection needs a variable the fallback does
+            # not define, at which point it fails for a reason the warning
+            # actively misdirects you away from.
+            ENV_FILE="$GITHUB_WORKSPACE/server/apps/${{ inputs.app-name }}/${{ inputs.newman-environment-path }}"
             if [ -f "$ENV_FILE" ]; then
               # Rewrite localhost:8080 for CI (PHP built-in server runs on 8080)
               echo "Using environment file: ${{ inputs.newman-environment-path }}"


### PR DESCRIPTION
Three defects in the shared `Integration Tests (Newman)` job. All measured on [openconnector run 30821823343](https://github.com/ConductionNL/openconnector/actions/runs/30821823343), job `91713730053`.

## 1. `php -S` is single-worker in this job — fatal for self-referential fixtures

An integration collection routinely points a fixture at the instance under test. openconnector's does exactly that: it creates a Source whose `location` is this server's own OpenRegister API — the cheapest way to get a real, reachable upstream — and then runs a synchronization against it. Serving that means **the app calls back into the same instance while it is still handling the outer request**.

`php -S` is single-worker by default. The one worker is blocked inside the outer request, so the nested request can never be accepted, and both hang forever.

Observed precisely that:

```
❏ 13 — User journeys (E2E) / J2 — Source → Synchronization → Run → Contract
↳ J2.1 create self-pointing source   POST .../objects/openconnector/source  [201 Created, 214ms]
↳ J2.2 create synchronization        POST .../objects/openconnector/synchronization [201 Created, 209ms]
↳ J2.3 test sync (dry-run)
                                     <-- nothing, ever
```

The job sat in `Run Newman tests` for ~30 minutes and was killed by `timeout-minutes`.

This is not hypothetical for other repos either — any collection that exercises an app's own gateway/proxy/webhook path against itself hits the same wall.

**The Playwright job's identical `php -S` step already sets `PHP_CLI_SERVER_WORKERS: 8`**, for a different symptom (SPA boot requests serialising behind one another). Its comment notes:

> Callers cannot set this — the `php -S` invocation lives here — so it has to be fixed here.

Same fix, same reason, applied to the second job that starts the same server.

## 2. The Newman seed step exported no environment at all

`newman-seed-command` runs a script that drives the app's admin API, but the step declared no `env:`. A seed script therefore saw neither `BASE_URL` nor `ADMIN_USER` and had to hardcode `http://localhost:8080` — a literal that on a developer box is the **shared dev container**, which makes the same script unsafe to run anywhere else. Now mirrors the Playwright seed step's block.

## 3. The `--environment` file was never actually found

```sh
ENV_FILE="../../../apps/${{ inputs.app-name }}/${{ inputs.newman-environment-path }}"
```

relative to a cwd three levels down, and off by one: from `server/apps/<app>/tests/postman`, `../../..` is `server/apps`, so this resolved to `server/apps/apps/<app>/…`. Every run silently took the fallback branch and warned that a committed, present file was "not found":

```
##[warning]Environment file 'tests/postman/openconnector.postman_environment.json' not found, falling back to default env vars.
```

The fallback sets the same three variables (`base_url`, `admin_user`, `admin_password`), which is why this stayed invisible — until a collection needs a variable the fallback does not define, at which point it fails for a reason the warning actively misdirects you away from.

Now absolute via `$GITHUB_WORKSPACE`, so it no longer depends on how deep `newman-collection-path` happens to be.

---

Not merging this myself — it changes the shared workflow for every fleet repo, so it wants a maintainer's eyes. Blocks the openconnector-side cleanup in ConductionNL/openconnector#1126.