### PR TITLE
fix(gates): gate-53 ignored the diff scope, gate-22 printed FAIL — 0, gate-33 had never run

### DIFF
--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Run the invariant suite
         run: bash hydra-gates/tests/test-hydra-gates-bin.sh
 
+      # FIRST, with no node_modules at all — this is the only state in which the
+      # DEGRADED contract can be exercised. Gate 22's whole point is that a
+      # validator which could not resolve Ajv must exit 3 and say so, never 0;
+      # once ajv is installed below, `NODE_PATH=/nonexistent` no longer hides it
+      # (node still resolves from ./node_modules) and that assertion self-skips.
+      - name: "Manifest validator: the no-Ajv degraded contract"
+        run: bash hydra-gates/scripts/lib/test_check_manifest.sh
+
       # Ajv is what gates 22 and 53 validate manifests WITH. Without it the
       # vendored validator can only run its structural lint, and the suite below
       # would skip exactly the paths worth testing. It is a devDependency of

--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -51,6 +51,27 @@ jobs:
       - name: Run the invariant suite
         run: bash hydra-gates/tests/test-hydra-gates-bin.sh
 
+      # Ajv is what gates 22 and 53 validate manifests WITH. Without it the
+      # vendored validator can only run its structural lint, and the suite below
+      # would skip exactly the paths worth testing. It is a devDependency of
+      # every fleet app already; installing it here means CI exercises the same
+      # code path a real `npm ci` repo does.
+      - name: Install ajv for the manifest-validation helpers
+        run: npm install --no-save --no-audit --no-fund ajv ajv-formats
+
+      # These three cover the gate-22 verdict contract and the gate-53 ADR-020
+      # diff scoping. They lived in scripts/lib/ and were run by NOTHING —
+      # test_check_manifest.sh in particular had been green for its whole life
+      # while pointing at a fixture directory that did not exist (a missing
+      # manifest path makes the validator print "Tier 0, skipping" and exit 0,
+      # which is what two of its three assertions expected).
+      - name: Manifest gate helper suites
+        run: |
+          set -eu
+          bash hydra-gates/scripts/lib/test_check_manifest.sh
+          node hydra-gates/scripts/lib/test_manifest_scope_filter.js
+          python3 hydra-gates/scripts/lib/test_manifest_diff_scope.py
+
   install-from-published-location:
     name: "Install from published location (php:8.3-cli)"
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2698,9 +2698,14 @@ jobs:
         # Installed INTO the package dir so `require('ajv')` from
         # scripts/lib/check_manifest.js resolves by walking up to
         # gates/hydra-gates/node_modules. A global install would need NODE_PATH
-        # and would silently not be found — which the manifest gates survive via
-        # a vendored fallback, meaning the miss would not be visible here. The
-        # coverage block at the end of the run is what makes any such gap loud.
+        # and would silently not be found.
+        #
+        # Since 2026-08-03 a miss here is loud rather than survivable: gate-22
+        # used to fall back to a structural lint that checks only the AppHost
+        # blocks and report the result as a PASS — a manifest certified without
+        # ever being schema-validated. It now FAILS with a named reason (the
+        # validator exits 3 DEGRADED), exactly as gate-53 already refused to run
+        # fail-open. If this step is ever removed, both gates say so.
         run: npm --prefix gates/hydra-gates install --no-save --no-audit --no-fund ajv
 
       - name: Resolve the diff base

--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -78,9 +78,17 @@ website and the docs tree are `export-ignore`d and do not follow.
 ## What it needs at runtime
 
 `bash`, `git`, `python3` (about twenty gates are Python helpers) and `node`
-(gates 22 and 53 only, and they additionally want `ajv` resolvable). PHP is
-required only because composer is one of the two delivery mechanisms; **no gate
-executes PHP**.
+(gates 22 and 53 only). PHP is required only because composer is one of the two
+delivery mechanisms; **no gate executes PHP**.
+
+**Gates 22 and 53 need `ajv` resolvable, and both now say so instead of
+degrading quietly.** `ajv` is already a transitive devDependency in every fleet
+app's `package-lock.json`, so a `npm ci` resolves it; a bare checkout without
+`node_modules` does not. Gate 53 has always refused to run without it. Gate 22
+used to fall back to a structural lint that checks only the AppHost blocks and
+report the result as a PASS — a manifest certified without ever being
+schema-validated. It now fails with a named reason instead. Set `NODE_PATH` or
+run `npm ci` before the gates if you see it.
 
 **No gate needs a Nextcloud runtime.** Nothing under `scripts/` loads
 `../../lib/base.php` — that constraint belongs to `phpunit`, not to the gates,
@@ -147,25 +155,95 @@ clean one. So:
   construction.
 - A genuinely empty diff is **stated as empty** rather than reported as a pass.
 
+### Scope granularity, and where file granularity is not enough
+
+Most gates scope by **file**: a finding in a file the PR did not touch does not
+block. Gates 51 (schema-property-titles) and 55 (detail-page-discipline) go
+finer and scope by the **changed lines** inside a touched file, so legacy debt
+elsewhere in a file you edited does not block either.
+
+Gate 53 (effective-manifest-crossref) used to scope by file, and for that gate
+file granularity was indistinguishable from no scoping at all: an app's entire
+navigation surface lives in `src/manifest.json` + `src/manifest.d/*`, so
+touching any of it re-judged all of it. Measured 2026-08-03 on a one-line
+`title` change:
+
+| repo | full-repo | diff-scoped (before) | diff-scoped (after) |
+| --- | --- | --- | --- |
+| pipelinq | 24 | 24 | 0 blocking, 24 reported PRE-EXISTING |
+| shillinq | 246 | 246 | 0 blocking, 397 reported PRE-EXISTING |
+
+Gate 53 now separates two things that are not the same:
+
+- **Answering** a cross-reference needs the whole assembled manifest. You cannot
+  resolve `menu[].route` → page id, or check the ADR-044 no-orphan-removal
+  invariant, from a diff. That part of the gate is legitimately whole-repo and
+  stays so.
+- **Blocking** on the answer does not. Every finding carries a JSON pointer that
+  resolves to a page id, a menu id or a top-level block, and it blocks only when
+  the PR touched that entry.
+
+Findings on untouched entries are **printed as `PRE-EXISTING`, never dropped**,
+and their count is reported on stdout, so a scoped green cannot be read as "the
+manifest is clean". Findings that address the manifest as a whole (no entry to
+attribute them to), and any PR whose scope cannot be determined — a brand-new
+fragment untracked at base, a changed register JSON, a parse failure — block
+regardless. Unverifiable scope is never treated as narrow scope.
+
+The only part of the suite that is whole-repo **by nature** — as opposed to by
+oversight — is that residual set of gate-53 invariants. Everything else measured
+on 2026-08-03 (gates 34, 51, 55) narrows correctly, and the two other
+whole-manifest checks in the same family, gates 22 and 52, are triggered only
+by a change to the artefact they judge.
+
 ---
 
 ## Reading a green
 
 A green from this package says how much it covers, because a green that
 overstates its coverage is the same defect as `|| echo '...skipping'` one layer
-up. The runner's own closing line reads `ALL 61 GATES GREEN` regardless of how
-many gates ran; measured on openbuild, 59 of 61 report and gates 24 and 33 skip
-silently when their prerequisites are absent. So every run ends with:
+up.
+
+Every gate in the runner is wrapped in a prerequisite test (`if [ -d src ]`,
+`if [ -f tests/axe/report.json ]`, …). Until 2026-08-03 a gate whose
+prerequisite was absent emitted **nothing at all** — no line, no count, no
+trace — and the runner still closed with `ALL 63 GATES GREEN`. Measured across
+13 fleet repos, **gate 33 (axe-core) had never run in any of them**: the
+`tests/axe/report.json` it consumes is produced by a `scripts/run-browser-tests.sh`
+that exists in no app, while `axe-core` sits in every app's `devDependencies`
+so the prerequisite looks wired. Every green the fleet had ever produced
+excluded accessibility runtime checking, and nothing said so. Gate 24
+(integration-parity) was absent in most repos for the same structural reason.
+
+Both layers now account for it. A gate that cannot run says so on its own line:
 
 ```
-[hydra-gates] COVERAGE: 59 of 61 declared gates reported a result.
-[hydra-gates] GATES THAT DID NOT RUN: 24 33
-[hydra-gates] RESULT: ALL GATES PASSED — EXCEPT GATES 24 33, WHICH DID NOT RUN.
-[hydra-gates] This green covers 59 gates. It says NOTHING about gates 24 33.
+[gate-24] integration-parity: SKIPPED — no scripts/check-integration-parity.sh …
+[gate-33] axe-core: SKIPPED — no tests/axe/report.json in this repo — axe-core
+          never ran against a rendered DOM, so contrast / landmark /
+          ARIA-validity / live-region accessibility is UNVERIFIED. …
 ```
+
+and every run — `bin/hydra-gates` **and** a direct `run-hydra-gates.sh`
+invocation — ends with the accounting:
+
+```
+[hydra-gates] COVERAGE: 60 of 63 declared gates reported a result.
+[hydra-gates] GATES THAT DID NOT RUN — they inspected NOTHING, and their subject
+[hydra-gates] matter is UNVERIFIED by this run:
+[hydra-gates]   gate-4 composer-audit
+[hydra-gates]   gate-24 integration-parity
+[hydra-gates]   gate-33 axe-core
+[hydra-gates] 60 GATE(S) GREEN — but 3 of 63 DID NOT RUN (named above).
+[hydra-gates] This is NOT 'all 63 gates green'. …
+```
+
+A `SKIPPED` line is **not** counted as coverage — a gate reporting that it did
+nothing did nothing. `--require-full-coverage` turns an incomplete run into
+exit 98.
 
 The inventory is read out of the runner itself rather than hardcoded, so adding
-gate 62 does not silently leave the coverage check measuring against a stale 61.
+gate 64 does not silently leave the coverage check measuring against a stale 63.
 
 ### Waivers
 
@@ -188,14 +266,29 @@ A green earned by passing is then distinguishable from one earned by waiving.
 
 ```
 bash hydra-gates/tests/test-hydra-gates-bin.sh     # or: composer test:package
+
+# manifest gate helpers (gate 22's verdict contract, gate 53's diff scoping).
+# Install ajv first or the schema paths state a SKIP instead of passing:
+npm install --no-save ajv ajv-formats
+bash hydra-gates/scripts/lib/test_check_manifest.sh
+node hydra-gates/scripts/lib/test_manifest_scope_filter.js
+python3 hydra-gates/scripts/lib/test_manifest_diff_scope.py
 ```
 
-Asserts the four invariants — exit-code-is-count, loud unresolvable base, stated
-empty diff, self-describing coverage — against a synthesized fixture repo. The
-positive control runs in **both** directions: the injected violation must be
-*named* by the gate that catches it, and the same fixture must go green once it
-is removed. A one-directional control cannot distinguish "the check caught it"
-from "the check never ran".
+Asserts the invariants — exit-code-is-count, loud unresolvable base, stated
+empty diff, self-describing coverage, named unrun gates, one-line-per-verdict —
+against a synthesized fixture repo. The positive control runs in **both**
+directions: the injected violation must be *named* by the gate that catches it,
+and the same fixture must go green once it is removed. A one-directional control
+cannot distinguish "the check caught it" from "the check never ran".
+
+`test_check_manifest.sh` was itself an example of that failure until
+2026-08-03: it pointed at a `scripts/test-fixtures/manifest-validation/`
+directory that had never existed, and `check_manifest.js <missing-path>` prints
+"Tier 0, skipping" and exits 0 — which is exactly what two of its three
+assertions expected. It had been green its whole life while validating nothing.
+The fixtures now ship, and the suite refuses to run at all if they go missing
+again.
 
 CI for this package lives in
 [`.github/workflows/hydra-gates-package.yml`](../.github/workflows/hydra-gates-package.yml):

--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -73,6 +73,29 @@ Then `composer update conduction/hydra-gates`.
 `vendor/conduction/hydra-gates` lands at about 1.2 MB. The org profile, the
 website and the docs tree are `export-ignore`d and do not follow.
 
+### Upgrading to `v1.1.0` from `v1.0.x`
+
+`^1.0` picks this up on the next `composer update`, and **verdicts move**. Three
+things to do before you upgrade:
+
+1. **Make `ajv` resolvable before the gates run** — `npm ci`, or
+   `npm --prefix <package-dir> install --no-save ajv` (Option A's shared
+   workflow already does this). Gate 22 previously fell back to a structural
+   lint that checks only the AppHost blocks and reported the result as a PASS;
+   it now **fails** with a named reason rather than certifying a manifest it
+   never schema-validated. Gate 53 has always refused to run without it.
+2. **Expect gate-22 verdicts to move in both directions.** Its verdict used to
+   come from the app's own `npm run check:manifest`; it now comes from the
+   vendored canonical validator, and the app script is surfaced as an advisory.
+   Apps whose local checker was weaker will surface real findings; apps failed
+   by a stale app-local page-type enum will go green.
+3. **Treat `: SKIPPED` as "did not run", not as a pass**, if you parse
+   `^\[gate-N\]` lines. New verdict; see *Reading a green* below.
+
+The upside: **gate 53 becomes usable under `--scope-to-diff`**. It was
+previously unenablable on any repo with manifest debt, because a one-line change
+reproduced the full-repo finding count exactly.
+
 ---
 
 ## What it needs at runtime

--- a/hydra-gates/bin/hydra-gates
+++ b/hydra-gates/bin/hydra-gates
@@ -28,13 +28,21 @@
 #      shallow clone it may not exist at all.
 #
 #   3. A COVERAGE ASSERTION ON THE GREEN.
-#      The runner ends with "ALL 61 GATES GREEN" whether or not 61 gates ran.
-#      Measured on openbuild, only 59 of the 61 emit a line — gates 24 and 33
-#      skip silently when their prerequisites are absent. A green that counts
-#      gates it never executed is the same defect as `|| echo 'skipping'`, one
-#      layer up. We diff the gate numbers that actually reported against the
-#      inventory declared by the runner itself, and say plainly which gates did
-#      not run and what the green therefore does not cover.
+#      The runner used to end with "ALL 63 GATES GREEN" whether or not 63 gates
+#      ran. Measured on openbuild, only 59 of 61 emitted a line — gates 24 and
+#      33 skipped silently when their prerequisites were absent; measured
+#      2026-08-03 across 13 repos, gate-33 (axe-core) has never run in ANY of
+#      them. A green that counts gates it never executed is the same defect as
+#      `|| echo 'skipping'`, one layer up. We diff the gate numbers that
+#      actually reported against the inventory declared by the runner itself,
+#      and say plainly which gates did not run and what the green therefore
+#      does not cover.
+#
+#      As of 2026-08-03 the runner performs the same accounting in its own
+#      summary, so a direct `run-hydra-gates.sh` invocation (which most of the
+#      fleet uses) is no longer blind to it. Gates that state their own absence
+#      now print `[gate-N] <name>: SKIPPED — <reason>`; that line is NOT counted
+#      as "reported" below — a gate that says it did nothing did nothing.
 #
 #   4. A LOUD, STATED SKIP FOR MISSING PREREQUISITES.
 #      Never `|| echo '...skipping'`. A prerequisite that is genuinely absent is
@@ -267,8 +275,13 @@ RC="${PIPESTATUS[0]}"
 # adds gate 62, and a coverage check that silently measures against a stale
 # inventory is the very defect this step exists to catch.
 # ---------------------------------------------------------------------------
-DECLARED="$(grep -oE '_(pass|fail) [0-9]+' "${RUNNER}" | awk '{print $2}' | sort -un)"
-EMITTED="$(grep -oE '^\[gate-[0-9]+\]' "${_out}" | grep -oE '[0-9]+' | sort -un)"
+DECLARED="$(grep -oE '_(pass|fail|skip) [0-9]+' "${RUNNER}" | awk '{print $2}' | sort -un)"
+# A `[gate-N] name: SKIPPED — reason` line is the gate REPORTING THAT IT DID NOT
+# RUN. Counting it as coverage would turn the fix into the bug: the whole point
+# of making the skip visible is that it stays outside the "reported a result"
+# tally. Excluded here by verdict, not by gate number.
+EMITTED="$(grep -E '^\[gate-[0-9]+\]' "${_out}" | grep -v ': SKIPPED' \
+    | grep -oE '^\[gate-[0-9]+\]' | grep -oE '[0-9]+' | sort -un)"
 DECLARED_N="$(printf '%s\n' "${DECLARED}" | grep -c . || true)"
 EMITTED_N="$(printf '%s\n' "${EMITTED}" | grep -c . || true)"
 

--- a/hydra-gates/scripts/lib/check_manifest.js
+++ b/hydra-gates/scripts/lib/check_manifest.js
@@ -44,6 +44,13 @@
 //   0 — manifest validates with zero errors (or no manifest → caller skips)
 //   1 — manifest fails validation (errors printed one per line: "at <path>: …")
 //   2 — vendored canonical schema could not be loaded (gate misconfiguration)
+//   3 — DEGRADED: Ajv was not resolvable (or the merged schema would not
+//       compile), so only the AppHost structural lint ran and it found nothing.
+//       This is NOT a pass: the schema was never applied. Callers must surface
+//       it as a distinct verdict — a silent downgrade to a weaker check is the
+//       failure mode this whole package exists to remove. Exit 1 still wins
+//       when the structural lint DID find something, so a real finding is
+//       never masked by the degradation.
 
 'use strict'
 
@@ -54,9 +61,22 @@ const path = require('path')
 // It is the ADR-040 SUPERSET (published v2 base + observability + deepLinks).
 const CANONICAL_SCHEMA_PATH = path.resolve(__dirname, '..', 'schemas', 'app-manifest-v2.schema.json')
 
-const MANIFEST_PATH = process.argv[2]
-	? path.resolve(process.argv[2])
+// `--scope-ids FILE` (ADR-020): findings on manifest entries the PR did not
+// touch are reported as PRE-EXISTING instead of blocking. Absent → full-repo.
+const _argv = process.argv.slice(2)
+let SCOPE_IDS_FILE = null
+const _positional = []
+for (let i = 0; i < _argv.length; i++) {
+	if (_argv[i] === '--scope-ids') { SCOPE_IDS_FILE = _argv[++i]; continue }
+	if (_argv[i].startsWith('--scope-ids=')) { SCOPE_IDS_FILE = _argv[i].slice('--scope-ids='.length); continue }
+	_positional.push(_argv[i])
+}
+
+const MANIFEST_PATH = _positional[0]
+	? path.resolve(_positional[0])
 	: path.resolve(process.cwd(), 'src', 'manifest.json')
+
+const scopeFilter = require('./manifest_scope_filter.js')
 
 // Base-schema candidates, in priority order. The CANONICAL hydra-vendored
 // schema wins (2026-07-06 manifest audit, item 4): pinned-first meant "pass"
@@ -144,11 +164,26 @@ function semanticChecks(manifest) {
 // line — both on stdout (every stdout line is valid JSON). Human-readable
 // `at <path>: <first line>` diagnostics go to stderr, which also keeps
 // run-hydra-gates.sh's `grep -cE '^at /'` failure count working.
-function report(errors) {
+function report(allErrors, degradedReason, manifest) {
+	// ADR-020: answer over the whole manifest, block only on entries the PR
+	// touched. `scope` is null on a full-repo run and everything blocks.
+	const scope = scopeFilter.loadScope(SCOPE_IDS_FILE)
+	const parts = scopeFilter.partition(allErrors, manifest || {}, scope)
+	scopeFilter.reportScope('check_manifest', parts)
+	const errors = parts.blocking
 	const failed = errors.length > 0 ? 1 : 0
 	if (failed === 1) {
 		for (const e of errors) console.error(`at ${e.path || '/'}: ${String(e.message).split('\n')[0]}`)
 		console.log(JSON.stringify({ file: path.relative(process.cwd(), MANIFEST_PATH), schemaVersion: 'v2', errors }))
+	}
+	// A zero-finding run that never applied the schema is NOT a pass. Say so on
+	// both channels and exit 3 so the caller cannot mistake it for one.
+	if (failed === 0 && degradedReason) {
+		console.error(`[check_manifest] DEGRADED — SCHEMA VALIDATION DID NOT HAPPEN: ${degradedReason}`)
+		console.error('[check_manifest] The AppHost structural lint found nothing, but it checks only the observability/deepLinks blocks.')
+		console.error('[check_manifest] Reporting this as a pass would certify a manifest that was never validated against the canonical schema.')
+		console.log(JSON.stringify({ status: 'degraded', checked: 1, failed: 0, reason: degradedReason }))
+		process.exit(3)
 	}
 	console.log(JSON.stringify({ status: failed === 1 ? 'failed' : 'passed', checked: 1, failed }))
 	process.exit(failed)
@@ -340,7 +375,7 @@ function main() {
 			validate = ajv.compile(schema)
 		} catch (e) {
 			console.error(`[check_manifest] Ajv could not compile the merged schema (${e.message}); falling back to AppHost structural lint`)
-			return finishStructural(manifest)
+			return finishStructural(manifest, `Ajv could not compile the merged canonical schema (${e.message})`)
 		}
 		const errors = []
 		if (validate(manifest)) {
@@ -351,20 +386,20 @@ function main() {
 			}
 		}
 		errors.push(...semanticChecks(manifest))
-		return report(errors)
+		return report(errors, null, manifest)
 	}
 
 	console.error('[check_manifest] Ajv not installed; using AppHost structural lint (observability/deepLinks still validated for-real)')
-	return finishStructural(manifest)
+	return finishStructural(manifest, 'Ajv is not resolvable from this process (no node_modules, no NODE_PATH)')
 }
 
-function finishStructural(manifest) {
+function finishStructural(manifest, degradedReason) {
 	const errors = structuralLintAppHost(manifest)
 	if (errors.length === 0) {
 		console.error('[check_manifest] AppHost structural lint against canonical ADR-040 enums: PASS')
 	}
 	errors.push(...semanticChecks(manifest))
-	return report(errors)
+	return report(errors, degradedReason, manifest)
 }
 
 main()

--- a/hydra-gates/scripts/lib/check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/check_manifest_crossref.js
@@ -72,15 +72,22 @@ try {
 
 let APP_DIR = process.cwd()
 let MANIFEST_FILE = null
+// `--scope-ids FILE` (ADR-020) — see manifest_scope_filter.js. The joins are
+// still answered against the WHOLE assembled manifest; the flag only decides
+// which of the answers block this PR.
+let SCOPE_IDS_FILE = null
 {
 	const argv = process.argv.slice(2)
 	for (let i = 0; i < argv.length; i++) {
 		if (argv[i] === '--app-dir' && argv[i + 1]) { APP_DIR = path.resolve(argv[++i]); continue }
 		if (argv[i] === '--manifest' && argv[i + 1]) { MANIFEST_FILE = path.resolve(argv[++i]); continue }
+		if (argv[i] === '--scope-ids' && argv[i + 1]) { SCOPE_IDS_FILE = argv[++i]; continue }
 		console.error(`[check_manifest_crossref] unknown argument: ${argv[i]}`)
 		process.exit(2)
 	}
 }
+
+const scopeFilter = require('./manifest_scope_filter.js')
 
 // --- findings accumulator ----------------------------------------------------
 
@@ -397,22 +404,37 @@ function main() {
 		}
 	}
 
-	report(manifestLabel)
+	report(manifestLabel, manifest)
 }
 
 // Emit the gate-22 report shape: per-file findings line (when any findings,
 // error OR warn), then always the summary line — both valid JSON on stdout.
 // Human diagnostics on stderr; WARNs never set the failure exit code.
-function report(manifestLabel) {
-	const errors = findings.filter((f) => f.severity === 'error')
+function report(manifestLabel, manifest) {
+	// ADR-020 diff scoping. WARNs are advisory already and are never scoped out
+	// — they cost nothing and vanishing them would hide debt twice over. Only
+	// error-severity findings are partitioned into blocking vs pre-existing.
+	const scope = scopeFilter.loadScope(SCOPE_IDS_FILE)
+	const errorFindings = findings.filter((f) => f.severity === 'error')
+	const parts = scopeFilter.partition(errorFindings, manifest || {}, scope)
+	const preexisting = new Set(parts.preexisting)
+	const errors = parts.blocking
 	const failed = errors.length > 0 ? 1 : 0
 	for (const f of findings) {
 		const first = String(f.message).split('\n')[0]
 		if (f.severity === 'warn') {
 			console.error(`at ${f.path || '/'}: WARN ${first}`)
+		} else if (preexisting.has(f)) {
+			console.error(`at ${f.path || '/'}: PRE-EXISTING ${first}`)
 		} else {
 			console.error(`at ${f.path || '/'}: ${first}`)
 		}
+	}
+	if (parts.preexisting.length > 0) {
+		console.error(`[check_manifest_crossref] diff-scope (ADR-020): ${parts.preexisting.length} cross-reference finding(s) sit on manifest entries this PR did not touch — reported above as PRE-EXISTING, not blocking.`)
+	}
+	if (parts.unscopable.length > 0) {
+		console.error(`[check_manifest_crossref] ${parts.unscopable.length} finding(s) address the manifest as a WHOLE and block regardless of scope.`)
 	}
 	if (findings.length > 0) {
 		console.log(JSON.stringify({

--- a/hydra-gates/scripts/lib/manifest_diff_scope.py
+++ b/hydra-gates/scripts/lib/manifest_diff_scope.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-53 helper — compute the ADR-020 diff scope of a manifest change.
+
+WHY THIS EXISTS (measured 2026-08-03)
+-------------------------------------
+gate-53 (effective-manifest-crossref) was diff-scoped at FILE granularity: if a
+PR touched ``src/manifest.json``, any ``src/manifest.d/*.json`` fragment, or
+``src/menu-layout.json``, it re-judged the ENTIRE assembled manifest. Because an
+app's whole navigation surface lives in that one input set, file granularity is
+indistinguishable from no scoping at all. Measured:
+
+    pipelinq  one-line ``title`` change on one index page
+              → full-repo 24 findings, diff-scoped 24 findings
+    shillinq  one-line ``title`` change in ONE of 80 fragments
+              → full-repo 246 findings, diff-scoped 246 findings
+
+Every one of those findings sat on a page the PR had never touched. Enabling the
+gate would have blocked every manifest-touching PR in those repos on inherited
+debt, however small the change — which is how a gate gets switched off.
+
+The cross-reference joins themselves genuinely need the WHOLE assembled manifest
+to be ANSWERED (you cannot resolve ``menu[].route`` → page id from a diff). That
+is not the same as needing the whole manifest to be BLOCKING. This helper draws
+the second line: the answer is computed repo-wide, and the finding blocks only
+when the PR touched the entry the finding is ABOUT. It is the same model gate-55
+(detail-page-discipline) already uses, and gate-55 measurably scopes correctly.
+
+WHAT IT EMITS
+-------------
+One token per line on stdout, for consumption by
+``manifest_scope_filter.js``::
+
+    page:<pageId>       a pages[] entry whose JSON object span intersects the diff
+    menu:<menuId>       a menu[] entry (or nested child) whose span intersects
+    key:<topLevelKey>   a non-pages/non-menu top-level key whose span intersects
+                        (e.g. ``key:observability``, ``key:deepLinks``)
+    ALLMENU             menu-layout.json changed — relocations/removals restructure
+                        the merged menu wholesale, so every /menu finding is in scope
+    ALL                 scope could not be determined; EVERYTHING blocks
+
+``ALL`` is emitted whenever the answer is unknowable rather than empty — a file
+untracked at base (brand-new manifest/fragment), a JSON parse failure, a git
+invocation that fails, or a changed register JSON (a register edit can orphan a
+schema reference anywhere in the manifest). Fail TOWARD enforcement: an
+unverifiable scope must never be reported as a narrow one. That is the same
+rule the runner applies to an unresolvable base ref.
+
+Usage::
+
+    HYDRA_GATE_BASE_REF=origin/development \\
+        manifest_diff_scope.py <changed-file> [<changed-file> ...]
+
+Only paths that are manifest INPUTS are interpreted; anything else is ignored.
+With no base ref set the helper prints ``ALL`` (a full-repo run scopes nothing).
+"""
+
+import importlib.util
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_line_parser():
+    """Borrow the line-tracking JSON parser from check_detail_page_discipline.
+
+    That module already carries a tokenizer that records the start/end line of
+    every object and array — the machinery gate-55 uses for its page-span
+    scoping. Importing it keeps ONE parser in the package: a second copy would
+    be a second thing to keep in sync, and a scope computation that disagrees
+    with gate-55's about where a page begins is worse than no scoping at all.
+    """
+    path = os.path.join(_HERE, "check_detail_page_discipline.py")
+    spec = importlib.util.spec_from_file_location("_hydra_dpd", path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:  # noqa: BLE001 — any import failure means "cannot scope"
+        return None
+    return mod
+
+
+_DPD = _load_line_parser()
+
+
+def _is_manifest_page_input(rel):
+    return rel == "src/manifest.json" or rel.startswith("src/manifest.d/")
+
+
+def _spans_of(node):
+    """(start_line, end_line) for a parsed node, or None when untracked."""
+    start = getattr(node, "start_line", 0)
+    end = getattr(node, "end_line", 0)
+    if not start or not end:
+        return None
+    return (start, end)
+
+
+def _intersects(span, changed):
+    if span is None:
+        return True  # unknown span → assume touched (fail toward enforcement)
+    lo, hi = span
+    for ln in changed:
+        if lo <= ln <= hi:
+            return True
+    return False
+
+
+def _collect_menu_ids(entry, changed, out):
+    """Emit menu ids for `entry` and any nested children the diff touches.
+
+    A parent whose own span is touched puts the parent in scope; a touched CHILD
+    also puts the child in scope on its own, so editing one leaf of a 30-item
+    menu tree does not drag the whole tree in.
+    """
+    if not isinstance(entry, dict):
+        return
+    span = _spans_of(entry)
+    ident = entry.get("id") or entry.get("route")
+    children = entry.get("children")
+    child_hit = False
+    if isinstance(children, list):
+        for child in children:
+            before = len(out)
+            _collect_menu_ids(child, changed, out)
+            if len(out) > before:
+                child_hit = True
+    if isinstance(ident, str) and ident and (child_hit or _intersects(span, changed)):
+        out.add("menu:" + ident)
+
+
+def _scope_one_file(path, base_ref, tokens):
+    """Add tokens for one changed manifest input. Returns False on 'cannot scope'."""
+    if _DPD is None:
+        return False
+    changed = _DPD._changed_lines(path, base_ref)
+    if changed is None:
+        # Untracked at base (new file) / git unavailable / bad base — unknowable.
+        return False
+    if not changed:
+        return True  # tracked and byte-identical: contributes nothing
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            doc = _DPD._Parser(fh.read()).parse()
+    except (OSError, ValueError):
+        return False
+    if not isinstance(doc, dict):
+        return False
+
+    for key, value in doc.items():
+        if key == "pages" and isinstance(value, list):
+            for page in value:
+                if not isinstance(page, dict):
+                    continue
+                pid = page.get("id")
+                if isinstance(pid, str) and pid and _intersects(_spans_of(page), changed):
+                    tokens.add("page:" + pid)
+        elif key == "menu" and isinstance(value, list):
+            for entry in value:
+                _collect_menu_ids(entry, changed, tokens)
+        else:
+            span = None
+            if hasattr(value, "start_line"):
+                span = _spans_of(value)
+            elif key in doc.key_lines:
+                line = doc.key_lines[key]
+                span = (line, line)
+            if _intersects(span, changed):
+                tokens.add("key:" + key)
+    return True
+
+
+def main(argv):
+    base_ref = os.environ.get("HYDRA_GATE_BASE_REF", "").strip()
+    if not base_ref:
+        print("ALL")
+        return 0
+
+    tokens = set()
+    scoped_anything = False
+    for raw in argv[1:]:
+        rel = raw.lstrip("./")
+        if rel == "src/menu-layout.json":
+            # Relocations and removals rewrite the merged menu wholesale — a
+            # single removal can orphan a route declared in a different file.
+            # Do not pretend a per-entry answer exists.
+            tokens.add("ALLMENU")
+            scoped_anything = True
+            continue
+        if "register" in rel and rel.endswith(".json") and rel.startswith("lib/"):
+            # A register edit can invalidate a register/schema slug referenced
+            # from ANY page. There is no per-page answer to be had.
+            print("ALL")
+            return 0
+        if not _is_manifest_page_input(rel):
+            continue
+        if not _scope_one_file(rel, base_ref, tokens):
+            print("ALL")
+            return 0
+        scoped_anything = True
+
+    if not scoped_anything:
+        # No manifest input in the changed set at all. The caller only invokes
+        # us when one WAS touched, so reaching here means our idea of "manifest
+        # input" disagrees with the caller's — do not narrow on a disagreement.
+        print("ALL")
+        return 0
+
+    for token in sorted(tokens):
+        print(token)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/manifest_scope_filter.js
+++ b/hydra-gates/scripts/lib/manifest_scope_filter.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: EUPL-1.2
+//
+// manifest_scope_filter.js — ADR-020 diff scoping for manifest findings.
+//
+// Shared by check_manifest.js and check_manifest_crossref.js (gate-53). Given
+// the scope token file produced by manifest_diff_scope.py and the ASSEMBLED
+// manifest, decide whether a finding BLOCKS this PR or is pre-existing debt on
+// an entry the PR never touched.
+//
+// The split this module encodes:
+//
+//   ANSWERING a cross-reference needs the whole assembled manifest — you cannot
+//   resolve `menu[].route` → page id from a diff. That is why gate-53 is, and
+//   must remain, a whole-manifest CHECK.
+//
+//   BLOCKING on the answer does not. Every finding carries a JSON pointer into
+//   the assembled manifest, and that pointer resolves to a page id, a menu id
+//   or a top-level block. If the PR did not touch that entry, the finding is
+//   inherited debt and must not block — ADR-020.
+//
+// Findings that resolve to NOTHING addressable (pointer `/`, an assembly
+// failure, a whole-document invariant) stay blocking under every scope. Those
+// are the legitimately-whole-repo part of this gate, and they are reported
+// under their own heading so the distinction is visible rather than assumed.
+//
+// Out-of-scope findings are NOT discarded: they are printed as
+// `at <ptr>: PRE-EXISTING <message>` so a reader can still see the debt, and
+// counted separately. Silently dropping them would replace one invisible
+// failure with another.
+
+'use strict'
+
+const fs = require('fs')
+
+/**
+ * Read a scope token file written by manifest_diff_scope.py.
+ *
+ * @param {string} file Path to the token file (one token per line).
+ * @return {object|null} `{ all, allMenu, pages:Set, menu:Set, keys:Set }`, or
+ *   null when no scoping applies (no file given, or unreadable → full-repo).
+ */
+function loadScope(file) {
+	if (!file) return null
+	let text
+	try {
+		text = fs.readFileSync(file, 'utf8')
+	} catch (_) {
+		// An unreadable scope file is an unknown scope, not an empty one.
+		return { all: true, allMenu: true, pages: new Set(), menu: new Set(), keys: new Set() }
+	}
+	const scope = { all: false, allMenu: false, pages: new Set(), menu: new Set(), keys: new Set() }
+	for (const raw of text.split('\n')) {
+		const line = raw.trim()
+		if (!line || line.startsWith('#')) continue
+		if (line === 'ALL') { scope.all = true; continue }
+		if (line === 'ALLMENU') { scope.allMenu = true; continue }
+		const idx = line.indexOf(':')
+		if (idx <= 0) continue
+		const kind = line.slice(0, idx)
+		const value = line.slice(idx + 1)
+		if (kind === 'page') scope.pages.add(value)
+		else if (kind === 'menu') scope.menu.add(value)
+		else if (kind === 'key') scope.keys.add(value)
+	}
+	return scope
+}
+
+function decodeSegment(seg) {
+	return seg.replace(/~1/g, '/').replace(/~0/g, '~')
+}
+
+/**
+ * Resolve a JSON pointer into the assembled manifest to the scope tokens the
+ * finding is attributable to.
+ *
+ * @param {string} ptr JSON pointer, e.g. `/pages/12/config/widgets/0`.
+ * @param {object} manifest The ASSEMBLED manifest.
+ * @return {Array<string>|null} Tokens, or null when the finding addresses
+ *   nothing scopable (a whole-document invariant → always blocking).
+ */
+function tokensForPointer(ptr, manifest) {
+	if (typeof ptr !== 'string' || ptr === '' || ptr === '/') return null
+	const segs = ptr.replace(/^\//, '').split('/').map(decodeSegment)
+	if (segs.length === 0) return null
+	const head = segs[0]
+
+	if (head === 'pages') {
+		const idx = Number(segs[1])
+		const pages = Array.isArray(manifest && manifest.pages) ? manifest.pages : []
+		const page = Number.isInteger(idx) ? pages[idx] : undefined
+		const id = page && typeof page.id === 'string' ? page.id : null
+		// A page whose id cannot be read cannot be attributed — block it.
+		return id ? ['page:' + id] : null
+	}
+
+	if (head === 'menu') {
+		// Walk /menu/<i>[/children/<j>...] collecting every id on the path, so a
+		// finding on a leaf is in scope when either the leaf OR an ancestor was
+		// edited (editing a parent's `order` legitimately re-homes its children).
+		const tokens = []
+		let node = Array.isArray(manifest && manifest.menu) ? manifest.menu : []
+		let i = 1
+		let cursor = node[Number(segs[i])]
+		while (cursor && typeof cursor === 'object') {
+			const id = typeof cursor.id === 'string' ? cursor.id : (typeof cursor.route === 'string' ? cursor.route : null)
+			if (id) tokens.push('menu:' + id)
+			i += 1
+			if (segs[i] !== 'children' || !Array.isArray(cursor.children)) break
+			i += 1
+			cursor = cursor.children[Number(segs[i])]
+		}
+		return tokens.length ? tokens : null
+	}
+
+	// Anything else is a top-level block: /observability/..., /deepLinks/0/...,
+	// /menu-layout/removals/2, /version, ...
+	return ['key:' + head]
+}
+
+/**
+ * Partition findings into blocking vs pre-existing under a diff scope.
+ *
+ * @param {Array<object>} findings Each `{ path, message, ... }`.
+ * @param {object} manifest The assembled manifest.
+ * @param {object|null} scope Result of loadScope(); null → no scoping.
+ * @return {object} `{ blocking, preexisting, unscopable }`.
+ */
+function partition(findings, manifest, scope) {
+	if (!scope || scope.all) {
+		return { blocking: findings.slice(), preexisting: [], unscopable: [] }
+	}
+	const blocking = []
+	const preexisting = []
+	const unscopable = []
+	for (const f of findings) {
+		const tokens = tokensForPointer(f.path, manifest)
+		if (tokens === null) {
+			unscopable.push(f)
+			blocking.push(f)
+			continue
+		}
+		const hit = tokens.some((t) => {
+			if (t.startsWith('page:')) return scope.pages.has(t.slice(5))
+			if (t.startsWith('menu:')) return scope.allMenu || scope.menu.has(t.slice(5))
+			if (t.startsWith('key:')) {
+				const key = t.slice(4)
+				if (key === 'menu' && scope.allMenu) return true
+				if (key === 'menu-layout' && scope.allMenu) return true
+				return scope.keys.has(key)
+			}
+			return true
+		})
+		if (hit) blocking.push(f)
+		else preexisting.push(f)
+	}
+	return { blocking, preexisting, unscopable }
+}
+
+/**
+ * Emit the standard accounting lines for a scoped run.
+ *
+ * @param {string} tag Helper name for the log prefix.
+ * @param {object} parts Result of partition().
+ * @return {void}
+ */
+function reportScope(tag, parts) {
+	if (parts.preexisting.length === 0 && parts.unscopable.length === 0) return
+	for (const f of parts.preexisting) {
+		console.error(`at ${f.path || '/'}: PRE-EXISTING ${String(f.message).split('\n')[0]}`)
+	}
+	if (parts.preexisting.length > 0) {
+		console.error(`[${tag}] diff-scope (ADR-020): ${parts.preexisting.length} finding(s) sit on manifest entries this PR did not touch — reported above as PRE-EXISTING, not blocking.`)
+	}
+	if (parts.unscopable.length > 0) {
+		console.error(`[${tag}] ${parts.unscopable.length} finding(s) address the manifest as a WHOLE (no page/menu entry to attribute them to) and block regardless of scope.`)
+	}
+}
+
+module.exports = { loadScope, tokensForPointer, partition, reportScope }

--- a/hydra-gates/scripts/lib/test_check_manifest.sh
+++ b/hydra-gates/scripts/lib/test_check_manifest.sh
@@ -3,11 +3,25 @@
 #
 # test_check_manifest.sh — gate-22 (manifest-validation) verification.
 #
-# Proves the 3-way contract of scripts/lib/check_manifest.js:
-#   1. valid-apphost   → PASS (observability + deepLinks validated for-real)
+# Proves the contract of scripts/lib/check_manifest.js:
+#   1. valid-apphost     → PASS (observability + deepLinks validated for-real)
 #   2. malformed-apphost → FAIL (unknown check type / metric kind / missing
 #      deepLink required key → really validating, not fail-open)
-#   3. non-apphost     → PASS (no observability/deepLinks → unaffected)
+#   3. non-apphost       → PASS (no observability/deepLinks → unaffected)
+#   4. no Ajv            → exit 3 DEGRADED, never 0. A run that never applied
+#      the schema is not a pass, and it must say so on both channels.
+#   5. --scope-ids       → ADR-020: a finding on an entry the PR did not touch
+#      is reported PRE-EXISTING and does not set the exit code; the SAME
+#      finding does block once that entry is in scope.
+#
+# THE FIXTURES ARE PART OF THIS TEST. Before 2026-08-03 this file referenced
+# ../test-fixtures/manifest-validation/*.json — a directory that has never
+# existed in this repository. `node check_manifest.js <missing-path>` prints
+# "no src/manifest.json — Tier 0, skipping" and exits 0, which is exactly what
+# assertions 1 and 3 expected. Two of the three therefore passed by inspecting
+# NOTHING; only the malformed case (which wanted rc=1) ever reported the truth.
+# A suite that is green because its inputs are absent is the same defect this
+# package exists to catch, one level down.
 #
 # Run twice: once with Ajv available (full schema path) and once with Ajv
 # forced unavailable (structural-lint fallback), so both code paths are covered.
@@ -18,40 +32,112 @@ VALIDATOR="${SCRIPT_DIR}/check_manifest.js"
 FIX="${SCRIPT_DIR}/../test-fixtures/manifest-validation"
 
 _fails=0
-_assert() { # <expected-rc> <fixture> <label>
+_ok() { echo "PASS — $1"; }
+_no() { echo "FAIL — $1"; _fails=$((_fails + 1)); }
+
+# Guard the guard: if the fixtures go missing again, say so rather than quietly
+# re-running the "Tier 0, skipping" exit-0 path and reporting it as green.
+for _f in valid-apphost malformed-apphost non-apphost; do
+	if [ ! -f "${FIX}/${_f}.manifest.json" ]; then
+		echo "FAIL — fixture ${FIX}/${_f}.manifest.json is MISSING; this suite cannot assert anything"
+		exit 1
+	fi
+done
+
+_assert() { # <expected-rc> <fixture> <label> [extra args...]
 	local want="$1" fixture="$2" label="$3" rc
-	node "${VALIDATOR}" "${FIX}/${fixture}" >/tmp/_tcm.log 2>&1
+	shift 3
+	node "${VALIDATOR}" "${FIX}/${fixture}" "$@" >/tmp/_tcm.log 2>&1
 	rc=$?
 	if [ "${rc}" -eq "${want}" ]; then
-		echo "PASS — ${label} (rc=${rc})"
+		_ok "${label} (rc=${rc})"
 	else
-		echo "FAIL — ${label}: expected rc=${want}, got rc=${rc}"
+		_no "${label}: expected rc=${want}, got ${rc}"
 		sed 's/^/    /' /tmp/_tcm.log
-		_fails=$((_fails + 1))
 	fi
 }
 
-run_suite() {
-	echo "== ${1} =="
-	_assert 0 valid-apphost.manifest.json     "valid observability + deepLinks → PASS"
-	_assert 1 malformed-apphost.manifest.json "malformed observability/deepLinks → FAIL"
-	_assert 0 non-apphost.manifest.json       "non-AppHost manifest → PASS (unaffected)"
+_assert_log() { # <grep-ere> <label>
+	if grep -qE "$1" /tmp/_tcm.log; then
+		_ok "$2"
+	else
+		_no "$2 (pattern not found: $1)"
+		sed 's/^/    /' /tmp/_tcm.log
+	fi
 }
 
-# Path A: Ajv available (default resolution).
-run_suite "Ajv path"
+_HAVE_AJV=0
+if node -e "require('ajv/dist/2020')" >/dev/null 2>&1; then _HAVE_AJV=1; fi
 
-# Path B: force Ajv unavailable → structural-lint fallback. NODE_PATH is cleared
-# and a stub module dir shadows nothing; instead we set a flag the validator
-# does not read — so emulate by pointing require at an empty dir. Simplest:
-# run from a dir with no resolvable ajv by overriding NODE_PATH to /nonexistent
-# AND disabling the global cache via a child node that can't find ajv.
-echo
-if NODE_PATH=/nonexistent-no-ajv node -e "try{require('ajv/dist/2020');process.exit(0)}catch(e){process.exit(3)}" 2>/dev/null; then
-	echo "== structural-lint path: SKIPPED (ajv resolvable even with NODE_PATH override; Ajv path already proves the contract) =="
+echo "== Ajv path =="
+if [ "${_HAVE_AJV}" -eq 0 ]; then
+	# Say it out loud rather than reporting a green over a path that never ran —
+	# the caller (CI) is expected to `npm i ajv ajv-formats` first.
+	echo "SKIP — ajv is not resolvable here, so the FULL SCHEMA path was NOT exercised."
+	echo "SKIP — install it (npm i ajv ajv-formats, or set NODE_PATH) to test it for real."
 else
-	NODE_PATH=/nonexistent-no-ajv run_suite "structural-lint path (no Ajv)"
+	_assert 0 valid-apphost.manifest.json     "valid observability + deepLinks → PASS"
+	_assert 1 malformed-apphost.manifest.json "malformed observability/deepLinks → FAIL"
+	_assert_log '^at /observability/health/checks/0/type' "the failure NAMES the bad health-check type"
+	_assert_log '^at /deepLinks/0' "the failure NAMES the incomplete deepLink"
+	_assert 0 non-apphost.manifest.json       "non-AppHost manifest → PASS (unaffected)"
 fi
+
+# --- the degraded contract --------------------------------------------------
+echo
+echo "== no-Ajv path: a weaker check must not report as a pass =="
+if NODE_PATH=/nonexistent-no-ajv node -e "try{require('ajv/dist/2020');process.exit(0)}catch(e){process.exit(3)}" 2>/dev/null; then
+	echo "SKIP — ajv resolves even with NODE_PATH overridden; cannot exercise the degraded path here"
+else
+	NODE_PATH=/nonexistent-no-ajv _assert 3 valid-apphost.manifest.json \
+		"clean manifest without Ajv → exit 3 DEGRADED, NOT 0"
+	_assert_log 'SCHEMA VALIDATION DID NOT HAPPEN' "the degradation is stated in words, not just an exit code"
+	_assert_log '"status":"degraded"' "the machine-readable summary says degraded, not passed"
+	# A real finding must still win: the degradation must never mask a violation.
+	NODE_PATH=/nonexistent-no-ajv _assert 1 malformed-apphost.manifest.json \
+		"malformed manifest without Ajv → exit 1 (a real finding still wins over the degradation)"
+fi
+
+# --- ADR-020 diff scoping ---------------------------------------------------
+echo
+echo "== --scope-ids: findings on untouched entries must not block =="
+_scope_in="$(mktemp)"
+if [ "${_HAVE_AJV}" -eq 0 ]; then
+	# Without Ajv a zero-blocking run correctly exits 3 (DEGRADED), which would
+	# make the exit codes below untestable for the reason they are meant to
+	# test. State the skip; do not weaken the assertions to fit.
+	echo "SKIP — ajv unavailable: a scoped-clean run exits 3 (degraded), so the exit-code contract cannot be isolated here."
+	rm -f "${_scope_in}"
+	if [ "${_fails}" -eq 0 ]; then
+		echo
+		echo "gate-22 manifest-validation: all RUNNABLE assertions PASSED (schema + scope paths SKIPPED — no ajv)"
+		exit 0
+	fi
+	echo
+	echo "${_fails} gate-22 assertion(s) FAILED"
+	exit 1
+fi
+
+# The malformed fixture's findings all hang off top-level blocks
+# (/observability, /deepLinks), so a scope naming a DIFFERENT block must
+# suppress every one of them.
+printf 'key:pages\n' > "${_scope_in}"
+_assert 0 malformed-apphost.manifest.json \
+	"out-of-scope findings → exit 0 (reported, not blocking)" --scope-ids "${_scope_in}"
+_assert_log 'PRE-EXISTING' "out-of-scope findings are still PRINTED, marked PRE-EXISTING"
+
+# Reverse direction on the SAME fixture: this is what makes the pass above
+# evidence rather than an absent check.
+printf 'key:observability\nkey:deepLinks\n' > "${_scope_in}"
+_assert 1 malformed-apphost.manifest.json \
+	"same fixture, entries IN scope → exit 1 (the scoping can fail)" --scope-ids "${_scope_in}"
+_assert_log '^at /observability/health/checks/0/type: must' "an in-scope finding is printed WITHOUT the PRE-EXISTING marker"
+
+printf 'ALL\n' > "${_scope_in}"
+_assert 1 malformed-apphost.manifest.json \
+	"ALL token → nothing is scoped out (fail toward enforcement)" --scope-ids "${_scope_in}"
+
+rm -f "${_scope_in}"
 
 if [ "${_fails}" -eq 0 ]; then
 	echo

--- a/hydra-gates/scripts/lib/test_manifest_diff_scope.py
+++ b/hydra-gates/scripts/lib/test_manifest_diff_scope.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
+# SPDX-License-Identifier: EUPL-1.2
+"""Verification for manifest_diff_scope.py (gate-53 ADR-020 scoping).
+
+Builds a throwaway git repo with a base manifest and a fragment, commits it,
+then edits ONE page and asserts that only that page's token is emitted. The
+reverse direction is asserted too: with nothing edited the token set is empty,
+and with an untracked new fragment the helper returns ``ALL``.
+
+Why the reverse direction matters here specifically: this helper's whole job is
+to make a set SMALLER. A bug that makes it emit nothing would make every gate-53
+finding "pre-existing" and turn the gate off entirely — and the symptom would be
+an unbroken run of green PRs. So every "it narrowed correctly" assertion is
+paired with one proving the narrowing can still produce a hit.
+
+Run: python3 scripts/lib/test_manifest_diff_scope.py   (exit 0 = pass)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HELPER = os.path.join(HERE, "manifest_diff_scope.py")
+
+_fails = []
+
+
+def ok(cond, label):
+    print(("PASS — " if cond else "FAIL — ") + label)
+    if not cond:
+        _fails.append(label)
+
+
+def git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", repo] + list(args),
+        capture_output=True, text=True, check=False,
+    )
+
+
+def page(pid, title="T"):
+    return {"id": pid, "route": "/" + pid.lower(), "type": "index", "title": title}
+
+
+def write_json(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(obj, fh, indent=2)
+        fh.write("\n")
+
+
+def run_helper(repo, base, *files):
+    env = dict(os.environ)
+    env["HYDRA_GATE_BASE_REF"] = base
+    proc = subprocess.run(
+        [sys.executable, HELPER] + list(files),
+        cwd=repo, capture_output=True, text=True, check=False, env=env,
+    )
+    return sorted(l for l in proc.stdout.split("\n") if l.strip())
+
+
+def main():
+    repo = tempfile.mkdtemp(prefix="gate53-scope-")
+    try:
+        git(repo, "init", "-q", ".")
+        git(repo, "config", "user.email", "ci@example.invalid")
+        git(repo, "config", "user.name", "hydra-gates ci")
+
+        base_manifest = {
+            "$schema": "x",
+            "version": "1.0.0",
+            "menu": [
+                {"id": "Alpha", "label": "Alpha", "route": "Alpha"},
+                {"id": "Group", "label": "Group", "children": [
+                    {"id": "Nested", "label": "Nested", "route": "Nested"},
+                ]},
+            ],
+            "pages": [page("Alpha"), page("Beta"), page("Gamma")],
+        }
+        write_json(os.path.join(repo, "src", "manifest.json"), base_manifest)
+        write_json(os.path.join(repo, "src", "manifest.d", "10-extra.json"),
+                   {"pages": [page("Delta")]})
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "base")
+        base_sha = git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        # --- nothing changed --------------------------------------------------
+        tokens = run_helper(repo, base_sha, "src/manifest.json")
+        ok(tokens == [], "unchanged manifest → no tokens (nothing is in scope)")
+
+        # --- one page edited --------------------------------------------------
+        base_manifest["pages"][1]["title"] = "Beta renamed"
+        write_json(os.path.join(repo, "src", "manifest.json"), base_manifest)
+        git(repo, "commit", "-aqm", "touch Beta")
+        tokens = run_helper(repo, base_sha, "src/manifest.json")
+        ok("page:Beta" in tokens, "the edited page IS in scope")
+        ok("page:Alpha" not in tokens and "page:Gamma" not in tokens,
+           "untouched sibling pages are NOT in scope")
+
+        # --- a nested menu child ---------------------------------------------
+        base_manifest["menu"][1]["children"][0]["label"] = "Nested renamed"
+        write_json(os.path.join(repo, "src", "manifest.json"), base_manifest)
+        git(repo, "commit", "-aqm", "touch nested menu child")
+        tokens = run_helper(repo, base_sha, "src/manifest.json")
+        ok("menu:Nested" in tokens, "an edited nested menu child IS in scope")
+        ok("menu:Alpha" not in tokens, "an untouched top-level menu entry is NOT in scope")
+
+        # --- a fragment, not the base ----------------------------------------
+        frag_path = os.path.join(repo, "src", "manifest.d", "10-extra.json")
+        write_json(frag_path, {"pages": [page("Delta", "Delta renamed")]})
+        git(repo, "commit", "-aqm", "touch Delta in a fragment")
+        tokens = run_helper(repo, base_sha, "src/manifest.d/10-extra.json")
+        ok("page:Delta" in tokens, "a page edited inside a FRAGMENT is in scope")
+
+        # --- menu-layout is whole-menu ---------------------------------------
+        write_json(os.path.join(repo, "src", "menu-layout.json"), {"removals": ["Alpha"]})
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "add menu-layout")
+        tokens = run_helper(repo, base_sha, "src/menu-layout.json")
+        ok(tokens == ["ALLMENU"],
+           "menu-layout.json → ALLMENU (relocations/removals restructure the whole menu)")
+
+        # --- unknowable scope → ALL -------------------------------------------
+        write_json(os.path.join(repo, "src", "manifest.d", "20-new.json"),
+                   {"pages": [page("Epsilon")]})
+        tokens = run_helper(repo, base_sha, "src/manifest.d/20-new.json")
+        ok(tokens == ["ALL"],
+           "a manifest input untracked at base → ALL (fail toward enforcement)")
+
+        tokens = run_helper(repo, base_sha, "lib/Settings/fixture_register.json")
+        ok(tokens == ["ALL"],
+           "a changed register JSON → ALL (a register edit can orphan any page)")
+
+        # --- no base ref at all ------------------------------------------------
+        proc = subprocess.run(
+            [sys.executable, HELPER, "src/manifest.json"],
+            cwd=repo, capture_output=True, text=True, check=False,
+            env={k: v for k, v in os.environ.items() if k != "HYDRA_GATE_BASE_REF"},
+        )
+        ok(proc.stdout.strip() == "ALL", "no HYDRA_GATE_BASE_REF → ALL (a full-repo run scopes nothing)")
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+    print()
+    if _fails:
+        print(f"{len(_fails)} manifest_diff_scope assertion(s) FAILED")
+        return 1
+    print("ALL manifest_diff_scope assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hydra-gates/scripts/lib/test_manifest_scope_filter.js
+++ b/hydra-gates/scripts/lib/test_manifest_scope_filter.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: EUPL-1.2
+//
+// test_manifest_scope_filter.js — verification for manifest_scope_filter.js.
+//
+// This module decides which gate-53 findings BLOCK a PR. Its failure modes are
+// asymmetric and both are dangerous:
+//
+//   too wide  → gate-53 blocks every manifest-touching PR on inherited debt,
+//               which is how the gate ends up switched off (the bug this
+//               module was written to fix: pipelinq 24/24, shillinq 246/246).
+//   too narrow → every finding becomes "pre-existing" and the gate silently
+//               stops enforcing while continuing to print PASS.
+//
+// So every assertion here is paired: something must be suppressed AND something
+// must survive, over the same manifest and the same finding set.
+//
+// Run: node scripts/lib/test_manifest_scope_filter.js   (exit 0 = pass)
+
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const filter = require('./manifest_scope_filter.js')
+
+let fails = 0
+function assert(cond, label) {
+	console.log((cond ? 'PASS — ' : 'FAIL — ') + label)
+	if (!cond) fails++
+}
+
+const manifest = {
+	menu: [
+		{ id: 'Alpha', route: 'Alpha' },
+		{ id: 'Group', children: [{ id: 'Nested', route: 'Nested' }] },
+	],
+	pages: [
+		{ id: 'Alpha', type: 'index' },
+		{ id: 'Beta', type: 'index' },
+		{ id: 'Untitled' },
+		{ type: 'index' }, // no id — unattributable on purpose
+	],
+	deepLinks: [{ registerSlug: 'r', schemaSlug: 's' }],
+}
+
+function scopeFrom(lines) {
+	const f = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'scopefilter-')), 'scope')
+	fs.writeFileSync(f, lines.join('\n') + '\n')
+	return filter.loadScope(f)
+}
+
+// --- pointer attribution ----------------------------------------------------
+assert(JSON.stringify(filter.tokensForPointer('/pages/1/config/widgets/0', manifest)) === '["page:Beta"]',
+	'a deep pointer under a page attributes to that page id')
+assert(filter.tokensForPointer('/pages/3', manifest) === null,
+	'a page with no id is UNATTRIBUTABLE (null) — it must not be silently scoped out')
+assert(filter.tokensForPointer('/pages/99', manifest) === null,
+	'an out-of-range page index is unattributable, not "page:undefined"')
+assert(JSON.stringify(filter.tokensForPointer('/menu/1/children/0', manifest)) === '["menu:Group","menu:Nested"]',
+	'a nested menu pointer collects BOTH the ancestor and the leaf id')
+assert(JSON.stringify(filter.tokensForPointer('/deepLinks/0/urlTemplate', manifest)) === '["key:deepLinks"]',
+	'a top-level block attributes to its key')
+assert(filter.tokensForPointer('/', manifest) === null,
+	'the root pointer is a whole-document finding (null → always blocking)')
+assert(filter.tokensForPointer('', manifest) === null,
+	'an empty pointer is a whole-document finding')
+
+// --- partition, both directions ---------------------------------------------
+const findings = [
+	{ path: '/pages/0', message: 'alpha finding' },
+	{ path: '/pages/1', message: 'beta finding' },
+	{ path: '/menu/1/children/0', message: 'nested menu finding' },
+	{ path: '/deepLinks/0', message: 'deeplink finding' },
+	{ path: '/pages/3', message: 'unattributable finding' },
+]
+
+{
+	const parts = filter.partition(findings, manifest, scopeFrom(['page:Beta']))
+	const blockingPaths = parts.blocking.map((f) => f.path).sort()
+	assert(blockingPaths.join(',') === '/pages/1,/pages/3',
+		'scope page:Beta → only the Beta finding blocks, plus the unattributable one')
+	assert(parts.preexisting.length === 3,
+		'the other three are reported as PRE-EXISTING, not discarded')
+	assert(parts.unscopable.length === 1,
+		'the unattributable finding is counted as whole-manifest')
+}
+
+{
+	// Reverse direction over the SAME inputs: change only the scope.
+	const parts = filter.partition(findings, manifest, scopeFrom(['page:Alpha']))
+	assert(parts.blocking.some((f) => f.path === '/pages/0'),
+		'scope page:Alpha → the Alpha finding blocks (the filter can select either way)')
+	assert(!parts.blocking.some((f) => f.path === '/pages/1'),
+		'…and Beta is now the suppressed one')
+}
+
+{
+	const parts = filter.partition(findings, manifest, scopeFrom(['menu:Nested']))
+	assert(parts.blocking.some((f) => f.path === '/menu/1/children/0'),
+		'a menu-leaf scope token blocks the leaf finding')
+}
+
+{
+	const parts = filter.partition(findings, manifest, scopeFrom(['ALLMENU']))
+	assert(parts.blocking.some((f) => f.path === '/menu/1/children/0'),
+		'ALLMENU puts every menu finding in scope')
+	assert(!parts.blocking.some((f) => f.path === '/pages/0'),
+		'…but ALLMENU does not drag pages in')
+}
+
+{
+	const parts = filter.partition(findings, manifest, scopeFrom(['ALL']))
+	assert(parts.blocking.length === findings.length && parts.preexisting.length === 0,
+		'ALL → nothing is scoped out')
+}
+
+{
+	const parts = filter.partition(findings, manifest, null)
+	assert(parts.blocking.length === findings.length,
+		'no scope at all (full-repo run) → every finding blocks')
+}
+
+{
+	const parts = filter.partition(findings, manifest, filter.loadScope('/nonexistent/scope/file'))
+	assert(parts.blocking.length === findings.length,
+		'an UNREADABLE scope file is an unknown scope, not an empty one — everything blocks')
+}
+
+console.log('')
+if (fails > 0) {
+	console.log(`${fails} manifest_scope_filter assertion(s) FAILED`)
+	process.exit(1)
+}
+console.log('ALL manifest_scope_filter assertions PASSED')

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -66,13 +66,24 @@ set -u
 # /some/app`), because the relative script path no longer resolves from inside
 # the app dir.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+# Absolute path to THIS file. The summary reads its own gate inventory back out
+# of it (see the coverage block at the bottom) rather than hardcoding a count —
+# a hardcoded "63" goes stale the first time someone adds gate 64, and a
+# coverage assertion measured against a stale inventory is the very defect the
+# assertion exists to catch.
+RUNNER_SELF="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]:-$0}")"
 
 SCOPE_TO_DIFF=0
 BASE_REF="origin/development"
 APP_DIR=""
+# Treat "a declared gate did not run" as a failure (exit 98). Off by default so
+# a Tier-0 app is not blocked by gates it has no surface for; on, the run
+# refuses to report green while any gate's subject matter is unverified.
+REQUIRE_FULL_COVERAGE="${HYDRA_GATE_REQUIRE_FULL_COVERAGE:-0}"
 while [ $# -gt 0 ]; do
     case "$1" in
         --scope-to-diff) SCOPE_TO_DIFF=1; shift ;;
+        --require-full-coverage) REQUIRE_FULL_COVERAGE=1; shift ;;
         --base) BASE_REF="$2"; shift 2 ;;
         --base=*) BASE_REF="${1#--base=}"; shift ;;
         *) APP_DIR="$1"; shift ;;
@@ -222,9 +233,60 @@ _enum_tracked() {
         | sort -u || true
 }
 
+# ---------------------------------------------------------------------------
+# _count <pattern> <file>  — how many lines of <file> match <pattern> (ERE).
+#
+# `grep -c` ALREADY prints the count on no-match ("0") and THEN exits 1, so the
+# idiom `$(grep -c … || echo 0)` captures BOTH: the variable becomes the
+# two-line string "0\n0". `[ "0\n0" -eq 0 ]` is not an integer comparison — it
+# errors to stderr and returns 2, so the "clamp to at least 1" guard that
+# follows never fires, and the failure message is emitted with an embedded
+# newline. That is how gate-22 came to print
+#
+#     [gate-22] manifest-validation: FAIL — 0
+#     1 schema violation(s) in src/manifest.json — see /tmp/…
+#
+# on opencatalogi: a real finding sat in the log, the count line read "0", and
+# the rest of the message was orphaned onto a second line that no `^\[gate-`
+# consumer parses. Diagnosed once before at gate-17 and fixed there only; eight
+# other call sites still carried it. One helper, used everywhere.
+# ---------------------------------------------------------------------------
+_count() {
+    local _n
+    _n=$(grep -cE "$1" "$2" 2>/dev/null) || true
+    _n="${_n%%$'\n'*}"
+    case "${_n}" in ''|*[!0-9]*) _n=0 ;; esac
+    printf '%s' "${_n}"
+}
+
 _FAILED=0
-_fail() { echo "[gate-$1] $2: FAIL${3:+ — $3}"; _FAILED=$((_FAILED + 1)); }
-_pass() { echo "[gate-$1] $2: PASS"; }
+_EMITTED_GATES=""
+_SKIPPED_GATES=""
+# A reason may arrive with embedded newlines (a helper echoing a multi-line
+# message, a miscounted variable). Flatten it: the contract of this runner's
+# stdout is ONE `[gate-N] name: VERDICT` line per gate, and every consumer —
+# bin/hydra-gates' coverage assertion, the reviewer skill, the builder's Rule 0b
+# wrapper — anchors on `^\[gate-`. A verdict that wraps onto a second line is
+# a verdict that silently loses its own reason.
+_fail() {
+    local _reason
+    _reason=$(printf '%s' "${3:-}" | tr '\n' ' ')
+    echo "[gate-$1] $2: FAIL${_reason:+ — ${_reason}}"
+    _FAILED=$((_FAILED + 1))
+    _EMITTED_GATES="${_EMITTED_GATES}$1 "
+}
+_pass() { echo "[gate-$1] $2: PASS"; _EMITTED_GATES="${_EMITTED_GATES}$1 "; }
+
+# _skip <n> <name> <reason> — the gate did NOT run. Distinct from PASS on
+# purpose: a prerequisite was absent, so the gate inspected NOTHING and its
+# subject matter is UNVERIFIED. Recorded separately so the summary can never
+# fold it into an "ALL GATES GREEN" banner.
+_skip() {
+    local _reason
+    _reason=$(printf '%s' "${3:-}" | tr '\n' ' ')
+    echo "[gate-$1] $2: SKIPPED — ${_reason}"
+    _SKIPPED_GATES="${_SKIPPED_GATES}$1 "
+}
 
 # An abort before the summary (set -e / set -u, a helper blowing up, ...) used
 # to be indistinguishable from a completed run: the per-gate PASS lines were
@@ -234,6 +296,11 @@ _pass() { echo "[gate-$1] $2: PASS"; }
 # reported as green because nobody noticed the summary was missing.
 # Make that failure mode impossible to misread.
 _SUMMARY_REACHED=0
+# `_rc` is assigned inside the trap body below, which ShellCheck analyses as its
+# own scope. Seed it here so the reference is unambiguous — it used to be
+# incidentally satisfied by an unrelated `_rc=$?` in gate-22, which is not
+# something the trap should depend on.
+_rc=0
 trap '_rc=$?; if [ "${_SUMMARY_REACHED}" -eq 0 ]; then
         echo "" >&2
         echo "[hydra-gates] ABORTED before the summary (exit ${_rc}) — GATE COVERAGE IS INCOMPLETE." >&2
@@ -1355,14 +1422,42 @@ fi
 #
 # Behavior:
 #   - No src/manifest.json   → skip (PASS quietly, no log line)
-#   - Has src/manifest.json:
-#       * Run `npm run check:manifest` if defined in package.json
-#       * Otherwise fall back to a thin Node one-liner that imports
-#         validateManifest from @conduction/nextcloud-vue and runs it
-#       * If the library is missing from node_modules → log warning + PASS
-#         (fail-open per spec — apps mid-migration may not have installed
-#         the renderer yet)
-#       * If validateManifest reports errors → FAIL with error count
+#   - Has src/manifest.json  → validate it with the HYDRA-VENDORED canonical
+#     validator, scripts/lib/check_manifest.js (the same one gate-53 runs over
+#     the assembled manifest): canonical ADR-040 schema, merged AppHost blocks,
+#     plus the post-schema semantic checks JSON Schema cannot express.
+#
+# WHY THE APP'S OWN `npm run check:manifest` IS NO LONGER THE AUTHORITY
+# (2026-08-03). The gate used to PREFER the app's package.json script and only
+# fall back to the vendored validator. Three things follow from that, all of
+# them measured:
+#
+#   1. The verdict was app-owned. pipelinq's `check:manifest` is a 50-line
+#      structural guard that asserts four top-level keys exist; it certifies any
+#      manifest as OK. An app could turn a fleet gate green by writing a weaker
+#      checker — the exact "I made the gate green by lying" shape gate-35 exists
+#      to catch elsewhere.
+#   2. The verdict was WRONG in the other direction too. opencatalogi's and
+#      shillinq's `check:manifest` runs tests/validate-manifest.js against a
+#      per-app vendored schema copy, which without Ajv falls back to a hardcoded
+#      "v1.x enum" that predates ADR-040. It rejects `type: "roadmap"` — a page
+#      type the CANONICAL schema has accepted since 2.x. gate-22 was failing
+#      apps for conforming to the standard.
+#   3. Those app scripts announce their own downgrade
+#      ("no schema candidate resolved; falling back to structural lint") on a
+#      line the gate neither surfaced nor acted on.
+#
+# The app script still RUNS when defined — its output is captured and surfaced
+# as an advisory line — but it can no longer decide this gate.
+#
+# FAIL-CLOSED ON A DEGRADED VALIDATION (exit 3). If Ajv cannot be resolved, the
+# vendored validator can only run its structural lint, which checks the AppHost
+# blocks and nothing else. Reporting that as PASS is a silent fallback to a
+# weaker check — the defect class this package exists to remove — so it FAILs
+# with a named reason instead, exactly as gate-53 already refuses to run without
+# Ajv. `ajv` is in every fleet app's package-lock.json, so a `npm ci` (which CI
+# does) resolves it; a bare checkout without node_modules will now say so out
+# loud rather than certifying a manifest it never schema-validated.
 #
 # Skill: .claude/skills/hydra-gate-manifest-validation/SKILL.md
 # Spec: openspec/changes/adopt-app-manifest/specs/adopt-app-manifest/spec.md
@@ -1370,66 +1465,43 @@ fi
 if [ -f src/manifest.json ]; then
     _mv_log=/tmp/hydra-gate-manifest-validation.log
     : > "${_mv_log}"
-    _mv_fail=0
+    _mv_validator="${SCRIPT_DIR}/lib/check_manifest.js"
     # Diff-scope: when --scope-to-diff is set and src/manifest.json was NOT
     # touched in this PR, the gate runs informationally (PASS without
     # spending time on a clean manifest the PR didn't touch).
     if [ "${SCOPE_TO_DIFF}" = "1" ] && ! _in_scope "src/manifest.json"; then
         _pass 22 "manifest-validation"
+    elif [ ! -f "${_mv_validator}" ]; then
+        _fail 22 "manifest-validation" "vendored validator missing at ${_mv_validator} — gate misconfiguration, fail-closed"
     else
-        # Prefer the package.json `check:manifest` script — apps adopting
-        # the convention add it per ADR-024.
+        set +e
+        node "${_mv_validator}" src/manifest.json >> "${_mv_log}" 2>&1
+        _mv_rc=$?
+        set -e
+        # Advisory: run the app's own check:manifest when it exists, purely so
+        # a divergence between it and the canonical validator is VISIBLE.
+        _mv_app_note=""
         if [ -f package.json ] && grep -q '"check:manifest"' package.json 2>/dev/null; then
-            if npm run --silent check:manifest >> "${_mv_log}" 2>&1; then
-                _pass 22 "manifest-validation"
-            else
-                _mv_fail=$(grep -cE 'at /|error:|ERROR' "${_mv_log}" 2>/dev/null || echo 1)
-                [ "${_mv_fail}" -eq 0 ] && _mv_fail=1
-                _fail 22 "manifest-validation" "${_mv_fail} schema violation(s) in src/manifest.json — see ${_mv_log}"
+            echo "--- advisory: the app's own \`npm run check:manifest\` (NOT the gate verdict) ---" >> "${_mv_log}"
+            set +e
+            npm run --silent check:manifest >> "${_mv_log}" 2>&1
+            _mv_app_rc=$?
+            set -e
+            if [ "${_mv_app_rc}" -ne 0 ]; then
+                _mv_app_note=" [advisory: the app's own check:manifest also exits ${_mv_app_rc} — see ${_mv_log}]"
             fi
-        elif [ -f node_modules/@conduction/nextcloud-vue/src/utils/validateManifest.js ] \
-          || [ -f node_modules/@conduction/nextcloud-vue/dist/utils/validateManifest.js ]; then
-            # Fallback: invoke validateManifest directly via node one-liner.
-            # Apps that haven't wired `check:manifest` into package.json yet
-            # still get gated, as long as the library is installed.
-            node -e "
-                const fs = require('fs');
-                const path = require('path');
-                let validateManifest;
-                try {
-                    validateManifest = require('@conduction/nextcloud-vue/utils/validateManifest').validateManifest
-                        || require('@conduction/nextcloud-vue').validateManifest;
-                } catch (e) {
-                    console.error('validateManifest library not installed; skipping');
-                    process.exit(0);
-                }
-                if (typeof validateManifest !== 'function') {
-                    console.error('validateManifest export missing — library version mismatch; skipping');
-                    process.exit(0);
-                }
-                const manifest = JSON.parse(fs.readFileSync('src/manifest.json', 'utf8'));
-                const result = validateManifest(manifest);
-                if (result && result.valid === false) {
-                    for (const err of (result.errors || [])) {
-                        console.error('at ' + (err.instancePath || err.dataPath || '/') + ': ' + (err.message || JSON.stringify(err)));
-                    }
-                    process.exit(1);
-                }
-                process.exit(0);
-            " >> "${_mv_log}" 2>&1
-            _rc=$?
-            if [ "${_rc}" -eq 0 ]; then
-                _pass 22 "manifest-validation"
-            else
-                _mv_fail=$(grep -cE '^at /' "${_mv_log}" 2>/dev/null || echo 1)
-                [ "${_mv_fail}" -eq 0 ] && _mv_fail=1
-                _fail 22 "manifest-validation" "${_mv_fail} schema violation(s) in src/manifest.json — see ${_mv_log}"
-            fi
-        else
-            # Fail-open per spec: missing library is treated as warning + PASS.
-            echo "validateManifest library not installed; skipping" >> "${_mv_log}"
-            _pass 22 "manifest-validation"
         fi
+        if grep -q 'no schema candidate resolved\|falling back to structural lint\|Falling back to a structural lint' "${_mv_log}" 2>/dev/null; then
+            echo "[gate-22] NOTE: an app-local manifest checker announced a fallback to a weaker structural lint. That line is advisory only — this gate's verdict comes from the vendored canonical validator."
+        fi
+        case "${_mv_rc}" in
+            0)  _pass 22 "manifest-validation" ;;
+            3)  _fail 22 "manifest-validation" "SCHEMA VALIDATION DID NOT HAPPEN — Ajv is not resolvable, so the vendored validator could only run its AppHost structural lint. A weaker check reported as a pass is not a pass. Run \`npm ci\` (ajv is already in package-lock.json) or set NODE_PATH; see ${_mv_log}" ;;
+            2)  _fail 22 "manifest-validation" "vendored canonical schema could not be loaded — gate misconfiguration; see ${_mv_log}" ;;
+            *)  _mv_fail=$(_count '^at ' "${_mv_log}")
+                [ "${_mv_fail}" -eq 0 ] && _mv_fail=1
+                _fail 22 "manifest-validation" "${_mv_fail} schema violation(s) in src/manifest.json — see ${_mv_log}${_mv_app_note}" ;;
+        esac
     fi
 fi
 
@@ -1474,7 +1546,7 @@ if [ -d lib ]; then
         else
             # In BLOCK mode (post bake-in epoch) the script exits 1 on any
             # match. Count the per-rule lines in the log.
-            _or_abs_hits=$(grep -cE '^\s+\[' "${_or_abs_log}" 2>/dev/null || echo 0)
+            _or_abs_hits=$(_count '^\s+\[' "${_or_abs_log}")
             [ "${_or_abs_hits}" -eq 0 ] && _or_abs_hits=1
             _fail 23 "or-abstraction-anti-patterns" "${_or_abs_hits} OR-abstraction match(es) — see ${_or_abs_log}"
         fi
@@ -1541,8 +1613,16 @@ fi
 #           (Decision 4 — parity correlation is a gate-24 concern; Decision 7 —
 #           renderMode-keyed render pair + server↔JS renderMode agreement).
 # ---------------------------------------------------------------------------
+#
+# Like gate-33, this gate used to vanish without a trace when its prerequisite
+# was absent: no scripts/check-integration-parity.sh → no output at all. It was
+# measured absent in MOST fleet repos on 2026-08-03, which is why fleet coverage
+# was never the declared gate count anywhere. It now says so.
 _parity_log=/tmp/hydra-gate-integration-parity.log
 : > "${_parity_log}"
+if [ ! -f scripts/check-integration-parity.sh ]; then
+    _skip 24 "integration-parity" "no scripts/check-integration-parity.sh in this repo — server↔JS leaf parity (ADR-066 Decisions 4/7: phantom render surfaces, orphan JS registrations, renderMode mismatch) was NOT checked."
+fi
 if [ -f scripts/check-integration-parity.sh ]; then
     if bash scripts/check-integration-parity.sh >> "${_parity_log}" 2>&1; then
         # The WARN-only ADR-066 cross-ref advisory lines start with `⚠`/its
@@ -1557,7 +1637,7 @@ if [ -f scripts/check-integration-parity.sh ]; then
         # WARN-only advisory lines carry "phantom"/"orphan"/"NO matching" and a
         # `⚠` header — never "missing"/"mismatch"/`^✗` — so this hard-failure
         # count excludes them by construction.
-        _parity_hits=$(grep -cE '^✗|missing|mismatch' "${_parity_log}" 2>/dev/null || echo 0)
+        _parity_hits=$(_count '^✗|missing|mismatch' "${_parity_log}")
         [ "${_parity_hits}" -eq 0 ] && _parity_hits=1
         _fail 24 "integration-parity" "${_parity_hits} parity violation(s) — see ${_parity_log}"
     fi
@@ -1993,15 +2073,30 @@ fi
 # can reliably detect. See WCAG 2.2 AA SC 1.4.3, 1.4.11, 1.3.1, 4.1.2, 4.1.3.
 #
 # Contract: if `tests/axe/report.json` exists, parse its `violations` array
-# and fail on any entry with `impact` of `serious` or `critical`. If the
-# report file does not exist, the gate SKIPS silently — the test runner
-# either didn't run axe yet, or this app doesn't have a browser-test stage.
-# This mirrors gate-4 (composer-audit) which skips when composer.json is
-# absent.
+# and fail on any entry with `impact` of `serious` or `critical`.
 #
-# To produce the report, add an axe-core invocation to the Playwright
-# session inside `scripts/run-browser-tests.sh`. See the `hydra-gate-axe`
-# skill for the canonical Playwright snippet.
+# THIS GATE HAS NEVER RUN — ANYWHERE (measured 2026-08-03, fleet-wide).
+#
+# The report it consumes is documented as the output of
+# `scripts/run-browser-tests.sh`. That script exists in NO app in the fleet,
+# and `tests/axe/report.json` exists in none either — while `axe-core` sits in
+# every app's package.json devDependencies, so the prerequisite LOOKS wired.
+# Until 2026-08-03 the missing report made the gate emit NOTHING: no line, no
+# count, no trace. Its silence was byte-identical to a pass, and it disappeared
+# under an "ALL 63 GATES GREEN" banner. Every green this fleet has produced
+# therefore excluded accessibility RUNTIME checking (contrast, landmark
+# structure, ARIA validity, live regions) — the exact class of defect the
+# static gates 31/32/35-45 cannot see.
+#
+# It now reports SKIPPED with the reason, is counted as NOT RUN by the summary
+# and by bin/hydra-gates' coverage assertion, and can be made a hard failure
+# with --require-full-coverage.
+#
+# To make it RUN: produce tests/axe/report.json from the app's Playwright
+# suite (`@axe-core/playwright` → `new AxeBuilder({ page }).analyze()` →
+# `fs.writeFileSync('tests/axe/report.json', JSON.stringify(results))`), or
+# add the documented scripts/run-browser-tests.sh. See the `hydra-gate-axe`
+# skill for the canonical snippet.
 #
 # References:
 #   - ADR-010 (NL Design — WCAG 2.2 AA)
@@ -2009,6 +2104,13 @@ fi
 #   - .claude/skills/hydra-gate-axe/SKILL.md (how the report is produced)
 # ---------------------------------------------------------------------------
 _axe_report="tests/axe/report.json"
+if [ ! -f "${_axe_report}" ]; then
+    if [ -d src ]; then
+        _skip 33 "axe-core" "no ${_axe_report} in this repo — axe-core never ran against a rendered DOM, so contrast / landmark / ARIA-validity / live-region accessibility is UNVERIFIED. Produce the report from the Playwright suite (@axe-core/playwright) or add scripts/run-browser-tests.sh."
+    else
+        _skip 33 "axe-core" "no src/ and no ${_axe_report} — no frontend to run axe-core against in this repo."
+    fi
+fi
 if [ -f "${_axe_report}" ]; then
     _axe_log=/tmp/hydra-gate-axe.log
     : > "${_axe_log}"
@@ -2849,9 +2951,18 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
     _csrf_removed=$(git diff -U0 "${BASE_REF}...HEAD" -- 'lib/Controller/*.php' 2>/dev/null \
         | grep -E '^-.*(@NoCSRFRequired|#\[NoCSRFRequired\])' || true)
     if [ -n "${_csrf_removed}" ]; then
-        # Look for frontend co-change signals in the diff
+        # Look for frontend co-change signals in the diff.
+        #
+        # The `|| echo 0` here was worse than cosmetic: on ZERO signals grep
+        # printed "0" and exited 1, the fallback appended a second "0", and the
+        # `-eq 0` test below then ERRORED on "0\n0" and took the else branch —
+        # i.e. "no frontend co-change at all" was read as "co-change found" and
+        # the gate PASSED. A CSRF-protection removal with no frontend counterpart
+        # is precisely what this gate exists to stop, so the bug was fail-OPEN.
         _csrf_fe_signals=$(git diff "${BASE_REF}...HEAD" -- 'src/**/*.vue' 'src/**/*.js' 'src/**/*.ts' 2>/dev/null \
-            | grep -cE '^\+.*(OCS-APIRequest|requesttoken|@nextcloud/axios|getRequestToken)' 2>/dev/null || echo 0)
+            | grep -cE '^\+.*(OCS-APIRequest|requesttoken|@nextcloud/axios|getRequestToken)' 2>/dev/null || true)
+        _csrf_fe_signals="${_csrf_fe_signals%%$'\n'*}"
+        case "${_csrf_fe_signals}" in ''|*[!0-9]*) _csrf_fe_signals=0 ;; esac
         if [ "${_csrf_fe_signals}" -eq 0 ]; then
             # Check for opt-out
             _csrf_optout_re='\[hydra-gate-csrf-cochange exclude\][[:space:]]+.{20,}'
@@ -3261,6 +3372,66 @@ if [ -f src/manifest.json ]; then
         # manifest for real — refuse to run fail-open (fleet-sweep guard).
         _fail 53 "effective-manifest-crossref" "ajv not resolvable from ${SCRIPT_DIR}/lib — refusing to run fail-open (set NODE_PATH or install ajv)"
     else
+        # ---------------------------------------------------------------
+        # ADR-020 diff scope (fixed 2026-08-03). The trigger above is FILE
+        # granularity — and because an app's whole navigation surface lives in
+        # one input set, file granularity was indistinguishable from no scoping:
+        # a one-line `title` change reproduced the full-repo finding count
+        # exactly (pipelinq 24/24, shillinq 246/246, every finding on a page the
+        # PR had never touched).
+        #
+        # The joins are still ANSWERED over the whole assembled manifest — a
+        # menu route cannot be resolved to a page id from a diff, and that part
+        # of this gate is legitimately whole-repo. What changes is which answers
+        # BLOCK: a finding blocks when the PR touched the page / menu entry /
+        # top-level block it is about. Findings that address the manifest as a
+        # whole keep blocking under every scope and are reported as such.
+        # ---------------------------------------------------------------
+        _em_scope_file=""
+        _em_scoper="${SCRIPT_DIR}/lib/manifest_diff_scope.py"
+        if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -f "${_em_scoper}" ]; then
+            _em_scope_file=$(mktemp /tmp/hydra-gate53-scope.XXXXXX 2>/dev/null || true)
+            if [ -n "${_em_scope_file}" ]; then
+                _em_inputs=()
+                while IFS= read -r _em_f; do
+                    [ -z "${_em_f}" ] && continue
+                    case "${_em_f}" in
+                        src/manifest.json|src/manifest.d/*|src/menu-layout.json|lib/Settings/*register*.json)
+                            _em_inputs+=("${_em_f}") ;;
+                    esac
+                done <<< "${CHANGED_FILES}"
+                set +e
+                if [ "${#_em_inputs[@]}" -gt 0 ]; then
+                    HYDRA_GATE_BASE_REF="${BASE_REF}" \
+                        python3 "${_em_scoper}" "${_em_inputs[@]}" > "${_em_scope_file}" 2>>"${_em_log}"
+                    _em_scope_rc=$?
+                else
+                    # The trigger said a manifest input changed; we found none.
+                    # A disagreement is not a narrow scope.
+                    echo "ALL" > "${_em_scope_file}"
+                    _em_scope_rc=0
+                fi
+                set -e
+                if [ "${_em_scope_rc}" -ne 0 ]; then
+                    # Could not compute a scope → do not narrow. Say so.
+                    echo "ALL" > "${_em_scope_file}"
+                    echo "[gate-53] scope computation failed (rc=${_em_scope_rc}) — running UNSCOPED (fail toward enforcement)."
+                fi
+                if grep -qx 'ALL' "${_em_scope_file}" 2>/dev/null; then
+                    echo "[gate-53] diff scope is INDETERMINATE for this PR (new/untracked manifest input, or a register JSON changed) — every finding blocks."
+                fi
+            fi
+        fi
+        # Built as two plain words rather than an array: `"${arr[@]}"` on an
+        # EMPTY array is an unbound-variable error under `set -u` on bash < 4.4,
+        # and this runner ships into containers we do not choose the bash of.
+        _em_scope_flag=""
+        _em_scope_val=""
+        if [ -n "${_em_scope_file}" ]; then
+            _em_scope_flag="--scope-ids"
+            _em_scope_val="${_em_scope_file}"
+        fi
+
         _em_tmp=$(mktemp /tmp/hydra-gate53-effective.XXXXXX.json 2>/dev/null || true)
         _em_reason=""
         if [ -z "${_em_tmp}" ]; then
@@ -3268,21 +3439,42 @@ if [ -f src/manifest.json ]; then
             _em_reason="mktemp failed — cannot write the assembled manifest (fail-closed)"
         elif ! node "${_em_builder}" --app-dir . --out "${_em_tmp}" >> "${_em_log}" 2>&1; then
             _em_reason="effective manifest could not be assembled (bad JSON input?) — see ${_em_log}"
-        elif ! node "${_em_validator}" "${_em_tmp}" >> "${_em_log}" 2>&1; then
-            _em_n=$(grep -cE '^at ' "${_em_log}" 2>/dev/null || true)
-            { [ -z "${_em_n}" ] || [ "${_em_n}" -eq 0 ]; } && _em_n=1
-            _em_reason="${_em_n} structural violation(s) in the ASSEMBLED manifest (base+fragments+menu-layout) — see ${_em_log}"
-        elif ! node "${_em_crossref}" --app-dir . --manifest "${_em_tmp}" >> "${_em_log}" 2>&1; then
-            # Count error-severity findings only — WARN lines never fail.
-            _em_n=$(grep -E '^at ' "${_em_log}" 2>/dev/null | grep -cv ': WARN ' || true)
-            { [ -z "${_em_n}" ] || [ "${_em_n}" -eq 0 ]; } && _em_n=1
-            _em_reason="${_em_n} cross-reference failure(s) in the effective manifest — see ${_em_log}"
+        else
+            set +e
+            node "${_em_validator}" "${_em_tmp}" ${_em_scope_flag} ${_em_scope_val} >> "${_em_log}" 2>&1
+            _em_val_rc=$?
+            set -e
+            if [ "${_em_val_rc}" -eq 3 ]; then
+                _em_reason="SCHEMA VALIDATION DID NOT HAPPEN — the vendored validator degraded to its structural lint (Ajv unresolvable mid-run); see ${_em_log}"
+            elif [ "${_em_val_rc}" -ne 0 ]; then
+                # Blocking findings only — PRE-EXISTING/WARN lines are excluded
+                # by the prefix, so the count is what this PR must actually fix.
+                _em_n=$(grep -E '^at ' "${_em_log}" 2>/dev/null | grep -cvE ': (WARN|PRE-EXISTING) ' || true)
+                { [ -z "${_em_n}" ] || [ "${_em_n}" -eq 0 ]; } && _em_n=1
+                _em_reason="${_em_n} structural violation(s) in the ASSEMBLED manifest (base+fragments+menu-layout) — see ${_em_log}"
+            else
+                set +e
+                node "${_em_crossref}" --app-dir . --manifest "${_em_tmp}" ${_em_scope_flag} ${_em_scope_val} >> "${_em_log}" 2>&1
+                _em_cr_rc=$?
+                set -e
+                if [ "${_em_cr_rc}" -ne 0 ]; then
+                    _em_n=$(grep -E '^at ' "${_em_log}" 2>/dev/null | grep -cvE ': (WARN|PRE-EXISTING) ' || true)
+                    { [ -z "${_em_n}" ] || [ "${_em_n}" -eq 0 ]; } && _em_n=1
+                    _em_reason="${_em_n} cross-reference failure(s) in the effective manifest — see ${_em_log}"
+                fi
+            fi
         fi
         [ -n "${_em_tmp}" ] && rm -f "${_em_tmp}"
+        [ -n "${_em_scope_file}" ] && rm -f "${_em_scope_file}"
         # Surface WARN-severity findings on stdout even on a pass (they never
         # set the exit code, but they must not vanish either).
-        _em_warns=$(grep -cE '^at .*: WARN ' "${_em_log}" 2>/dev/null || true)
-        [ -n "${_em_warns}" ] && [ "${_em_warns}" -gt 0 ] && echo "[gate-53] effective-manifest-crossref: ${_em_warns} WARN finding(s) (non-blocking) — see ${_em_log}"
+        _em_warns=$(_count '^at .*: WARN ' "${_em_log}")
+        [ "${_em_warns}" -gt 0 ] && echo "[gate-53] effective-manifest-crossref: ${_em_warns} WARN finding(s) (non-blocking) — see ${_em_log}"
+        # Same for pre-existing debt suppressed by the diff scope: it is real,
+        # it just is not this PR's to fix. Stating the count keeps a scoped
+        # green from reading as "the manifest is clean".
+        _em_pre=$(_count '^at .*: PRE-EXISTING ' "${_em_log}")
+        [ "${_em_pre}" -gt 0 ] && echo "[gate-53] effective-manifest-crossref: ${_em_pre} PRE-EXISTING finding(s) on manifest entries this PR did not touch (ADR-020, not blocking) — see ${_em_log}"
         if [ -z "${_em_reason}" ]; then
             _pass 53 "effective-manifest-crossref"
         else
@@ -3643,7 +3835,7 @@ if [ -f src/manifest.json ]; then
         if [ "${_iv_rc}" -eq 0 ]; then
             _pass 60 "icon-vocabulary"
         else
-            _iv_n=$(grep -cE '^FAIL' "${_iv_log}" 2>/dev/null || echo 1)
+            _iv_n=$(_count '^FAIL' "${_iv_log}")
             [ "${_iv_n}" -eq 0 ] && _iv_n=1
             _fail 60 "icon-vocabulary" "${_iv_n} icon(s) outside the canonical vocabulary (ADR-077); see ${_iv_log}"
         fi
@@ -3697,7 +3889,7 @@ if [ -d lib/AppInfo ]; then
     if [ "${_lwp_rc}" -eq 0 ]; then
         _pass 61 "listener-work-placement"
     else
-        _lwp_n=$(grep -cE '^FAIL' "${_lwp_log}" 2>/dev/null || echo 1)
+        _lwp_n=$(_count '^FAIL' "${_lwp_log}")
         [ "${_lwp_n}" -eq 0 ] && _lwp_n=1
         _fail 61 "listener-work-placement" "${_lwp_n} post-event listener(s) doing synchronous work with no deferral and no justification (ADR-078); see ${_lwp_log}"
     fi
@@ -3717,7 +3909,7 @@ set -e
 if [ "${_sp_rc}" -eq 0 ]; then
     _pass 62 "store-plane"
 else
-    _sp_n=$(grep -cE '^FAIL' "${_sp_log}" 2>/dev/null || echo 1)
+    _sp_n=$(_count '^FAIL' "${_sp_log}")
     [ "${_sp_n}" -eq 0 ] && _sp_n=1
     _fail 62 "store-plane" "${_sp_n} store/templates/catalogue naming or discovery violation(s) (ADR-080); see ${_sp_log}"
 fi
@@ -3734,18 +3926,81 @@ set -e
 if [ "${_ss_rc}" -eq 0 ]; then
     _pass 63 "settings-surface"
 else
-    _ss_n=$(grep -cE '^FAIL' "${_ss_log}" 2>/dev/null || echo 1)
+    _ss_n=$(_count '^FAIL' "${_ss_log}")
     [ "${_ss_n}" -eq 0 ] && _ss_n=1
     _fail 63 "settings-surface" "${_ss_n} settings-placement violation(s) (ADR-079); see ${_ss_log}"
 fi
 
 # ---------------------------------------------------------------------------
-# Summary
+# Summary + COVERAGE ACCOUNTING
+#
+# The banner used to read "ALL 63 GATES GREEN" whenever the failure count was
+# zero — whether or not 63 gates had actually run. Every gate in this file is
+# wrapped in a prerequisite test (`if [ -d src ]`, `if [ -f
+# tests/axe/report.json ]`, …) and a gate whose prerequisite is absent emitted
+# NOTHING AT ALL: no line, no count, no trace. Its absence was byte-identical
+# to its success.
+#
+# Measured 2026-08-03 across the fleet: gate-33 (axe-core) has never run in ANY
+# repository, because the `tests/axe/report.json` it consumes is produced by a
+# `scripts/run-browser-tests.sh` that exists in no app — so every "all gates
+# green" this fleet has ever produced excluded accessibility RUNTIME checking
+# entirely. gate-24 (integration-parity) is absent in most repos for the same
+# structural reason. Neither was visible anywhere in the output.
+#
+# The inventory is read back out of THIS FILE (number + name of every gate that
+# can report), so it cannot go stale against a hardcoded constant, and gates
+# that did not run are named — not merely counted.
 # ---------------------------------------------------------------------------
 _SUMMARY_REACHED=1
 echo ""
+
+# Declared inventory: "<n> <name>" per line, first declaration of each number
+# wins (a gate may call _pass/_fail/_skip from several branches).
+_declared=$(grep -oE '_(pass|fail|skip) [0-9]+ "[^"]+"' "${RUNNER_SELF}" 2>/dev/null \
+    | sed -E 's/^_(pass|fail|skip) ([0-9]+) "([^"]+)"$/\2 \3/' \
+    | sort -n -k1,1 -s | awk '!seen[$1]++' || true)
+_declared_n=$(printf '%s\n' "${_declared}" | grep -c . || true)
+_declared_n="${_declared_n:-0}"
+_emitted_n=$(printf '%s\n' ${_EMITTED_GATES} | grep -c . || true)
+_emitted_n="${_emitted_n:-0}"
+
+# Gates that never reported: declared minus emitted. Membership test rather
+# than comm(1) — comm compares in collating order, these lists are numeric,
+# and an under-reported coverage gap is exactly what this block exists to stop.
+_not_run=""
+while read -r _dn _dname; do
+    [ -z "${_dn:-}" ] && continue
+    case " ${_EMITTED_GATES}" in
+        *" ${_dn} "*) continue ;;
+    esac
+    _not_run="${_not_run}${_not_run:+
+}${_dn} ${_dname}"
+done <<< "${_declared}"
+_not_run_n=$(printf '%s\n' "${_not_run}" | grep -c . || true)
+_not_run_n="${_not_run_n:-0}"
+
+echo "[hydra-gates] COVERAGE: ${_emitted_n} of ${_declared_n} declared gates reported a result."
+if [ "${_not_run_n}" -gt 0 ]; then
+    echo "[hydra-gates] GATES THAT DID NOT RUN — they inspected NOTHING, and their subject"
+    echo "[hydra-gates] matter is UNVERIFIED by this run:"
+    while IFS= read -r _nr; do
+        [ -z "${_nr}" ] && continue
+        echo "[hydra-gates]   gate-${_nr%% *} ${_nr#* }"
+    done <<< "${_not_run}"
+fi
+
 if [ "${_FAILED}" -eq 0 ]; then
-    echo "[hydra-gates] ALL 63 GATES GREEN"
+    if [ "${_not_run_n}" -eq 0 ]; then
+        echo "[hydra-gates] ALL ${_declared_n} GATES GREEN — and all ${_declared_n} of them ran."
+    else
+        echo "[hydra-gates] ${_emitted_n} GATE(S) GREEN — but ${_not_run_n} of ${_declared_n} DID NOT RUN (named above)."
+        echo "[hydra-gates] This is NOT 'all ${_declared_n} gates green'. It says nothing about the gates that skipped."
+        if [ "${REQUIRE_FULL_COVERAGE}" = "1" ]; then
+            echo "[hydra-gates] --require-full-coverage was set: treating incomplete coverage as failure."
+            exit 98
+        fi
+    fi
 else
     echo "[hydra-gates] ${_FAILED} gate(s) failed"
 fi

--- a/hydra-gates/scripts/test-fixtures/manifest-validation/malformed-apphost.manifest.json
+++ b/hydra-gates/scripts/test-fixtures/manifest-validation/malformed-apphost.manifest.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://conduction.nl/schemas/app-manifest-v2.schema.json",
+	"version": "1.0.0",
+	"menu": [
+		{
+			"id": "Widgets",
+			"label": "Widgets",
+			"icon": "ViewDashboardOutline",
+			"route": "Widgets",
+			"order": 10
+		}
+	],
+	"pages": [
+		{
+			"id": "Widgets",
+			"route": "/widgets",
+			"type": "index",
+			"title": "Widgets",
+			"config": {
+				"register": "fixture",
+				"schema": "widget"
+			}
+		}
+	],
+	"observability": {
+		"health": {
+			"statusCodePolicy": "adr006",
+			"checks": [
+				{ "id": "db", "type": "postgres", "severity": "critical" },
+				{ "id": "or", "type": "orAvailable", "severity": "catastrophic" }
+			]
+		},
+		"metrics": [
+			{
+				"name": "fixture_widgets_total",
+				"type": "histogram",
+				"source": { "kind": "psychicIntuition" }
+			}
+		]
+	},
+	"deepLinks": [
+		{
+			"registerSlug": "fixture",
+			"displayName": "Widget"
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/manifest-validation/non-apphost.manifest.json
+++ b/hydra-gates/scripts/test-fixtures/manifest-validation/non-apphost.manifest.json
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://conduction.nl/schemas/app-manifest-v2.schema.json",
+	"version": "1.0.0",
+	"menu": [
+		{
+			"id": "Widgets",
+			"label": "Widgets",
+			"icon": "ViewDashboardOutline",
+			"route": "Widgets",
+			"order": 10
+		}
+	],
+	"pages": [
+		{
+			"id": "Widgets",
+			"route": "/widgets",
+			"type": "index",
+			"title": "Widgets",
+			"config": {
+				"register": "fixture",
+				"schema": "widget"
+			}
+		},
+		{
+			"id": "WidgetDetail",
+			"route": "/widgets/:id",
+			"type": "detail",
+			"title": "Widget",
+			"config": {
+				"register": "fixture",
+				"schema": "widget"
+			}
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/manifest-validation/valid-apphost.manifest.json
+++ b/hydra-gates/scripts/test-fixtures/manifest-validation/valid-apphost.manifest.json
@@ -1,0 +1,50 @@
+{
+	"$schema": "https://conduction.nl/schemas/app-manifest-v2.schema.json",
+	"version": "1.0.0",
+	"menu": [
+		{
+			"id": "Widgets",
+			"label": "Widgets",
+			"icon": "ViewDashboardOutline",
+			"route": "Widgets",
+			"order": 10
+		}
+	],
+	"pages": [
+		{
+			"id": "Widgets",
+			"route": "/widgets",
+			"type": "index",
+			"title": "Widgets",
+			"config": {
+				"register": "fixture",
+				"schema": "widget"
+			}
+		}
+	],
+	"observability": {
+		"health": {
+			"statusCodePolicy": "adr006",
+			"cors": false,
+			"checks": [
+				{ "id": "db", "type": "database", "severity": "critical" },
+				{ "id": "or", "type": "orAvailable", "severity": "degraded" }
+			]
+		},
+		"metrics": [
+			{
+				"name": "fixture_widgets_total",
+				"type": "gauge",
+				"source": { "kind": "objectCount", "register": "fixture", "schema": "widget" }
+			}
+		]
+	},
+	"deepLinks": [
+		{
+			"registerSlug": "fixture",
+			"schemaSlug": "widget",
+			"urlTemplate": "/index.php/apps/fixture/#/widgets/{id}",
+			"displayName": "Widget"
+		}
+	]
+}

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -211,6 +211,75 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 4b — a gate that DID NOT RUN is named, and cannot hide under a green.
+#
+# Measured 2026-08-03 across 13 fleet repos: gate-33 (axe-core) has never run in
+# any of them, because the tests/axe/report.json it consumes is produced by a
+# scripts/run-browser-tests.sh that exists nowhere. Until then it emitted NOTHING
+# when its prerequisite was absent — no line, no count — and the runner still
+# printed "ALL 63 GATES GREEN". Every green this fleet has produced therefore
+# excluded accessibility runtime checking, and nothing in the output said so.
+#
+# The fixture has no tests/axe/report.json, so this is the real condition.
+# ---------------------------------------------------------------------------
+echo "[test] a gate that did not run is named, not folded into the green"
+if printf '%s' "${OUT}" | grep -qE '^\[gate-33\] axe-core: SKIPPED'; then
+    _ok "gate-33 states its own absence instead of emitting nothing"
+else
+    _bad "gate-33 emitted no SKIPPED line — its absence is still indistinguishable from a pass"
+fi
+if printf '%s' "${OUT}" | grep -q "GATES THAT DID NOT RUN"; then
+    _ok "the summary names the gates that did not run"
+else
+    _bad "the summary did not name a single unrun gate, though gate-33 cannot have run here"
+fi
+if printf '%s' "${OUT}" | grep -qE 'ALL [0-9]+ GATES GREEN'; then
+    _bad "an 'ALL N GATES GREEN' banner was printed while gate-33 did not run"
+else
+    _ok "no 'ALL N GATES GREEN' banner while a gate did not run"
+fi
+# A SKIPPED gate must not be counted as coverage — that would turn the fix into
+# the bug. Coverage must be strictly less than the declared inventory here.
+_cov_line="$(printf '%s' "${OUT}" | grep -m1 -oE 'COVERAGE: [0-9]+ of [0-9]+' || true)"
+_cov_ran="$(printf '%s' "${_cov_line}" | awk '{print $2}')"
+_cov_all="$(printf '%s' "${_cov_line}" | awk '{print $4}')"
+if [ -n "${_cov_ran:-}" ] && [ -n "${_cov_all:-}" ] && [ "${_cov_ran}" -lt "${_cov_all}" ]; then
+    _ok "SKIPPED gates are excluded from the coverage tally (${_cov_ran} of ${_cov_all})"
+else
+    _bad "coverage read '${_cov_line}' — a skipped gate is being counted as having reported"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4c — --require-full-coverage turns an incomplete run into a failure.
+# Reverse control for the above: the same fixture, exit 0 without the flag and
+# non-zero with it, proves the coverage gap is really being detected rather
+# than the banner merely being reworded.
+# ---------------------------------------------------------------------------
+echo "[test] --require-full-coverage refuses an incomplete green"
+"${BIN}" --app-dir "${FIX}" --base "${BASE_SHA}" --require-full-coverage > /dev/null 2>&1; RC_RFC=$?
+if [ "${RC_RFC}" -eq 98 ]; then
+    _ok "incomplete coverage exits 98 when the caller asked for full coverage"
+else
+    _bad "expected exit 98 with --require-full-coverage, got ${RC_RFC}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4d — no gate verdict line may wrap onto a second line.
+#
+# gate-22 printed "FAIL — 0" on opencatalogi with the rest of its message
+# orphaned onto an unparseable second line, because a `grep -c … || echo 1`
+# captured "0\n1". Every consumer of this runner anchors on `^\[gate-`, so a
+# wrapped verdict silently loses its own reason AND its count.
+# ---------------------------------------------------------------------------
+echo "[test] every gate verdict is exactly one line"
+_orphans="$(printf '%s\n' "${OUT}" | grep -cE '^[0-9]+ (schema violation|parity violation|structural violation|cross-reference)' || true)"
+if [ "${_orphans}" = "0" ]; then
+    _ok "no orphaned continuation line from a miscounted gate message"
+else
+    _bad "a gate message wrapped onto a second line — the count variable held a newline"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 5 — a broken install is exit 99, never a green.
 # ---------------------------------------------------------------------------
 echo "[test] a package with no runner cannot report green"


### PR DESCRIPTION
Three defects in `conduction/hydra-gates`, all of one family: **a check whose absence or degradation is byte-identical to its success.**

Everything below was re-measured against the running system. Two of the briefed findings did not reproduce; that is reported here too.

---

## Defect 1 — gate-53 ignored the diff scope

gate-53 (`effective-manifest-crossref`) was diff-scoped at **file** granularity. An app's whole navigation surface lives in `src/manifest.json` + `src/manifest.d/*`, so touching any of it re-judged all of it. File granularity was indistinguishable from no scoping.

Measured on a **one-line `title` change**, before the fix:

| repo | full-repo | diff-scoped | delta |
| --- | --- | --- | --- |
| pipelinq | 24 | **24** | 0 |
| shillinq (1 line, in 1 of 80 fragments) | 246 | **246** | 0 |

Every finding sat on a page the PR had never touched.

**What changed.** *Answering* a cross-reference genuinely needs the whole assembled manifest — you cannot resolve `menu[].route` → page id, or check the ADR-044 no-orphan-removal invariant, from a diff. That part is legitimately whole-repo and stays so. *Blocking* on the answer does not: every finding carries a JSON pointer that resolves to a page id, a menu id or a top-level block.

- `scripts/lib/manifest_diff_scope.py` — maps the diff to the manifest entries it touched (page ids, menu ids incl. nested children, top-level keys). Reuses gate-55's line-tracking JSON parser so the two gates cannot disagree about where a page begins.
- `scripts/lib/manifest_scope_filter.js` — shared by `check_manifest.js` and `check_manifest_crossref.js`; partitions findings into blocking / pre-existing / unscopable.

Suppressed findings are **printed as `PRE-EXISTING` and counted on stdout**, never dropped — a scoped green must not read as "the manifest is clean". Whole-manifest invariants keep blocking, and so does any PR whose scope cannot be determined (a fragment untracked at base, a changed register JSON, a parse failure). Unverifiable scope is never treated as narrow scope.

After:

| repo | full-repo | diff-scoped (blocking) | reported pre-existing |
| --- | --- | --- | --- |
| pipelinq | 24 | **0** | 24 |
| shillinq | 246 | **0** | 397 |

**Positive control, both directions, same repo and same base:** adding a commit that touches the `Prospects` page (which carries 3 real findings) → `FAIL — 3`, naming `/pages/51`, 21 pre-existing. `git revert --no-edit` of that commit, verified applied by re-reading the file and by `git diff --name-only` no longer listing it → back to `PASS`, 24 pre-existing. 3 + 21 = 24.

### Briefed findings that did NOT reproduce

- **pipelinq gate-34 `9/9`** — gate-34 scopes correctly. Full-repo 9; diff-scoped with an unrelated file touched **0**; diff-scoped with one of the nine debt files touched **1**.
- **opencatalogi gate-51** — scopes correctly, at *property* granularity. Full-repo 7 → scoped **0**. On shillinq, 35 → **0**.
- **openconnector gate-55** — scopes correctly, at *page* granularity. Full-repo 1 → scoped **0** with an unrelated page touched → **1** again with `ConsumerDetail` touched.

So gate-53 was the only gate ignoring scope. The others were most likely measured against a base ref that made the whole app the diff.

### Adjacent finding: gate-53 is red-on-arrival without `ajv`

`[gate-53] … FAIL — ajv not resolvable … refusing to run fail-open` in every repo without `node_modules`. It fails *closed* and says so, which is the right shape — but no code change can turn it green. `ajv` is in every fleet app's `package-lock.json`, so `npm ci` before the gates resolves it. Documented in the README.

---

## Defect 2 — gate-22 printed `FAIL — 0`

Reproduced verbatim on opencatalogi: `[gate-22] manifest-validation: FAIL — 0`.

`grep -c … || echo 1` captures **both** the `0` that `grep -c` prints on no-match **and** the fallback `1`, giving `"0\n1"`. `[ "0\n1" -eq 0 ]` is not an integer comparison — it errors and returns 2, so the "clamp to at least 1" guard never fired and the message was emitted with an embedded newline. The visible line read `FAIL — 0`; the rest was orphaned onto a second line no `^\[gate-` consumer parses.

Diagnosed once before at gate-17 and fixed there only. **Eight other call sites still carried it.** One at gate-48 (`csrf-cochange`) was **fail-open**: zero frontend co-change signals produced `"0\n0"`, the `-eq 0` test errored into the else branch, and a CSRF-protection removal with no frontend counterpart passed. All replaced with a single `_count` helper.

Underneath the count sat a worse problem: **gate-22's verdict was app-owned.** It preferred `npm run check:manifest`:

- pipelinq's is a 50-line structural guard asserting four top-level keys exist — it certifies any manifest. An app could turn a fleet gate green by writing a weaker checker.
- opencatalogi's and shillinq's run a per-app vendored schema copy which, without Ajv, falls back to a hardcoded *"v1.x enum"* predating ADR-040 and rejects `type: "roadmap"` — a page type the **canonical** schema has accepted since 2.x. The gate was failing apps for conforming to the standard. **That was the "real finding in the log": a false positive from a stale app-local lint.**
- Those scripts announce their own downgrade (`no schema candidate resolved; falling back to structural lint`) on a line the gate neither surfaced nor acted on.

The vendored canonical validator now decides. The app script still runs; its output is captured and surfaced as an explicit advisory that cannot set the verdict.

**Loud fallback.** `check_manifest.js` now exits **3 — DEGRADED** when Ajv is unresolvable and it found nothing, on both channels (`SCHEMA VALIDATION DID NOT HAPPEN`, `"status":"degraded"`). A real finding still exits 1, so degradation never masks a violation. gate-22 reports that as a named FAIL rather than a pass, mirroring gate-53's existing stance.

Corrected output on opencatalogi:

```
[gate-22] manifest-validation: FAIL — 3 schema violation(s) in src/manifest.json — see /tmp/… [advisory: the app's own check:manifest also exits 1 — …]
    at /pages/3: must have required property '_note' (keyword=required)
    at /pages/3: must match "else" schema (keyword=if)
    at /pages/3: must match "then" schema (keyword=if)
```

and without `ajv`:

```
[gate-22] NOTE: an app-local manifest checker announced a fallback to a weaker structural lint. That line is advisory only — this gate's verdict comes from the vendored canonical validator.
[gate-22] manifest-validation: FAIL — SCHEMA VALIDATION DID NOT HAPPEN — Ajv is not resolvable, so the vendored validator could only run its AppHost structural lint. A weaker check reported as a pass is not a pass. Run `npm ci` … 
```

---

## Defect 3 — gate-33 (axe-core) has never run, anywhere

**Established cause.** The gate consumes `tests/axe/report.json`, documented as the output of `scripts/run-browser-tests.sh`. Checked across pipelinq, shillinq, opencatalogi and openconnector: **neither the report nor the producing script exists in any of them.** Meanwhile `axe-core` is a declared devDependency in every one, so the prerequisite *looks* wired. Nothing anywhere writes that file (`grep -rn 'axe/report.json\|AxeBuilder\|axe.run'` → no hits outside `node_modules`).

It was never wired. And because a gate whose prerequisite is absent emitted **nothing at all** — no line, no count, no trace — while the runner closed with a hardcoded `ALL 63 GATES GREEN`, **every green this fleet has ever produced excluded accessibility runtime checking** and nothing said so. gate-24 (`integration-parity`) was absent in most repos for the same structural reason.

Both now state their own absence:

```
[gate-33] axe-core: SKIPPED — no tests/axe/report.json in this repo — axe-core never ran
          against a rendered DOM, so contrast / landmark / ARIA-validity / live-region
          accessibility is UNVERIFIED. Produce the report from the Playwright suite
          (@axe-core/playwright) or add scripts/run-browser-tests.sh.
```

and the **runner** now performs the declared-vs-reported accounting its wrapper already did — most of the fleet invokes `run-hydra-gates.sh` directly and was blind to it:

```
[hydra-gates] COVERAGE: 60 of 63 declared gates reported a result.
[hydra-gates] GATES THAT DID NOT RUN — they inspected NOTHING, and their subject
[hydra-gates] matter is UNVERIFIED by this run:
[hydra-gates]   gate-4 composer-audit
[hydra-gates]   gate-24 integration-parity
[hydra-gates]   gate-33 axe-core
[hydra-gates] 60 GATE(S) GREEN — but 3 of 63 DID NOT RUN (named above).
[hydra-gates] This is NOT 'all 63 gates green'. It says nothing about the gates that skipped.
```

A `SKIPPED` line is **not** counted as coverage in either layer — `bin/hydra-gates` excludes it explicitly, so the fix cannot become the bug. `--require-full-coverage` (now accepted by the runner too) exits 98. The inventory is read out of the runner itself, so adding gate 64 cannot leave the check measuring a stale 63.

---

## Pre-existing defect found while working: a dead test suite

`scripts/lib/test_check_manifest.sh` pointed at `scripts/test-fixtures/manifest-validation/` — **a directory that has never existed in this repository.** `node check_manifest.js <missing-path>` prints "Tier 0, skipping" and exits 0, which is exactly what two of its three assertions expected. It had been green its whole life while validating nothing, and it was in no CI job.

Fixtures now ship, the suite refuses to run if they go missing again, and three suites are wired into CI (with `ajv` installed, so the schema paths are exercised for real rather than skipped):

- `test_check_manifest.sh` — 14 assertions incl. the degraded contract and the scope filter, both directions
- `test_manifest_scope_filter.js` — 18 assertions on pointer attribution and partitioning, every "suppressed" paired with a "survived"
- `test_manifest_diff_scope.py` — 10 assertions in a throwaway git repo

`test_check_manifest_crossref.js` has the same problem (`scripts/test-fixtures/effective-manifest/{good,broken}` never shipped) and is left as-is — out of scope here, and its subject is covered live by the pipelinq/shillinq measurements above. Worth a follow-up.

The package's own suite goes 13 → 19 assertions, adding: gate-33 states its absence; the summary names unrun gates; no `ALL N GATES GREEN` banner while a gate skipped; skipped gates excluded from the coverage tally; `--require-full-coverage` exits 98; no gate verdict wraps onto a second line.

---

## Consumer impact

`v1.0.1` behaviour changes for consumers who pin it. A new tag is needed. Once tagged:

1. **Run `npm ci` before the gates** (or set `NODE_PATH`). gate-22 now FAILS rather than passing when it cannot resolve `ajv` — it will not certify a manifest it never schema-validated. `ajv` is already in every fleet app's lockfile.
2. **Expect gate-22 verdicts to move**, in both directions. Apps whose `check:manifest` was weaker than the canonical schema will surface real findings; apps failed by a stale app-local `roadmap` enum will go green.
3. **Expect `SKIPPED` lines and a `COVERAGE:` block** in `run-hydra-gates.sh` output. Anything parsing `^\[gate-N\]` must treat `: SKIPPED` as *not run*, not as a pass.
4. **gate-53 gets usable under `--scope-to-diff`** — it was previously unenablable on any repo with manifest debt.

Full-repo runs are unchanged in strictness (verified on pipelinq: 24 / 8 / 9 before and after).

---

## Verification

- Package suite: 19/19.
- Helper suites: 14/14, 18/18, 10/10.
- ShellCheck clean on every `*.sh` in the repo (baseline was clean; one new SC2154 was introduced by removing an incidental `_rc` assignment and is fixed properly, not suppressed).
- Live gate runs on pipelinq, shillinq, opencatalogi, openconnector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
