### PR TITLE
fix(quality): the npm legs died before they could skip themselves

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -813,8 +813,15 @@ jobs:
           php-version: ${{ inputs.php-version }}
           tools: composer:v2
 
+      # `enable-npm` must be in this condition, not only in the audit step below.
+      # actions/setup-node with `cache: npm` HARD-FAILS when there is no
+      # package-lock.json, so on a PHP-only repo (enable-npm: false) this step
+      # died before the audit step could report its polite "npm ecosystem is
+      # disabled — skipping". The npm leg then failed, and the Quality Report
+      # gate failed with it — a permanent red on every repo that legitimately
+      # has no package.json. Observed on ConductionNL/hydra 2026-08-04.
       - name: Setup Node.js
-        if: matrix.ecosystem == 'npm'
+        if: matrix.ecosystem == 'npm' && inputs.enable-npm
         uses: actions/setup-node@v4
         with:
           node-version: "${{ inputs.node-version }}"
@@ -937,8 +944,11 @@ jobs:
           php-version: ${{ inputs.php-version }}
           tools: composer:v2
 
+      # See the identical note on the security job's Setup Node.js step —
+      # `cache: npm` hard-fails without a package-lock.json, so this must also
+      # be gated on enable-npm, not only on the matrix leg.
       - name: Setup Node.js
-        if: matrix.ecosystem == 'npm'
+        if: matrix.ecosystem == 'npm' && inputs.enable-npm
         uses: actions/setup-node@v4
         with:
           node-version: "${{ inputs.node-version }}"


### PR DESCRIPTION
`enable-npm: false` repos were permanently red.

`actions/setup-node` with `cache: npm` hard-fails without a `package-lock.json`. In the `security` and `license` matrix jobs it was gated only on `matrix.ecosystem == 'npm'`, so on a PHP-only repo it died **before** the step below it could emit its polite `npm ecosystem is disabled — skipping`.

The fingerprint on ConductionNL/hydra run `30883321674` (jobs `91909084932`, `91909084936`):

    4  Setup Node.js         failure   (14s)
    5  Install dependencies  skipped
    6  Check npm licenses    skipped

The skip logic was correct and simply unreachable. `Quality Report` then failed on the gate step, so the whole quality pipeline reported red for a reason that had nothing to do with the code under test.

Both `Setup Node.js` steps now also require `inputs.enable-npm`. No behaviour change for repos that have a package.json.