### PR TITLE
fix(gate-28): license-triangle reported PASS on repos with no lib/, having opened zero files

### DIFF
--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2225,8 +2225,15 @@ elif [ "${_lt_checked}" -gt 0 ]; then
     _pass 28 "license-triangle"
 elif [ ! -d lib ]; then
     _skip 28 "license-triangle" na "this repo has no lib/ directory, so there are no per-file @license PHPDoc tags for composer.json's license to be compared against. Nothing was inspected and nothing could be. Typical of the Python ExApp sidecars, whose application code lives in ex_app/ and whose only PHP is phpcs-custom-sniffs/. This gate becomes applicable the moment PHP app code lands under lib/."
+elif [ ! -f composer.json ]; then
+    # NOT APPLICABLE, not structural. This gate compares two declarations; with
+    # no composer.json there is no second declaration to compare against and no
+    # change inside this repo can create one to compare. Nothing is missing —
+    # the gate simply has no subject matter. (Contrast the branch below: a
+    # composer.json that exists but declares no license IS a fixable gap.)
+    _skip 28 "license-triangle" na "lib/ exists but this repo has no composer.json, so there is no \`license\` declaration for per-file @license tags to be compared against. This gate compares two declarations and only one exists here."
 elif [ -z "${_composer_lic}" ]; then
-    _skip 28 "license-triangle" structural "lib/ exists but composer.json declares no \`license\` field (or there is no composer.json), so there is nothing to compare per-file @license tags against. Per-file/composer license agreement is UNVERIFIED by this run."
+    _skip 28 "license-triangle" structural "lib/ and composer.json both exist, but composer.json declares no \`license\` field, so there is nothing to compare per-file @license tags against. Per-file/composer license agreement is UNVERIFIED by this run. Fixable here: add \`\"license\": \"EUPL-1.2\"\` to composer.json."
 else
     _skip 28 "license-triangle" structural "lib/ exists and composer.json declares license=${_composer_lic}, but 0 in-scope lib/**/*.php file carried an @license PHPDoc tag, so NOTHING was compared. Per-file/composer license agreement is UNVERIFIED by this run. (Presence of the tag is gate-1's job, not this gate's.)"
 fi

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2155,20 +2155,33 @@ if [ "${_pcar_ran}" -eq 1 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Gate 28: License triangle — every per-file `@license` PHPDoc tag in lib/ + the
-# `license` field in composer.json MUST agree (Conduction convention: EUPL-1.2).
-# Gate-1 (SPDX) only checks PRESENCE of the @license tag; this gate checks the
-# VALUES line up across the three locations a Conduction app declares its
-# license: composer.json (.license), appinfo/info.xml (<licence>), per-file
-# @license PHPDoc tags.
+# Gate 28: License triangle — every per-file `@license` PHPDoc tag in lib/ and
+# the `license` field in composer.json MUST agree (Conduction convention:
+# EUPL-1.2). Gate-1 (SPDX) only checks PRESENCE of the @license tag; this gate
+# checks that the VALUES line up.
 #
-# Exception: appinfo/info.xml's <licence>agpl</licence> is the legacy Nextcloud
-# appstore signal that the app is published under EUPL-1.2 (the appstore taxonomy
-# pre-dates EUPL); per ADR-014 we accept that drift on info.xml ONLY. composer
-# .json and per-file headers must agree.
+# SCOPE, stated exactly, because the name oversells it: this compares TWO
+# locations — composer.json `.license` and per-file `@license` PHPDoc tags under
+# lib/. It does NOT read appinfo/info.xml. The `<licence>` element is outside
+# this gate's reach entirely, so nothing here can be read as a verdict on it.
+# (ADR-014 currently tells apps to declare `<licence>agpl</licence>` there while
+# the whole fleet declares EUPL-1.2 and the appstore's own info.xsd enumerates
+# EUPL-1.2 as valid. That contradiction is an ADR decision, not a gate change,
+# and is deliberately not resolved here.)
+#
+# WHY THE SKIP BRANCHES BELOW EXIST. Until 2026-08-05 this gate ran its
+# comparison inside `if [ -n "${_composer_lic}" ] && [ -d lib ]` but called
+# `_pass 28` unconditionally afterwards. A repo with no lib/ — every Python
+# ExApp sidecar in the fleet: valtimo, openklant, opentalk, openzaak — therefore
+# reported `[gate-28] license-triangle: PASS` having opened zero files, and the
+# coverage accounting counted it as a gate that reported a result. That is the
+# falsely-GREEN shape the coverage block exists to make impossible: a PASS and a
+# no-op were byte-identical in the output. A gate that inspected nothing now
+# says so.
 # ---------------------------------------------------------------------------
 _lt_log=/tmp/hydra-gate-license-triangle.log
 : > "${_lt_log}"
+_lt_checked=0
 _composer_lic=""
 if [ -f composer.json ]; then
     # composer.json's `license` may be a string ("EUPL-1.2") or an array of
@@ -2195,6 +2208,7 @@ if [ -n "${_composer_lic}" ] && [ -d lib ]; then
         _file_lic=$(grep -oE '^[[:space:]]*\*[[:space:]]*@license[[:space:]]+[^[:space:]*]+' "${_php}" 2>/dev/null \
             | head -1 | awk '{print $3}')
         if [ -z "${_file_lic}" ]; then continue; fi
+        _lt_checked=$((_lt_checked + 1))
         # Member-of check against the pipe-joined composer license set.
         case "|${_composer_lic}|" in
             *"|${_file_lic}|"*) ;;   # file license is in the allowed set
@@ -2205,10 +2219,16 @@ if [ -n "${_composer_lic}" ] && [ -d lib ]; then
     done < <(_enum_tracked '\.php$' lib)
 fi
 _lt_fail=$(wc -l < "${_lt_log}" 2>/dev/null || echo 0)
-if [ "${_lt_fail}" -eq 0 ]; then
-    _pass 28 "license-triangle"
-else
+if [ "${_lt_fail}" -ne 0 ]; then
     _fail 28 "license-triangle" "${_lt_fail} file(s) with @license != composer.json — see ${_lt_log}"
+elif [ "${_lt_checked}" -gt 0 ]; then
+    _pass 28 "license-triangle"
+elif [ ! -d lib ]; then
+    _skip 28 "license-triangle" na "this repo has no lib/ directory, so there are no per-file @license PHPDoc tags for composer.json's license to be compared against. Nothing was inspected and nothing could be. Typical of the Python ExApp sidecars, whose application code lives in ex_app/ and whose only PHP is phpcs-custom-sniffs/. This gate becomes applicable the moment PHP app code lands under lib/."
+elif [ -z "${_composer_lic}" ]; then
+    _skip 28 "license-triangle" structural "lib/ exists but composer.json declares no \`license\` field (or there is no composer.json), so there is nothing to compare per-file @license tags against. Per-file/composer license agreement is UNVERIFIED by this run."
+else
+    _skip 28 "license-triangle" structural "lib/ exists and composer.json declares license=${_composer_lic}, but 0 in-scope lib/**/*.php file carried an @license PHPDoc tag, so NOTHING was compared. Per-file/composer license agreement is UNVERIFIED by this run. (Presence of the tag is gate-1's job, not this gate's.)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`_pass 28` was called **unconditionally**, after a comparison that only runs inside:

```bash
if [ -n "${_composer_lic}" ] && [ -d lib ]; then
```

So a repo with no `lib/` printed

```
[gate-28] license-triangle: PASS
```

having opened **zero files** — and the coverage accounting counted it as a gate that reported a result. A PASS and a no-op were byte-identical in the output. That is the falsely-GREEN shape the coverage block exists to make impossible, appearing *inside* the thing meant to detect it.

Not hypothetical. Four Python ExApp sidecars in the fleet — **`valtimo`, `openklant`, `opentalk`, `openzaak`** — have no `lib/` at all (their application is a single `ex_app/lib/main.py`; the only PHP is `phpcs-custom-sniffs/`). All four report gate-28 PASS on a `--full` scan of their **entire tree**.

## The fix

Count the files actually compared, and route on that. The `na` / `structural` vocabulary already exists — this gate just wasn't using it.

| condition | before | after |
|---|---|---|
| a file's `@license` ∉ composer.json's set | `FAIL` | `FAIL` *(untouched)* |
| ≥ 1 file really compared, all agree | `PASS` | `PASS` *(untouched)* |
| **no `lib/` at all** | **`PASS`** | **`NOT APPLICABLE`** |
| `lib/` exists, composer.json declares no `license` | **`PASS`** | `SKIPPED (structural)` |
| `lib/` exists, 0 in-scope file carried an `@license` tag | **`PASS`** | `SKIPPED (structural)` |

## Three controls — measured, not asserted

**A — no `lib/`** (`valtimo`, `--full`):
```
was:  [gate-28] license-triangle: PASS
now:  [gate-28] license-triangle: NOT APPLICABLE — this repo has no lib/ directory, so there
      are no per-file @license PHPDoc tags for composer.json's license to be compared
      against. Nothing was inspected and nothing could be. ...

COVERAGE: 29 of 63  ->  28 of 63 reported (30 not applicable; 28 of 33 applicable gates ran)
```

**B — `lib/` present, licences agree** (`openbuild`, `--full`): `PASS` → `PASS`, `COVERAGE: 61 of 63`. Unchanged.

**C — `lib/` present, one file drifting** (fixture: `composer.json` `EUPL-1.2`, one file `@license AGPL-3.0-or-later`):
```
old script:  [gate-28] license-triangle: FAIL — 1 file(s) with @license != composer.json
new script:  [gate-28] license-triangle: FAIL — 1 file(s) with @license != composer.json
```

Control C was run against **both** the old and the new script on the same fixture, deliberately: it shows this removes a false green **without weakening the real assertion**. No waiver, no threshold change, no `continue-on-error`.

## Also: the header comment oversold the gate

It described *"the three locations a Conduction app declares its license"*, naming `appinfo/info.xml` — but **the code never reads `info.xml`**. It compares two locations: `composer.json .license` and per-file `@license` tags under `lib/`. The comment now says so, so nothing here can be read as a verdict on `<licence>`.

## 🔴 Related, and deliberately NOT resolved here

That same comment cites **ADR-014**, which says `appinfo/info.xml` MUST use `<licence>agpl</licence>` because *"Nextcloud app store does not recognise EUPL"*.

**That rationale is factually false.** The live appstore schema — https://apps.nextcloud.com/schema/apps/info.xsd — enumerates **`EUPL-1.2`** as an allowed `<licence>` value. (It does *not* enumerate `eupl`.)

And the fleet already contradicts the ADR: `openregister`, `opencatalogi`, `openconnector`, `docudesk`, `nldesign`, `softwarecatalog`, `larpingapp`, `pipelinq`, `procest`, `openbuild`, `decidesk`, `portaliq` — **12 of 12 checked declare `EUPL-1.2`**.

Amending an ADR that six repos mirror and this gate cites is a decision, not a cleanup. Written up with the evidence in **ConductionNL/openbuild#135**; no ADR is touched by this PR.
