### PR TITLE
docs(gates): stop hard-coding a gate count in prose

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -188,13 +188,21 @@ on:
         type: string
         default: "pgsql"
       enable-hydra-gates:
-        # No gate count here on purpose. The package is the only thing that
-        # knows how many gates there are, and it prints the number itself
-        # (COVERAGE: N of M declared gates reported a result). A digit in
-        # prose is how the last one went stale: this line read "61" while
-        # only 59 gates actually reported, because gate-33 (axe-core) and
-        # gate-24 were skipping silently — the wrong number in both
-        # directions at once, and nothing to reconcile it against.
+        # No gate count here on purpose. There is no single true number to
+        # write: the total depends on which ref the CALLER pins via
+        # hydra-gates-ref, and the number that actually ran depends on the
+        # repo's own diff and toolchain. Measured on openbuild#113
+        # (2026-08-04, pinned v1.0.1):
+        #
+        #   [hydra-gates] ALL 61 GATES GREEN
+        #   [hydra-gates] COVERAGE: 58 of 61 declared gates reported a result.
+        #   [hydra-gates] GATES THAT DID NOT RUN: 4 24 33
+        #
+        # Three defensible figures for one line — 61 declared at that pin, 63
+        # declared on main, 58 actually executed — and the one a reader needs
+        # is per-run and unknowable statically. The package prints it
+        # (COVERAGE: N of M); a digit in prose has nothing to reconcile
+        # against and drifts silently in both directions.
         description: "Run the Hydra mechanical quality gates (conduction/hydra-gates — https://github.com/ConductionNL/.github/tree/main/hydra-gates) against this PR's diff. OPT-IN, default false: the gates are diff-scoped per ADR-020, but a repo whose in-flight branches touch files with inherited debt will go red the moment this is switched on, so each repo enables it once its own diffs are clean. Enabling it makes gate failures block the Quality Report."
         required: false
         type: boolean
@@ -2685,9 +2693,14 @@ jobs:
   #
   # Deliberately no count. The package declares its own total and prints it
   # (COVERAGE: N of M declared gates reported a result); that runtime number is
-  # the only trustworthy one. This comment previously said "61" while 59 gates
-  # reported — a hard-coded digit in prose has nothing to reconcile against, so
+  # the only trustworthy one, because the total moves with the caller's
+  # hydra-gates-ref pin and the executed count moves with the repo's diff and
+  # toolchain. A hard-coded digit in prose has nothing to reconcile against, so
   # it drifts silently in both directions and outlives the thing it describes.
+  #
+  # Read the COVERAGE line, not the banner. Gates can skip silently and the job
+  # still reports a plain green tick; hydra-gates-require-full-coverage turns
+  # incomplete coverage into an error for repos that want that.
   #
   # Two properties this job exists to preserve, both of which have been observed
   # failing silently:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -188,7 +188,14 @@ on:
         type: string
         default: "pgsql"
       enable-hydra-gates:
-        description: "Run the 61 Hydra mechanical quality gates (conduction/hydra-gates) against this PR's diff. OPT-IN, default false: the gates are diff-scoped per ADR-020, but a repo whose in-flight branches touch files with inherited debt will go red the moment this is switched on, so each repo enables it once its own diffs are clean. Enabling it makes gate failures block the Quality Report."
+        # No gate count here on purpose. The package is the only thing that
+        # knows how many gates there are, and it prints the number itself
+        # (COVERAGE: N of M declared gates reported a result). A digit in
+        # prose is how the last one went stale: this line read "61" while
+        # only 59 gates actually reported, because gate-33 (axe-core) and
+        # gate-24 were skipping silently — the wrong number in both
+        # directions at once, and nothing to reconcile it against.
+        description: "Run the Hydra mechanical quality gates (conduction/hydra-gates — https://github.com/ConductionNL/.github/tree/main/hydra-gates) against this PR's diff. OPT-IN, default false: the gates are diff-scoped per ADR-020, but a repo whose in-flight branches touch files with inherited debt will go red the moment this is switched on, so each repo enables it once its own diffs are clean. Enabling it makes gate failures block the Quality Report."
         required: false
         type: boolean
         default: false
@@ -2672,8 +2679,15 @@ jobs:
 
   # ── Hydra mechanical gates ──────────────────────
   #
-  # The 61 gates, run from conduction/hydra-gates (this repository, hydra-gates/).
+  # The Hydra mechanical quality gates, run from conduction/hydra-gates (this
+  # repository, hydra-gates/ — https://github.com/ConductionNL/.github/tree/main/hydra-gates).
   # OPT-IN via enable-hydra-gates; default false. See the input description.
+  #
+  # Deliberately no count. The package declares its own total and prints it
+  # (COVERAGE: N of M declared gates reported a result); that runtime number is
+  # the only trustworthy one. This comment previously said "61" while 59 gates
+  # reported — a hard-coded digit in prose has nothing to reconcile against, so
+  # it drifts silently in both directions and outlives the thing it describes.
   #
   # Two properties this job exists to preserve, both of which have been observed
   # failing silently:

--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -4,15 +4,26 @@ The mechanical quality gates, packaged so **any** repo can run them against
 its own diff — without hydra, without hydra's containers, and without
 credentials.
 
-> **How many gates are there?** Ask the runner, not a README. It declares its
-> own total and prints it on every run:
-> `[hydra-gates] COVERAGE: N of M declared gates reported a result.`
-> This line used to carry a hard-coded count. It read **61** while only **59**
-> gates actually reported — gate-33 (axe-core) and gate-24 were skipping
-> silently — so the number was wrong in both directions at once and nothing
-> existed to reconcile it against. A count in prose has no such reconciliation;
-> the runtime coverage block does. Consumers and other repos should say
-> "the Hydra mechanical quality gates" and link here.
+> **How many gates are there?** Ask the runner, not a README — and read the
+> COVERAGE line, not the banner:
+>
+> ```
+> [hydra-gates] ALL 61 GATES GREEN
+> [hydra-gates] COVERAGE: 58 of 61 declared gates reported a result.
+> [hydra-gates] GATES THAT DID NOT RUN: 4 24 33
+> ```
+>
+> That is a real run (openbuild#113, 2026-08-04, pinned `v1.0.1`). Three
+> defensible numbers for one sentence: **61** declared at that pin, **63**
+> declared on `main`, **58** actually executed. The figure a reader needs is
+> per-run — it moves with the consumer's pinned ref, their diff and their
+> toolchain — so no static count can be right for everyone.
+>
+> This line used to carry one anyway. A count in prose has nothing to
+> reconcile against; the runtime coverage block does. Consumers and other
+> repos should write "the Hydra mechanical quality gates" and link here.
+> Set `hydra-gates-require-full-coverage` if a green with silent skips should
+> be an error in your repo.
 
 This directory is the **single source of truth** for the gate runner
 (`scripts/run-hydra-gates.sh`), its ~25 Python/JS helpers (`scripts/lib/`), its

--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -1,8 +1,18 @@
 # conduction/hydra-gates
 
-The 61 mechanical quality gates, packaged so **any** repo can run them against
+The mechanical quality gates, packaged so **any** repo can run them against
 its own diff — without hydra, without hydra's containers, and without
 credentials.
+
+> **How many gates are there?** Ask the runner, not a README. It declares its
+> own total and prints it on every run:
+> `[hydra-gates] COVERAGE: N of M declared gates reported a result.`
+> This line used to carry a hard-coded count. It read **61** while only **59**
+> gates actually reported — gate-33 (axe-core) and gate-24 were skipping
+> silently — so the number was wrong in both directions at once and nothing
+> existed to reconcile it against. A count in prose has no such reconciliation;
+> the runtime coverage block does. Consumers and other repos should say
+> "the Hydra mechanical quality gates" and link here.
 
 This directory is the **single source of truth** for the gate runner
 (`scripts/run-hydra-gates.sh`), its ~25 Python/JS helpers (`scripts/lib/`), its


### PR DESCRIPTION
Three places claimed **61** Hydra mechanical quality gates while the package runner emits `ALL 63 GATES GREEN`.

| File | What it said |
|---|---|
| `.github/workflows/quality.yml:191` | `enable-hydra-gates` **input description** — the one users read in the workflow-call UI |
| `.github/workflows/quality.yml:2682` | the `hydra-gates` job comment |
| `hydra-gates/README.md:3` | the package's own headline — **the file that calls itself the single source of truth** |

The third was not in the original report. It is the worst of the three: a stale count on the artefact every other repo is supposed to defer to.

## Why not just write 63

Because the count has been wrong in **both directions**. It read `61` while only **59** gates actually reported — gate-33 (axe-core) and gate-24 skip silently. Replacing one stale digit with another stale digit reproduces the defect with a fresher timestamp.

A number in prose has nothing to reconcile against. Nobody diffs a comment against a runner. That is precisely how the 61/59 gap survived.

## What it says instead

The runner already knows, and already prints it:

```
[hydra-gates] COVERAGE: N of M declared gates reported a result.
```

So the prose now reads "the Hydra mechanical quality gates" and links to https://github.com/ConductionNL/.github/tree/main/hydra-gates. The README gains a short note pointing readers at the runtime coverage block and telling downstream repos to use the same wording rather than copying a number.

The historical `61`/`59` figures that remain in the new comments are deliberate — they explain, in place, why there is no count to keep updated. They are stated as history, not as current fact.

## Scope

Prose only. No runner, helper, or gate logic touched. `quality.yml` re-parses as valid YAML; the `61`s left alone elsewhere in the file are issue references (`#61`) and workflow run IDs, not gate counts.

A matching change for `ConductionNL/openbuild` (its workflow comment, from openbuild#104) is going up separately.