### PR TITLE
fix(quality): the new Frontend Build gate fails on any repo with >40 build outputs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -637,8 +637,22 @@ jobs:
           fi
           tar --null -czf /tmp/frontend-build-output.tar.gz -T /tmp/frontend-build-files.z
           echo "uploaded=true" >> "$GITHUB_OUTPUT"
-          tr '\0' '\n' < /tmp/frontend-build-files.z | head -40
-          echo "…"
+          # `sed -n '1,40p'`, NOT `head -40`. `head` closes the pipe as soon as
+          # it has its 40 lines, `tr` then dies of SIGPIPE, and `set -o pipefail`
+          # (three lines up) turns that into a FAILED JOB — for a log-preview
+          # line that has no bearing on whether the build worked.
+          #
+          # It only fires when the producer is still writing when head leaves,
+          # i.e. on repos with many build outputs. openregister's build writes
+          # fewer than 40 files and passed; nextcloud-vue's dist is thousands of
+          # files and failed every run. Reproduced: 200k NUL-separated entries
+          # through `tr | head -40` under pipefail exits 141 and the step never
+          # reaches the next line. `sed` reads its input to the end, so there is
+          # nothing to break.
+          tr '\0' '\n' < /tmp/frontend-build-files.z | sed -n '1,40p'
+          if [ "$COUNT" -gt 40 ]; then
+            echo "… and $((COUNT - 40)) more"
+          fi
 
       - name: Upload build output
         if: steps.package.outputs.uploaded == 'true'
@@ -2858,8 +2872,15 @@ jobs:
 
           # Coverage (if available)
           if [ -f "coverage/clover.xml" ]; then
-            COVERED=$(grep -oP 'coveredstatements="\K[0-9]+' coverage/clover.xml | head -1 || echo "0")
-            TOTAL_STMTS=$(grep -oP 'statements="\K[0-9]+' coverage/clover.xml | head -1 || echo "0")
+            # `grep -m1` rather than `grep | head -1`: this step also runs under
+            # `set -o pipefail`, so head closing the pipe on a clover.xml with
+            # many matches kills grep with SIGPIPE. The `|| echo "0"` then does
+            # not rescue the value — it APPENDS "0" to whatever head already
+            # printed, and the arithmetic below gets "1234\n0". Reporting a wrong
+            # coverage number is worse than failing, because nobody re-checks a
+            # number that rendered. -m1 stops grep itself, so there is no pipe.
+            COVERED=$(grep -oPm1 'coveredstatements="\K[0-9]+' coverage/clover.xml || echo "0")
+            TOTAL_STMTS=$(grep -oPm1 'statements="\K[0-9]+' coverage/clover.xml || echo "0")
             if [ "$TOTAL_STMTS" -gt 0 ]; then
               COVERAGE=$(echo "scale=1; $COVERED * 100 / $TOTAL_STMTS" | bc)
               echo "**Coverage:** ${COVERAGE}% ($COVERED/$TOTAL_STMTS statements)" >> "$REPORT"


### PR DESCRIPTION
The Frontend Build gate added in 835918f5 (today, 16:40) fails on any repo whose build writes more than 40 files.

```
tr '\0' '\n' < /tmp/frontend-build-files.z | head -40
```

`head` closes the pipe as soon as it has its 40 lines, `tr` dies of SIGPIPE, and the `set -o pipefail` three lines above turns that into a **failed job** — for a log-preview line that has no bearing on whether the build worked.

It only fires when the producer is still writing as `head` leaves, so it is invisible on small builds and certain on large ones:

| repo | build output | Frontend Build |
|---|---|---|
| openregister | <40 files | ✅ passed |
| nextcloud-vue | `dist/` is thousands of files | ❌ failed **every** run since the gate landed |

### Reproduced outside CI

```console
$ bash -c "set -euo pipefail; tr '\0' '\n' < big.z | head -40 >/dev/null; echo REACHED-AFTER"
exit=141          # 128+13 = SIGPIPE, and REACHED-AFTER never prints

$ bash -c "set -euo pipefail; tr '\0' '\n' < big.z | sed -n '1,40p' >/dev/null; echo REACHED-AFTER"
REACHED-AFTER
exit=0
```

`sed` reads its input to the end, so there is nothing to break, and it still prints exactly 40 lines. The `…` trailer now reports how many files were elided rather than implying there might be none.

### Same bug, worse failure mode, same file

The Quality Report step:

```
COVERED=$(grep -oP 'coveredstatements="\K[0-9]+' clover.xml | head -1 || echo "0")
```

That step also sets `pipefail`, and here `|| echo "0"` does **not** rescue the value — it *appends* `"0"` to what `head` already printed, so the arithmetic below receives `"1234\n0"`. Measured against a 60k-file clover.xml:

```
old: COVERED=[0
0]
new: COVERED=[0]
```

Reporting a wrong coverage number is worse than failing, because nobody re-verifies a number that rendered. Switched to `grep -oPm1`, which stops grep itself and removes the pipe rather than working around it.

No other `| head` under `pipefail` remains in this workflow.

### Why this is urgent

The gate is `enable-frontend`, which is on across the fleet, and it blocks. Every affected repo is red right now for a reason unrelated to its own code — including two open PRs of mine in nextcloud-vue that are otherwise green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
