### PR TITLE
test(gates): real fixtures for gate-30, and run every helper suite

### DIFF
--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -67,18 +67,30 @@ jobs:
       - name: Install ajv for the manifest-validation helpers
         run: npm install --no-save --no-audit --no-fund ajv ajv-formats
 
-      # These three cover the gate-22 verdict contract and the gate-53 ADR-020
-      # diff scoping. They lived in scripts/lib/ and were run by NOTHING —
-      # test_check_manifest.sh in particular had been green for its whole life
-      # while pointing at a fixture directory that did not exist (a missing
-      # manifest path makes the validator print "Tier 0, skipping" and exit 0,
-      # which is what two of its three assertions expected).
-      - name: Manifest gate helper suites
-        run: |
-          set -eu
-          bash hydra-gates/scripts/lib/test_check_manifest.sh
-          node hydra-gates/scripts/lib/test_manifest_scope_filter.js
-          python3 hydra-gates/scripts/lib/test_manifest_diff_scope.py
+      # EVERY scripts/lib/test_* suite, discovered rather than listed.
+      #
+      # This step used to name three files by hand. The package ships 19, so 15
+      # of them were executed by nothing at all — they existed, they looked like
+      # coverage, and no job ever ran them. Two were pointing at fixture
+      # directories that had never existed:
+      #
+      #   test_check_manifest.sh          green its whole life (a missing
+      #                                   manifest path makes the validator
+      #                                   print "Tier 0, skipping" and exit 0,
+      #                                   which is what 2 of its 3 assertions
+      #                                   expected) — fixed 2026-08-03
+      #   test_check_manifest_crossref.js red its whole life, unseen, because
+      #                                   nothing ran it — fixed 2026-08-04
+      #
+      # A hand-written list of test names decays exactly like a hand-written
+      # paths filter: adding a file does not add it to the list and the omission
+      # is invisible. The runner discovers instead, so a new scripts/lib/test_*
+      # is enforced the moment it lands, with no workflow edit to forget. Suites
+      # may be quarantined only with a stated reason, and the quarantine cannot
+      # rot — an entry that no longer exists, or that starts passing, fails the
+      # step.
+      - name: All helper suites (discovered, not listed)
+        run: bash hydra-gates/tests/run-helper-suites.sh
 
   install-from-published-location:
     name: "Install from published location (php:8.3-cli)"

--- a/hydra-gates/scripts/lib/test_build_effective_manifest.js
+++ b/hydra-gates/scripts/lib/test_build_effective_manifest.js
@@ -15,6 +15,7 @@
 
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 const {
 	buildManifest,
@@ -25,6 +26,33 @@ const {
 	applySettingsSection,
 	assembleFromDir,
 } = require('./build_effective_manifest.js')
+
+// --- guard the guard --------------------------------------------------------
+// The last block of this file assembles from
+// scripts/test-fixtures/effective-manifest/good/. Until 2026-08-04 that
+// directory did not exist and nothing in CI ran this file, so the in-memory
+// assertions above it reported PASS and the run then died on an uncaught
+// ENOBASE stack trace. Fail with a cause instead — and before, not after, the
+// misleading passes.
+{
+	const goodDir = path.resolve(__dirname, '..', 'test-fixtures', 'effective-manifest', 'good')
+	const required = [
+		'src/manifest.json',
+		'src/manifest.d/10-archive.json',
+		'src/manifest.d/20-settings.json',
+		'src/menu-layout.json',
+	]
+	const missing = required.filter((rel) => !fs.existsSync(path.join(goodDir, rel)))
+	if (missing.length > 0) {
+		console.log(`FAIL — ${missing.length} fixture file(s) MISSING under ${goodDir}; this suite cannot assert anything:`)
+		for (const rel of missing) console.log(`    ${rel}`)
+		console.log('')
+		console.log('Refusing to run. The assembly assertions at the end of this file need them,')
+		console.log('and reporting the in-memory passes above without them would announce a green')
+		console.log('for a suite that never reached its integration leg.')
+		process.exit(1)
+	}
+}
 
 let fails = 0
 function assert(cond, label) {

--- a/hydra-gates/scripts/lib/test_check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/test_check_manifest_crossref.js
@@ -17,6 +17,20 @@
 //             check_manifest.js on the fragment-introduced `layout[]`
 //             violation (structural stage, Ajv path only).
 //
+// THE FIXTURES ARE PART OF THIS TEST. Until 2026-08-04 this file referenced
+// ../test-fixtures/effective-manifest/{good,broken}/ — a directory that had
+// never existed in this repository, and nothing in CI ran the file, so nobody
+// found out. Its sibling test_check_manifest.sh had the same defect and was
+// WORSE: a missing manifest path makes the validator print "Tier 0, skipping"
+// and exit 0, which is exactly what two of its three assertions expected, so
+// it reported GREEN for its whole life while inspecting nothing.
+//
+// This file failed loudly instead (13 of 21 assertions red) — but four of the
+// eight it "passed" it passed for the wrong reason: with no fixture, the
+// checker found zero findings, and "zero errors" is indistinguishable from
+// "nothing was ever loaded". The guard below refuses to run at all rather than
+// let that shape recur.
+//
 // Run: node scripts/lib/test_check_manifest_crossref.js   (exit 0 = pass)
 
 'use strict'
@@ -31,6 +45,42 @@ const FIX = path.resolve(LIB, '..', 'test-fixtures', 'effective-manifest')
 const BUILDER = path.join(LIB, 'build_effective_manifest.js')
 const CHECKER = path.join(LIB, 'check_manifest_crossref.js')
 const VALIDATOR = path.join(LIB, 'check_manifest.js')
+
+// --- guard the guard --------------------------------------------------------
+// If the fixtures go missing, say so and stop. A suite whose inputs are absent
+// cannot assert anything, and several of the assertions below would otherwise
+// be satisfied by the empty result an absent fixture produces.
+{
+	const required = [
+		'good/src/manifest.json',
+		'good/src/manifest.d/10-archive.json',
+		'good/src/manifest.d/20-settings.json',
+		'good/src/menu-layout.json',
+		'good/lib/Settings/items-register.json',
+		'broken/src/manifest.json',
+		'broken/src/manifest.d/10-besluiten.json',
+		'broken/src/menu-layout.json',
+		'broken/lib/Settings/zaken-register.json',
+	]
+	const missing = required.filter((rel) => !fs.existsSync(path.join(FIX, rel)))
+	if (missing.length > 0) {
+		console.log(`FAIL — ${missing.length} gate-30 fixture file(s) MISSING under ${FIX}; this suite cannot assert anything:`)
+		for (const rel of missing) console.log(`    ${rel}`)
+		console.log('')
+		console.log('Refusing to run. Without the fixtures the checker reports zero findings,')
+		console.log('and "zero errors" would satisfy several assertions below while inspecting')
+		console.log('nothing at all — the exact defect this gate exists to catch, one level down.')
+		process.exit(1)
+	}
+	// The helpers under test must also be present; requiring them via spawn
+	// would otherwise surface as a confusing non-zero exit rather than a cause.
+	for (const [label, p] of [['builder', BUILDER], ['checker', CHECKER], ['validator', VALIDATOR]]) {
+		if (!fs.existsSync(p)) {
+			console.log(`FAIL — the ${label} under test is missing at ${p}; this suite cannot assert anything`)
+			process.exit(1)
+		}
+	}
+}
 
 let fails = 0
 function assert(cond, label) {

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/broken/lib/Settings/zaken-register.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/broken/lib/Settings/zaken-register.json
@@ -1,0 +1,20 @@
+{
+	"_note": "Declares register 'zaken' and schema 'zaak' — but NOT 'besluit'. That asymmetry is load-bearing: gate-30 only FAILS a slug reference when a register JSON exists AND the referenced register is declared. Delete this file and the besluit reference degrades to a WARN (runtime-bound registers) instead, and the broken fixture stops producing the error it exists to produce.",
+	"components": {
+		"registers": {
+			"zaken": {
+				"slug": "zaken",
+				"title": "Zaken",
+				"schemas": [
+					"zaak"
+				]
+			}
+		},
+		"schemas": {
+			"zaak": {
+				"slug": "zaak",
+				"title": "Zaak"
+			}
+		}
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/manifest.d/10-besluiten.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/manifest.d/10-besluiten.json
@@ -1,0 +1,27 @@
+{
+	"_note": "Seeds two defects that are INVISIBLE outside the effective manifest — the whole reason gate-30 assembles before checking. (1) It REPLACES zaken-detail (mergePages is replace-by-id) with a copy carrying a zaak-besluiten widget whose dataSource names schema 'besluit', which lib/Settings/*register*.json does not declare -> slug-resolution error, the zaakafhandelapp failure class. (2) The replacement page also carries a top-level `layout` key. pages[] has additionalProperties:false, so the ASSEMBLED manifest fails canonical validation — while the base manifest on its own is perfectly valid, so gate-22 alone never sees it.",
+	"pages": [
+		{
+			"id": "zaken-detail",
+			"route": "/zaken/:id",
+			"type": "detail",
+			"title": "Zaak",
+			"layout": [],
+			"widgets": [
+				{
+					"id": "zaak-besluiten",
+					"widgetKey": "objectTable",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 12,
+					"gridHeight": 6,
+					"dataSource": {
+						"register": "zaken",
+						"schema": "besluit"
+					}
+				}
+			]
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/manifest.json
@@ -1,0 +1,73 @@
+{
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "1.0.0",
+	"pages": [
+		{
+			"id": "zaken-index",
+			"route": "/zaken",
+			"type": "index",
+			"title": "Zaken",
+			"config": {
+				"register": "zaken",
+				"schema": "zaak"
+			},
+			"actions": [
+				{
+					"id": "open-missing",
+					"label": "Open case",
+					"type": "open-page",
+					"target": "missing-page"
+				},
+				{
+					"id": "quick-edit",
+					"label": "Quick edit",
+					"type": "open-modal",
+					"target": "EditZaakModal"
+				}
+			]
+		},
+		{
+			"id": "zaken-detail",
+			"route": "/zaken/:id",
+			"type": "detail",
+			"title": "Zaak"
+		},
+		{
+			"id": "cases-index-page",
+			"route": "/cases",
+			"type": "index",
+			"title": "Cases (legacy)"
+		}
+	],
+	"menu": [
+		{
+			"id": "zaken-group",
+			"label": "Zaken",
+			"children": [
+				{
+					"id": "zaken-index-entry",
+					"label": "Alle zaken",
+					"route": "zaken-index"
+				},
+				{
+					"id": "cases-index",
+					"label": "Cases (legacy)",
+					"route": "cases-index-page"
+				}
+			]
+		},
+		{
+			"id": "cases-overview-entry",
+			"label": "Cases overview",
+			"route": "cases-overview"
+		}
+	],
+	"deepLinks": [
+		{
+			"registerSlug": "zaken",
+			"schemaSlug": "zaak",
+			"urlTemplate": "/besluiten/{id}",
+			"displayName": "Besluit"
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/menu-layout.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/broken/src/menu-layout.json
@@ -1,0 +1,6 @@
+{
+	"_note": "ADR-044 violation, deliberately. Unlike the good fixture's removal, 'cases-index' is the ONLY menu entry reaching route 'cases-index-page'. Removing it leaves the page routable but unreachable from the navigation — no-functionality-loss breach -> removals-invariant error. The removal id DOES match a merged entry, so this is a real orphaning, not the 'stale removal' WARN.",
+	"removals": [
+		"cases-index"
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/good/lib/Settings/items-register.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/good/lib/Settings/items-register.json
@@ -1,0 +1,20 @@
+{
+	"_note": "Register/schema declarations gate-30 resolves manifest slug references against (check (c), slug-resolution). Every (register, schema) pair the good manifest references — pages[].config, widget dataSource, deepLinks[].registerSlug/schemaSlug — resolves here, so the good fixture emits ZERO slug-resolution findings. Without this file the checker would fall back to the 'no register JSON in repo' WARN and the good fixture would report more than the single expected warning.",
+	"components": {
+		"registers": {
+			"items": {
+				"slug": "items",
+				"title": "Items",
+				"schemas": [
+					"item"
+				]
+			}
+		},
+		"schemas": {
+			"item": {
+				"slug": "item",
+				"title": "Item"
+			}
+		}
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.d/10-archive.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.d/10-archive.json
@@ -1,0 +1,41 @@
+{
+	"_note": "ADR-037 fragment. Adds the archive surface and a FIRST cut of the settings page — 20-settings.json replaces it, which is what pins 'later fragment wins' in mergePages. Also re-declares reports-entry with order 25; the base already sets order 20, and mergeMenuItems only fills UNDEFINED keys, so the base value must survive.",
+	"pages": [
+		{
+			"id": "archive-index",
+			"route": "/archive",
+			"type": "index",
+			"title": "Archive",
+			"config": {
+				"register": "items",
+				"schema": "item"
+			}
+		},
+		{
+			"id": "settings-page",
+			"route": "/settings",
+			"type": "settings",
+			"title": "Settings",
+			"component": "ArchiveSettingsPage"
+		}
+	],
+	"menu": [
+		{
+			"id": "items-group",
+			"label": "Items",
+			"children": [
+				{
+					"id": "archive-entry",
+					"label": "Archive",
+					"route": "archive-index"
+				}
+			]
+		},
+		{
+			"id": "reports-entry",
+			"label": "Reports",
+			"route": "reports-page",
+			"order": 25
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.d/20-settings.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.d/20-settings.json
@@ -1,0 +1,12 @@
+{
+	"_note": "Sorts after 10-archive.json, so mergePages REPLACES that fragment's settings-page wholesale. component becomes SettingsPage — the observable proof that fragment order is ascending-by-filename and that a later page declaration wins outright rather than deep-merging.",
+	"pages": [
+		{
+			"id": "settings-page",
+			"route": "/settings",
+			"type": "settings",
+			"title": "Settings",
+			"component": "SettingsPage"
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/manifest.json
@@ -1,0 +1,96 @@
+{
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "1.0.0",
+	"pages": [
+		{
+			"id": "items-index",
+			"route": "/items",
+			"type": "index",
+			"title": "Items",
+			"config": {
+				"register": "items",
+				"schema": "item"
+			},
+			"actions": [
+				{
+					"id": "open-item-detail",
+					"label": "Open",
+					"type": "open-page",
+					"target": "items-detail"
+				}
+			]
+		},
+		{
+			"id": "items-detail",
+			"route": "/items/:id",
+			"type": "detail",
+			"title": "Item",
+			"actions": [
+				{
+					"id": "edit-item",
+					"label": "Edit",
+					"type": "open-modal",
+					"target": "EditItemModal"
+				}
+			]
+		},
+		{
+			"id": "reports-page",
+			"route": "/reports",
+			"type": "dashboard",
+			"title": "Reports",
+			"widgets": [
+				{
+					"id": "items-by-status",
+					"widgetKey": "chart",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4,
+					"dataSource": {
+						"register": "items",
+						"schema": "item"
+					}
+				}
+			]
+		}
+	],
+	"menu": [
+		{
+			"id": "items-group",
+			"label": "Items",
+			"children": [
+				{
+					"id": "items-index-entry",
+					"label": "All items",
+					"route": "items-index"
+				},
+				{
+					"id": "items-index-duplicate",
+					"label": "Items",
+					"route": "items-index"
+				}
+			]
+		},
+		{
+			"id": "reports-entry",
+			"label": "Reports",
+			"route": "reports-page",
+			"order": 20
+		},
+		{
+			"id": "app-settings-entry",
+			"label": "Settings",
+			"route": "settings-page"
+		}
+	],
+	"deepLinks": [
+		{
+			"registerSlug": "items",
+			"schemaSlug": "item",
+			"urlTemplate": "/items/{id}",
+			"displayName": "Item"
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/menu-layout.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/good/src/menu-layout.json
@@ -1,0 +1,12 @@
+{
+	"_note": "ADR-044 canonical navigation layout. Exercises all three stages in pipeline order (relocations -> removals -> settingsSection). The removal is ADR-044-clean: items-index-duplicate retires a DUPLICATE entry whose route 'items-index' is still reached by items-index-entry, so nothing becomes unreachable and the removals-invariant produces no finding.",
+	"relocations": {
+		"reports-entry": "items-group"
+	},
+	"removals": [
+		"items-index-duplicate"
+	],
+	"settingsSection": [
+		"app-settings-entry"
+	]
+}

--- a/hydra-gates/tests/run-helper-suites.sh
+++ b/hydra-gates/tests/run-helper-suites.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# run-helper-suites.sh — run EVERY scripts/lib/test_* suite in this package.
+#
+# WHY THIS EXISTS
+# ---------------
+# The package ships ~19 helper self-tests under scripts/lib/. Until 2026-08-04
+# CI named four of them by hand and ran those four. The other fifteen existed,
+# looked like coverage, and were executed by nothing. Two of them had been
+# pointing at fixture directories that never existed:
+#
+#   test_check_manifest.sh            — GREEN its whole life. A missing manifest
+#                                       path makes the validator print "Tier 0,
+#                                       skipping" and exit 0, which is exactly
+#                                       what 2 of its 3 assertions expected.
+#   test_check_manifest_crossref.js   — RED its whole life (13 of 21 assertions),
+#                                       which nobody saw, because no job ran it.
+#
+# A hand-maintained list of test names is the same failure mode as a
+# hand-maintained paths filter: adding a file does not add it to the list, and
+# the omission is invisible. So this runner DISCOVERS the suites instead. A new
+# scripts/lib/test_* file is executed by CI the moment it lands, with no
+# workflow edit and nothing to forget.
+#
+# QUARANTINE
+# ----------
+# A suite may be quarantined only with a reason, and the quarantine cannot rot:
+#   * a quarantined suite that no longer exists      -> hard failure (stale)
+#   * a quarantined suite that now PASSES            -> hard failure (un-quarantine it)
+# So the list can only shrink, and it tells you why each entry is on it.
+#
+# Run: bash hydra-gates/tests/run-helper-suites.sh   (exit 0 = all green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+LIB="${PKG_ROOT}/scripts/lib"
+
+# --- quarantine: "<basename>|<reason>" --------------------------------------
+# These two fail for the SAME reason the crossref suite did — they reference
+# fixture directories that have never existed in this repository:
+#   scripts/test-fixtures/register-handler-resolution-{pass,fail}/
+#   scripts/test-fixtures/orphaned-write-capability-{pass,fail}/
+#   scripts/test-fixtures/orphaned-write-crossapp/
+#   (+ the glob-recursion fixture tree)
+# test_gate_orphaned_capability_fixtures.sh is the worse of the two: its `cd`
+# into the missing directory fails, the gate then finds nothing, and its
+# "pass fixture: 0 finding(s)" assertions report PASS on that empty result —
+# green because the input is absent. Tracked, not silently unrun.
+QUARANTINE=(
+	"test_gate_glob_recursion_fixtures.sh|fixtures absent — 7 assertions red; needs the nested lib/ + src/ fixture tree authored (follow-up to the gate-30 fixture work)"
+	"test_gate_orphaned_capability_fixtures.sh|fixtures absent — 3 assertions red AND 2 green-because-empty; needs register-handler-resolution-{pass,fail}, orphaned-write-capability-{pass,fail}, orphaned-write-crossapp authored"
+)
+
+is_quarantined() { # <basename> -> 0 if quarantined; echoes reason
+	local name="$1" entry
+	for entry in "${QUARANTINE[@]}"; do
+		if [ "${entry%%|*}" = "${name}" ]; then
+			printf '%s' "${entry#*|}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+runner_for() { # <basename> -> interpreter
+	case "$1" in
+		*.py) echo python3 ;;
+		*.js) echo node ;;
+		*.sh) echo bash ;;
+		*) echo "" ;;
+	esac
+}
+
+if [ ! -d "${LIB}" ]; then
+	echo "FAIL — ${LIB} does not exist; this runner cannot discover anything"
+	exit 1
+fi
+
+mapfile -t SUITES < <(find "${LIB}" -maxdepth 1 -type f -name 'test_*' -printf '%f\n' | sort)
+
+# Guard the guard: discovering nothing must not look like "everything passed".
+if [ "${#SUITES[@]}" -eq 0 ]; then
+	echo "FAIL — discovered ZERO test suites under ${LIB}."
+	echo "       An empty run is not a green run. Either the layout changed or"
+	echo "       the discovery glob broke."
+	exit 1
+fi
+
+echo "== discovered ${#SUITES[@]} helper suite(s) under scripts/lib/ =="
+echo
+
+_failed=()
+_passed=0
+_skipped=()
+
+for name in "${SUITES[@]}"; do
+	if reason="$(is_quarantined "${name}")"; then
+		_skipped+=("${name}")
+		echo "QUARANTINED — ${name}"
+		echo "              ${reason}"
+		continue
+	fi
+	cmd="$(runner_for "${name}")"
+	if [ -z "${cmd}" ]; then
+		echo "FAIL — ${name}: no interpreter for this extension"
+		_failed+=("${name}")
+		continue
+	fi
+	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "/tmp/_helper_${name}.log" 2>&1; then
+		echo "PASS — ${name}"
+		_passed=$((_passed + 1))
+	else
+		echo "FAIL — ${name} (exit $?)"
+		sed 's/^/      /' "/tmp/_helper_${name}.log" | tail -40
+		_failed+=("${name}")
+	fi
+done
+
+# --- the quarantine must not rot --------------------------------------------
+echo
+echo "== quarantine integrity =="
+_rot=0
+for entry in "${QUARANTINE[@]}"; do
+	name="${entry%%|*}"
+	if [ ! -f "${LIB}/${name}" ]; then
+		echo "FAIL — quarantined suite '${name}' no longer exists. Remove it from QUARANTINE."
+		_rot=$((_rot + 1))
+		continue
+	fi
+	cmd="$(runner_for "${name}")"
+	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "/tmp/_quar_${name}.log" 2>&1; then
+		echo "FAIL — quarantined suite '${name}' now PASSES. Un-quarantine it: delete its"
+		echo "       QUARANTINE entry so CI enforces it from here on."
+		_rot=$((_rot + 1))
+	else
+		echo "still failing as documented — ${name}"
+	fi
+done
+
+echo
+echo "== summary =="
+echo "   passed:      ${_passed}"
+echo "   quarantined: ${#_skipped[@]}"
+echo "   failed:      ${#_failed[@]}"
+
+if [ "${#_failed[@]}" -eq 0 ] && [ "${_rot}" -eq 0 ]; then
+	echo
+	echo "ALL discovered helper suites PASSED (${#_skipped[@]} quarantined, each with a reason)"
+	exit 0
+fi
+
+echo
+if [ "${#_failed[@]}" -gt 0 ]; then
+	echo "FAILED SUITES: ${_failed[*]}"
+fi
+if [ "${_rot}" -gt 0 ]; then
+	echo "QUARANTINE ROT: ${_rot} entry/entries need attention"
+fi
+exit 1


### PR DESCRIPTION
`test_check_manifest_crossref.js` referenced `scripts/test-fixtures/effective-manifest/{good,broken}/` — a directory that **has never existed in this repository**.

Unlike its already-fixed sibling `test_check_manifest.sh` (green its whole life, because a missing manifest path makes the validator print `Tier 0, skipping` and exit 0), this one was **red** its whole life — 13 of 21 assertions failing. Nobody saw it, because **no CI job ran it**.

And four of the eight assertions it *did* pass, it passed for the wrong reason. With no fixture the checker returns zero findings, and `zero errors` is indistinguishable from `nothing was ever loaded`:

```
PASS — good: zero error findings                 ← nothing was loaded
PASS — broken: checker exits 1                   ← for the wrong reason
PASS — broken: summary line is {"status":"failed"…}
```

## Fixtures

`good/` and `broken/` are real app trees — `src/manifest.json`, ADR-037 `manifest.d/` fragments, ADR-044 `menu-layout.json`, `lib/Settings/*register*.json`. Every seeded defect is commented **in place** with why it fires and what would silence it.

They serve **both** fixture-dependent suites. `test_build_effective_manifest.js` assembles from `good/` too — it was printing its in-memory assertions as PASS and then dying on an uncaught `ENOBASE` stack trace.

`good/` → 0 errors, exactly 1 WARN (the open-modal registry, app code the gate cannot statically parse), assembled manifest passes canonical validation.

`broken/` → one defect per gate-30 check:

| check | seeded defect |
|---|---|
| `menu-route` | dangling route `cases-overview` |
| `action-target` | `open-page` → `missing-page` |
| `slug-resolution` | widget `zaak-besluiten` → undeclared schema `besluit` (the zaakafhandelapp failure class) |
| `deeplink-route` | `urlTemplate: /besluiten/{id}` reaches no page |
| `removals-invariant` | removal `cases-index` orphans its route (ADR-044) |

Plus a fragment-introduced `layout[]` page key — invisible in the base manifest *and* to the crossref checker, caught only when the **assembled** manifest meets `pages[].additionalProperties: false`. That is precisely why gate-30 assembles before checking.

## Positive control

A fixture change that neutralises a seeded defect must turn the suite red **naming it**:

```
$ # broken/src/manifest.json: route "cases-overview" → "zaken-index"
$ node scripts/lib/test_check_manifest_crossref.js
FAIL — broken: exactly one menu-route error (dangling route cases-overview)
FAIL — broken: exactly 5 error findings — none missed, none extra (got 4)
2 gate-30 assertion(s) FAILED     (exit 1)
```

Reverted, and the revert **verified byte-identical on disk** by checksum rather than trusted:

```
$ sha256sum -c fixture-baseline.sha
./broken/src/manifest.json: OK          (all 9 files OK)
$ node scripts/lib/test_check_manifest_crossref.js
ALL gate-30 effective-manifest-crossref assertions PASSED    (exit 0)
```

Second control — both suites now **refuse to run** without their inputs, instead of proceeding into assertions an absent fixture can satisfy:

```
$ mv scripts/test-fixtures/effective-manifest /tmp/
FAIL — 9 gate-30 fixture file(s) MISSING …; this suite cannot assert anything:
    good/src/manifest.json
    …
Refusing to run. Without the fixtures the checker reports zero findings,
and "zero errors" would satisfy several assertions below while inspecting
nothing at all — the exact defect this gate exists to catch, one level down.
                                                                     (exit 1)
```

## The root cause was bigger than the fixtures

CI named **four** test files by hand. The package ships **19**. Fifteen were executed by nothing at all — they existed, and they looked like coverage.

A hand-written list of test names decays exactly like a hand-written paths filter: adding a file does not add it to the list, and the omission is invisible. So `tests/run-helper-suites.sh` **discovers** `scripts/lib/test_*` instead — a new suite is enforced the moment it lands, with no workflow edit to forget. It refuses to report green on an empty discovery.

**17 suites now run where 4 did.**

Two are quarantined, each with a stated reason — they have the *same* missing-fixture defect (`register-handler-resolution-{pass,fail}`, `orphaned-write-capability-{pass,fail}`, `orphaned-write-crossapp`, and the glob-recursion tree). The quarantine cannot rot: an entry that no longer exists, **or that starts passing**, fails the step. The list can only shrink.

`test_gate_orphaned_capability_fixtures.sh` deserves a callout — its `cd` into the missing directory fails, the gate then finds nothing, and its `pass fixture: 0 finding(s)` assertions report **PASS** on that empty result. Green because the input is absent, one more time. Authoring those fixtures is the obvious follow-up.

## Verification

Rehearsed the exact CI sequence locally, including the no-Ajv leg and installing `ajv` at the repo root the way the workflow does:

- `test-hydra-gates-bin.sh` — OK
- `test_check_manifest.sh` with no `node_modules` — degraded contract exercised, all runnable assertions pass
- `npm install ajv ajv-formats` at repo root, then `run-helper-suites.sh` — **17 passed, 2 quarantined, 0 failed**
- confirmed the crossref structural leg genuinely **runs** rather than self-skipping (no `SKIP —` line; node resolves the root-level `ajv` by walking up from `scripts/lib/`)
- `koalaman/shellcheck:stable -S warning` on the new runner — clean
- workflow YAML re-parses

No gate logic, runner, or helper behaviour changed — only fixtures, two test guards, and which suites CI executes.