### PR TITLE
ci(quality): let an app declare the Playwright front-controller preflight URL

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -137,6 +137,11 @@ on:
         required: false
         type: string
         default: ""
+      playwright-preflight-path:
+        description: "Pretty URL the Playwright job probes to prove the php -S front controller is routing, before any spec runs. Defaults to /apps/<app-name>/, which is right for every app that serves a main page. Set it for apps that legitimately have NO main route — e.g. an admin-settings-only app like nldesign, whose routes.php declares only /api/* and /settings/* and whose /apps/nldesign/ therefore correctly 404s. Without an override the preflight reports that correct 404 as a broken front controller and fails the job before a single spec runs."
+        required: false
+        type: string
+        default: ""
       enable-playwright-coverage:
         description: "Collect V8 code coverage during Playwright tests and enforce threshold"
         required: false
@@ -2012,10 +2017,24 @@ jobs:
           # Prove the front controller is actually routing before any spec runs.
           # `/apps/<app>/` is the URL the fleet's specs use; without the router
           # it is a hard 404 and every one of them fails on a selector timeout.
-          PRETTY="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:8080/apps/${{ inputs.app-name }}/")"
-          echo "Front-controller check: /apps/${{ inputs.app-name }}/ -> HTTP ${PRETTY}"
+          #
+          # A 404 here means "the router is broken" ONLY for an app that
+          # actually serves a main page. Not every app does: an
+          # admin-settings-only app such as nldesign declares just /api/* and
+          # /settings/* in routes.php and no <navigation> in info.xml, so
+          # /apps/nldesign/ is a CORRECT 404 — and this check read that as a
+          # broken front controller and killed the job before any spec ran.
+          # `playwright-preflight-path` lets such an app name a URL it really
+          # serves. Default is unchanged, so no existing caller is affected.
+          PREFLIGHT_PATH="${{ inputs.playwright-preflight-path }}"
+          if [ -z "$PREFLIGHT_PATH" ]; then
+            PREFLIGHT_PATH="/apps/${{ inputs.app-name }}/"
+          fi
+          PRETTY="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:8080${PREFLIGHT_PATH}")"
+          echo "Front-controller check: ${PREFLIGHT_PATH} -> HTTP ${PRETTY}"
           if [ "$PRETTY" = "404" ]; then
-            echo "::error::The php -S front-controller router is not routing pretty URLs — /apps/${{ inputs.app-name }}/ returned 404. Every spec using a pretty Nextcloud URL will fail on a selector timeout."
+            echo "::error::The php -S front-controller router is not routing pretty URLs — ${PREFLIGHT_PATH} returned 404. Every spec using a pretty Nextcloud URL will fail on a selector timeout."
+            echo "::error::If this app legitimately serves no page at that path (an admin-settings-only app, for instance), set the 'playwright-preflight-path' input to a URL it does serve."
             exit 1
           fi
           # And prove the OTHER Nextcloud PHP entry points still reach


### PR DESCRIPTION
## Problem

The Playwright job's preflight probes `/apps/<app-name>/` and treats **HTTP 404** as proof that the `php -S` front controller is not routing pretty URLs:

```
::error::The php -S front-controller router is not routing pretty URLs —
/apps/nldesign/ returned 404. Every spec using a pretty Nextcloud URL will
fail on a selector timeout.
```

That inference is only valid for an app that actually serves a main page.

**nldesign does not.** Its `appinfo/routes.php` declares only `/api/*` and `/settings/*` routes, and its `appinfo/info.xml` declares a `<settings>` section with **no `<navigation>`** — it is an admin-settings-only theming app. `/apps/nldesign/` is a *correct* 404. The preflight read that correct 404 as a broken front controller and exited 1 **before a single spec ran**, so enabling e2e on nldesign could never produce a verdict.

Observed live on ConductionNL/nldesign#206.

## Change

Adds one input, `playwright-preflight-path`.

- **Default is empty**, and empty falls back to `/apps/<app-name>/`.
- So every existing caller probes byte-for-byte what it probed before. This cannot change behaviour for any repo that does not set it.

The failure message now also names the input, so the next app to hit this reads the actual cause instead of investigating a router that is working fine.

The **OCS entry-point check immediately below is untouched.** That check — `/ocs/v2.php/cloud/user` returning 401 (reached `ocs/v2.php`) versus 404 (swallowed into `index.php`) — remains the load-bearing proof that the router itself is functioning, and it is not weakened or made optional here. An app overriding the pretty-URL path still has to pass it.

## Verification

Fallback semantics checked directly:

| input | probes |
| --- | --- |
| `""` (default) | `/apps/<app-name>/` |
| `/settings/admin/nldesign` | `/settings/admin/nldesign` |

YAML parses; input count 41; `playwright-test-path` and every other default unchanged. The diff against `main` is exactly two hunks.

## Note on concurrency

This branch was rebased onto current `main` before pushing. An earlier attempt was based on the `main` I read at the start of the session and would have **silently reverted** #140 (*"stop a phpmd finding from silently deleting the PHPUnit signal"*) — a `contents` PUT overwrites the whole file, so a stale base reverts anything that landed meanwhile without any conflict being reported. Verified after rebase: #140's change is intact on this branch.

## Blocking

ConductionNL/nldesign#206 cannot get an E2E verdict until this lands, since callers reference `quality.yml@main`.

**Not self-merging** — this workflow is consumed by ~30 repos and `main` is left to a human.