### PR TITLE
fix(gate-5): route-auth reported a resolution failure as a security finding, and never saw a camelCase route

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_route_auth.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_auth.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_route_auth.sh — control-pair suite for gate-5 (route-auth) and the
+# reachability invariant gate-14 took over from it.
+#
+# WHY THIS EXISTS
+# ---------------
+# ConductionNL/.github#153. Gate-5 had two defects, both live on scholiq:
+#
+#   (a) it reported a RESOLUTION FAILURE as a SECURITY FINDING. scholiq's
+#       health/metrics/preferences controllers are ADR-040 AppHost generics
+#       registered by \OCA\OpenRegister\AppHost\Bootstrap::register(); the files
+#       are absent from the leaf repo by design. The gate said
+#       "4 routed method(s) missing auth attribute". They are not missing —
+#       the gate was looking in the wrong repository.
+#
+#   (b) it was not diff-scoped. The missing-file branch `continue`d BEFORE the
+#       `_in_scope` call, so those 4 findings fired on a diff of package.json +
+#       package-lock.json. Every scholiq PR, Dependabot included, was blocked.
+#
+# The fix for (a) is the one that can go wrong quietly: "teach the gate about
+# AppHost" is one careless edit away from "AppHost apps are exempt", and a gate
+# that stops failing is worse than the false positive it replaced. So EVERY
+# assertion here is one half of a control pair — for each thing that must not
+# fire, there is a neighbouring fixture where the same code path MUST fire.
+#
+#   unguarded          -> FAIL  (a real IDOR shape: id-taking write, no attribute)
+#   guarded            -> PASS  (same routes, attributes present)
+#   apphost            -> PASS  (scholiq's shape: no finding, 4 NOT JUDGED)
+#   apphost-unguarded  -> FAIL  (AppHost adopter that ALSO ships a bad method)
+#   orphan-route       -> gate-5 declines, gate-14 raises it (no dead gate)
+#
+# Run: bash scripts/lib/test_gate_route_auth.sh   (exit 0 = all green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+FIXTURES="${PKG_ROOT}/scripts/test-fixtures/route-auth"
+
+_fail_n=0
+_pass_n=0
+
+_ok()   { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad()  { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# _run <app-dir> [extra runner args...]  — capture the whole run into _OUT.
+#
+# The runner's contract is that its LAST word is the summary. An abort before
+# the summary leaves the per-gate PASS lines on stdout and looks exactly like a
+# completed clean run, so every invocation here is rejected unless the
+# COVERAGE line is present. A suite that accepts a truncated run is measuring
+# nothing.
+# ---------------------------------------------------------------------------
+_OUT=""
+_UNRES=""
+_RRLOG=""
+_run() {
+    local _dir="$1"; shift
+    _OUT="$(bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    # The gates write their detail logs to fixed /tmp paths, which a
+    # concurrently running gate suite would truncate. Snapshot them straight
+    # away and assert against the snapshot.
+    _UNRES="$(cat /tmp/hydra-gate-route-auth-unresolved.log 2>/dev/null || true)"
+    _RRLOG="$(cat /tmp/hydra-gate-route-reachability.log 2>/dev/null || true)"
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "run in ${_dir} ABORTED before the summary — verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_gate_line() { printf '%s' "${_OUT}" | grep -E "^\[gate-$1\] " | head -1; }
+
+# _expect_gate <n> <PASS|FAIL> <description>
+_expect_gate() {
+    local _n="$1" _want="$2" _desc="$3" _line
+    _line="$(_gate_line "${_n}")"
+    if [ -z "${_line}" ]; then
+        _bad "${_desc} — gate-${_n} emitted NO verdict line at all"
+        return
+    fi
+    case "${_line}" in
+        *": ${_want}"*) _ok "${_desc} — ${_line}" ;;
+        *) _bad "${_desc} — wanted ${_want}, got: ${_line}" ;;
+    esac
+}
+
+_expect_out() {   # <regex> <description>
+    if printf '%s' "${_OUT}" | grep -qE "$1"; then _ok "$2"; else
+        _bad "$2 — no line matching /$1/"
+    fi
+}
+_expect_no_out() { # <regex> <description>
+    if printf '%s' "${_OUT}" | grep -qE "$1"; then
+        _bad "$2 — unexpected line: $(printf '%s' "${_OUT}" | grep -E "$1" | head -1)"
+    else _ok "$2"; fi
+}
+_expect_log() {   # <snapshot-var-contents> <regex> <description>
+    if printf '%s' "$1" | grep -qE "$2"; then _ok "$3"; else
+        _bad "$3 — no log line matching /$2/"
+    fi
+}
+
+echo "== gate-5 route-auth / gate-14 reachability control pairs =="
+echo
+
+for _f in unguarded guarded apphost apphost-unguarded orphan-route; do
+    if [ ! -d "${FIXTURES}/${_f}" ]; then
+        _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 1. POSITIVE CONTROL. A real IDOR shape must still fail. Everything below is
+#    only meaningful because this one is red-when-it-should-be.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/unguarded"; then
+    _expect_gate 5 FAIL "unguarded fixture: a routed, attribute-less write still FAILS gate-5"
+    _expect_out 'gate-5\] route-auth: FAIL — 2 routed method' \
+        "unguarded fixture: exactly TWO findings (the guarded sibling method is not reported)"
+    _RALOG="$(cat /tmp/hydra-gate-route-auth.log 2>/dev/null || true)"
+    _expect_log "${_RALOG}" 'WidgetController.php:[0-9]+ method=update' \
+        "unguarded fixture: the snake/lowercase slug's unguarded method is named"
+    # camelCase slug. Invisible to gate-5's old `'[a-z_]+#…'` regex.
+    _expect_log "${_RALOG}" 'PaymentTransactionController.php:[0-9]+ method=callback' \
+        "unguarded fixture: a camelCase route slug is judged at all"
+fi
+
+# 2. NEGATIVE CONTROL of the same code path.
+if _run "${FIXTURES}/guarded"; then
+    _expect_gate 5 PASS "guarded fixture: same routes (camelCase slug included) with attributes PASS"
+    _expect_no_out 'NOT JUDGED' "guarded fixture: nothing unresolved (every class resolved)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. DEFECT (a). scholiq's shape: AppHost generics produce NO finding, and the
+#    fact that they were not judged is STATED rather than silently dropped.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/apphost"; then
+    _expect_gate 5 PASS "apphost fixture: AppHost generics produce NO auth finding"
+    _expect_out 'gate-5 route-auth: 4 routed entr\(ies\) NOT JUDGED' \
+        "apphost fixture: the 4 unresolved entries are reported as NOT JUDGED, not as findings"
+    _expect_log "${_UNRES}" 'OpenRegister AppHost generic controller' \
+        "apphost fixture: the reason names AppHost explicitly"
+    _expect_gate 14 PASS "apphost fixture: gate-14 does not call an AppHost alias unreachable"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. THE ANTI-DEAD-GATE CONTROL. Same AppHost adoption, plus one genuinely
+#    unguarded method. If the AppHost knowledge ever becomes a blanket
+#    exemption, this goes green and the suite goes red.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/apphost-unguarded"; then
+    _expect_gate 5 FAIL "apphost-unguarded fixture: AppHost adoption does NOT exempt the app's own controllers"
+    _expect_out 'gate-5 route-auth: 5 routed entr\(ies\) NOT JUDGED' \
+        "apphost-unguarded fixture: the AppHost entries are still merely unjudged"
+    # AppHost adoption excuses the FIVE generics and nothing else. `gadget#run`
+    # names a class nobody provides — still a reachability defect.
+    _expect_gate 14 FAIL "apphost-unguarded fixture: a NON-generic missing controller is still raised"
+    _expect_log "${_RRLOG}" "GadgetController.php route='gadget#run' rule=controller-class-not-found" \
+        "apphost-unguarded fixture: gate-14 names gadget#run, not the AppHost generics"
+    if printf '%s' "${_RRLOG}" | grep -qE '(Health|Metrics|Preferences)Controller'; then
+        _bad "apphost-unguarded fixture: gate-14 wrongly reported an AppHost generic"
+    else
+        _ok "apphost-unguarded fixture: gate-14 reported no AppHost generic"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. NO HOLE. A route naming a class this repo does not ship is real, and is
+#    now raised by the gate that owns reachability instead of being reported as
+#    an auth finding by the gate that cannot see the class.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/orphan-route"; then
+    _expect_gate 5 PASS "orphan-route fixture: an unresolvable class is NOT an auth finding"
+    _expect_out 'gate-5 route-auth: 2 routed entr\(ies\) NOT JUDGED' \
+        "orphan-route fixture: both unresolvable entries are stated"
+    _expect_gate 14 FAIL "orphan-route fixture: gate-14 DOES raise the unreachable route"
+    _expect_log "${_RRLOG}" 'rule=controller-class-not-found' \
+        "orphan-route fixture: gate-14 log names controller-class-not-found"
+    _expect_log "${_RRLOG}" 'rule=method-not-found-on-target-controller' \
+        "orphan-route fixture: gate-14 still names the missing-method shape too"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. DEFECT (b): diff scoping. Needs a real git repo, so build one per case.
+# ---------------------------------------------------------------------------
+_TMP="$(mktemp -d)"
+trap 'rm -rf "${_TMP}"' EXIT
+
+# _mkrepo <fixture> <name> — copy the fixture into a fresh git repo and commit
+# it. Sets the globals ${_REPO} and ${_BASE}. Deliberately NOT a function that
+# echoes the path: `_repo="$(_mkrepo …)"` runs it in a SUBSHELL, so ${_BASE}
+# would be discarded and every scoped run would be handed an empty base. The
+# runner fails closed on that (exit 99), which is the only reason the mistake
+# was visible at all rather than silently passing on an empty diff.
+_BASE=""
+_REPO=""
+_mkrepo() {
+    local _fx="$1" _name="$2"
+    _REPO="${_TMP}/${_name}"
+    mkdir -p "${_REPO}"
+    cp -r "${FIXTURES}/${_fx}/." "${_REPO}/"
+    git -C "${_REPO}" init -q 2>/dev/null
+    git -C "${_REPO}" config user.email t@example.invalid
+    git -C "${_REPO}" config user.name test
+    printf '{"name":"fixture","version":"1.0.0"}\n' > "${_REPO}/package.json"
+    git -C "${_REPO}" add -A >/dev/null 2>&1
+    git -C "${_REPO}" commit -q -m base >/dev/null 2>&1
+    _BASE="$(git -C "${_REPO}" rev-parse HEAD)"
+}
+
+# --- 6a. package.json-only diff on the fixture that DOES have a real finding.
+#     This is the exact shape that blocked scholiq. It must produce nothing —
+#     and note the finding IS there in the tree (assertion 1 proved it), so a
+#     PASS here is scoping, not absence.
+_mkrepo unguarded scope-deps
+printf '{"name":"fixture","version":"1.0.1"}\n' > "${_REPO}/package.json"
+printf 'lockfile\n' > "${_REPO}/package-lock.json"
+git -C "${_REPO}" add package.json package-lock.json >/dev/null 2>&1
+git -C "${_REPO}" commit -q -m bump >/dev/null 2>&1
+if _run "${_REPO}" --scope-to-diff --base "${_BASE}"; then
+    _expect_gate 5 PASS "package.json-only diff: gate-5 reports NO finding (scoped out, not absent)"
+fi
+
+# --- 6b. same repo, same finding, but the diff touches the controller.
+_mkrepo unguarded scope-ctrl
+printf '\n// touched\n' >> "${_REPO}/lib/Controller/WidgetController.php"
+git -C "${_REPO}" add lib/Controller/WidgetController.php >/dev/null 2>&1
+git -C "${_REPO}" commit -q -m touch >/dev/null 2>&1
+if _run "${_REPO}" --scope-to-diff --base "${_BASE}"; then
+    _expect_gate 5 FAIL "controller in the diff: the same missing attribute FAILS"
+fi
+
+# --- 6c. the diff touches appinfo/routes.php only. Adding or altering a route
+#     is exactly when its auth posture must be re-checked, so the routed
+#     methods come back into scope even though no controller changed.
+_mkrepo unguarded scope-routes
+printf '\n// touched\n' >> "${_REPO}/appinfo/routes.php"
+git -C "${_REPO}" add appinfo/routes.php >/dev/null 2>&1
+git -C "${_REPO}" commit -q -m touch >/dev/null 2>&1
+if _run "${_REPO}" --scope-to-diff --base "${_BASE}"; then
+    _expect_gate 5 FAIL "routes.php in the diff: routed methods are re-judged"
+fi
+
+# --- 6d. AppHost app, package.json-only diff: scholiq's actual PR. Clean.
+_mkrepo apphost scope-apphost-deps
+printf '{"name":"fixture","version":"1.0.1"}\n' > "${_REPO}/package.json"
+git -C "${_REPO}" add package.json >/dev/null 2>&1
+git -C "${_REPO}" commit -q -m bump >/dev/null 2>&1
+if _run "${_REPO}" --scope-to-diff --base "${_BASE}"; then
+    _expect_gate 5 PASS "AppHost app, dependency-only diff: gate-5 clean (the scholiq case)"
+    _expect_gate 14 PASS "AppHost app, dependency-only diff: gate-14 clean"
+fi
+
+echo
+echo "== summary =="
+echo "   passed: ${_pass_n}"
+echo "   failed: ${_fail_n}"
+if [ "${_pass_n}" -eq 0 ]; then
+    echo "FAIL — zero assertions ran; an empty suite is not a green suite"
+    exit 1
+fi
+[ "${_fail_n}" -eq 0 ] || exit 1
+echo "ALL gate-5 / gate-14 control pairs PASSED"
+exit 0

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -259,6 +259,105 @@ _count() {
     printf '%s' "${_n}"
 }
 
+# ---------------------------------------------------------------------------
+# ADR-040 AppHost adoption — shared between gate-5 (route-auth) and gate-14
+# (route-reachability).
+#
+# An app that calls `\OCA\OpenRegister\AppHost\Bootstrap::register()` from
+# lib/AppInfo/Application.php does NOT ship the dashboard / preferences /
+# settings / health / metrics controllers. Bootstrap registers the OpenRegister
+# *generic* controllers under the leaf app's conventional class names
+# (`OCA\<Leaf>\Controller\HealthController`, ...) via
+# `IRegistrationContext::registerService()`, so `appinfo/routes.php` names a
+# class that resolves at runtime but has NO FILE in this repository, by design.
+#
+# Before 2026-08-05 both gates read that absence as a finding:
+#   gate-5  reported it as "routed method missing auth attribute" — a SECURITY
+#           verdict on a file the gate simply could not open. On scholiq that
+#           was 4 findings on every PR (ConductionNL/.github#153). A security
+#           gate that cries wolf on correct code is worse than no gate: it
+#           trains readers to skip the whole tier.
+#   gate-14 deferred to gate-5 and skipped it entirely.
+#
+# The generic controllers DO carry their auth attributes — in the openregister
+# package, which this run has no access to. "I cannot see it" is not "it is
+# absent"; only the first of those is true, and only the first may be reported.
+#
+# NB: Bootstrap uses `aliasControllerUnlessLeafDefinesIt` — a leaf that ships
+# its own e.g. SettingsController.php keeps it, and the file therefore exists
+# and is judged normally. This helper only ever fires when the file is ABSENT.
+# ---------------------------------------------------------------------------
+_HYDRA_APPHOST=0
+if [ -f lib/AppInfo/Application.php ] \
+    && grep -qE 'AppHost\\+Bootstrap' lib/AppInfo/Application.php \
+    && grep -qE 'Bootstrap::register[[:space:]]*\(' lib/AppInfo/Application.php; then
+    _HYDRA_APPHOST=1
+fi
+# The five controller class names Bootstrap::register() aliases, as route
+# slugs. Source of truth: openregister lib/AppHost/Bootstrap.php
+# ::registerControllers(). Deliberately an explicit list, not a wildcard —
+# a wildcard would let ANY missing controller hide behind AppHost adoption.
+_HYDRA_APPHOST_SLUGS="dashboard preferences settings health metrics"
+
+# _apphost_serves <route-slug> — 0 when this app adopts AppHost AND the slug is
+# one of the generics AppHost provides, i.e. the missing file is expected.
+_apphost_serves() {
+    [ "${_HYDRA_APPHOST}" -eq 1 ] || return 1
+    case " ${_HYDRA_APPHOST_SLUGS} " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# _ctrl_path_from_name <route-slug> — the file a routed `controller#method`
+# name resolves to. Handles the three shapes Nextcloud accepts:
+#
+#   Settings\Foo  -> lib/Controller/Settings/FooController.php
+#   my_thing      -> lib/Controller/MyThingController.php   (snake_case)
+#   credentialVerify -> lib/Controller/CredentialVerifyController.php
+#
+# SHARED by gate-5 (route-auth) and gate-14 (route-reachability). It used to be
+# defined INSIDE gate-14 only, and gate-5 carried its own narrower copy —
+# including its own route-name regex, `'[a-z_]+#…'`. That regex matches only
+# all-lowercase and snake_case slugs, so EVERY camelCase route was invisible to
+# gate-5 and reported nothing, in either direction. Measured on scholiq
+# 2026-08-05: 14 of 37 routed names matched; the other 23 — among them
+# `paymentTransaction#callback`, `keyAdmin#generateKey` and
+# `credentialVerify#verify` — were never opened. A positive control (stripping
+# both the attributes AND the docblock tags from a real routed method) still
+# reported PASS, which is how this was caught. Two gates reading route names
+# through two different regexes is the defect; one helper is the fix.
+# ---------------------------------------------------------------------------
+_ctrl_path_from_name() {
+    local _name="$1"
+    case "${_name}" in
+        *\\*)
+            local _last="${_name##*\\}"
+            local _ns="${_name%\\*}"
+            # SC2155: declare and assign separately so awk's exit code isn't
+            # masked by `local`.
+            local _last_cap
+            _last_cap="$(printf '%s' "${_last}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
+            echo "lib/Controller/${_ns}/${_last_cap}Controller.php"
+            ;;
+        *_*)
+            local _camel
+            _camel=$(echo "${_name}" | awk -F'_' '{for(i=1;i<=NF;i++) printf toupper(substr($i,1,1)) substr($i,2); print ""}')
+            echo "lib/Controller/${_camel}Controller.php"
+            ;;
+        *)
+            local _cap
+            _cap=$(printf '%s' "${_name}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+            echo "lib/Controller/${_cap}Controller.php"
+            ;;
+    esac
+}
+
+# The one regex both route gates read `appinfo/routes.php` through.
+_ROUTE_NAME_RX="'name'\s*=>\s*'[A-Za-z][A-Za-z0-9_\\]*#[a-zA-Z0-9_]+'"
+_ROUTE_PAIR_RX="[A-Za-z][A-Za-z0-9_\\]*#[a-zA-Z0-9_]+"
+
 _FAILED=0
 _EMITTED_GATES=""
 # _SKIPPED_GATES is written by _skip but deliberately NOT read by the coverage
@@ -511,32 +610,93 @@ fi
 # Gate 5: Route-auth — every method registered in appinfo/routes.php has
 # an NC middleware attribute (#[PublicPage] / #[NoAdminRequired] /
 # #[NoCSRFRequired] / #[AuthorizedAdminSetting]) or legacy docblock tag.
+#
+# TWO DEFECTS FIXED 2026-08-05 (ConductionNL/.github#153):
+#
+# (a) A RESOLUTION FAILURE WAS REPORTED AS A SECURITY FINDING. When
+#     lib/Controller/<X>Controller.php did not exist, or existed without the
+#     routed method, the gate wrote a line into the failure log and the verdict
+#     read "N routed method(s) missing auth attribute". Those two states are
+#     not the same thing and only one of them is a security signal:
+#         "the attribute is absent"      -> a finding, and a real one
+#         "I could not open the class"   -> the gate learned NOTHING
+#     Reported live on scholiq, whose health/metrics/preferences controllers
+#     are ADR-040 AppHost generics (see _apphost_serves above). This gate now
+#     separates the two: unresolvable entries go to an UNRESOLVED log and are
+#     stated as such, never counted as auth findings.
+#
+#     ⚠️ The dangerous over-correction would be to swallow the unresolved
+#     entries. A route whose class this repo genuinely does not ship is a real
+#     defect (ReflectionException 500) — it is just not THIS gate's defect. It
+#     is now raised by gate-14 (route-reachability), which owns that invariant.
+#     Removing it here without adding it there would have created a dead gate.
+#
+# (b) IT WAS NOT DIFF-SCOPED. The `missing file` branch `continue`d BEFORE the
+#     `_in_scope` call, so a route whose controller was absent fired on every
+#     PR regardless of the diff — a package.json-only Dependabot bump included.
+#     Per ADR-020 a routed method is now judged when the PR touched EITHER the
+#     controller that serves it OR appinfo/routes.php itself (adding/altering a
+#     route is exactly when its auth posture must be re-checked).
 # ---------------------------------------------------------------------------
 if [ -f appinfo/routes.php ]; then
     _ra_fail=0 _ra_log=/tmp/hydra-gate-route-auth.log
+    _ra_unresolved_log=/tmp/hydra-gate-route-auth-unresolved.log
     : > "${_ra_log}"
-    grep -oE "'name'\s*=>\s*'[a-z_]+#[a-zA-Z0-9_]+'" appinfo/routes.php \
-        | grep -oE "[a-z_]+#[a-zA-Z0-9_]+" | sort -u \
-        | while IFS='#' read ctrl method; do
-            class=$(echo "$ctrl" | awk -F'_' '{for(i=1;i<=NF;i++) printf toupper(substr($i,1,1)) substr($i,2); print ""}')
-            path="lib/Controller/${class}Controller.php"
+    : > "${_ra_unresolved_log}"
+    # Touching appinfo/routes.php puts every routed method back in scope.
+    _ra_routes_touched=0
+    _in_scope "appinfo/routes.php" && _ra_routes_touched=1
+    # Process substitution, not a pipeline: the loop must run in THIS shell so
+    # the log appends and the scope flags are read from one consistent state.
+    while IFS='#' read ctrl method; do
+            [ -n "${ctrl:-}" ] || continue
+            path=$(_ctrl_path_from_name "${ctrl}")
             if [ ! -f "$path" ]; then
-                echo "${ctrl}#${method} — ${path} missing" >> "${_ra_log}"
+                if _apphost_serves "${ctrl}"; then
+                    echo "${ctrl}#${method} — served by the OpenRegister AppHost generic controller (ADR-040); its auth attribute lives in the openregister package and is NOT visible from this repository" >> "${_ra_unresolved_log}"
+                else
+                    echo "${ctrl}#${method} — ${path} is not present in this repository; controller class UNRESOLVED (see gate-14, which owns route reachability)" >> "${_ra_unresolved_log}"
+                fi
                 continue
             fi
-            _in_scope "$path" || continue
+            if [ "${_ra_routes_touched}" -eq 0 ]; then
+                _in_scope "$path" || continue
+            fi
             def_line=$(grep -nE "^\s*public\s+function\s+${method}\s*\(" "$path" | head -1 | cut -d: -f1)
             if [ -z "$def_line" ]; then
-                echo "${path}: no method ${method}" >> "${_ra_log}"
+                echo "${path}: routed method ${method} does not exist on this class; UNRESOLVED (see gate-14, which owns route reachability)" >> "${_ra_unresolved_log}"
                 continue
             fi
             start=$((def_line > 20 ? def_line - 20 : 1))
+            # ⚠️ THIRD DEFECT, found 2026-08-05 by this gate's own positive
+            # control (scripts/lib/test_gate_route_auth.sh). The 20-line
+            # lookback is not bounded by the START OF THE METHOD, so it reads
+            # back over the PREVIOUS member. A short guarded method sitting
+            # within 20 lines above an unguarded one donated its
+            # `#[NoAdminRequired]` to its neighbour and the unguarded method
+            # passed. That is a false NEGATIVE in a security gate — the
+            # expensive direction, and invisible because a pass leaves no log.
+            # Clamp the window to the line after the previous member's closing
+            # brace: an attribute or docblock for THIS method can only appear
+            # after it, so this can never hide a genuine attribute — it can
+            # only stop one being borrowed.
+            prev_close=$(awk -v L="${def_line}" 'NR < L && /^[[:space:]]*\}/ { n = NR } END { print n + 0 }' "$path")
+            if [ "${prev_close}" -ge "${start}" ]; then
+                start=$((prev_close + 1))
+            fi
             head_block=$(sed -n "${start},${def_line}p" "$path")
             if ! echo "$head_block" | grep -qE '#\[(PublicPage|NoAdminRequired|NoCSRFRequired|AuthorizedAdminSetting)\b|@(PublicPage|NoAdminRequired|NoCSRFRequired)\b'; then
                 echo "${path}:${def_line} method=${method} rule=missing-auth-attribute" >> "${_ra_log}"
             fi
-        done
-    _ra_fail=$(wc -l < "${_ra_log}" 2>/dev/null || echo 0)
+    done < <(grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
+        | grep -oE "${_ROUTE_PAIR_RX}" | sort -u)
+    _ra_fail=$(_count '.' "${_ra_log}")
+    _ra_unres=$(_count '.' "${_ra_unresolved_log}")
+    # Stated, never folded into the verdict. Does NOT start with `[gate-` so it
+    # cannot be mistaken for a verdict line by any `^\[gate-` consumer.
+    if [ "${_ra_unres}" -gt 0 ]; then
+        echo "[hydra-gates] gate-5 route-auth: ${_ra_unres} routed entr(ies) NOT JUDGED (controller class unresolvable here) — see ${_ra_unresolved_log}. This is not a pass for them; reachability is gate-14's."
+    fi
     if [ "${_ra_fail}" -eq 0 ]; then
         _pass 5 "route-auth"
     else
@@ -932,6 +1092,11 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     _rr_log=/tmp/hydra-gate-route-reachability.log
     : > "${_rr_log}"
 
+    # Touching appinfo/routes.php puts every routed entry back in scope for
+    # invariant 2 — see the scope note at that loop.
+    _rr_routes_touched=0
+    _in_scope "appinfo/routes.php" && _rr_routes_touched=1
+
     # Resource auto-routes (entries inside the top-level `'resources' => [...]`
     # block) generate index/show/create/update/destroy on the named
     # controller; methods on those auto-routes are excluded from invariant 1.
@@ -1013,46 +1178,38 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     done < <(_enum_tracked 'Controller\.php$' lib/Controller)
 
     # ---- Invariant 2: every routed entry resolves to a method that exists.
-    grep -oE "'name'\s*=>\s*'[A-Za-z][A-Za-z0-9_\\]*#[a-zA-Z0-9_]+'" appinfo/routes.php \
-        | grep -oE "[A-Za-z][A-Za-z0-9_\\]*#[a-zA-Z0-9_]+" | sort -u \
+    grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
+        | grep -oE "${_ROUTE_PAIR_RX}" | sort -u \
         | while IFS='#' read _ctrl _method; do
-            # Resolve controller name → file path. Settings\Foo → Settings/FooController.php.
-            # snake_case → camelCase + Controller.php.
-            _ctrl_path_from_name() {
-                local _name="$1"
-                case "${_name}" in
-                    *\\*)
-                        # Settings\Foo → Settings/FooController.php
-                        local _last="${_name##*\\}"
-                        local _ns="${_name%\\*}"
-                        # SC2155: declare and assign separately so awk's exit
-                        # code isn't masked by `local`.
-                        local _last_cap
-                        _last_cap="$(printf '%s' "${_last}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-                        echo "lib/Controller/${_ns}/${_last_cap}Controller.php"
-                        ;;
-                    *_*)
-                        # snake_case → CamelCase
-                        local _camel
-                        _camel=$(echo "${_name}" | awk -F'_' '{for(i=1;i<=NF;i++) printf toupper(substr($i,1,1)) substr($i,2); print ""}')
-                        echo "lib/Controller/${_camel}Controller.php"
-                        ;;
-                    *)
-                        local _cap
-                        _cap=$(printf '%s' "${_name}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
-                        echo "lib/Controller/${_cap}Controller.php"
-                        ;;
-                esac
-            }
+            # Resolver is shared with gate-5 — see _ctrl_path_from_name above.
+            # It lived here, inline, while gate-5 carried a narrower private
+            # copy; the divergence is what let 23 of scholiq's 37 routes go
+            # unjudged by gate-5.
             _path=$(_ctrl_path_from_name "${_ctrl}")
+            # Diff scope: enforce when the PR touched the controller OR
+            # appinfo/routes.php itself, so inherited debt doesn't bounce
+            # unrelated PRs (per ADR-020) while a newly added or edited route
+            # is still checked against the class it names.
+            _rr_scoped=0
+            [ "${_rr_routes_touched}" -eq 1 ] && _rr_scoped=1
+            _in_scope "${_path}" && _rr_scoped=1
+            [ "${_rr_scoped}" -eq 1 ] || continue
             if [ ! -f "${_path}" ]; then
-                # Treat missing controller file as out of this gate's scope —
-                # gate-5 (route-auth) already flags this. Skip to avoid duplicates.
+                # UNTIL 2026-08-05 this `continue`d with the comment "gate-5
+                # already flags this". Gate-5 flagged it as a MISSING AUTH
+                # ATTRIBUTE, which it is not, and gate-5 no longer does
+                # (ConductionNL/.github#153). The invariant is this gate's:
+                # a route naming a class that does not exist is a
+                # ReflectionException 500 at request time — precisely
+                # invariant 2, one step earlier than a missing method.
+                #
+                # ADR-040 AppHost generics are the ONE legitimate absence:
+                # Bootstrap::register() binds those class names in the DI
+                # container, so the route resolves with no file on disk.
+                _apphost_serves "${_ctrl}" && continue
+                echo "${_path} route='${_ctrl}#${_method}' rule=controller-class-not-found" >> "${_rr_log}"
                 continue
             fi
-            # Diff scope: only enforce on changed files so inherited debt
-            # doesn't bounce unrelated PRs (per ADR-020).
-            _in_scope "${_path}" || continue
             if ! grep -qE "^[[:space:]]*public function ${_method}[[:space:]]*\(" "${_path}"; then
                 echo "${_path} route='${_ctrl}#${_method}' rule=method-not-found-on-target-controller" >> "${_rr_log}"
             fi

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/appinfo/routes.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture mirroring scholiq: AppHost adoption (ADR-040). The settings,
+// preferences, health and metrics controllers are the OpenRegister AppHost
+// generics, aliased onto this app's conventional controller class names in
+// lib/AppInfo/Application.php via \OCA\OpenRegister\AppHost\Bootstrap::register().
+// Those files therefore do NOT exist here, by design.
+//
+// `gadget#run` is the second half of the control: an AppHost adopter may still
+// name a class it does not ship and AppHost does not provide. Adoption must
+// excuse the FIVE generics and nothing else, so gate-14 must still raise this
+// one. Widening _apphost_serves() to accept any slug is caught here.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'gadget#run',  'url' => '/api/gadgets/run',  'verb' => 'POST'],
+
+        ['name' => 'health#index',  'url' => '/api/health',  'verb' => 'GET'],
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/lib/AppInfo/Application.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'fixture';
+
+    public function register(IRegistrationContext $context): void
+    {
+        // ADR-040: adopt the OpenRegister AppHost. One call wires the generic
+        // SPA/settings/preferences/health/metrics controllers.
+        Bootstrap::register(
+            $context,
+            self::APP_ID,
+            ['namespace' => 'OCA\\Fixture']
+        );
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost-unguarded/lib/Controller/WidgetController.php
@@ -1,0 +1,23 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * ANTI-DEAD-GATE CONTROL.
+ *
+ * This app adopts AppHost exactly like the `apphost` fixture next door, and
+ * additionally ships one genuinely unguarded routed method. If teaching the
+ * gate about AppHost ever degrades into "AppHost apps are exempt", THIS
+ * fixture goes green and the suite fails — which is the point of it.
+ */
+class WidgetController extends Controller
+{
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost/appinfo/routes.php
@@ -1,0 +1,19 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture mirroring scholiq: AppHost adoption (ADR-040). The settings,
+// preferences, health and metrics controllers are the OpenRegister AppHost
+// generics, aliased onto this app's conventional controller class names in
+// lib/AppInfo/Application.php via \OCA\OpenRegister\AppHost\Bootstrap::register().
+// Those files therefore do NOT exist here, by design.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+
+        ['name' => 'health#index',  'url' => '/api/health',  'verb' => 'GET'],
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost/lib/AppInfo/Application.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'fixture';
+
+    public function register(IRegistrationContext $context): void
+    {
+        // ADR-040: adopt the OpenRegister AppHost. One call wires the generic
+        // SPA/settings/preferences/health/metrics controllers.
+        Bootstrap::register(
+            $context,
+            self::APP_ID,
+            ['namespace' => 'OCA\\Fixture']
+        );
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/apphost/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/apphost/lib/Controller/WidgetController.php
@@ -1,0 +1,20 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+
+/**
+ * The one controller this AppHost-adopting app actually ships. Guarded.
+ */
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/guarded/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/guarded/appinfo/routes.php
@@ -1,0 +1,11 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture: every routed method carries an auth attribute. Gate-5 MUST pass.
+return [
+    'routes' => [
+        ['name' => 'widget#show',   'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'widget#update', 'url' => '/api/widgets/{id}', 'verb' => 'PUT'],
+        // camelCase slug, guarded — the negative half of the pair.
+        ['name' => 'paymentTransaction#callback', 'url' => '/api/payments/callback', 'verb' => 'POST'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/guarded/lib/Controller/PaymentTransactionController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/guarded/lib/Controller/PaymentTransactionController.php
@@ -1,0 +1,22 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+
+/**
+ * camelCase route slug (`paymentTransaction#callback`), guarded.
+ */
+class PaymentTransactionController extends Controller
+{
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function callback(string $reference): JSONResponse
+    {
+        return new JSONResponse(['reference' => $reference]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/guarded/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/guarded/lib/Controller/WidgetController.php
@@ -1,0 +1,26 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+
+/**
+ * Fixture controller — both routed methods declare their auth posture.
+ */
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+
+    #[NoAdminRequired]
+    public function update(string $id, array $data): JSONResponse
+    {
+        return new JSONResponse(['id' => $id, 'data' => $data]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/orphan-route/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/orphan-route/appinfo/routes.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture: NOT an AppHost adopter, and `gadget#run` names a controller class
+// that this repository does not ship. That is a route-reachability defect
+// (ReflectionException 500 at request time), NOT a missing auth attribute.
+// Gate-5 must decline to judge it; gate-14 must raise it.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'gadget#run',  'url' => '/api/gadgets/run',  'verb' => 'POST'],
+        ['name' => 'widget#ghost', 'url' => '/api/widgets/ghost', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/orphan-route/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/orphan-route/lib/Controller/WidgetController.php
@@ -1,0 +1,20 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+
+/**
+ * `ghost` is routed but does not exist here — the second reachability shape.
+ */
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/unguarded/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/unguarded/appinfo/routes.php
@@ -1,0 +1,16 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture: a genuinely unguarded route. Gate-5 MUST fail on this.
+return [
+    'routes' => [
+        ['name' => 'widget#show',   'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'widget#update', 'url' => '/api/widgets/{id}', 'verb' => 'PUT'],
+
+        // camelCase slug. Gate-5 read route names through `'[a-z_]+#…'` until
+        // 2026-08-05, so a slug with a capital in it matched NOTHING and the
+        // method behind it was never judged — on scholiq that hid 23 of 37
+        // routes, `paymentTransaction#callback` among them. This entry is
+        // unguarded, so it must be reported.
+        ['name' => 'paymentTransaction#callback', 'url' => '/api/payments/callback', 'verb' => 'POST'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/unguarded/lib/Controller/PaymentTransactionController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/unguarded/lib/Controller/PaymentTransactionController.php
@@ -1,0 +1,21 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * camelCase route slug (`paymentTransaction#callback`), unguarded.
+ *
+ * The half of the pair that proves gate-5 can SEE a camelCase slug at all.
+ * Its guarded twin lives in the `guarded` fixture.
+ */
+class PaymentTransactionController extends Controller
+{
+    public function callback(string $reference): JSONResponse
+    {
+        return new JSONResponse(['reference' => $reference]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/unguarded/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/unguarded/lib/Controller/WidgetController.php
@@ -1,0 +1,32 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+
+/**
+ * Fixture controller with a REAL IDOR shape: `update` takes an object id
+ * straight from the request and writes it, with no auth attribute at all.
+ */
+class WidgetController extends Controller
+{
+    /**
+     * Guarded — the control half of the pair. Must NOT be reported.
+     */
+    #[NoAdminRequired]
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+
+    /**
+     * UNGUARDED — no attribute, arbitrary id, write. Must be reported.
+     */
+    public function update(string $id, array $data): JSONResponse
+    {
+        return new JSONResponse(['id' => $id, 'data' => $data]);
+    }
+}


### PR DESCRIPTION
fix(gate-5): route-auth reported a resolution failure as a security finding, and never saw a camelCase route

Closes ConductionNL/.github#153.

Gate-5 had FOUR defects. Two were reported (#153); the other two this work
found, and one of them is the expensive direction.

1. A RESOLUTION FAILURE WAS REPORTED AS A SECURITY FINDING.
   When lib/Controller/<X>Controller.php did not exist, the gate wrote a line
   into the failure log and the verdict read "N routed method(s) missing auth
   attribute". Live on scholiq, whose health/metrics/preferences controllers
   are ADR-040 AppHost generics registered by
   \OCA\OpenRegister\AppHost\Bootstrap::register(): the files are absent from
   the leaf repo BY DESIGN and the attributes live in the openregister package.
   "I cannot see it" is not "it is absent". A security gate that cries wolf on
   correct code trains readers to skip the whole tier.

2. IT WAS NOT DIFF-SCOPED. The missing-file branch `continue`d BEFORE the
   `_in_scope` call, so those findings fired regardless of the diff — measured
   on a package.json + package-lock.json Dependabot bump. Every scholiq PR was
   blocked by a finding it did not introduce and could not fix. Per ADR-020 a
   routed method is now judged when the PR touched EITHER its controller OR
   appinfo/routes.php (altering a route is exactly when its auth posture must
   be re-checked).

3. FOUND HERE — camelCase route slugs were invisible. Gate-5 read route names
   through `'[a-z_]+#…'`, which matches only lowercase and snake_case. Gate-14
   already used `'[A-Za-z][A-Za-z0-9_\\]*#…'`. Two gates, two regexes, and the
   narrower one was the security gate. Measured on scholiq: 14 of 37 routed
   names matched; the other 23 — `paymentTransaction#callback`,
   `keyAdmin#generateKey`, `credentialVerify#verify` among them — were never
   opened, in either direction. Caught because the positive control for this
   very fix (strip both the attributes AND the docblock tags from a real
   routed method) still reported PASS. The resolver and the regex are now one
   shared helper used by both gates.

4. FOUND HERE — the 20-line attribute lookback was not bounded by the start of
   the method, so it read back over the PREVIOUS member. A short guarded
   method within 20 lines above an unguarded one donated its
   `#[NoAdminRequired]` to its neighbour and the unguarded method passed. False
   NEGATIVE, and invisible, because a pass leaves no log. The window is now
   clamped to the line after the previous member's closing brace — it can only
   stop an attribute being borrowed, never hide a genuine one.

NO HOLE OPENED. A route naming a class this repo genuinely does not ship is a
real defect (ReflectionException 500) — it is just not gate-5's. Gate-14
(route-reachability) used to `continue` past it with the comment "gate-5
already flags this"; it now raises it as `rule=controller-class-not-found`,
diff-scoped the same way. Removing the finding from gate-5 without adding it to
gate-14 would have created exactly the dead gate this change exists to avoid.
AppHost adoption excuses the FIVE generics Bootstrap::register() provides and
nothing else.

EVIDENCE — scripts/lib/test_gate_route_auth.sh, 25 assertions, every one half
of a control pair, auto-discovered by tests/run-helper-suites.sh:

  unguarded         -> FAIL (real IDOR shape + a camelCase slug)
  guarded           -> PASS (same routes, attributes present)
  apphost           -> PASS, 4 entries stated as NOT JUDGED with the reason
  apphost-unguarded -> FAIL (adoption does not exempt the app's own code) and
                       gate-14 still raises its non-generic missing controller
  orphan-route      -> gate-5 declines, gate-14 raises both reachability shapes
  + four scoped runs over real git repos: package.json-only diff clean while
    the finding is demonstrably present in the tree; controller-touched and
    routes.php-touched diffs both FAIL.

MUTATION-TESTED. Three realistic degradations were introduced and the suite
went red for each: skipping gate-5 for AppHost apps (6 assertions), widening
_apphost_serves to any slug (2), and reverting gate-14 to "gate-5 already flags
this" (3). Reverting the lookback clamp fails 4.

VERIFIED ON THE REAL REPO. scholiq @ a363b9b, full-tree: gate-5 PASS with the
4 AppHost entries stated as unjudged, gate-14 PASS. Strip the attributes and
the docblock tags from CredentialVerifyController::verify and the same run
reports `FAIL — 1 … CredentialVerifyController.php:85 method=verify` — so the
green is a measurement, not an absence.

Every run in the suite is rejected unless its COVERAGE line is present: an
abort before the summary leaves the PASS lines on stdout and reads as green.

ShellCheck clean.

---

## How to check this yourself

```bash
bash hydra-gates/scripts/lib/test_gate_route_auth.sh     # 25 control-pair assertions
bash hydra-gates/tests/run-helper-suites.sh              # auto-discovers the above
bash hydra-gates/tests/test-hydra-gates-bin.sh           # 25 entry-point tests, unchanged
```

## Blast radius, stated honestly

Defects 3 and 4 make gate-5 see code it never saw. **Expect new, real findings
in repos whose gate-5 has been quietly green.** That is the point of the change,
not a regression — but it means the pin move off `v1.0.1` should be treated as a
measurement, not a formality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
