### PR TITLE
docs: require resolvable approver identity in license override examples

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -996,11 +996,15 @@ jobs:
   #   - The package is dual-licensed and the checker picks the wrong one
   #
   #   Keys are package names (composer: "vendor/package", npm: "package-name").
-  #   Values are a justification string (who approved it and when).
+  #   Values are a justification string: the reason, who approved it, and
+  #   when. Write the approver as a RESOLVABLE identity — GitHub handle with
+  #   profile link, or the PR number of the reviewing PR — not a bare name:
+  #   a name is ambiguous years later; a handle or PR resolves to an account
+  #   and a review trail.
   #   Example:
   #     {
-  #       "vendor/some-package": "Approved by legal (Jan de Vries) — 2026-03-14, dual-licensed MIT/proprietary, we use MIT terms",
-  #       "some-npm-package": "License is 'Artistic-2.0', compatible with EUPL — approved 2026-03-01"
+  #       "vendor/some-package": "Dual-licensed MIT/proprietary, we use the MIT terms. Approved 2026-03-14 by @nfoconductionnl (https://github.com/nfoconductionnl).",
+  #       "some-npm-package": "License is 'Artistic-2.0', compatible with EUPL. Approved in #157 by @nfoconductionnl."
   #     }
   #
   # How it works:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -998,13 +998,14 @@ jobs:
   #   Keys are package names (composer: "vendor/package", npm: "package-name").
   #   Values are a justification string: the reason, who approved it, and
   #   when. Write the approver as a RESOLVABLE identity — GitHub handle with
-  #   profile link, or the PR number of the reviewing PR — not a bare name:
+  #   profile link, or the full URL of the reviewing PR — not a bare name:
   #   a name is ambiguous years later; a handle or PR resolves to an account
-  #   and a review trail.
+  #   and a review trail. Use full URLs, not "#123": bare number references
+  #   only auto-link inside GitHub issues/PRs, not in a JSON file.
   #   Example:
   #     {
-  #       "vendor/some-package": "Dual-licensed MIT/proprietary, we use the MIT terms. Approved 2026-03-14 by @nfoconductionnl (https://github.com/nfoconductionnl).",
-  #       "some-npm-package": "License is 'Artistic-2.0', compatible with EUPL. Approved in #157 by @nfoconductionnl."
+  #       "vendor/some-package": "Dual-licensed MIT/proprietary, we use the MIT terms. Approved 2026-03-14 by @infoconductionnl (https://github.com/infoconductionnl).",
+  #       "some-npm-package": "License is 'Artistic-2.0', compatible with EUPL. Approved in https://github.com/ConductionNL/.github/pull/157 by @infoconductionnl."
   #     }
   #
   # How it works:


### PR DESCRIPTION
## License override justification format

The `.license-overrides.json` documentation in `quality.yml` asked for "who approved it and when", with an example using a bare name. A bare name is ambiguous over time; this updates the documented format to a resolvable identity:

- **GitHub handle with profile link**, and/or
- **the full URL of the reviewing PR** — a full URL rather than a bare `#123`, since number references only auto-link inside GitHub issues/PRs, not in a JSON file.

Both example entries are rewritten to demonstrate the two forms.

Documentation-only — the check's behaviour is unchanged, and existing override files stay valid (values are free-form justification strings).
