### PR TITLE
fix(quality): a CANCELLED dependency let the Quality Report gate pass — and cancelled() is not the discriminator it looks like

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3675,6 +3675,53 @@ jobs:
           echo "::error::One or more quality jobs failed — see the report above."
           exit 1
 
+      # A CANCELLED job renders NO verdict, so treating it as merely
+      # "not a failure" lets this gate go green over a leg that never ran.
+      # Observed live on pipelinq run 30903070948: `E2E Tests (Playwright)`
+      # and `Hydra Gates` both CANCELLED, `Quality Report` still SUCCESS.
+      #
+      # But cancellation has two shapes and only one of them is a defect:
+      #
+      #   (a) a job cancelled while its run CARRIES ON — a real gap: that leg
+      #       produced no verdict while its siblings produced theirs. Reached
+      #       via a job-level `concurrency` group, a lost runner, or a
+      #       fail-fast matrix sibling. MUST fail the gate.
+      #
+      #   (b) the WHOLE run cancelled, almost always by this workflow's own
+      #       `concurrency: cancel-in-progress` when a newer commit supersedes
+      #       it. Entirely legitimate and routine — four merge commits in one
+      #       programme were superseded exactly this way. Must stay quiet, or
+      #       every rapid push turns into a wall of red.
+      #
+      # `cancelled()` is the discriminator: it reflects the RUN's cancellation
+      # state, not an individual job's. In shape (b) it is true, so this step
+      # is skipped and a superseded run stays silent. In shape (a) the run is
+      # alive, so it is false and the gate fires. (This job's own
+      # `if: always()` is what makes it reach here at all in shape (b);
+      # `always()` runs a job even when the run is cancelled.)
+      #
+      # RESIDUE, stated rather than papered over: a run cancelled by a HUMAN
+      # pressing "Cancel workflow" is indistinguishable from (b) in the
+      # expression context — there is no cancellation-reason field — so it
+      # stays quiet too and this job still reports success. Guarding against
+      # that needs a different mechanism than an `if:` expression.
+      - name: Gate — fail when an upstream job was cancelled mid-run
+        if: ${{ !cancelled() && contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more quality jobs were CANCELLED while the run continued. A cancelled job renders no verdict, so this gate cannot pass."
+          {
+            echo ""
+            echo "## ❌ Gate failed — cancelled job(s)"
+            echo ""
+            echo "The following jobs were cancelled while the run carried on, so they"
+            echo "produced no verdict:"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo '${{ toJSON(needs) }}' \
+            | jq -r 'to_entries[] | select(.value.result == "cancelled") | "- `\(.key)`"' \
+            >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
   # ╔══════════════════════════════════════════════╗
   # ║  STAGE 4 — SBOM Generation & Validation      ║
   # ║                                               ║

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3693,28 +3693,67 @@ jobs:
       #       programme were superseded exactly this way. Must stay quiet, or
       #       every rapid push turns into a wall of red.
       #
-      # `cancelled()` is the discriminator: it reflects the RUN's cancellation
-      # state, not an individual job's. In shape (b) it is true, so this step
-      # is skipped and a superseded run stays silent. In shape (a) the run is
-      # alive, so it is false and the gate fires. (This job's own
-      # `if: always()` is what makes it reach here at all in shape (b);
-      # `always()` runs a job even when the run is cancelled.)
+      # THE EXPRESSION CONTEXT CANNOT SEPARATE THEM. Measured, not assumed, on
+      # petstore's `probe/cancel-gate-semantics` branch:
       #
-      # RESIDUE, stated rather than papered over: a run cancelled by a HUMAN
-      # pressing "Cancel workflow" is indistinguishable from (b) in the
-      # expression context — there is no cancellation-reason field — so it
-      # stays quiet too and this job still reports success. Guarding against
-      # that needs a different mechanism than an `if:` expression.
+      #   run 30906581133 — shape (a), job-level concurrency cancelled ONE job
+      #     while the run carried on:  cancelled() = FALSE, run.conclusion = cancelled
+      #   run 30906801110 — shape (b), workflow-level `cancel-in-progress`
+      #     superseded the WHOLE run:  cancelled() = FALSE, run.conclusion = cancelled
+      #
+      # Both identical. So `cancelled()` is NOT the discriminator it looks like:
+      # it does not report true for a concurrency supersession, and a run's
+      # conclusion is `cancelled` merely because SOME job in it was cancelled.
+      # Gating on `!cancelled()` alone would have turned every superseded run
+      # red — the exact wall of red this must avoid.
+      #
+      # The property that actually differs is: **is this run still the
+      # authoritative one for its ref?** A supersession happens precisely
+      # because a newer commit arrived, so a superseded run's head SHA is no
+      # longer the branch tip. A run whose SHA is still the tip has not been
+      # superseded, so a cancelled leg in it is a real gap.
+      #
+      # That needs only `contents: read`, which every caller already grants.
+      #
+      # RESIDUE, stated rather than papered over:
+      #   * A run cancelled by a HUMAN, with no new commit pushed, still looks
+      #     like shape (a) and will now fail this gate. That is arguably right
+      #     (a cancelled leg rendered no verdict) but it is a behaviour change.
+      #   * A shape-(a) cancellation that coincides with a new push is read as
+      #     a supersession and stays quiet. Errs toward silence; the newer run
+      #     is the one whose verdict gates the PR.
+      #   * The tip lookup failing is treated as "not superseded" (fail loudly)
+      #     rather than silently waving a cancelled leg through.
       - name: Gate — fail when an upstream job was cancelled mid-run
         if: ${{ !cancelled() && contains(needs.*.result, 'cancelled') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          echo "::error::One or more quality jobs were CANCELLED while the run continued. A cancelled job renders no verdict, so this gate cannot pass."
+          set -uo pipefail
+
+          TIP="$(gh api "repos/${{ github.repository }}/commits/${RUN_REF}" --jq .sha 2>/dev/null || true)"
+
+          if [ -n "$TIP" ] && [ "$TIP" != "$RUN_SHA" ]; then
+            echo "::notice::Job(s) cancelled, but this run has been SUPERSEDED (${RUN_REF} is now at ${TIP:0:7}, this run is ${RUN_SHA:0:7}). Concurrency cancellation of an outdated run is not a defect — staying quiet."
+            {
+              echo ""
+              echo "### ⏭️ Cancelled jobs ignored — run superseded"
+              echo ""
+              echo "\`${RUN_REF}\` has moved to \`${TIP:0:7}\`; this run is \`${RUN_SHA:0:7}\`."
+              echo "The newer run is the one whose verdict counts."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::One or more quality jobs were CANCELLED while this run was still the tip of ${RUN_REF}. A cancelled job renders no verdict, so this gate cannot pass."
           {
             echo ""
             echo "## ❌ Gate failed — cancelled job(s)"
             echo ""
-            echo "The following jobs were cancelled while the run carried on, so they"
-            echo "produced no verdict:"
+            echo "These jobs were cancelled while this run was still the authoritative"
+            echo "run for \`${RUN_REF}\` (\`${RUN_SHA:0:7}\`), so they produced no verdict:"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
           echo '${{ toJSON(needs) }}' \


### PR DESCRIPTION
## The defect

The Quality Report gate only tested `contains(needs.*.result, 'failure')`.

A **cancelled** job renders no verdict, so "not a failure" let the aggregate go green over a leg that never ran.

Observed live on **pipelinq run 30903070948**: `quality / E2E Tests (Playwright)` and `quality / Hydra Gates` both **CANCELLED**, `quality / Quality Report` still **SUCCESS**.

## Why the obvious fix would have broken all ~13 caller repos

The natural patch is `if: !cancelled() && contains(needs.*.result, 'cancelled')`. **I shipped that first and then disproved it.**

Cancellation has two shapes, and only one is a defect:

- **(a)** a job cancelled while its run **carries on** — a real gap, that leg produced no verdict while its siblings produced theirs → must fail the gate
- **(b)** the **whole run** superseded by this workflow's own `concurrency: cancel-in-progress` when a newer commit arrives — routine and legitimate → must stay quiet

Measured on a purpose-built probe in petstore, not assumed:

| run | shape | `cancelled()` | `run.conclusion` |
|-----|-------|---------------|------------------|
| [30906581133](https://github.com/ConductionNL/petstore/actions/runs/30906581133) | (a) job-level concurrency cancelled one job, run carried on | **FALSE** | cancelled |
| [30906801110](https://github.com/ConductionNL/petstore/actions/runs/30906801110) | (b) workflow-level `cancel-in-progress` superseded the whole run | **FALSE** | cancelled |

**Identical.** Two consequences:

1. `cancelled()` does **not** report a concurrency supersession. Gating on `!cancelled()` alone would have turned **every superseded run red across all callers**.
2. `run.conclusion == "cancelled"` does **not** mean the run was cancelled — it is `cancelled` merely because *some* job in it was.

## The discriminator that does work

A supersession happens *precisely because a newer commit arrived*, so a superseded run's head SHA is **no longer the tip of its ref**. A run still at the tip has not been superseded, so a cancelled leg in it is a real gap.

The lookup needs only `contents: read`, which every caller already grants (verified working on the runner).

## Both directions proven — same file, same step, opposite outcomes

| phase | setup | RUN_SHA vs TIP | verdict | `report` |
|-------|-------|----------------|---------|----------|
| **3** — shape (a) | sibling branch cancels `dep` via a shared job-level concurrency group; branch A's tip **unmoved** | `06c01f9` == `06c01f9` | `STILL TIP — cancelled-gate FIRED` | **failure** ✅ |
| **4** — shape (b) | second push to the same branch supersedes the run; tip **moves** | `84838b5` != `2d0cba2` | `SUPERSEDED — cancelled-gate stayed QUIET` | **success** ✅ |

In phase 3 the log also shows `contains-failure = false` — i.e. **the old gate would have gone green** on exactly that run. That is the defect reproduced and the fix demonstrated in a single run.

## All-green control on the real workflow

ConductionNL/petstore#24 pins petstore's caller at this branch. With the revised workflow (`fc52615`), `quality / Quality Report` = **SUCCESS** on a normal all-green run. A gate that always fails is not a gate.

**Verified on: `ConductionNL/petstore` only**, before this can propagate to the other callers.

## Residue — stated, not papered over

- A run cancelled by a **human**, with no new commit pushed, now looks like shape (a) and **will fail this gate**. Arguably correct (a cancelled leg rendered no verdict) but it is a behaviour change.
- A genuine shape-(a) cancellation that *coincides* with a new push is read as a supersession and stays quiet. Errs toward silence; the newer run is the one whose verdict gates the PR.
- A failed tip lookup is treated as "not superseded" (fail loudly) rather than silently waving a cancelled leg through.

## Before merging

ConductionNL/petstore#24 must be **closed, not merged** — it pins the caller to this branch and must revert to `@main`.
