### PR TITLE
fix(hydra-gates): a not-applicable gate is not a coverage gap — fix the accounting, then flip the flag

### DIFF
--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -118,9 +118,17 @@ jobs:
 
       - name: Resolve the ref under test
         id: ref
+        # `github.head_ref` is attacker-controlled on a fork PR — a branch named
+        # with shell metacharacters is interpolated verbatim into this script by
+        # the expression expander, before bash ever sees it. Passed through the
+        # environment instead, where it is data rather than source text.
+        # Pre-existing; flagged by actionlint and fixed here rather than left.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -eu
-          REF="${{ github.head_ref || github.ref_name }}"
+          REF="${HEAD_REF:-${REF_NAME}}"
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
           echo "Installing conduction/hydra-gates from branch: ${REF}"
 
@@ -303,11 +311,34 @@ jobs:
             || { echo "::error::the green did not state its own coverage"; exit 1; }
           printf '%s' "${OUT}" | grep -q "WAIVERS:" \
             || { echo "::error::no waiver accounting — a passed green cannot be told from a waived one"; exit 1; }
-          # node was deliberately not installed, so the run MUST say which gates
-          # that left unrun rather than counting them toward the green.
-          printf '%s' "${OUT}" | grep -q "GATES THAT DID NOT RUN:" \
-            || { echo "::error::node is absent, yet nothing reported an unrun gate — the coverage check is not measuring"; exit 1; }
-          echo "OK — exit 0, coverage stated, waivers stated, unrun gates named."
+          # This assertion used to be `grep -q "GATES THAT DID NOT RUN:"`, on the
+          # reasoning that node is deliberately absent here so something must be
+          # reported unrun. That reasoning was wrong, and it was a PROXY: the two
+          # gates that need node (22, 53) are guarded by `[ -f src/manifest.json ]`
+          # and this fixture has no manifest, so node's absence never reached
+          # them. What actually produced the line was the `git rm` above emptying
+          # src/ — the a11y gates went silent for a reason that had nothing to do
+          # with node, and the control passed on a coincidence.
+          #
+          # It stopped passing the moment those gates began declaring themselves
+          # NOT APPLICABLE by name, which is the correct verdict for a repo with
+          # no frontend. Rather than relax it, assert the thing it was reaching
+          # for — that the accounting ACCOUNTS FOR EVERY GATE. Nothing may fall
+          # out of the tally silently, whatever the reason it did not run.
+          _decl="$(printf '%s' "${OUT}" | grep -m1 -oE 'COVERAGE: [0-9]+ of [0-9]+' | awk '{print $4}')"
+          _ran="$(printf '%s' "${OUT}" | grep -m1 -oE 'COVERAGE: [0-9]+ of [0-9]+' | awk '{print $2}')"
+          _na="$(printf '%s' "${OUT}" | grep -m1 -oE '\(([0-9]+) not applicable' | grep -oE '[0-9]+' || echo 0)"
+          _unrun="$(printf '%s' "${OUT}" | grep -m1 -oE 'GATES THAT DID NOT RUN: .*' | sed 's/.*RUN: //' | wc -w || echo 0)"
+          [ -n "${_decl:-}" ] && [ -n "${_ran:-}" ] \
+            || { echo "::error::could not parse the COVERAGE line — the coverage check is not measuring"; exit 1; }
+          [ "$(( _ran + _na + _unrun ))" -eq "${_decl}" ] \
+            || { echo "::error::coverage does not account for every gate: ran=${_ran} + notApplicable=${_na} + didNotRun=${_unrun} != declared=${_decl}. A gate has fallen out of the tally silently, which is the exact defect this accounting exists to prevent."; exit 1; }
+          # And every gate that did not run must have SAID so on its own line —
+          # a number in a summary is not a trace.
+          _named="$(printf '%s\n' "${OUT}" | grep -cE '^\[gate-[0-9]+\] [a-z0-9-]+: (SKIPPED|NOT APPLICABLE)' || true)"
+          [ "${_named}" -ge "$(( _na + _unrun ))" ] \
+            || { echo "::error::${_na} not-applicable + ${_unrun} unrun gates are counted, but only ${_named} said so on their own line. A gate is disappearing from the per-gate output while still being tallied."; exit 1; }
+          echo "OK — exit 0, coverage stated, waivers stated, and ran=${_ran} + na=${_na} + unrun=${_unrun} = declared=${_decl}, each named."
 
       - name: "Unresolvable base ref must exit 99 with no green"
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -286,10 +286,40 @@ on:
         type: string
         default: "main"
       hydra-gates-require-full-coverage:
-        description: "Treat 'a declared gate did not run' as a failure (exit 98). Off by default: a control that blocks legitimate work gets switched off, and a switched-off control is worth less than a loud one. The coverage block is printed either way."
+        # ON by default as of this change, and only because the accounting was
+        # fixed first. It could not be switched on before: "did not run"
+        # collapsed three different facts into one, and the flag failed on all
+        # of them. Measured on a Tier-0 fixture with nothing wrong with it, 30
+        # of 63 gates emitted NOTHING — 25 of those simply because they are
+        # wrapped in `if [ -d src ]` and the repo has no frontend — and the flag
+        # exited 98. A control that red-flags a repo for gates it has no surface
+        # for is a control that gets switched off.
+        #
+        # The runner now distinguishes:
+        #   NOT APPLICABLE  subject matter absent from this repo or this diff.
+        #                   Named in the output, excluded from coverage, does
+        #                   NOT fail. (No src/ → no <img> to lack an alt. No
+        #                   composer file in the diff → no dependency change to
+        #                   audit, per ADR-020.)
+        #   SKIPPED (structural)  the subject matter EXISTS and nothing produced
+        #                   the gate's input. Fails.
+        #   SKIPPED (wiring)  the gate's own machinery is missing — a helper
+        #                   script, a tool. Fails, and this is the worst of the
+        #                   three: it is how gate-7 once reported PASS over 11
+        #                   real unguarded IDOR endpoints.
+        #
+        # Silence still counts AGAINST coverage. A gate stops counting only by
+        # declaring itself not-applicable out loud, with a category that is
+        # validated — an unrecognised one is a hard failure, never a default.
+        #
+        # Measured against five fleet repos with the flag on: openregister,
+        # opencatalogi and docudesk have ZERO gates that did not run; hermiq and
+        # openconnector have exactly one each (gate-24), and it is a genuine gap
+        # — both register integration leaves and neither ships a parity check.
+        description: "Fail the run (exit 98) when a gate whose subject matter EXISTS did not report. ON by default. A gate that is legitimately not applicable — a Tier-0 app with no src/, or gate-4 correctly diff-scoped out under ADR-020 because no composer file changed — reports NOT APPLICABLE, is named in the coverage block, and does NOT fail the run. Only two states fail: a STRUCTURAL gap (the subject matter exists and nothing produced the gate's input, e.g. a repo that registers integration leaves but ships no parity check) and a WIRING gap (the gate's own helper or tool is missing — the shape that once let gate-7 report PASS over 11 real unguarded IDOR endpoints). A gate that emits nothing at all still counts against coverage: not-applicable must be DECLARED, and its category is validated, so a gate cannot stop counting by staying quiet or by misspelling its reason. Set false only if you knowingly want a green that may be silent about what it did not check — the coverage block is printed either way."
         required: false
         type: boolean
-        default: false
+        default: true
 
 concurrency:
   group: quality-${{ github.ref }}
@@ -3773,6 +3803,18 @@ jobs:
           if [ "${{ inputs.hydra-gates-require-full-coverage }}" = "true" ]; then
             ARGS="${ARGS} --require-full-coverage"
           fi
+          # gate-33's input is the ONE input this runner cannot make for itself
+          # — it comes from a browser in the Playwright job, and only when the
+          # caller opted in. Telling the runner what the caller undertook is
+          # what lets it distinguish "this repo has not opted into runtime
+          # accessibility enforcement" (not applicable; the choice is a visible
+          # line in the caller's workflow) from "it DID opt in and the report
+          # never arrived" (a real gap, and it fails). Without this the runner
+          # has to guess, and guessing "unverified" in both cases is what made
+          # --require-full-coverage unusable in every repo in the fleet.
+          if [ "${{ inputs.enable-axe }}" = "true" ]; then
+            ARGS="${ARGS} --axe-enabled"
+          fi
           # The default shell for a `run:` block is `bash -e {0}`. A bare
           # invocation followed by `RC=$?` would therefore never reach the
           # assignment — the step would abort on the first failing gate and the
@@ -3792,7 +3834,7 @@ jobs:
             exit 1
           fi
           if [ "${RC}" -eq 98 ]; then
-            echo "::error::hydra-gates passed but coverage was incomplete, and hydra-gates-require-full-coverage is set. See the GATES THAT DID NOT RUN line above."
+            echo "::error::hydra-gates passed every gate that ran, but a gate whose SUBJECT MATTER EXISTS did not report, and hydra-gates-require-full-coverage is set. See the GATES THAT DID NOT RUN line above — each names itself as either 'structural' (nothing produced its input) or 'wiring' (its own helper or tool is missing). Gates listed under NOT APPLICABLE are NOT the cause: they were excluded from this verdict."
             exit 1
           fi
           echo "::error::${RC} Hydra gate(s) failed. The exit code is the failure COUNT — see the named [gate-N] FAIL lines above."

--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -22,8 +22,9 @@ credentials.
 > This line used to carry one anyway. A count in prose has nothing to
 > reconcile against; the runtime coverage block does. Consumers and other
 > repos should write "the Hydra mechanical quality gates" and link here.
-> Set `hydra-gates-require-full-coverage` if a green with silent skips should
-> be an error in your repo.
+> `hydra-gates-require-full-coverage` is ON by default: a gate whose subject
+> matter exists but did not report is an error. Gates that are legitimately not
+> applicable do not fail it.
 
 This directory is the **single source of truth** for the gate runner
 (`scripts/run-hydra-gates.sh`), its ~25 Python/JS helpers (`scripts/lib/`), its
@@ -110,8 +111,10 @@ things to do before you upgrade:
    vendored canonical validator, and the app script is surfaced as an advisory.
    Apps whose local checker was weaker will surface real findings; apps failed
    by a stale app-local page-type enum will go green.
-3. **Treat `: SKIPPED` as "did not run", not as a pass**, if you parse
-   `^\[gate-N\]` lines. New verdict; see *Reading a green* below.
+3. **Treat `: SKIPPED` and `: NOT APPLICABLE` as "did not run", not as a pass**,
+   if you parse `^\[gate-N\]` lines. Two verdicts, and they differ: `SKIPPED
+   (structural|wiring)` is a coverage GAP, `NOT APPLICABLE` means the gate had
+   no subject matter here. Neither is a result. See *Reading a green* below.
 
 The upside: **gate 53 becomes usable under `--scope-to-diff`**. It was
 previously unenablable on any repo with manifest debt, because a one-line change
@@ -294,19 +297,48 @@ and every run — `bin/hydra-gates` **and** a direct `run-hydra-gates.sh`
 invocation — ends with the accounting:
 
 ```
-[hydra-gates] COVERAGE: 60 of 63 declared gates reported a result.
+[hydra-gates] COVERAGE: 60 of 63 declared gates reported a result (2 not applicable
+[hydra-gates]           to this repo/diff; 60 of 61 applicable gates ran).
+[hydra-gates] NOT APPLICABLE — subject matter absent from this repo or this diff.
+[hydra-gates] These do NOT count against coverage. Each stated its own reason above:
+[hydra-gates]   gate-4 composer-audit
+[hydra-gates]   gate-33 axe-core
 [hydra-gates] GATES THAT DID NOT RUN — they inspected NOTHING, and their subject
 [hydra-gates] matter is UNVERIFIED by this run:
-[hydra-gates]   gate-4 composer-audit
 [hydra-gates]   gate-24 integration-parity
-[hydra-gates]   gate-33 axe-core
-[hydra-gates] 60 GATE(S) GREEN — but 3 of 63 DID NOT RUN (named above).
-[hydra-gates] This is NOT 'all 63 gates green'. …
+[hydra-gates] 60 GATE(S) GREEN — but 1 of 61 APPLICABLE gates DID NOT RUN (named above).
 ```
 
-A `SKIPPED` line is **not** counted as coverage — a gate reporting that it did
-nothing did nothing. `--require-full-coverage` turns an incomplete run into
-exit 98.
+### Three states, not two
+
+Neither a `SKIPPED` nor a `NOT APPLICABLE` line counts as coverage — a gate
+reporting that it did nothing did nothing. But only two of the three fail:
+
+| verdict | meaning | counts against coverage? |
+|---|---|---|
+| `NOT APPLICABLE` | the gate's subject matter does not exist in this repo or this diff — no `src/` at all, or a diff with no composer file under ADR-020 scoping | **no** |
+| `SKIPPED (structural)` | the subject matter EXISTS and nothing produced the gate's input — e.g. a repo that registers integration leaves but ships no parity check | yes |
+| `SKIPPED (wiring)` | the gate's own machinery is missing — a helper script, a tool not on PATH | yes |
+
+`--require-full-coverage` (ON by default in the shared workflow) turns the last
+two into exit 98. It ignores the first — that is what makes it switchable-on at
+all: before the split, a Tier-0 app with nothing wrong with it failed on 30 of
+63 gates, 25 of them merely because they are wrapped in `if [ -d src ]`.
+
+Two properties stop `NOT APPLICABLE` becoming a mute:
+
+- **Silence still counts against coverage.** A gate that emits nothing at all is
+  a gap by default. To stop counting it must *declare* itself not-applicable, by
+  name and with a reason.
+- **The category is validated.** `na`, `structural` and `wiring` are the only
+  accepted values; anything else is a hard gate failure, never a default. A gate
+  cannot stop counting by misspelling its reason.
+
+`--axe-enabled` (set by the shared workflow from `enable-axe`) tells the runner
+whether the caller undertook to produce gate-33's report. Without it a missing
+report means "this repo has not opted into runtime a11y enforcement" — a visible
+choice in the caller's workflow, not a hidden gap. With it, a missing report
+means the producer broke, and that fails.
 
 The inventory is read out of the runner itself rather than hardcoded, so adding
 gate 64 does not silently leave the coverage check measuring against a stale 63.

--- a/hydra-gates/bin/hydra-gates
+++ b/hydra-gates/bin/hydra-gates
@@ -60,10 +60,19 @@
 #   --base REF                diff base (default: see resolution order below)
 #   --full                    scan the whole repo instead of the diff. Reports
 #                             inherited debt; use for audits, not for gating.
-#   --require-full-coverage   treat "a gate did not run" as a failure. Off by
-#                             default: a control that blocks legitimate work
-#                             gets switched off, and a switched-off control is
-#                             worth less than a loud one.
+#   --require-full-coverage   treat "an APPLICABLE gate did not run" as a
+#                             failure. Gates that reported NOT APPLICABLE — their
+#                             subject matter is absent from this repo or this
+#                             diff — are excluded, so a Tier-0 app is not blocked
+#                             by gates it has no surface for. A control that
+#                             blocks legitimate work gets switched off, and a
+#                             switched-off control is worth less than a loud one.
+#   --axe-enabled             tell the runner the caller undertook to produce
+#                             tests/axe/report.json (i.e. `enable-axe: true`).
+#                             Without it, a missing report means "this repo has
+#                             not opted into runtime a11y enforcement" (NOT
+#                             APPLICABLE); with it, a missing report means the
+#                             producer broke (a real gap, and it fails).
 #
 # Base ref resolution order (first that resolves wins, and it is printed):
 #   1. --base REF
@@ -109,6 +118,7 @@ APP_DIR=""
 BASE_REF_ARG=""
 SCOPE_DIFF=1
 REQUIRE_FULL_COVERAGE=0
+AXE_ENABLED="${HYDRA_GATE_AXE_ENABLED:-0}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -118,6 +128,7 @@ while [ $# -gt 0 ]; do
         --base=*) BASE_REF_ARG="${1#--base=}"; shift ;;
         --full) SCOPE_DIFF=0; shift ;;
         --require-full-coverage) REQUIRE_FULL_COVERAGE=1; shift ;;
+        --axe-enabled) AXE_ENABLED=1; shift ;;
         -h|--help) sed -n '3,70p' "${_self}" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) APP_DIR="$1"; shift ;;
     esac
@@ -259,6 +270,11 @@ set -- "${APP_DIR}"
 if [ "${SCOPE_DIFF}" = "1" ]; then
     set -- --scope-to-diff --base "${BASE_REF}" "$@"
 fi
+# Forwarded, not re-derived. The runner is the only thing that reads gate-33's
+# report; this wrapper just has to stop swallowing the caller's declaration.
+if [ "${AXE_ENABLED}" = "1" ]; then
+    set -- --axe-enabled "$@"
+fi
 
 _out="$(mktemp -t hydra-gates-out.XXXXXX)"
 trap 'rm -f "${_out}"' EXIT
@@ -276,14 +292,27 @@ RC="${PIPESTATUS[0]}"
 # inventory is the very defect this step exists to catch.
 # ---------------------------------------------------------------------------
 DECLARED="$(grep -oE '_(pass|fail|skip) [0-9]+' "${RUNNER}" | awk '{print $2}' | sort -un)"
-# A `[gate-N] name: SKIPPED — reason` line is the gate REPORTING THAT IT DID NOT
-# RUN. Counting it as coverage would turn the fix into the bug: the whole point
-# of making the skip visible is that it stays outside the "reported a result"
-# tally. Excluded here by verdict, not by gate number.
-EMITTED="$(grep -E '^\[gate-[0-9]+\]' "${_out}" | grep -v ': SKIPPED' \
+# A `[gate-N] name: SKIPPED (…) — reason` line is the gate REPORTING THAT IT DID
+# NOT RUN. Counting it as coverage would turn the fix into the bug: the whole
+# point of making the skip visible is that it stays outside the "reported a
+# result" tally. Excluded here by verdict, not by gate number.
+#
+# `NOT APPLICABLE` is a THIRD verdict and must be excluded from BOTH tallies —
+# it is neither a result nor a gap. Note it is excluded here explicitly rather
+# than left to fall through: a `NOT APPLICABLE` line contains no ': SKIPPED', so
+# the old filter would have counted every not-applicable gate as having REPORTED
+# A RESULT. This wrapper recomputes coverage independently of the runner, so a
+# verdict it does not know about is silently miscounted in the direction that
+# always reads better than the truth.
+EMITTED="$(grep -E '^\[gate-[0-9]+\]' "${_out}" | grep -v ': SKIPPED' | grep -v ': NOT APPLICABLE' \
+    | grep -oE '^\[gate-[0-9]+\]' | grep -oE '[0-9]+' | sort -un)"
+NOT_APPLICABLE="$(grep -E '^\[gate-[0-9]+\].*: NOT APPLICABLE' "${_out}" \
     | grep -oE '^\[gate-[0-9]+\]' | grep -oE '[0-9]+' | sort -un)"
 DECLARED_N="$(printf '%s\n' "${DECLARED}" | grep -c . || true)"
 EMITTED_N="$(printf '%s\n' "${EMITTED}" | grep -c . || true)"
+NA_N="$(printf '%s\n' "${NOT_APPLICABLE}" | grep -c . || true)"
+APPLICABLE_N=$((DECLARED_N - NA_N))
+NOT_APPLICABLE_INLINE="$(printf '%s' "${NOT_APPLICABLE}" | tr '\n' ' ' | sed 's/ *$//')"
 
 # Set difference by membership test, NOT by comm(1). comm requires its inputs
 # to be sorted in the COLLATING order it compares with; these lists are sorted
@@ -292,13 +321,20 @@ EMITTED_N="$(printf '%s\n' "${EMITTED}" | grep -c . || true)"
 # coverage gap is the exact failure this block exists to prevent.
 NOT_RUN=""
 for _d in ${DECLARED}; do
-    printf '%s\n' "${EMITTED}" | grep -qx "${_d}" || NOT_RUN="${NOT_RUN}${_d} "
+    printf '%s\n' "${EMITTED}" | grep -qx "${_d}" && continue
+    printf '%s\n' "${NOT_APPLICABLE}" | grep -qx "${_d}" && continue
+    NOT_RUN="${NOT_RUN}${_d} "
 done
 NOT_RUN="${NOT_RUN% }"
 
 echo ""
 echo "=============================================================="
-echo "[hydra-gates] COVERAGE: ${EMITTED_N} of ${DECLARED_N} declared gates reported a result."
+echo "[hydra-gates] COVERAGE: ${EMITTED_N} of ${DECLARED_N} declared gates reported a result (${NA_N} not applicable; ${EMITTED_N} of ${APPLICABLE_N} applicable gates ran)."
+if [ -n "${NOT_APPLICABLE}" ]; then
+    echo "[hydra-gates] NOT APPLICABLE: ${NOT_APPLICABLE_INLINE}"
+    echo "[hydra-gates] Their subject matter does not exist in this repo or this diff — each said"
+    echo "[hydra-gates] so by name above. They do NOT count against coverage."
+fi
 
 # The single most dangerous shape: a scoped run over an empty diff. Every gate
 # passes having read nothing, and the output is otherwise identical to a real
@@ -358,7 +394,18 @@ fi
 
 if [ "${RC}" -eq 0 ]; then
     if [ -z "${NOT_RUN}" ]; then
-        echo "[hydra-gates] RESULT: ALL ${DECLARED_N} GATES PASSED — and all ${DECLARED_N} of them ran."
+        if [ "${NA_N}" -eq 0 ]; then
+            echo "[hydra-gates] RESULT: ALL ${DECLARED_N} GATES PASSED — and all ${DECLARED_N} of them ran."
+        else
+            # NEVER "all ${DECLARED_N} ran" here. ${NA_N} of them did not run —
+            # they had nothing to run against. Saying otherwise would print the
+            # exact banner this whole accounting exists to make impossible, and
+            # it would print it precisely when the run is MOST incomplete.
+            echo "[hydra-gates] RESULT: ALL ${APPLICABLE_N} APPLICABLE GATES PASSED — and all ${APPLICABLE_N} of them ran."
+            echo "[hydra-gates] ${NA_N} gate(s) were NOT APPLICABLE to this repo/diff and did not run: ${NOT_APPLICABLE_INLINE}"
+            echo "[hydra-gates] This green covers ${EMITTED_N} of ${DECLARED_N} declared gates. It says nothing"
+            echo "[hydra-gates] about the ${NA_N} above — only that they had no subject matter here."
+        fi
     else
         echo "[hydra-gates] RESULT: ALL GATES PASSED — EXCEPT GATES ${NOT_RUN}, WHICH DID NOT RUN."
         echo "[hydra-gates] This green covers ${EMITTED_N} gates. It says NOTHING about gates ${NOT_RUN}."

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1779,6 +1779,14 @@ if [ -f src/manifest.json ]; then
         _pass 22 "manifest-validation"
     elif [ ! -f "${_mv_validator}" ]; then
         _fail 22 "manifest-validation" "vendored validator missing at ${_mv_validator} — gate misconfiguration, fail-closed"
+    elif ! command -v node >/dev/null 2>&1; then
+        # WIRING, and named as such. Without this the `node …` below is a
+        # command-not-found (127), which falls through to the catch-all branch
+        # and is reported as "1 schema violation(s) in src/manifest.json" — a
+        # missing interpreter wearing a finding's clothes, and a reason nobody
+        # can act on. Same shape as gate-4 reporting "CVEs or advisories" for a
+        # composer that could not run.
+        _skip 22 "manifest-validation" wiring "src/manifest.json exists but \`node\` is not on PATH — the vendored canonical validator (${_mv_validator}) could not be executed, so the manifest was NOT schema-validated. This is a missing tool in the runner environment, not a finding about the manifest."
     else
         set +e
         node "${_mv_validator}" src/manifest.json >> "${_mv_log}" 2>&1
@@ -3753,6 +3761,12 @@ if [ -f src/manifest.json ]; then
     elif [ ! -f "${_em_builder}" ] || [ ! -f "${_em_crossref}" ] || [ ! -f "${_em_validator}" ]; then
         # Gate misconfiguration — a vendored helper is missing. Fail-closed.
         _fail 53 "effective-manifest-crossref" "vendored helper missing under ${SCRIPT_DIR}/lib (need build_effective_manifest.js + check_manifest_crossref.js + check_manifest.js) — fail-closed"
+    elif ! command -v node >/dev/null 2>&1; then
+        # WIRING. Named before the ajv probe below, which is itself a `node -e`
+        # — with node absent that probe fails for the wrong reason and reports
+        # "ajv not resolvable", sending a reader to install a library when the
+        # interpreter is what is missing.
+        _skip 53 "effective-manifest-crossref" wiring "a manifest input is in scope but \`node\` is not on PATH — the effective manifest could not be assembled or cross-referenced. This is a missing tool in the runner environment, not a finding about the manifest."
     elif ! node -e "require('ajv/dist/2020')" >/dev/null 2>&1 \
         && ! node -e "require.resolve('ajv/dist/2020', { paths: ['${SCRIPT_DIR}/lib'] })" >/dev/null 2>&1; then
         # Without Ajv the structural stage cannot validate the assembled

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -80,10 +80,29 @@ APP_DIR=""
 # a Tier-0 app is not blocked by gates it has no surface for; on, the run
 # refuses to report green while any gate's subject matter is unverified.
 REQUIRE_FULL_COVERAGE="${HYDRA_GATE_REQUIRE_FULL_COVERAGE:-0}"
+# Whether the CALLER undertook to produce gate-33's input (tests/axe/report.json).
+# gate-33 is the one gate whose input this runner cannot make for itself: it is
+# produced by the Playwright job, and only when `enable-axe: true` is set on the
+# shared quality workflow. That makes the ABSENCE of the report ambiguous, and
+# the two readings are opposites:
+#
+#   enable-axe NOT set  — the repo has not opted into runtime accessibility
+#                         enforcement. The absence is a declared, visible choice
+#                         living in the caller's workflow file, not a gap hidden
+#                         in here. NOT APPLICABLE to this run.
+#   enable-axe set      — the repo DID opt in and the report still did not
+#                         arrive. Something between the browser and this script
+#                         broke. That is a real coverage gap and it must fail.
+#
+# Without this flag the runner cannot tell those apart and has to guess. It used
+# to guess "unverified" in both cases, which is why --require-full-coverage was
+# unusable in every repo in the fleet.
+AXE_ENABLED="${HYDRA_GATE_AXE_ENABLED:-0}"
 while [ $# -gt 0 ]; do
     case "$1" in
         --scope-to-diff) SCOPE_TO_DIFF=1; shift ;;
         --require-full-coverage) REQUIRE_FULL_COVERAGE=1; shift ;;
+        --axe-enabled) AXE_ENABLED=1; shift ;;
         --base) BASE_REF="$2"; shift 2 ;;
         --base=*) BASE_REF="${1#--base=}"; shift ;;
         *) APP_DIR="$1"; shift ;;
@@ -360,16 +379,23 @@ _ROUTE_PAIR_RX="[A-Za-z][A-Za-z0-9_\\]*#[a-zA-Z0-9_]+"
 
 _FAILED=0
 _EMITTED_GATES=""
-# _SKIPPED_GATES is written by _skip but deliberately NOT read by the coverage
-# summary, and it must stay that way. The summary derives "gates that did not
-# run" as DECLARED minus _EMITTED_GATES, which is strictly broader: it catches
-# both a gate that skipped explicitly AND a gate that emitted nothing at all
-# because its enclosing `if [ -d src ]`-style prerequisite was false. Driving
-# the report off _SKIPPED_GATES instead would narrow it back to only the
-# explicit skips and silently reopen the hole this accounting exists to close.
-# Kept as a record of what skipped, for a caller that wants to distinguish the
-# two shapes.
+# _SKIPPED_GATES holds the gates that skipped for a reason that COUNTS against
+# coverage (categories `structural` and `wiring` — see _skip below).
+#
+# It is still not what the summary subtracts. "Gates that did not run" is
+# derived as DECLARED minus _EMITTED_GATES minus _NA_GATES, which stays strictly
+# broader than _SKIPPED_GATES: it catches a gate that emitted NOTHING AT ALL
+# because its enclosing `if [ -d src ]`-style prerequisite was false and it
+# never reached a _skip call. Driving the report off _SKIPPED_GATES instead
+# would narrow it back to only the explicit skips and silently reopen the hole
+# this accounting exists to close. A silent non-reporter is therefore counted
+# against coverage by DEFAULT — to stop counting, a gate must say so, by name
+# and with a category.
 _SKIPPED_GATES=""
+# Gates whose SUBJECT MATTER does not exist in this repository or this diff.
+# Held separately from _SKIPPED_GATES because the two mean opposite things to a
+# reader deciding whether to trust the run — see _skip below.
+_NA_GATES=""
 # A reason may arrive with embedded newlines (a helper echoing a multi-line
 # message, a miscounted variable). Flatten it: the contract of this runner's
 # stdout is ONE `[gate-N] name: VERDICT` line per gate, and every consumer —
@@ -385,15 +411,55 @@ _fail() {
 }
 _pass() { echo "[gate-$1] $2: PASS"; _EMITTED_GATES="${_EMITTED_GATES}$1 "; }
 
-# _skip <n> <name> <reason> — the gate did NOT run. Distinct from PASS on
-# purpose: a prerequisite was absent, so the gate inspected NOTHING and its
-# subject matter is UNVERIFIED. Recorded separately so the summary can never
-# fold it into an "ALL GATES GREEN" banner.
+# _skip <n> <name> <category> <reason> — the gate did NOT run. Distinct from
+# PASS on purpose: the gate inspected NOTHING.
+#
+# The CATEGORY is the point of this helper, and it is mandatory. "Did not run"
+# collapses three situations that a reader — and --require-full-coverage — must
+# treat differently:
+#
+#   na          NOT APPLICABLE. The gate's subject matter does not exist here.
+#               A Tier-0 app with no src/ has no <img> to be missing an alt; a
+#               diff that touches no composer file has no dependency change to
+#               audit (ADR-020). Nothing is unverified, because there is nothing
+#               to verify. This does NOT count against coverage.
+#
+#   structural  The subject matter EXISTS and nothing produced the gate's input.
+#               An app with src/ that ships no axe report has runtime
+#               accessibility defects it has not looked for. A real gap.
+#
+#   wiring      The gate's own machinery is missing — a helper script absent, a
+#               tool not installed. This is the worst of the three because the
+#               repository looks fully covered while a check has quietly stopped
+#               existing. (Measured 2026-08: a missing helper made gate-7 report
+#               PASS over 11 real unguarded IDOR endpoints.)
+#
+# `structural` and `wiring` both count against coverage and both fail a run
+# started with --require-full-coverage. Only `na` does not.
+#
+# The category is validated, and an unrecognised one is a HARD FAILURE rather
+# than a default. A typo that silently resolved to `na` would be a lever for
+# making any gate's absence stop counting — which is precisely the accounting
+# hole this whole block exists to close, re-opened from the inside.
 _skip() {
-    local _reason
-    _reason=$(printf '%s' "${3:-}" | tr '\n' ' ')
-    echo "[gate-$1] $2: SKIPPED — ${_reason}"
-    _SKIPPED_GATES="${_SKIPPED_GATES}$1 "
+    local _cat _reason
+    _cat="${3:-}"
+    _reason=$(printf '%s' "${4:-}" | tr '\n' ' ')
+    case "${_cat}" in
+        na)
+            echo "[gate-$1] $2: NOT APPLICABLE — ${_reason}"
+            _NA_GATES="${_NA_GATES}$1 "
+            ;;
+        structural|wiring)
+            echo "[gate-$1] $2: SKIPPED (${_cat}) — ${_reason}"
+            _SKIPPED_GATES="${_SKIPPED_GATES}$1 "
+            ;;
+        *)
+            echo "[gate-$1] $2: FAIL — internal error: _skip called with reason category '${_cat}', which is not one of na|structural|wiring. Refusing to guess: an unclassified skip would silently stop counting against coverage."
+            _FAILED=$((_FAILED + 1))
+            _EMITTED_GATES="${_EMITTED_GATES}$1 "
+            ;;
+    esac
 }
 
 # An abort before the summary (set -e / set -u, a helper blowing up, ...) used
@@ -573,10 +639,36 @@ fi
 # pins the transitive tree. `--locked` needs no vendor/, so this gate no longer
 # depends on whether some earlier step happened to run `composer install`.
 # ---------------------------------------------------------------------------
+#
+# COVERAGE CLASSIFICATION (gate-4). This gate had THREE ways to emit nothing at
+# all, and all three were byte-identical to its success. Each now says which of
+# the three it is, because they are not the same fact:
+#
+#   no composer.json           NOT APPLICABLE. No PHP dependency tree exists to
+#                              audit. A JS-only / Tier-0 app is not less secure
+#                              for it.
+#   composer.json unchanged    NOT APPLICABLE, under ADR-020 diff scoping. The
+#     in a --scope-to-diff run  dependency tree this PR ships is the one the
+#                              base branch already audited; re-auditing it is
+#                              not this PR's gap. This is the case the product
+#                              owner named, and the case that made
+#                              --require-full-coverage unusable.
+#   composer NOT INSTALLED     WIRING. composer.json exists — there IS a
+#                              dependency tree, and the tool that audits it is
+#                              absent from the runner. This is a real dead gate
+#                              and it was the most silent of the three.
+if [ ! -f composer.json ]; then
+    _skip 4 "composer-audit" na "no composer.json — this repo declares no PHP dependency tree, so there is nothing for \`composer audit\` to audit."
+elif ! command -v composer >/dev/null 2>&1; then
+    _skip 4 "composer-audit" wiring "composer.json is present but the \`composer\` binary is not on PATH — the dependency tree EXISTS and was NOT audited. Known CVEs in it are UNVERIFIED by this run."
+fi
 if [ -f composer.json ] && command -v composer >/dev/null 2>&1; then
     _run_audit=1
     if [ "${SCOPE_TO_DIFF}" = "1" ]; then
         _in_scope "composer.json" || _in_scope "composer.lock" || _run_audit=0
+    fi
+    if [ "${_run_audit}" = "0" ]; then
+        _skip 4 "composer-audit" na "neither composer.json nor composer.lock is in this diff — under ADR-020 diff scoping the dependency tree is unchanged from the base branch, so this PR introduces no dependency change to audit."
     fi
     if [ "${_run_audit}" = "1" ]; then
         _ca_log=/tmp/hydra-gate-composer-audit.log
@@ -749,7 +841,7 @@ _oa_ran=1
 # "GATES THAT DID NOT RUN" instead of folding it into ALL GATES GREEN.
 if [ "${#_oa_files[@]}" -eq 0 ]; then
     _oa_ran=0
-    _skip 6 "orphan-auth" "scope was empty — 0 lib/Service or lib/Controller PHP file(s) in this diff, so NOTHING was inspected; orphaned (defined-but-never-called) authorization methods are UNVERIFIED by this run."
+    _skip 6 "orphan-auth" na "scope was empty — 0 lib/Service or lib/Controller PHP file(s) in this diff, so NOTHING was inspected; orphaned (defined-but-never-called) authorization methods are UNVERIFIED by this run."
 fi
 if [ "${#_oa_files[@]}" -gt 0 ]; then
     _oa_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
@@ -761,7 +853,7 @@ if [ "${#_oa_files[@]}" -gt 0 ]; then
             >> "${_oa_log}" 2>/dev/null || true
     else
         _oa_ran=0
-        _skip 6 "orphan-auth" "check_orphan_auth.py not found at ${_oa_lib_dir} — ${#_oa_files[@]} PHP file(s) were in scope and NONE were inspected; orphaned (defined-but-never-called) authorization methods are UNVERIFIED by this run."
+        _skip 6 "orphan-auth" wiring "check_orphan_auth.py not found at ${_oa_lib_dir} — ${#_oa_files[@]} PHP file(s) were in scope and NONE were inspected; orphaned (defined-but-never-called) authorization methods are UNVERIFIED by this run."
     fi
 fi
 if [ "${_oa_ran}" -eq 1 ]; then
@@ -827,7 +919,7 @@ _idor_ran=1
 # coverage summary rather than silently green.
 if [ "${#_idor_files[@]}" -eq 0 ]; then
     _idor_ran=0
-    _skip 7 "no-admin-idor" "scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run."
+    _skip 7 "no-admin-idor" na "scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run."
 fi
 if [ "${#_idor_files[@]}" -gt 0 ]; then
     _gate_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
@@ -839,7 +931,7 @@ if [ "${#_idor_files[@]}" -gt 0 ]; then
             >> "${_idor_log}" 2>/dev/null || true
     else
         _idor_ran=0
-        _skip 7 "no-admin-idor" "check_no_admin_idor.py not found at ${_gate_lib_dir} — ${#_idor_files[@]} controller file(s) were in scope and NONE were inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run."
+        _skip 7 "no-admin-idor" wiring "check_no_admin_idor.py not found at ${_gate_lib_dir} — ${#_idor_files[@]} controller file(s) were in scope and NONE were inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run."
     fi
 fi
 if [ "${_idor_ran}" -eq 1 ]; then
@@ -953,7 +1045,7 @@ if [ "${#_sem_files[@]}" -gt 0 ]; then
             >> "${_sem_log}" 2>/dev/null || true
     else
         _sem_ran=0
-        _skip 9 "semantic-auth" "check_semantic_auth.py not found near $(dirname "${BASH_SOURCE[0]:-$0}") — ${#_sem_files[@]} controller file(s) were in scope and NONE were inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run."
+        _skip 9 "semantic-auth" wiring "check_semantic_auth.py not found near $(dirname "${BASH_SOURCE[0]:-$0}") — ${#_sem_files[@]} controller file(s) were in scope and NONE were inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run."
     fi
 fi
 if [ "${_sem_ran}" -eq 1 ]; then
@@ -1264,7 +1356,7 @@ if [ -f src/manifest.json ]; then
         _da_fail=$(wc -l < "${_da_log}" 2>/dev/null || echo 0)
     else
         _da_ran=0
-        _skip 15 "dashboard-antipattern" "check_dashboard_antipattern.py not found at ${_da_lib_dir} — src/manifest.json is present but was NOT inspected; nested dashboard-in-dashboard patterns are UNVERIFIED by this run."
+        _skip 15 "dashboard-antipattern" wiring "check_dashboard_antipattern.py not found at ${_da_lib_dir} — src/manifest.json is present but was NOT inspected; nested dashboard-in-dashboard patterns are UNVERIFIED by this run."
     fi
     if [ "${_da_ran}" -eq 1 ]; then
         if [ "${_da_fail}" -eq 0 ]; then
@@ -1305,7 +1397,7 @@ if [ -d lib ] || [ -d src ]; then
         _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)
     else
         _sc_ran=0
-        _skip 16 "spec-coverage" "check_spec_coverage.py not found at ${_sc_lib_dir} — no changed method was inspected; @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run."
+        _skip 16 "spec-coverage" wiring "check_spec_coverage.py not found at ${_sc_lib_dir} — no changed method was inspected; @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run."
     fi
     if [ "${_sc_ran}" -eq 1 ]; then
         if [ "${_sc_fail}" -eq 0 ]; then
@@ -1438,7 +1530,7 @@ if [ -n "${_nd_register_files}" ]; then
         done
     else
         _nd_ran=0
-        _skip 18 "notification-dialect" "check_notification_dialect.py not found at ${_nd_lib_dir} — register file(s) were in scope and NONE were inspected; the obsolete legacy notification dialect (ADR-031) is UNVERIFIED by this run. The imperative-dispatch advisory below is unaffected and still ran."
+        _skip 18 "notification-dialect" wiring "check_notification_dialect.py not found at ${_nd_lib_dir} — register file(s) were in scope and NONE were inspected; the obsolete legacy notification dialect (ADR-031) is UNVERIFIED by this run. The imperative-dispatch advisory below is unaffected and still ran."
     fi
 fi
 _nd_fail=$(wc -l < "${_nd_log}" 2>/dev/null || echo 0)
@@ -1519,7 +1611,7 @@ if [ -d openspec/specs ] || [ -d tests/e2e ]; then
         set -e
     else
         _e2e_ran=0
-        _skip 19 "e2e-coverage" "check_e2e_coverage.py not found at ${_e2e_lib_dir} — no spec scenario was inspected; @e2e traceability (ADR-020) is UNVERIFIED by this run."
+        _skip 19 "e2e-coverage" wiring "check_e2e_coverage.py not found at ${_e2e_lib_dir} — no spec scenario was inspected; @e2e traceability (ADR-020) is UNVERIFIED by this run."
     fi
     if [ "${_e2e_ran}" -eq 1 ]; then
         if [ "${_e2e_fail}" -eq 0 ]; then
@@ -1834,8 +1926,37 @@ fi
 # was never the declared gate count anywhere. It now says so.
 _parity_log=/tmp/hydra-gate-integration-parity.log
 : > "${_parity_log}"
+#
+# COVERAGE CLASSIFICATION (gate-24). "No parity script" was one message for two
+# opposite situations, so it is split on the gate's OWN SUBJECT MATTER rather
+# than on the presence of its checker — which is the only test that cannot
+# drift away from what the gate actually correlates:
+#
+#   no LeafDescriptor and     NOT APPLICABLE. Parity is a correlation between
+#   no registerIntegration    two sets. Both are empty, so there is no pair that
+#                             could be phantom, orphaned, or renderMode-mismatched.
+#   either one present, but   STRUCTURAL. This repo DOES register leaves and
+#   no parity script          nothing correlates the two halves. A phantom
+#                             render surface here is invisible, which is the
+#                             exact defect ADR-066 Decision 4 exists to catch.
+#
+# Deciding this from `[ -f scripts/check-integration-parity.sh ]` alone is what
+# made every repo in the fleet report the same skip regardless of whether it had
+# any leaves at all.
 if [ ! -f scripts/check-integration-parity.sh ]; then
-    _skip 24 "integration-parity" "no scripts/check-integration-parity.sh in this repo — server↔JS leaf parity (ADR-066 Decisions 4/7: phantom render surfaces, orphan JS registrations, renderMode mismatch) was NOT checked."
+    _parity_has_php=0
+    _parity_has_js=0
+    if [ -d lib ] && grep -rqE 'new[[:space:]]+LeafDescriptor[[:space:]]*\(' lib/ --include='*.php' 2>/dev/null; then
+        _parity_has_php=1
+    fi
+    if [ -d src ] && grep -rqE '\bregisterIntegration[[:space:]]*\(' src/ 2>/dev/null; then
+        _parity_has_js=1
+    fi
+    if [ "${_parity_has_php}" = "0" ] && [ "${_parity_has_js}" = "0" ]; then
+        _skip 24 "integration-parity" na "no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no \`new LeafDescriptor(\` in lib/ and no \`registerIntegration(\` in src/. There is no server↔JS pair for parity to correlate."
+    else
+        _skip 24 "integration-parity" structural "no scripts/check-integration-parity.sh, but this repo DOES register integration leaves (lib/ LeafDescriptor: ${_parity_has_php}, src/ registerIntegration: ${_parity_has_js}). server↔JS leaf parity (ADR-066 Decisions 4/7: phantom render surfaces, orphan JS registrations, renderMode mismatch) is UNVERIFIED — a leaf whose other half never registered is invisible to this run."
+    fi
 fi
 if [ -f scripts/check-integration-parity.sh ]; then
     if bash scripts/check-integration-parity.sh >> "${_parity_log}" 2>&1; then
@@ -1894,7 +2015,7 @@ if [ -f appinfo/routes.php ]; then
         set -e
     else
         _cc_ran=0
-        _skip 25 "contract-coverage" "check_contract_coverage.py not found at ${_cc_lib_dir} — appinfo/routes.php is present but NO endpoint was inspected; wire-contract coverage of newly-exposed endpoints is UNVERIFIED by this run."
+        _skip 25 "contract-coverage" wiring "check_contract_coverage.py not found at ${_cc_lib_dir} — appinfo/routes.php is present but NO endpoint was inspected; wire-contract coverage of newly-exposed endpoints is UNVERIFIED by this run."
     fi
     if [ "${_cc_ran}" -eq 1 ]; then
         if [ "${_cc_fail}" -eq 0 ]; then
@@ -1939,7 +2060,7 @@ if [ -d src ]; then
         set -e
     else
         _vc_ran=0
-        _skip 26 "visual-coverage" "check_visual_coverage.py not found at ${_vc_lib_dir} — src/ is present but NO page component was inspected; visual-regression coverage of new screens is UNVERIFIED by this run."
+        _skip 26 "visual-coverage" wiring "check_visual_coverage.py not found at ${_vc_lib_dir} — src/ is present but NO page component was inspected; visual-regression coverage of new screens is UNVERIFIED by this run."
     fi
     if [ "${_vc_ran}" -eq 1 ]; then
         if [ "${_vc_fail}" -eq 0 ]; then
@@ -2006,7 +2127,7 @@ if [ "${#_pcar_files[@]}" -gt 0 ]; then
             >> "${_pcar_log}" 2>/dev/null || true
     else
         _pcar_ran=0
-        _skip 27 "no-phantom-cross-app-rpc" "check_phantom_cross_app_rpc.py not found at ${_pcar_lib_dir} — ${#_pcar_files[@]} PHP/Vue/JS/TS file(s) were in scope and NONE were inspected; phantom cross-app RPC patterns (ADR-041) are UNVERIFIED by this run."
+        _skip 27 "no-phantom-cross-app-rpc" wiring "check_phantom_cross_app_rpc.py not found at ${_pcar_lib_dir} — ${#_pcar_files[@]} PHP/Vue/JS/TS file(s) were in scope and NONE were inspected; phantom cross-app RPC patterns (ADR-041) are UNVERIFIED by this run."
     fi
 fi
 # Count findings. NOTE: gates 25/26 above leave `set -e` ENABLED, so a
@@ -2339,11 +2460,34 @@ fi
 #   - .claude/skills/hydra-gate-axe/SKILL.md (how the report is produced)
 # ---------------------------------------------------------------------------
 _axe_report="tests/axe/report.json"
+#
+# COVERAGE CLASSIFICATION (gate-33). This gate's input is the one thing this
+# script cannot produce for itself — it comes from a browser, in the Playwright
+# job, and only when the caller sets `enable-axe: true`. So the absence of the
+# report is read against what the caller SAID it would do:
+#
+#   no src/                   NOT APPLICABLE. No frontend, no rendered DOM.
+#   src/, enable-axe NOT set  NOT APPLICABLE to this run. The repo has not opted
+#                             into runtime accessibility enforcement, and that
+#                             choice is a visible line in its own workflow file
+#                             — it is not a gap hidden inside this script. This
+#                             is what makes --require-full-coverage usable
+#                             fleet-wide instead of red everywhere on day one.
+#   src/, enable-axe SET,     STRUCTURAL. The repo DID opt in and the report
+#   report absent             still did not arrive — the Playwright job skipped,
+#                             crashed, or the artifact was rejected. A real gap,
+#                             and it fails. (quality.yml fails the job for this
+#                             independently; both, deliberately.)
+#
+# The middle case is the one that could be abused into a mute, so it is stated
+# in the output as a choice with a named way to change it, never as silence.
 if [ ! -f "${_axe_report}" ]; then
-    if [ -d src ]; then
-        _skip 33 "axe-core" "no ${_axe_report} in this repo — axe-core never ran against a rendered DOM, so contrast / landmark / ARIA-validity / live-region accessibility is UNVERIFIED. Produce the report from the Playwright suite (@axe-core/playwright) or add scripts/run-browser-tests.sh."
+    if [ ! -d src ]; then
+        _skip 33 "axe-core" na "no src/ and no ${_axe_report} — no frontend to run axe-core against in this repo."
+    elif [ "${AXE_ENABLED}" = "1" ]; then
+        _skip 33 "axe-core" structural "the caller set enable-axe/--axe-enabled, so a ${_axe_report} was EXPECTED, and none arrived. axe-core never ran against a rendered DOM: contrast / landmark / ARIA-validity / live-region accessibility is UNVERIFIED. The Playwright job that produces it was skipped, failed, or its artifact was rejected — that is the thing to fix, not this gate."
     else
-        _skip 33 "axe-core" "no src/ and no ${_axe_report} — no frontend to run axe-core against in this repo."
+        _skip 33 "axe-core" na "no ${_axe_report}, and the caller did not set enable-axe — this repo has not opted into runtime accessibility enforcement. Runtime a11y (contrast / landmark / ARIA-validity / live-region) is therefore NOT enforced here, by a choice recorded in the caller's workflow rather than in this run. To enforce it, set \`enable-axe: true\` on ConductionNL/.github's quality.yml; this gate then becomes blocking and its absence becomes a failure."
     fi
 fi
 if [ -f "${_axe_report}" ]; then
@@ -3455,7 +3599,7 @@ if [ "${#_spt_files[@]}" -gt 0 ]; then
         fi
     else
         _spt_ran=0
-        _skip 51 "schema-property-titles" "check_schema_property_meta.py not found at ${_spt_helper} — ${#_spt_files[@]} register file(s) were in scope and NONE were inspected; schema property title/description quality is UNVERIFIED by this run."
+        _skip 51 "schema-property-titles" wiring "check_schema_property_meta.py not found at ${_spt_helper} — ${#_spt_files[@]} register file(s) were in scope and NONE were inspected; schema property title/description quality is UNVERIFIED by this run."
     fi
 fi
 set +e
@@ -3527,7 +3671,7 @@ if [ "${#_cwr_files[@]}" -gt 0 ]; then
         set -e
     else
         _cwr_ran=0
-        _skip 52 "custom-widget-ratchet" "check_custom_widget_ratchet.py not found at ${_cwr_helper} — ${#_cwr_files[@]} frontend file(s) were in scope and NONE were inspected; custom kind:\"widget\" growth (ADR-049) is UNVERIFIED by this run — no base/head/delta counts were produced."
+        _skip 52 "custom-widget-ratchet" wiring "check_custom_widget_ratchet.py not found at ${_cwr_helper} — ${#_cwr_files[@]} frontend file(s) were in scope and NONE were inspected; custom kind:\"widget\" growth (ADR-049) is UNVERIFIED by this run — no base/head/delta counts were produced."
     fi
 fi
 # Surface the base/head/delta report on stdout (spec: the counts are always
@@ -3774,7 +3918,7 @@ if [ "${#_rd_files[@]}" -gt 0 ]; then
         fi
     else
         _rd_ran=0
-        _skip 54 "relation-dialect" "check_relation_dialect.py not found at ${_rd_helper} — ${#_rd_files[@]} register file(s) were in scope and NONE were inspected; non-canonical relation dialects are UNVERIFIED by this run (its advisory WARN half reads the same empty log and is therefore also silent)."
+        _skip 54 "relation-dialect" wiring "check_relation_dialect.py not found at ${_rd_helper} — ${#_rd_files[@]} register file(s) were in scope and NONE were inspected; non-canonical relation dialects are UNVERIFIED by this run (its advisory WARN half reads the same empty log and is therefore also silent)."
     fi
 fi
 set +e
@@ -3834,7 +3978,7 @@ if [ "${#_dpd_files[@]}" -gt 0 ]; then
         fi
     else
         _dpd_ran=0
-        _skip 55 "detail-page-discipline" "check_detail_page_discipline.py not found at ${_dpd_helper} — ${#_dpd_files[@]} manifest file(s) were in scope and NONE were inspected; detail-page discipline is UNVERIFIED by this run."
+        _skip 55 "detail-page-discipline" wiring "check_detail_page_discipline.py not found at ${_dpd_helper} — ${#_dpd_files[@]} manifest file(s) were in scope and NONE were inspected; detail-page discipline is UNVERIFIED by this run."
     fi
 fi
 set +e
@@ -3889,7 +4033,7 @@ if [ "${#_rhr_files[@]}" -gt 0 ]; then
         python3 "${_rhr_helper}" "${_rhr_files[@]}" >> "${_rhr_log}" 2>/dev/null || true
     else
         _rhr_ran=0
-        _skip 56 "register-handler-resolution" "check_register_handler_resolution.py not found at ${_rhr_helper} — ${#_rhr_files[@]} register file(s) were in scope and NONE were inspected; whether every referenced handler class/method actually resolves is UNVERIFIED by this run."
+        _skip 56 "register-handler-resolution" wiring "check_register_handler_resolution.py not found at ${_rhr_helper} — ${#_rhr_files[@]} register file(s) were in scope and NONE were inspected; whether every referenced handler class/method actually resolves is UNVERIFIED by this run."
     fi
 fi
 set +e
@@ -3943,7 +4087,7 @@ if [ "${#_owc_files[@]}" -gt 0 ]; then
         python3 "${_owc_helper}" "${_owc_files[@]}" >> "${_owc_log}" 2>/dev/null || true
     else
         _owc_ran=0
-        _skip 57 "orphaned-write-capability" "check_orphaned_write_capability.py not found at ${_owc_helper} — ${#_owc_files[@]} service file(s) were in scope and NONE were inspected; orphaned (mintable-but-unreachable) write capabilities are UNVERIFIED by this run."
+        _skip 57 "orphaned-write-capability" wiring "check_orphaned_write_capability.py not found at ${_owc_helper} — ${#_owc_files[@]} service file(s) were in scope and NONE were inspected; orphaned (mintable-but-unreachable) write capabilities are UNVERIFIED by this run."
     fi
 fi
 set +e
@@ -4221,25 +4365,125 @@ _declared=$(grep -oE '_(pass|fail|skip) [0-9]+ "[^"]+"' "${RUNNER_SELF}" 2>/dev/
     | sort -n -k1,1 -s | awk '!seen[$1]++' || true)
 _declared_n=$(printf '%s\n' "${_declared}" | grep -c . || true)
 _declared_n="${_declared_n:-0}"
+
+# ---------------------------------------------------------------------------
+# APPLICABILITY DECLARATIONS
+#
+# Most gates are wrapped in a bare prerequisite (`if [ -d src ]; then …`) with
+# no `else`. When the prerequisite is false the gate emits NOTHING AT ALL — no
+# line, no reason, no trace — and its silence is byte-identical to its success.
+# Measured on a Tier-0 fixture: 25 of 63 gates vanished this way, which is why
+# --require-full-coverage failed a repo that had nothing wrong with it.
+#
+# Each line below restates ONE gate group's own prerequisite, negated, and names
+# the gates it governs. The condition is written to MIRROR the `if` at the gate
+# — same test, same operator — so the two cannot mean different things.
+#
+# Two properties make this safe to state centrally rather than at each gate:
+#
+#   1. _declare_na REFUSES to touch a gate that already reported anything. A
+#      declaration can therefore never un-run a gate that ran, or overwrite a
+#      FAIL. It can only ever explain a silence.
+#   2. Each condition fires ONLY when the prerequisite is absent. If `src/`
+#      exists and a gate in that group still emitted nothing, that gate is a
+#      real dead gate and it stays in DID NOT RUN, exactly as before. The
+#      declaration cannot mask it, because the declaration did not fire.
+#
+# So the failure mode this could have introduced — a table drifting away from
+# the guards and quietly excusing a live gate — is closed by construction, not
+# by keeping the two in step by hand.
+# ---------------------------------------------------------------------------
+_declare_na() {
+    local _reason="$1"; shift
+    local _g _name
+    for _g in "$@"; do
+        # Already reported a verdict of any kind? Leave it entirely alone.
+        case " ${_EMITTED_GATES}" in *" ${_g} "*) continue ;; esac
+        case " ${_NA_GATES}" in *" ${_g} "*) continue ;; esac
+        case " ${_SKIPPED_GATES}" in *" ${_g} "*) continue ;; esac
+        _name=$(printf '%s\n' "${_declared}" | awk -v g="${_g}" '$1==g {print $2; exit}')
+        _skip "${_g}" "${_name:-gate-${_g}}" na "${_reason}"
+    done
+}
+
+# `if [ -d src ]` — gates 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45
+[ -d src ] || _declare_na "no src/ directory — this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect." \
+    10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45
+# `if [ -f appinfo/routes.php ]` — gates 5 25
+[ -f appinfo/routes.php ] || _declare_na "no appinfo/routes.php — this repo registers no HTTP routes, so there is no endpoint for this gate to inspect." \
+    5 25
+# `if [ -d lib/Controller ] && [ -f appinfo/routes.php ]` — gate 14
+{ [ -d lib/Controller ] && [ -f appinfo/routes.php ]; } || _declare_na "no lib/Controller/ and appinfo/routes.php pair — there is no controller-to-route mapping for this gate to resolve." \
+    14
+# `if [ -f src/manifest.json ]` — gates 15 22 53
+[ -f src/manifest.json ] || _declare_na "no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect." \
+    15 22 53
+# `if [ -d openspec/specs ] || [ -d tests/e2e ]` — gate 19
+{ [ -d openspec/specs ] || [ -d tests/e2e ]; } || _declare_na "no openspec/specs/ and no tests/e2e/ — there is neither a spec scenario to trace nor an e2e suite to trace it to." \
+    19
+# `if [ -d src ] || [ -d templates ]` — gate 38
+{ [ -d src ] || [ -d templates ]; } || _declare_na "no src/ and no templates/ — this repo renders no markup, so there is no document for a skip link to be missing from." \
+    38
+# `if [ -d templates ] || [ -d appinfo/templates ]` — gate 41
+{ [ -d templates ] || [ -d appinfo/templates ]; } || _declare_na "no templates/ and no appinfo/templates/ — this repo ships no server-rendered HTML document to carry a lang attribute." \
+    41
+
 _emitted_n=$(printf '%s\n' ${_EMITTED_GATES} | grep -c . || true)
 _emitted_n="${_emitted_n:-0}"
 
 # Gates that never reported: declared minus emitted. Membership test rather
 # than comm(1) — comm compares in collating order, these lists are numeric,
 # and an under-reported coverage gap is exactly what this block exists to stop.
+#
+# Three-way split, not two. "Did not report" collapsed two facts that a caller
+# must act on differently, and collapsing them is why --require-full-coverage
+# could not be switched on anywhere:
+#
+#   NOT APPLICABLE  the gate said, by name and with a category, that its subject
+#                   matter does not exist in this repo or this diff. Nothing is
+#                   unverified. Listed for the reader; does NOT count against
+#                   coverage; does NOT fail the run.
+#   DID NOT RUN     everything else — an explicit `structural`/`wiring` skip, OR
+#                   total silence from a gate whose prerequisite was false and
+#                   which never reached a _skip call at all. Counts, and fails
+#                   under --require-full-coverage.
+#
+# Note the default: silence still counts AGAINST coverage. A gate stops counting
+# only by declaring itself not-applicable out loud. That direction matters — the
+# opposite default would let any gate disappear by doing nothing, which is the
+# failure this accounting was built to catch.
 _not_run=""
+_na_list=""
 while read -r _dn _dname; do
     [ -z "${_dn:-}" ] && continue
     case " ${_EMITTED_GATES}" in
         *" ${_dn} "*) continue ;;
+    esac
+    case " ${_NA_GATES}" in
+        *" ${_dn} "*)
+            _na_list="${_na_list}${_na_list:+
+}${_dn} ${_dname}"
+            continue
+            ;;
     esac
     _not_run="${_not_run}${_not_run:+
 }${_dn} ${_dname}"
 done <<< "${_declared}"
 _not_run_n=$(printf '%s\n' "${_not_run}" | grep -c . || true)
 _not_run_n="${_not_run_n:-0}"
+_na_n=$(printf '%s\n' "${_na_list}" | grep -c . || true)
+_na_n="${_na_n:-0}"
+_applicable_n=$((_declared_n - _na_n))
 
-echo "[hydra-gates] COVERAGE: ${_emitted_n} of ${_declared_n} declared gates reported a result."
+echo "[hydra-gates] COVERAGE: ${_emitted_n} of ${_declared_n} declared gates reported a result (${_na_n} not applicable to this repo/diff; ${_emitted_n} of ${_applicable_n} applicable gates ran)."
+if [ "${_na_n}" -gt 0 ]; then
+    echo "[hydra-gates] NOT APPLICABLE — subject matter absent from this repo or this diff."
+    echo "[hydra-gates] These do NOT count against coverage. Each stated its own reason above:"
+    while IFS= read -r _na; do
+        [ -z "${_na}" ] && continue
+        echo "[hydra-gates]   gate-${_na%% *} ${_na#* }"
+    done <<< "${_na_list}"
+fi
 if [ "${_not_run_n}" -gt 0 ]; then
     echo "[hydra-gates] GATES THAT DID NOT RUN — they inspected NOTHING, and their subject"
     echo "[hydra-gates] matter is UNVERIFIED by this run:"
@@ -4251,12 +4495,21 @@ fi
 
 if [ "${_FAILED}" -eq 0 ]; then
     if [ "${_not_run_n}" -eq 0 ]; then
-        echo "[hydra-gates] ALL ${_declared_n} GATES GREEN — and all ${_declared_n} of them ran."
+        if [ "${_na_n}" -eq 0 ]; then
+            echo "[hydra-gates] ALL ${_declared_n} GATES GREEN — and all ${_declared_n} of them ran."
+        else
+            echo "[hydra-gates] ALL ${_applicable_n} APPLICABLE GATES GREEN — and all ${_applicable_n} of them ran."
+            echo "[hydra-gates] The other ${_na_n} are not applicable to this repo/diff and are named above."
+            echo "[hydra-gates] This is NOT 'all ${_declared_n} gates green' — it is 'nothing applicable was left unchecked'."
+        fi
     else
-        echo "[hydra-gates] ${_emitted_n} GATE(S) GREEN — but ${_not_run_n} of ${_declared_n} DID NOT RUN (named above)."
+        echo "[hydra-gates] ${_emitted_n} GATE(S) GREEN — but ${_not_run_n} of ${_applicable_n} APPLICABLE gates DID NOT RUN (named above)."
         echo "[hydra-gates] This is NOT 'all ${_declared_n} gates green'. It says nothing about the gates that skipped."
         if [ "${REQUIRE_FULL_COVERAGE}" = "1" ]; then
             echo "[hydra-gates] --require-full-coverage was set: treating incomplete coverage as failure."
+            echo "[hydra-gates] Only gates whose subject matter EXISTS are counted — the ${_na_n} not-applicable"
+            echo "[hydra-gates] gate(s) above were excluded. Every gate named as DID NOT RUN either found its"
+            echo "[hydra-gates] input missing (structural) or its own machinery missing (wiring)."
             exit 98
         fi
     fi

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -223,44 +223,141 @@ fi
 # The fixture has no tests/axe/report.json, so this is the real condition.
 # ---------------------------------------------------------------------------
 echo "[test] a gate that did not run is named, not folded into the green"
-if printf '%s' "${OUT}" | grep -qE '^\[gate-33\] axe-core: SKIPPED'; then
+# The fixture has no src/ and no tests/axe/report.json, so gate-33's subject
+# matter genuinely does not exist here: NOT APPLICABLE, not a coverage gap. What
+# matters is that it SAYS SO — the original defect was that it said nothing at
+# all, and silence read as a pass.
+if printf '%s' "${OUT}" | grep -qE '^\[gate-33\] axe-core: (SKIPPED|NOT APPLICABLE)'; then
     _ok "gate-33 states its own absence instead of emitting nothing"
 else
-    _bad "gate-33 emitted no SKIPPED line — its absence is still indistinguishable from a pass"
+    _bad "gate-33 emitted neither a SKIPPED nor a NOT APPLICABLE line — its absence is still indistinguishable from a pass"
 fi
-if printf '%s' "${OUT}" | grep -q "GATES THAT DID NOT RUN"; then
-    _ok "the summary names the gates that did not run"
+if printf '%s' "${OUT}" | grep -qE '^\[gate-33\] axe-core: NOT APPLICABLE'; then
+    _ok "gate-33 is NOT APPLICABLE on a fixture with no src/ (no frontend to analyse)"
 else
-    _bad "the summary did not name a single unrun gate, though gate-33 cannot have run here"
+    _bad "gate-33 was counted as a coverage gap on a repo with no frontend at all"
 fi
-if printf '%s' "${OUT}" | grep -qE 'ALL [0-9]+ GATES GREEN'; then
-    _bad "an 'ALL N GATES GREEN' banner was printed while gate-33 did not run"
+if printf '%s' "${OUT}" | grep -qE '^\[hydra-gates\] NOT APPLICABLE'; then
+    _ok "the summary names the not-applicable gates"
 else
-    _ok "no 'ALL N GATES GREEN' banner while a gate did not run"
+    _bad "the summary did not name a single not-applicable gate, though this fixture has no src/"
 fi
-# A SKIPPED gate must not be counted as coverage — that would turn the fix into
-# the bug. Coverage must be strictly less than the declared inventory here.
+# The banner must never claim all N gates ran when some did not — whatever the
+# reason they did not. NOT APPLICABLE is a reason not to FAIL; it is not a
+# reason to claim the gate ran.
+if printf '%s' "${OUT}" | grep -qE 'ALL [0-9]+ GATES (GREEN|PASSED) — and all'; then
+    _bad "an 'ALL N GATES ... and all N of them ran' banner was printed while $(printf '%s' "${OUT}" | grep -cE ': NOT APPLICABLE') gate(s) did not run"
+else
+    _ok "no 'all N of them ran' banner while gates did not run"
+fi
+# Neither a SKIPPED nor a NOT APPLICABLE gate may be counted as coverage — that
+# would turn the fix into the bug. Coverage must be strictly less than declared.
 _cov_line="$(printf '%s' "${OUT}" | grep -m1 -oE 'COVERAGE: [0-9]+ of [0-9]+' || true)"
 _cov_ran="$(printf '%s' "${_cov_line}" | awk '{print $2}')"
 _cov_all="$(printf '%s' "${_cov_line}" | awk '{print $4}')"
 if [ -n "${_cov_ran:-}" ] && [ -n "${_cov_all:-}" ] && [ "${_cov_ran}" -lt "${_cov_all}" ]; then
-    _ok "SKIPPED gates are excluded from the coverage tally (${_cov_ran} of ${_cov_all})"
+    _ok "SKIPPED and NOT APPLICABLE gates are excluded from the coverage tally (${_cov_ran} of ${_cov_all})"
 else
-    _bad "coverage read '${_cov_line}' — a skipped gate is being counted as having reported"
+    _bad "coverage read '${_cov_line}' — a gate that did not run is being counted as having reported"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 4c — --require-full-coverage turns an incomplete run into a failure.
-# Reverse control for the above: the same fixture, exit 0 without the flag and
-# non-zero with it, proves the coverage gap is really being detected rather
-# than the banner merely being reworded.
+# Test 4c — --require-full-coverage distinguishes THREE states, and only two of
+# them fail.
+#
+# The product owner's requirement, verbatim: "if a gate is legitimately not
+# applicable the flag shouldn't fail the run". Before this, it did — measured on
+# exactly this fixture: 30 of 63 gates emitted nothing, 25 of them because they
+# were guarded by an `if [ -d src ]` on a repo with no frontend, and the flag
+# exited 98 on a repository with nothing wrong with it.
+#
+# Both directions are asserted, because either one alone is satisfiable by a
+# broken implementation: a flag that never fails passes 4c-i, and a flag that
+# always fails passes 4c-ii.
 # ---------------------------------------------------------------------------
-echo "[test] --require-full-coverage refuses an incomplete green"
+echo "[test] --require-full-coverage passes when every non-reporting gate is NOT APPLICABLE"
 "${BIN}" --app-dir "${FIX}" --base "${BASE_SHA}" --require-full-coverage > /dev/null 2>&1; RC_RFC=$?
-if [ "${RC_RFC}" -eq 98 ]; then
-    _ok "incomplete coverage exits 98 when the caller asked for full coverage"
+if [ "${RC_RFC}" -eq 0 ]; then
+    _ok "a run whose only gaps are not-applicable gates PASSES with the flag set"
 else
-    _bad "expected exit 98 with --require-full-coverage, got ${RC_RFC}"
+    _bad "expected exit 0 with --require-full-coverage on an all-not-applicable fixture, got ${RC_RFC}"
+fi
+
+echo "[test] --require-full-coverage still FAILS on a structural gap"
+# Reverse control. Give the fixture a frontend that registers an integration
+# leaf: gate-24's subject matter now EXISTS, and nothing in this repo correlates
+# the two halves of it. That is category (b) — structurally impossible — and it
+# must fail. Same fixture, same flag, opposite verdict: this is what proves the
+# pass above is a verdict and not an inability to fail.
+mkdir -p "${FIX}/src"
+cat > "${FIX}/src/leaf.js" <<'JS'
+// SPDX-License-Identifier: EUPL-1.2
+import { registerIntegration } from '@conduction/nextcloud-vue'
+registerIntegration({ id: 'fixture-leaf', renderMode: 'component' })
+JS
+git -C "${FIX}" add -A >/dev/null 2>&1
+git -C "${FIX}" commit -qm "fixture: register an integration leaf" >/dev/null 2>&1
+OUT_STRUCT="$("${BIN}" --app-dir "${FIX}" --base "${BASE_SHA}" --require-full-coverage 2>&1)"; RC_STRUCT=$?
+if [ "${RC_STRUCT}" -eq 98 ]; then
+    _ok "a structural gap (leaves registered, no parity check) exits 98 with the flag set"
+else
+    _bad "expected exit 98 for a structural coverage gap, got ${RC_STRUCT}"
+fi
+if printf '%s' "${OUT_STRUCT}" | grep -qE '^\[gate-24\] integration-parity: SKIPPED \(structural\)'; then
+    _ok "gate-24 names its gap as structural, and says which half of the pair exists"
+else
+    _bad "gate-24 did not report a structural skip although this fixture registers a leaf"
+fi
+# Positive control for the applicability declarations: src/ now EXISTS, so the
+# gates guarded by `[ -d src ]` must genuinely RUN. If the declaration table
+# ever drifts away from the guards it mirrors, it would keep calling them
+# not-applicable here — which is the one way this change could hide a live gate.
+_still_na=""
+for _g in 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45; do
+    printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE" && _still_na="${_still_na}${_g} "
+done
+if [ -z "${_still_na}" ]; then
+    _ok "with src/ present, every src-guarded gate really runs (applicability table tracks its guards)"
+else
+    _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists — the table has drifted from the guards it mirrors"
+fi
+
+echo "[test] an unrecognised skip category is a hard failure, never a silent 'na'"
+# A typo'd category that defaulted to `na` would be a lever for making any
+# gate's absence stop counting — the accounting hole this block closes, reopened
+# from the inside. It must fail loudly instead.
+TYPO_PKG="${WORK}/typo"
+mkdir -p "${TYPO_PKG}/bin" "${TYPO_PKG}/scripts"
+cp "${BIN}" "${TYPO_PKG}/bin/hydra-gates"
+cp -r "${PKG_ROOT}/scripts/lib" "${TYPO_PKG}/scripts/lib"
+# Corrupt the category on the gate-33 branch this fixture actually REACHES
+# (src/ exists, no axe report, caller did not declare enable-axe). Patching a
+# branch that does not execute would make this test pass by never running the
+# code it claims to test — the same defect the whole suite exists to catch. The
+# assertion below therefore also proves the patch LANDED.
+python3 - "${PKG_ROOT}/scripts/run-hydra-gates.sh" "${TYPO_PKG}/scripts/run-hydra-gates.sh" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+needle = '_skip 33 "axe-core" na "no ${_axe_report}, and the caller did not set enable-axe'
+assert needle in s, "typo-test needle not found — the gate-33 branch it corrupts has been reworded"
+s = s.replace(needle, '_skip 33 "axe-core" nq "no ${_axe_report}, and the caller did not set enable-axe', 1)
+open(dst, 'w').write(s)
+PY
+chmod +x "${TYPO_PKG}/scripts/run-hydra-gates.sh"
+OUT_TYPO="$("${TYPO_PKG}/bin/hydra-gates" --app-dir "${FIX}" --base "${BASE_SHA}" 2>&1)"; RC_TYPO=$?
+if [ "${RC_TYPO}" -ne 0 ] && printf '%s' "${OUT_TYPO}" | grep -q "is not one of na|structural|wiring"; then
+    _ok "an unrecognised reason category fails the gate instead of resolving to 'na'"
+else
+    _bad "a typo'd reason category did not fail (exit ${RC_TYPO}) — any gate could stop counting by misspelling its category"
+fi
+# Reverse control: the UNPATCHED runner on the same fixture must NOT emit that
+# internal error. Without this, "the error appeared" could equally mean the
+# error appears always.
+if "${BIN}" --app-dir "${FIX}" --base "${BASE_SHA}" 2>&1 | grep -q "is not one of na|structural|wiring"; then
+    _bad "the unpatched runner also reports an unrecognised category — the assertion above proves nothing"
+else
+    _ok "reverse control — the unpatched runner reports no category error"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> PO instruction, verbatim: *"if a gate is legitimately not applicable the flag shouldnt fail the run"*

## What the current code actually does — measured, not inferred

`_skip` deliberately does **not** add to `_EMITTED_GATES`, so every skip counts against coverage. And most gates never even reach a `_skip`: they are wrapped in a bare `if [ -d src ]` with no `else`, so when the prerequisite is false they emit **nothing at all** — no line, no reason, no trace.

Measured on a Tier-0 fixture with **nothing wrong with it**:

```
[hydra-gates] COVERAGE: 33 of 63 declared gates reported a result.
[hydra-gates] GATES THAT DID NOT RUN: 4 5 6 7 10 12 13 14 15 19 22 24 25 26 31 32 33
                                      34 35 36 37 38 39 40 41 42 43 44 45 53
EXIT=98
```

**30 of 63 gates did not report; 25 of them only because the repo has no `src/`.** Of the 30, just 4 emitted a `SKIPPED` line at all — the other 26 were pure silence. So yes: category (a) currently fails the run, and the flag was unusable fleet-wide.

## Three states, only two fail

| verdict | meaning | counts? |
|---|---|---|
| `NOT APPLICABLE` | subject matter absent from this repo/diff | **no** |
| `SKIPPED (structural)` | subject matter EXISTS, nothing produced the gate's input | yes |
| `SKIPPED (wiring)` | the gate's own helper/tool is missing | yes |

`wiring` is called out separately because it is the worst shape: a missing helper once let **gate-7 report PASS over 11 real unguarded IDOR endpoints**.

## Gates 4, 24 and 33 — classified explicitly

**gate-4** had *three* ways to emit nothing, all byte-identical to success:
- no `composer.json` → **na** (no PHP dependency tree exists)
- `composer.json`/`.lock` not in a diff-scoped run → **na** (ADR-020 — *the case the PO named*)
- **`composer` not on PATH → wiring.** A dependency tree that exists and was never audited. This one had no output whatsoever before.

**gate-24** is split on the gate's **own subject matter**, not on the presence of its checker — the only test that cannot drift from what the gate correlates:
- no `new LeafDescriptor(` in `lib/` **and** no `registerIntegration(` in `src/` → **na** (there is no pair to correlate)
- either present, no parity script → **structural**

Deciding from `[ -f scripts/check-integration-parity.sh ]` alone is why every repo in the fleet reported the same skip regardless of whether it had any leaves.

**gate-33**'s input is the one thing the runner cannot make for itself:
- no `src/` → **na**
- `src/`, caller never declared `enable-axe` → **na** — that choice is a visible line in the caller's workflow, not a gap hidden in the runner
- `enable-axe` declared, report absent → **structural**, and it fails

quality.yml now passes `--axe-enabled` from `inputs.enable-axe` so the runner can tell those apart instead of guessing "unverified" for both — which is what made the flag unusable everywhere.

## Two things stop `NOT APPLICABLE` becoming a mute

1. **Silence still counts AGAINST coverage.** A gate that emits nothing is a gap *by default*. To stop counting it must *declare* itself not-applicable, by name and with a reason.
2. **The category is validated.** `na|structural|wiring` only; anything else is a **hard gate failure**, never a default. A gate cannot stop counting by misspelling its reason. Asserted in the suite — with a reverse control proving the unpatched runner does *not* emit that error.

The 25 silent gates are covered by applicability declarations restating each group's own `if` guard, negated. They **cannot mask a live gate**: `_declare_na` refuses to touch a gate that already reported, and each condition fires only when the prerequisite is absent — so a gate that stays silent while its subject *exists* remains a gap exactly as before. A positive control asserts that with `src/` present, **all 16** src-guarded gates really run, so table-vs-guard drift is detectable.

## Both directions proven

Either alone is satisfiable by a broken flag — one that never fails passes the first, one that always fails passes the second.

| run | expected | measured |
|---|---|---|
| only category-(a) skips, flag ON | 0 | **EXIT=0** — `33 of 33 applicable gates ran` |
| + an integration leaf registered, no parity check (b) | 98 | **EXIT=98** — `[gate-24] SKIPPED (structural)` |
| helper `check_no_admin_idor.py` removed (c) | 98 | **EXIT=98** — `[gate-7] SKIPPED (wiring)` |
| `--axe-enabled` with no report (b) | 98 | **EXIT=98** — `[gate-33] SKIPPED (structural)` |
| typo'd category `nq` | fail | **`FAIL — … not one of na\|structural\|wiring`** |

Suite **25 → 31 tests, 0 failing**.

## `bin/hydra-gates` had to learn the new verdict

It recomputes coverage independently. A `NOT APPLICABLE` line contains no `': SKIPPED'`, so the **old filter would have counted every not-applicable gate as having REPORTED A RESULT** — miscounted silently, in the direction that always reads better than the truth. It also no longer prints `ALL 63 GATES PASSED — and all 63 of them ran` over a run where 30 did not.

## Blast radius of the flip — measured on real repos, flag ON

| repo | not applicable | DID NOT RUN |
|---|---|---|
| openregister | 4, 33 | **none** |
| opencatalogi | 4, 7, 24, 33 | **none** |
| docudesk | 4, 6, 7, 24, 33 | **none** |
| hermiq | 4, 33 | **24** |
| openconnector | 4, 7, 33 | **24** |

Three of five have complete coverage. The two that don't fail on a **genuine, named, actionable** gap: both register integration leaves and neither ships a parity check. That is the flag working, not the flag misfiring. Only repos with `enable-hydra-gates: true` are affected at all.

## Verification

- `actionlint` positive-controlled (exit 1 with 2 real findings on a deliberately broken workflow); this branch exit 0.
- The `default: true` and the arg wiring verified from the **parsed YAML**, not the draft: `DEFAULT from parsed YAML : True bool`.
- Rebased onto `main` after #161 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)