### PR TITLE
fix(quality): stop the coverage-baseline gate reporting success while doing nothing (#61)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -168,7 +168,7 @@ on:
         type: string
         default: "[]"
       enable-coverage-guard:
-        description: "Run coverage baseline guard and auto-update"
+        description: "Enforce the .coverage-baseline ratchet — READ-ONLY, never commits. On pushes, hard-fails when measured coverage has moved past the committed baseline and attaches the recomputed value as the 'coverage-baseline' artifact; on PRs, rejects a baseline that has been LOWERED. Raise the baseline by committing the recomputed value in a normal pull request."
         required: false
         type: boolean
         default: false
@@ -2456,14 +2456,16 @@ jobs:
           # "main") not github.ref (e.g. "refs/heads/main") — git push wants a
           # bare branch.
           REF_NAME="${{ github.ref_name }}"
-          # Non-blocking on protected branches per ConductionNL/.github#61.
-          if git push origin "HEAD:${REF_NAME}"; then
-            echo "Screenshots pushed to ${REF_NAME}."
-            echo "changed=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::Could not push screenshot refresh — branch protection rejected the bot push (see ConductionNL/.github#61). Inspect the journeydoc-screenshots artifact and commit manually."
-            echo "changed=0" >> "$GITHUB_OUTPUT"
-          fi
+          # FAIL LOUDLY if the push is refused (#61). This used to swallow the
+          # rejection behind a `::warning::` and set changed=0, which made a
+          # refused push indistinguishable from "no screenshots changed" — the
+          # captures silently never landed and the job still reported success.
+          # The step runs under `set -euo pipefail`, so a non-zero `git push`
+          # fails the job. The screenshots are still uploaded as an artifact by
+          # the `if: always()` step below, so a refusal is recoverable by hand.
+          git push origin "HEAD:${REF_NAME}"
+          echo "Screenshots pushed to ${REF_NAME}."
+          echo "changed=1" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch deploy workflow if screenshots changed
         if: ${{ inputs.journeydoc-deploy-workflow != '' && steps.commit.outputs.changed == '1' }}
@@ -2528,29 +2530,80 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Check for manual baseline changes
+      # .coverage-baseline is a monotonic ratchet: coverage-guard.php only ever
+      # writes it when measured coverage EXCEEDS the stored value. This job used
+      # to ban every manual change outright, which was coherent only while the
+      # push-side job auto-committed the new value. That push has always been
+      # rejected on ruleset-protected branches (#61), so the blanket ban left the
+      # baseline unchangeable by anyone — bot or human — an unclosable gate.
+      #
+      # The anti-gaming property that matters is "the baseline never goes DOWN",
+      # so enforce exactly that: a PR may RAISE the baseline (this is how the
+      # push-side Coverage Baseline Check is closed) but never lower it. Fails
+      # closed on any value it cannot parse.
+      - name: Reject a lowered baseline
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^\.coverage-baseline$'; then
-            echo "::error::Manual changes to .coverage-baseline are not allowed."
+          set -euo pipefail
+          BASE="origin/${BASE_REF}"
+
+          if ! git diff --name-only "${BASE}...HEAD" | grep -q '^\.coverage-baseline$'; then
+            echo "No .coverage-baseline change in this PR."
+            exit 0
+          fi
+
+          NEW="$(tr -d '[:space:]' < .coverage-baseline)"
+          if ! OLD="$(git show "${BASE}:.coverage-baseline" 2>/dev/null | tr -d '[:space:]')"; then
+            OLD=""
+          fi
+
+          if [ -z "${OLD}" ]; then
+            echo "No baseline on ${BASE} — this PR introduces one (${NEW}). Accepted."
+            exit 0
+          fi
+
+          for v in "${OLD}" "${NEW}"; do
+            if ! awk -v v="${v}" 'BEGIN { exit !(v ~ /^[0-9]+(\.[0-9]+)?$/) }'; then
+              echo "::error::Unparseable coverage baseline value '${v}' — refusing to guess. Expected a bare number such as 55.54."
+              exit 1
+            fi
+          done
+
+          if awk -v o="${OLD}" -v n="${NEW}" 'BEGIN { exit !(n + 0 < o + 0) }'; then
+            echo "::error::.coverage-baseline was LOWERED from ${OLD} to ${NEW}. The baseline is a ratchet — it may be raised, never lowered."
             exit 1
           fi
-          echo "No manual baseline changes detected."
 
+          echo "Baseline change accepted: ${OLD} -> ${NEW} (not a decrease)."
+
+  # READ-ONLY by design, for the same reason as features-extract below. This job
+  # used to `git commit` + `git push` the recomputed .coverage-baseline back to
+  # the branch, with the push failure swallowed by `git push || echo "::warning::"`.
+  # On any repo whose development/main carries a ruleset ("Changes must be made
+  # through a pull request") that push is REJECTED — and because the failure was
+  # swallowed, the job still reported SUCCESS. The baseline therefore never moved
+  # while the gate read green (#61). A swallowed failure is worse than no job at
+  # all: it is indistinguishable from the work having been done.
+  #
+  # The job now recomputes the baseline, HARD-FAILS when it has drifted, and hands
+  # the regenerated file back as an artifact. The PR-side `baseline-protection`
+  # job above accepts a committed baseline as long as it does not LOWER the
+  # ratchet, so this gate is closable by a human via a normal pull request —
+  # it is deliberately not an unclosable gate.
   update-baseline:
     if: ${{ inputs.enable-coverage-guard && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development') }}
     runs-on: ubuntu-latest
-    name: "Update Coverage Baseline"
+    name: "Coverage Baseline Check"
     needs: phpunit
     # Observed across 3 executions: max 0.3 min (openregister). Downloads an
-    # artifact and commits; 15 min is generous for a push+commit round trip.
+    # artifact and recomputes a number; 15 min is generous.
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ github.token }}
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
@@ -2560,23 +2613,33 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
-      - name: Update baseline if improved
+      - name: Recompute baseline
         run: php scripts/coverage-guard.php coverage/clover.xml --update-baseline
-      - name: Commit updated baseline
+      - name: Fail if baseline drifted
+        id: fail-if-drifted
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet .coverage-baseline; then
-            echo "Baseline unchanged, nothing to commit."
+          if git diff --quiet -- .coverage-baseline; then
+            echo "Coverage baseline is up to date."
           else
-            git add .coverage-baseline
-            git commit -m "ci: update coverage baseline [skip ci]"
-            # Non-blocking: branch-protection rulesets reject the bot push on
-            # repos with a protected development/main. Surface a warning instead
-            # of failing the whole workflow over an auto-committed convenience
-            # file. Tracked in ConductionNL/.github#61 (add bot as a bypass actor).
-            git push || echo "::warning::Could not push the updated coverage baseline — branch protection rejected the bot push (see ConductionNL/.github#61). Commit .coverage-baseline manually."
+            echo "Measured coverage has moved beyond the committed baseline:"
+            git --no-pager diff -- .coverage-baseline
+            echo "::error::.coverage-baseline is out of date — measured coverage has improved past it. Commit the recomputed value (attached as the 'coverage-baseline' artifact of this run) in a pull request. The Coverage Baseline Protection job accepts any value that does not LOWER the baseline."
+            exit 1
           fi
+      - name: Upload recomputed baseline
+        # Gate on the drift step SPECIFICALLY, not `failure()` alone: if the
+        # Recompute step itself failed (coverage DROPPED below the baseline), the
+        # file on disk is the unchanged committed copy and publishing it under
+        # this name would invite committing a no-op. Only when fail-if-drifted
+        # failed is the on-disk file guaranteed to be the fresh value.
+        # (`failure() &&` is required — without a status-check function GitHub
+        # implies `success()`, and the step would never run after a failure.)
+        if: failure() && steps.fail-if-drifted.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-baseline
+          path: .coverage-baseline
+          retention-days: 7
 
   # ── Hydra mechanical gates ──────────────────────
   #


### PR DESCRIPTION
Closes the still-live half of #61.

## The bug — a gate that reports success while doing nothing

`update-baseline` ended in:

```
git push || echo "::warning::Could not push the updated coverage baseline ..."
```

On any repo whose `development`/`main` carries a ruleset (*"Changes must be made through a pull request"*) that push is **rejected**, and the `||` swallows it. The job then reports **success**.

Reproduced on a live run — openregister run [30851583987](https://github.com/ConductionNL/openregister/actions/runs/30851583987), job `91814324437`, conclusion **`success`**:

```
remote: error: GH013: Repository rule violations found for refs/heads/development.
- Changes must be made through a pull request.
! [remote rejected] development -> development (push declined due to repository rule violations)
##[warning]Could not push the updated coverage baseline ...
```

The baseline never moved, and nothing anywhere went red. A swallowed failure is worse than no job at all: it is indistinguishable from the work having been done.

> Note: the `features-extract` half of #61 was already fixed (read-only + hard-fail + artifact). This PR finishes the job for the two sites that still swallowed a push.

## Which fix, and why

**Chosen: make the gate honest and read-only** — mirroring the design already shipped for `features-extract` — rather than granting the bot a ruleset bypass.

I have admin on both repos, so adding `github-actions[bot]` as a bypass actor was available. I deliberately did not:

- it re-introduces exactly the hazard the `features-extract` redesign removed — a quality pipeline mutating the branch it is judging, via a `[skip ci]` commit that runs no checks;
- a bypass actor widens what *every* workflow in that repo may push, not just this job;
- it does not generalise: each repo that later enables `enable-coverage-guard` would need the same manual ruleset surgery, and forgetting it silently restores the swallowed-push behaviour.

## Changes

| job | before | after |
|---|---|---|
| `update-baseline` → **"Coverage Baseline Check"** | `contents: write`, commit + `git push \|\| echo ::warning::` | `contents: read`, no commit/push. Recomputes, **hard-fails on drift**, attaches the recomputed value as the `coverage-baseline` artifact |
| `baseline-protection` | banned **every** manual `.coverage-baseline` change | enforces the property that matters: the ratchet may be **raised**, never **lowered**; fails closed on an unparseable value |
| `journeydoc-capture` | refused push → `::warning::` + `changed=0` | refused push **fails the job**; screenshots still uploaded as an artifact |

### Why `baseline-protection` had to change too

Making the push job fail loudly on its own would have produced an **unclosable gate**: `baseline-protection` forbade humans editing `.coverage-baseline`, and the bot could not push it — so the baseline would be unchangeable by anyone, and every push to `development` would be permanently red with no way to close it.

The blanket ban was only ever coherent while the bot auto-committed. The anti-gaming property actually worth enforcing is *the baseline never goes down* — `coverage-guard.php` only writes it when `current > baseline`. So a PR may now raise it (that is how the push-side gate is closed) but never lower it.

## Verification

The new `baseline-protection` script was extracted **verbatim from the YAML** and run against real git repos. Every failing case was shown to actually fail:

| case | expected | got |
|---|---|---|
| no `.coverage-baseline` change | pass | pass |
| raised `55.54 → 60.00` | pass | pass |
| **lowered `55.54 → 50.00`** | **fail** | **fail** |
| equal `55.54 → 55.54` | pass | pass |
| **malformed value `abc`** | **fail** | **fail** |
| new baseline (absent on base) | pass | pass |
| **lowered by `0.01`** | **fail** | **fail** |
| raised int `9 → 10` | pass | pass |
| **lowered int `10 → 9`** | **fail** | **fail** |

Differential against the logic shipping today, confirming this is not a no-op: old logic **rejects** `raised 55.54 → 60.00` (the deadlock); new logic accepts it while still rejecting every lowering.

An earlier version of that harness was itself broken (`git init -b` is unsupported on git 2.25.1), so every case fell through to *"no baseline change"* and **falsely passed**. Caught by comparing expected against actual rather than reading the passes.

## What this change cannot break

Scanned 22 caller repos.

- `enable-coverage-guard` defaults **false**; **openregister is its only caller**. No other repo can reach either baseline job at all.
- `enable-journeydoc-capture` defaults **false** and **no caller in the fleet sets it** — 0 executions. That edit cannot execute today.
- **Nothing `needs:` `update-baseline`** (verified by parsing the job graph), so it cannot cascade into `Quality Report` — the only quality context any ruleset requires (`openregister` Beta/Main).
- `baseline-protection` does feed `Quality Report`, but the new script `exit 0`s early when the PR does not touch `.coverage-baseline` — every PR today. On the only path it can reach it is strictly **more permissive** than before.
- Renaming the job display name is safe: no ruleset references `Update Coverage Baseline`, and the job runs on `push` only, so it can never be a required PR status check. The job **key** is unchanged.
- Untouched, and not dependent on any changed job: PHP quality, frontend build, eslint/stylelint, security, license, SBOM, phpunit, newman, playwright, hydra-gates, features-check/features-extract, branch-protection, releases, docs deploy.

YAML parses; job count unchanged at 18.