### PR TITLE
fix(quality): stop a phpmd finding from silently deleting the PHPUnit signal

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1201,15 +1201,44 @@ jobs:
           path: quality-results/
 
   # ╔══════════════════════════════════════════════╗
-  # ║  STAGE 2 — Tests (gated behind Stage 1)      ║
+  # ║  STAGE 2 — Tests                              ║
   # ║                                               ║
   # ║  • PHPUnit matrix (PHP × Nextcloud versions)  ║
   # ║  • Integration tests (Newman)                 ║
   # ║  • E2E browser tests (Playwright)             ║
+  # ║                                               ║
+  # ║  Gated on `security` only. PHPUnit and        ║
+  # ║  Playwright deliberately do NOT gate on       ║
+  # ║  php-quality — a complexity or formatting     ║
+  # ║  finding must not silently delete the test    ║
+  # ║  signal. Newman still does; see its `if:`.    ║
   # ╚══════════════════════════════════════════════╝
 
   phpunit:
-    if: ${{ inputs.enable-php && inputs.enable-phpunit && !cancelled() && needs.php-quality.result != 'failure' && needs.security.result != 'failure' }}
+    # NOT gated on php-quality — deliberately. `php-quality` is a matrix job, so
+    # its result is 'failure' if ANY leg fails, including phpmd (complexity/mess
+    # detection) and phpcs (formatting). Neither says anything about whether the
+    # test suite passes, but gating on them meant a repo carrying architectural
+    # debt got NO test signal at all — and the loss renders in the checks list as
+    # a single greyed-out "skipping" placeholder, which reads like a non-event
+    # rather than a gate that stopped running.
+    #
+    # Observed 2026-08-04 on ConductionNL/procest: phpmd was red on 25 complexity
+    # findings, so `development` runs had 26 jobs and ZERO PHPUnit legs. Its 1684
+    # tests had had no CI signal for as long as phpmd had been red. The contrast
+    # is the proof — ConductionNL/decidesk, identical workflow inputs, produced 29
+    # jobs with 4 green PHPUnit legs, and the ONLY difference was that decidesk's
+    # phpmd was green. Worse, it was green only because a phpmd.baseline.xml was
+    # suppressing 73 real findings: whether the test suite ran at all was
+    # contingent on a suppression file.
+    #
+    # The security gate is kept — a repo with a known-vulnerable dependency
+    # should not spin up servers. This also aligns PHPUnit with the playwright
+    # job below, which already deliberately declines to gate on php-quality.
+    #
+    # `needs:` is retained for ordering only; with `!cancelled()` and no result
+    # condition on php-quality, PHPUnit runs regardless of static-analysis colour.
+    if: ${{ inputs.enable-php && inputs.enable-phpunit && !cancelled() && needs.security.result != 'failure' }}
     runs-on: ubuntu-latest
     name: "PHPUnit (PHP ${{ matrix.php-version }}, NC ${{ matrix.nextcloud-ref }})"
     needs: [php-quality, security]


### PR DESCRIPTION
## The defect

`phpunit` was gated on `needs.php-quality.result != 'failure'`.

`php-quality` is a **matrix** job, so its result is `failure` if *any* leg fails — `lint`, `phpcs`, **`phpmd`**, `psalm`, `phpstan`, `phpmetrics`. A complexity or formatting finding therefore deleted the entire PHPUnit matrix.

This is a dead gate in the strict sense: **its absence looks exactly like its success.** A skipped matrix renders in the checks list as a single greyed-out `skipping` placeholder — not red, not missing, just quietly not there. Nothing in the PR view says "your tests did not run".

## The evidence — a natural A/B, measured 2026-08-04

| repo | phpmd job | total jobs | PHPUnit legs |
|---|---|---|---|
| `ConductionNL/procest` (run 30863839239) | **failure** (25 findings) | 26 | **0** |
| `ConductionNL/decidesk` (run 30862373575) | success | 29 | 4, all green |

Identical workflow inputs. The only difference is phpmd's colour.

Two things follow:

1. **procest's 1684 tests had no CI signal at all** for as long as phpmd was red.
2. decidesk's phpmd was green **only because `phpmd.baseline.xml` was suppressing 73 real findings.** So whether decidesk's suite ran at all was contingent on a suppression file. Delete the baseline honestly — which is the direction that repo is going — and its test signal would have gone dark too.

That second point is the one that makes this structural rather than cosmetic: the fix for one problem (remove the suppression) silently caused another (lose the tests).

## The change

```diff
-    if: ${{ inputs.enable-php && inputs.enable-phpunit && !cancelled() && needs.php-quality.result != 'failure' && needs.security.result != 'failure' }}
+    if: ${{ inputs.enable-php && inputs.enable-phpunit && !cancelled() && needs.security.result != 'failure' }}
```

- **`security` gate kept.** A repo with a known-vulnerable dependency should not spin up servers.
- **`needs:` retained** for ordering; with `!cancelled()` and no result condition, PHPUnit runs regardless of static-analysis colour.
- **This aligns phpunit with `playwright`,** which in this same file already deliberately declines to gate on php-quality (its `if:` checks only `needs.security.result`). That inconsistency is itself evidence the php-quality gate on phpunit was an oversight rather than a decision.
- **`newman` keeps its php-quality gate.** It stands up a live stack and is a separate cost/risk decision; left unchanged and noted inline.

## Verification

- YAML parses; `jobs` count unchanged at 18; `phpunit.if` and `playwright.if` are now equivalent in their php-quality treatment.
- A live positive control is running: `ConductionNL/procest@ci/prove-phpunit-gate` points `code-quality.yml` at this branch **while procest's phpmd is still red**. If the fix works, that run shows phpmd failing *and* the PHPUnit legs executing. Result posted below as a comment.

## Blast radius

Fleet-wide (every Conduction app consumes `quality.yml@main`). The effect is strictly *more* signal: repos whose php-quality is green see no change; repos whose php-quality is red gain back their test results. CI cost rises only for repos that are currently red.