### PR TITLE
fix(quality): the coverage flag went ON at @main and reached OLD pinned runners — decidesk and doriath went red on gates 4, 24 and 33

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -259,7 +259,7 @@ on:
         type: boolean
         default: false
       hydra-gates-ref:
-        description: "Ref of ConductionNL/.github to take the gate package from. Pin this to a tag to stop a gate change from altering a repo's verdict without a commit in that repo."
+        description: "Ref of ConductionNL/.github to take the gate package from. Pin this to a tag to stop a gate change from altering a repo's verdict without a commit in that repo. NOTE: this workflow is consumed at @main while the package is consumed at this pin, so the two move independently and a new default here can reach an old runner. v1.3.0 is the minimum for hydra-gates-require-full-coverage and enable-axe to be honoured (earlier packages count every not-applicable gate as a coverage gap); v1.4.0 is the minimum for enable-axe to run at all (it ships the axe runner). Below those, the affected flag is withheld with a named warning rather than failing the run for something the repo did not do."
         required: false
         type: string
         default: "main"
@@ -294,7 +294,7 @@ on:
         # opencatalogi and docudesk have ZERO gates that did not run; hermiq and
         # openconnector have exactly one each (gate-24), and it is a genuine gap
         # — both register integration leaves and neither ships a parity check.
-        description: "Fail the run (exit 98) when a gate whose subject matter EXISTS did not report. ON by default. A gate that is legitimately not applicable — a Tier-0 app with no src/, or gate-4 correctly diff-scoped out under ADR-020 because no composer file changed — reports NOT APPLICABLE, is named in the coverage block, and does NOT fail the run. Only two states fail: a STRUCTURAL gap (the subject matter exists and nothing produced the gate's input, e.g. a repo that registers integration leaves but ships no parity check) and a WIRING gap (the gate's own helper or tool is missing — the shape that once let gate-7 report PASS over 11 real unguarded IDOR endpoints). A gate that emits nothing at all still counts against coverage: not-applicable must be DECLARED, and its category is validated, so a gate cannot stop counting by staying quiet or by misspelling its reason. Set false only if you knowingly want a green that may be silent about what it did not check — the coverage block is printed either way."
+        description: "Fail the run (exit 98) when a gate whose subject matter EXISTS did not report. ON by default. A gate that is legitimately not applicable — a Tier-0 app with no src/, or gate-4 correctly diff-scoped out under ADR-020 because no composer file changed — reports NOT APPLICABLE, is named in the coverage block, and does NOT fail the run. Only two states fail: a STRUCTURAL gap (the subject matter exists and nothing produced the gate's input, e.g. a repo that registers integration leaves but ships no parity check) and a WIRING gap (the gate's own helper or tool is missing — the shape that once let gate-7 report PASS over 11 real unguarded IDOR endpoints). A gate that emits nothing at all still counts against coverage: not-applicable must be DECLARED, and its category is validated, so a gate cannot stop counting by staying quiet or by misspelling its reason. REQUIRES hydra-gates-ref v1.3.0 or later — an earlier package cannot tell the three states apart and counts every not-applicable gate as a gap, so at an older pin this flag is WITHHELD with a named warning instead of failing the run (measured: decidesk and doriath went red at v1.0.1 on nothing but gates 4, 24 and 33). Set false only if you knowingly want a green that may be silent about what it did not check — the coverage block is printed either way."
         required: false
         type: boolean
         default: true
@@ -2343,15 +2343,15 @@ jobs:
       # measurement is not contingent on the e2e verdict, and gate-33 runs
       # either way.
       #
-      # The runner is embedded here rather than kept as a file in this repo on
-      # purpose. This job never checks ConductionNL/.github out — only the
-      # hydra-gates job does, at its own `hydra-gates-ref` — so a separate file
-      # would mean a second ref to reason about and a second thing that can
-      # drift away from the workflow that calls it. Same rationale as
-      # ci-router.php above.
-      # The axe runner lives in this repo, not in a heredoc — see the step below
-      # for why that is load-bearing. Same checkout the hydra-gates job uses, so
+      # The axe runner lives in this repo as a FILE, not in a heredoc — see the
+      # "Run axe-core" step below for why that is load-bearing rather than
+      # tidiness. It comes from the same checkout the hydra-gates job uses, so
       # the runner and the gate that consumes its report come from one place.
+      #
+      # (An earlier revision of this comment claimed the opposite — that the
+      # runner was embedded here deliberately. That was true until #161/#166/#168
+      # and is exactly the instruction that must not survive: inlining it is what
+      # made the whole workflow unresolvable fleet-wide.)
       - name: Checkout the axe runner
         if: ${{ inputs.enable-axe && !cancelled() }}
         uses: actions/checkout@v4
@@ -2359,6 +2359,25 @@ jobs:
           repository: ConductionNL/.github
           ref: ${{ inputs.hydra-gates-ref }}
           path: gates
+
+      # This workflow is consumed at @main and the runner at the caller's pin,
+      # so the file can simply not be there: axe-run.cjs was added in v1.4.0 and
+      # every caller in the fleet is currently pinned to v1.3.0. Without this
+      # step the miss surfaces as node's `Cannot find module` three steps later,
+      # then as "the axe report never arrived", which points the reader at
+      # Playwright — the one place the fault is not.
+      - name: Assert the axe runner exists at the pinned ref
+        if: ${{ inputs.enable-axe && !cancelled() }}
+        env:
+          GATES_REF: ${{ inputs.hydra-gates-ref }}
+        run: |
+          set -u
+          RUNNER="${GITHUB_WORKSPACE}/gates/hydra-gates/scripts/axe-run.cjs"
+          if [ ! -f "${RUNNER}" ]; then
+            echo "::error::enable-axe is set, but hydra-gates-ref='${GATES_REF}' ships no hydra-gates/scripts/axe-run.cjs — that file arrived in v1.4.0. No axe report can be produced at this pin, so gate-33 has no input and this job would fail for a reason that has nothing to do with accessibility. Bump hydra-gates-ref to v1.4.0 or later, or set enable-axe: false."
+            exit 1
+          fi
+          echo "axe runner present at ref ${GATES_REF}."
 
       - name: Install axe-core
         if: ${{ inputs.enable-axe && !cancelled() }}
@@ -3178,6 +3197,71 @@ jobs:
           ref: ${{ inputs.hydra-gates-ref }}
           path: gates
 
+      # ── Does the PINNED gate package know what "not applicable" means? ─────
+      #
+      # This workflow is consumed at @main; the gate package is consumed at
+      # whatever tag the caller pinned. The two move independently, so a NEW
+      # default here reaches an OLD runner — the pinned-ref hazard running
+      # backwards.
+      #
+      # It is not hypothetical. `hydra-gates-require-full-coverage` was flipped
+      # to default TRUE once the runner learned to tell a not-applicable gate
+      # from a real gap (#164, released as v1.3.0). Every caller still pinned at
+      # v1.0.1 then got the new flag handed to a runner that counts EVERY gate
+      # it did not run as a gap. Measured, both red on nothing but gates
+      # 4/24/33 — none of which had any subject matter in those repos:
+      #
+      #   decidesk  job 92432089644  ref v1.0.1  ALL 61 GATES GREEN
+      #                              COVERAGE: 58 of 61 / DID NOT RUN: 4 24 33 -> exit 98, JOB FAILED
+      #   doriath   job 92363547732  ref v1.0.1  same three gates, same verdict
+      #
+      # That is precisely the outcome the flag was fixed to stop producing: a
+      # legitimately not-applicable gate failing the run. So the flag is only
+      # handed to a package that can honour it, and when it is withheld the run
+      # says so out loud — a quiet downgrade of a control is how the control
+      # stops existing.
+      #
+      # The probe reads the package's own accounting rather than parsing the
+      # ref as a version: a caller may pin a branch, a SHA or a fork, and none
+      # of those compare. `_NA_GATES` (runner) and the `NOT APPLICABLE` verdict
+      # (wrapper, which recomputes coverage independently) are both introduced
+      # by the same change and absent from every earlier tag — verified against
+      # the published tags: v1.0.0/v1.0.1/v1.1.0/v1.2.0 have neither, v1.3.0 and
+      # v1.4.0 have both.
+      #
+      # THOSE TWO LITERALS ARE A CONTRACT, NOT AN IMPLEMENTATION DETAIL.
+      # Renaming either one in the package would silently disable coverage
+      # enforcement in every repo in the fleet, with a warning that reads like
+      # an old pin. hydra-gates/tests/test-hydra-gates-bin.sh asserts both, so
+      # a rename fails the package's own CI instead.
+      - name: Can the pinned gate package tell "not applicable" from a gap?
+        id: gatecap
+        env:
+          GATES_REF: ${{ inputs.hydra-gates-ref }}
+        run: |
+          set -u
+          RUNNER="${GITHUB_WORKSPACE}/gates/hydra-gates/scripts/run-hydra-gates.sh"
+          WRAPPER="${GITHUB_WORKSPACE}/gates/hydra-gates/bin/hydra-gates"
+          # A missing file is a broken checkout, not an old package. Fail — a
+          # capability probe that answers "no" to a question it could not read
+          # is the same defect one layer up.
+          for f in "${RUNNER}" "${WRAPPER}"; do
+            if [ ! -f "${f}" ]; then
+              echo "::error::the hydra-gates checkout at ref '${GATES_REF}' has no ${f#"${GITHUB_WORKSPACE}/gates/"}. This is not a version difference — the package did not check out. Nothing was gated."
+              exit 1
+            fi
+          done
+          CAP=0
+          if grep -q '_NA_GATES' "${RUNNER}" && grep -q 'NOT APPLICABLE' "${WRAPPER}"; then
+            CAP=1
+          fi
+          echo "categories=${CAP}" >> "$GITHUB_OUTPUT"
+          if [ "${CAP}" -eq 1 ]; then
+            echo "hydra-gates @ ${GATES_REF} reports NOT APPLICABLE separately from SKIPPED — coverage enforcement can be honoured."
+          else
+            echo "hydra-gates @ ${GATES_REF} predates the coverage accounting fix (v1.3.0)."
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -3358,7 +3442,11 @@ jobs:
           set -u
           ARGS="--app-dir ${GITHUB_WORKSPACE}/app"
           if [ "${{ inputs.hydra-gates-require-full-coverage }}" = "true" ]; then
-            ARGS="${ARGS} --require-full-coverage"
+            if [ "${{ steps.gatecap.outputs.categories }}" = "1" ]; then
+              ARGS="${ARGS} --require-full-coverage"
+            else
+              echo "::warning::hydra-gates-require-full-coverage is on, but this run pins hydra-gates-ref='${{ inputs.hydra-gates-ref }}', whose gate package cannot tell a NOT-APPLICABLE gate from a real gap — it counts every gate it did not run against coverage. Enforcing it here would fail this run for gates that have no subject matter in this repo at all (measured: decidesk and doriath, both red on nothing but gates 4, 24 and 33). COVERAGE ENFORCEMENT IS THEREFORE NOT APPLIED TO THIS RUN — the coverage block below is printed but not enforced. Bump hydra-gates-ref to v1.3.0 or later to get it back."
+            fi
           fi
           # gate-33's input is the ONE input this runner cannot make for itself
           # — it comes from a browser in the Playwright job, and only when the
@@ -3369,8 +3457,20 @@ jobs:
           # never arrived" (a real gap, and it fails). Without this the runner
           # has to guess, and guessing "unverified" in both cases is what made
           # --require-full-coverage unusable in every repo in the fleet.
+          #
+          # Gated on the same probe, because `--axe-enabled` arrived in the same
+          # release as the categories and the OLD wrapper's argument parser ends
+          # in `*) APP_DIR="$1"` — an unrecognised flag is swallowed as a
+          # POSITIONAL and CLOBBERS the app dir set moments earlier. A v1.0.1
+          # pin handed this flag aborts with
+          # `FATAL: --app-dir '--axe-enabled' is not a directory. No gate ran.`
+          # and exits 99: every gate lost, for a flag the caller never typed.
           if [ "${{ inputs.enable-axe }}" = "true" ]; then
-            ARGS="${ARGS} --axe-enabled"
+            if [ "${{ steps.gatecap.outputs.categories }}" = "1" ]; then
+              ARGS="${ARGS} --axe-enabled"
+            else
+              echo "::warning::enable-axe is on, but hydra-gates-ref='${{ inputs.hydra-gates-ref }}' predates the flag (v1.3.0) and its argument parser would swallow it as the app directory, losing every gate. The flag is withheld; gate-33 will report its usual skip instead of a structural gap. Bump hydra-gates-ref to v1.3.0 or later."
+            fi
           fi
           # The default shell for a `run:` block is `bash -e {0}`. A bare
           # invocation followed by `RC=$?` would therefore never reach the

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -522,6 +522,50 @@ else
     _bad "coverage went ${_sec_with_n:-?} → ${_sec_without_n:-?}; removing 2 helpers must remove exactly 2 from the tally"
 fi
 
+# ---------------------------------------------------------------------------
+# The capability literals ConductionNL/.github's quality.yml probes for.
+#
+# quality.yml is consumed at @main; this package is consumed at whatever tag the
+# caller pinned, so the workflow cannot assume the package it checked out can
+# honour --require-full-coverage. It decides by reading two literals out of the
+# package's own files:
+#
+#   _NA_GATES        in scripts/run-hydra-gates.sh   (the not-applicable tally)
+#   "NOT APPLICABLE" in bin/hydra-gates              (the wrapper's own recount)
+#
+# Both were introduced by the accounting fix and are absent from every earlier
+# published tag, which is what makes them a usable discriminator against a pin
+# that may be a tag, a branch, a SHA or a fork.
+#
+# Rename either one and the probe answers "this package is too old" for the
+# CURRENT package — coverage enforcement would switch itself off in every repo
+# in the fleet, and the warning would blame the caller's pin. The rename is the
+# realistic accident; that it fails silently, in the direction that looks
+# greener, is what makes it worth an assertion here rather than a comment there.
+echo "[test] the capability literals quality.yml probes for still exist"
+if grep -q '_NA_GATES' "${PKG_ROOT}/scripts/run-hydra-gates.sh"; then
+    _ok "run-hydra-gates.sh still carries _NA_GATES (quality.yml's capability probe)"
+else
+    _bad "run-hydra-gates.sh no longer contains _NA_GATES — quality.yml would read this package as predating the coverage accounting and WITHHOLD --require-full-coverage fleet-wide. Restore the name, or change the probe in .github/workflows/quality.yml in the same commit."
+fi
+if grep -q 'NOT APPLICABLE' "${BIN}"; then
+    _ok "bin/hydra-gates still emits the NOT APPLICABLE verdict (quality.yml's capability probe)"
+else
+    _bad "bin/hydra-gates no longer contains 'NOT APPLICABLE' — quality.yml would read this package as predating the coverage accounting and WITHHOLD --require-full-coverage fleet-wide. Restore the wording, or change the probe in .github/workflows/quality.yml in the same commit."
+fi
+# Reverse control: the probe must NOT match a package that genuinely predates
+# the fix. Without this, an assertion that greps for a common word would pass on
+# every version and prove nothing about the discriminator.
+_probe_old="${WORK}/probe-old"
+mkdir -p "${_probe_old}"
+printf '%s\n' 'echo "[hydra-gates] GATES THAT DID NOT RUN: 4 24 33"' > "${_probe_old}/runner.sh"
+printf '%s\n' 'echo "[hydra-gates] COVERAGE: 58 of 61 declared gates reported a result."' > "${_probe_old}/wrapper"
+if grep -q '_NA_GATES' "${_probe_old}/runner.sh" || grep -q 'NOT APPLICABLE' "${_probe_old}/wrapper"; then
+    _bad "the capability probe matches pre-v1.3.0 output too — it is not a discriminator, and every old pin would be handed a flag it cannot honour"
+else
+    _ok "reverse control — the probe does NOT match the pre-v1.3.0 shape of either file"
+fi
+
 echo ""
 echo "=================================================="
 echo "hydra-gates entry-point tests: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
fix(quality): the coverage flag went ON at @main and reached OLD pinned runners — decidesk and doriath went red on gates 4, 24 and 33

`hydra-gates-require-full-coverage` was flipped to default TRUE (#164) once the
runner could tell a not-applicable gate from a real gap. But this workflow is
consumed at @main while the gate package is consumed at the caller's own
`hydra-gates-ref`, so the new default was handed to runners that predate the
accounting entirely — and those count EVERY gate they did not run as a gap.

Measured, not inferred, both after the flip and both failing on nothing else:

  decidesk job 92432089644  ref v1.0.1  ALL 61 GATES GREEN
                            COVERAGE: 58 of 61 / DID NOT RUN: 4 24 33 -> exit 98
  doriath  job 92363547732  ref v1.0.1  same three gates, same verdict

Gates 4, 24 and 33 are the exact trio the product owner named as legitimately
not applicable. So the flip was producing the outcome it was made to prevent,
in every repo whose pin had not moved — and pins do not move on in-flight
branches.

The flag is now handed only to a package that can honour it. The probe reads the
package's own accounting (`_NA_GATES` in the runner, the `NOT APPLICABLE`
verdict in the wrapper) rather than comparing versions, because a pin may be a
tag, a branch, a SHA or a fork. Verified against every published tag:
v1.0.0/v1.0.1/v1.1.0/v1.2.0 -> withheld, v1.3.0/v1.4.0 -> applied. A checkout
missing either file is a broken checkout, not an old one, and fails.

Withholding is stated as a `::warning::` naming the pin and the fix. A control
that switches itself off quietly is a control that has stopped existing.

`--axe-enabled` is gated on the same probe. The old wrapper's parser ends in
`*) APP_DIR="$1"`, so an unrecognised flag is swallowed as a POSITIONAL and
clobbers the app dir set moments earlier: a v1.0.1 pin handed it aborts with
`FATAL: --app-dir '--axe-enabled' is not a directory. No gate ran.` — exit 99,
every gate lost, for a flag the caller never typed.

Same ref skew, second instance: axe-run.cjs landed in v1.4.0 and every caller is
pinned v1.3.0, so `enable-axe: true` would die on `Cannot find module` and then
present as "the axe report never arrived" — pointing at Playwright, the one
place the fault is not. Asserted at the checkout with a named error instead.

The two probe literals are a CONTRACT: renaming either would silently disable
coverage enforcement fleet-wide, with a warning blaming the caller's pin. The
package's own suite now asserts both, plus a reverse control proving the probe
does not match the pre-v1.3.0 shape of either file. Positive-controlled: with
both literals renamed in a copy, those assertions go red.

Four-way measurement on one fixture, one variable at a time:

  v1.0.1 + --require-full-coverage        exit 98  <- the observed failure
  v1.0.1, flag withheld (this change)     exit 0
  v1.4.0 + flag, only (a) gaps            exit 0   33 of 33 applicable gates ran
  v1.4.0 + flag + a structural gap        exit 98  [gate-24] SKIPPED (structural)

Also removes a stale comment left by the #161/#166/#168 cycle that instructed
future readers to embed the axe runner inline — the thing that made the whole
workflow unresolvable fleet-wide.

Suite 31 -> 34 tests, 0 failing. actionlint clean (positive-controlled: a
typo'd step id is reported). Largest `run:` step 8,533 B, far below the ~19 KB
that makes a workflow unresolvable.


---

## Gates 4, 24 and 33 — classified, with the evidence

| gate | verdict | evidence |
|---|---|---|
| **gate-4** composer-audit | **(a)** in both of its common shapes — no `composer.json` at all, and `composer.json`/`.lock` not in a diff-scoped run (ADR-020). **(c)** in a third: `composer.json` present but `composer` not on PATH — a dependency tree that exists and was never audited. | `run-hydra-gates.sh:661,663,671` — three `_skip 4` call sites, categorised `na`, `wiring`, `na`. Live: doriath job 92411975098 `[gate-4] composer-audit: NOT APPLICABLE — neither composer.json nor composer.lock is in this diff`. |
| **gate-24** integration-parity | **(a)** when the repo registers no integration leaves at all; **(b)** when it registers them and ships no parity check. Split on the gate's OWN subject matter, not on the presence of its checker. | `run-hydra-gates.sh:1964` (`na`) / `:1966` (`structural`). Both measured on one fixture: with no leaves, `NOT APPLICABLE`, exit 0; after adding one `new LeafDescriptor(`, `[gate-24] integration-parity: SKIPPED (structural)` and exit 98. |
| **gate-33** axe-core | **(a)** with no `src/`; **(a)** with `src/` but the caller never set `enable-axe` (that choice is a visible line in the caller's own workflow, not a gap hidden in the runner); **(b)** when `enable-axe` IS set and no report arrives. | `run-hydra-gates.sh:2494,2496,2498`. Live: doriath job 92411975098 `[gate-33] axe-core: NOT APPLICABLE — … the caller did not set enable-axe`. |

Note gate-33's (b) case was, until this PR, **unreachable at every pin in the fleet**: `--axe-enabled` cannot be passed to a v1.3.0 package without the axe runner (v1.4.0), and cannot be passed to anything older without destroying the run.

## Both directions, on real runs

Either direction alone is satisfiable by a broken flag — one that never fails passes the first, one that always fails passes the second.

**(1) only category-(a) non-reporters → PASSES with the flag on** — live GitHub Actions, flag on, no local anything:

| run | ref | verdict |
|---|---|---|
| doriath job **92411975098** | v1.3.0 | `hydra-gates-require-full-coverage: true` · `NOT APPLICABLE: 4 6 7 24 33` · `58 of 58 applicable gates ran` · job **success** |
| decidesk job **92441077855** | v1.3.0 | `58 of 63 … (5 not applicable; 58 of 58 applicable gates ran)` · job **success** |

**(2) a category-(b) non-reporter → FAILS with the flag on** — one fixture, one variable at a time:

| package | flag | injected | exit | line |
|---|---|---|---|---|
| v1.4.0 | on | — | **0** | `33 of 33 applicable gates ran` |
| v1.4.0 | on | one `new LeafDescriptor(`, no parity script | **98** | `[gate-24] integration-parity: SKIPPED (structural)` |
| v1.4.0 | on | `check_no_admin_idor.py` removed | counted against coverage | `[gate-7] no-admin-idor: SKIPPED (wiring)` · `51 of 53 applicable gates ran` |
| v1.0.1 | on | — | **98** | the fleet failure this PR fixes |
| v1.0.1 | withheld | — | **0** | what this PR does at an old pin |

That the workflow turns exit 98 into a red job is proven by a real run too — decidesk job 92432089644 exited 98 and the job is `failure`. Its *cause* was the misclassification; its *plumbing* is the same path a genuine structural gap takes.

## Verification

- The probe was extracted **out of the parsed YAML** (983 B, asserted free of `${{ }}`) and run against real checkouts of every published tag: `v1.0.0 v1.0.1 v1.1.0 v1.2.0 -> categories=0`, `v1.3.0 v1.4.0 -> categories=1`. Broken checkout (either file missing) -> exit 1 with a named error, no output variable written.
- The `ARGS` assembly was extracted from the parsed YAML the same way and exercised as a matrix: flag on + new pin -> `--require-full-coverage`; flag on + old pin -> no flag, warning; axe on + old pin -> no flag, both warnings.
- `actionlint` clean. Positive-controlled on this same file: a typo'd `steps.gatecapp` is reported at the exact line.
- `shellcheck` clean on the modified suite. Positive-controlled.
- Suite 31 -> 34 tests, 0 failing. Helper suites 18 passed / 2 quarantined — both quarantines pre-existing and documented (`test_gate_glob_recursion_fixtures.sh`, `test_gate_orphaned_capability_fixtures.sh`), neither touched here.
- Largest `run:` step in the file: **8,533 B**. The unresolvable-workflow threshold sits between ~19 KB and ~21 KB.

## Not fixed here

Every caller pins `hydra-gates-ref: v1.3.0` on its default branch, so nobody gets #168's axe DOM scoping or gate-46 anchor fix until those pins move to v1.4.0. That is a consumer-ref sweep, deliberately not folded into a workflow fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
