### PR TITLE
fix(gates): 46/40/28/9/7 were majority-false, and the runner corrupted its own measurements

### DIFF
--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -252,16 +252,31 @@ jobs:
           # The offending FILES must be named, so we know the gates fired on
           # what we injected and not on something else that happened to be
           # there. stdout carries only the COUNT per gate by design; the file
-          # list goes to the gate's own /tmp/hydra-gate-<name>.log, so that is
-          # where the attribution has to be checked. A gate that reported FAIL
-          # while writing no evidence at all would itself be a defect, so a
-          # missing log is a failure here too.
+          # list goes to the gate's own log, so that is where the attribution
+          # has to be checked. A gate that reported FAIL while writing no
+          # evidence at all would itself be a defect, so a missing log is a
+          # failure here too.
+          #
+          # The log DIRECTORY is read from the run's own first line rather than
+          # hardcoded. It used to be the shared /tmp/hydra-gate-<name>.log, and
+          # that was the same defect this assertion exists to catch, one level
+          # up: two runs on one host overwrote each other's evidence, so this
+          # check could read a DIFFERENT run's log and pass, or read a truncated
+          # one and fail, without either outcome saying anything about the
+          # fixture. Each invocation now mints its own directory and announces
+          # it; asking the run where it wrote is the only way to be sure the
+          # evidence belongs to it.
+          LOGDIR="$(printf '%s\n' "${OUT}" | sed -n 's/^\[hydra-gates\] findings logs: //p' | head -1)"
+          if [ -z "${LOGDIR}" ] || [ ! -d "${LOGDIR}" ]; then
+            echo "::error::the run did not announce a findings-log directory (expected a '[hydra-gates] findings logs: <dir>' line). Without it there is no way to attribute a verdict to its evidence."
+            exit 1
+          fi
           for probe in "forbidden-patterns:lib/GateControl.php" "window-confirm:src/gateControl.js"; do
             gate="${probe%%:*}"; want="${probe##*:}"
             # shellcheck disable=SC2012
-            log="$(ls -t "/tmp/hydra-gate-${gate}.log" /tmp/hydra-gate-"${gate}".*.log 2>/dev/null | head -1)"
+            log="$(ls -t "${LOGDIR}/hydra-gate-${gate}.log" "${LOGDIR}"/hydra-gate-"${gate}".*.log 2>/dev/null | head -1)"
             if [ -z "${log}" ]; then
-              echo "::error::gate ${gate} reported a result but wrote no /tmp/hydra-gate-${gate}*.log — no evidence for its verdict"
+              echo "::error::gate ${gate} reported a result but wrote no ${LOGDIR}/hydra-gate-${gate}*.log — no evidence for its verdict"
               exit 1
             fi
             echo "--- ${log}"; cat "${log}"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3178,6 +3178,52 @@ jobs:
           ref: ${{ inputs.hydra-gates-ref }}
           path: gates
 
+      # ── the floating-caller / pinned-callee contract ──────────────────────
+      #
+      # THIS WORKFLOW FLOATS ON @main; THE PACKAGE IT DRIVES IS PINNED.
+      #
+      # A caller references this file as
+      # `ConductionNL/.github/.github/workflows/quality.yml@main` while
+      # pinning `hydra-gates-ref` to a tag. So the two halves of one system
+      # move independently, and every path this workflow executes inside
+      # `gates/hydra-gates/` is an UNVERSIONED INTERFACE between them.
+      #
+      # That interface has broken three times in one day. The decisive one
+      # was #168: a change on @main made this workflow execute
+      # `gates/hydra-gates/scripts/axe-run.cjs` BY PATH, and every repo whose
+      # pin predated that file got a failure whose message named neither the
+      # pin nor the file.
+      #
+      # Pinning both halves from one tag, or floating both, is the real fix
+      # and is a human decision — it changes how 22 repos receive gate fixes.
+      # Until then this step makes the desync SAY SO. A named refusal is not
+      # a fix, but it is the difference between "gate-33 is broken" and
+      # "your pin is four fixes behind and here is the file it is missing".
+      - name: Verify the pinned gates package satisfies this workflow
+        run: |
+          set -uo pipefail
+          REF='${{ inputs.hydra-gates-ref }}'
+          MISSING=""
+          for p in \
+            bin/hydra-gates \
+            scripts/run-hydra-gates.sh \
+            scripts/axe-run.cjs \
+            scripts/lib/check_spec_anchors.py \
+            scripts/lib/check_form_labels.py \
+            scripts/lib/check_license_triangle.py \
+            scripts/lib/check_no_admin_idor.py \
+            scripts/lib/check_semantic_auth.py \
+            scripts/lib/check_orphan_auth.py
+          do
+            [ -e "${GITHUB_WORKSPACE}/gates/hydra-gates/${p}" ] || MISSING="${MISSING} ${p}"
+          done
+          if [ -n "${MISSING}" ]; then
+            echo "::error::hydra-gates-ref '${REF}' does not contain:${MISSING}"
+            echo "::error::This workflow floats on @main and executes those paths by name inside the PINNED package, so a pin older than them cannot run the gates they implement. Bump hydra-gates-ref to a tag that includes them. This is NOT a code-quality finding about your repository."
+            exit 1
+          fi
+          echo "Pinned gates package at '${REF}' provides every path this workflow executes."
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/hydra-gates/scripts/lib/check_form_labels.py
+++ b/hydra-gates/scripts/lib/check_form_labels.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-40 form-label-association — every form control must have an
+accessible name (WCAG 2.2 AA, SC 1.3.1 Info and Relationships and SC 3.3.2
+Labels or Instructions).
+
+WHY THIS WAS REWRITTEN
+----------------------
+The previous implementation flattened the file's newlines into spaces and
+ran four independent regexes over the result. It had no notion of nesting,
+of a component's slot, or of where the template ends — so it could only see
+attributes ON the element, and an accessible name that comes from anywhere
+else read as an absent one. Measured across 21 fleet repos: **1,211
+findings, 58% of them false**, in four shapes:
+
+  implicit label wrapping   `<label><input …><span>Safe mode</span></label>`
+                            is the canonical HTML association and needs no
+                            `for`/`id` pair at all. 268 findings.
+
+  NcCheckboxRadioSwitch     `<NcCheckboxRadioSwitch v-model="x">Installed
+  default slot              apps only</NcCheckboxRadioSwitch>` — nc-vue
+                            renders the default slot INTO the `<label>`.
+                            463 findings, and this is the dangerous one:
+                            the only way to satisfy the old gate was to add
+                            `aria-label`, which OVERRIDES the visible label
+                            and breaks speech-input users who say what they
+                            see. A gate whose remediation is an
+                            accessibility REGRESSION cannot be closed
+                            honestly.
+
+  dynamic :id / :for        `<label :for="`f-${id}`">` + `<input
+                            :id="`f-${id}`">` is a correct association the
+                            literal-only regex could not see. 56 findings.
+
+  commented-out markup      `<!-- <input type="text"> -->` ships nothing.
+                            5 findings.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+A control with no accessible name from ANY of the recognised sources is
+still reported. Every relaxation here is anchored to a real naming
+mechanism the browser implements — a wrapping `<label>`, a matching
+`for`/`id` pair (literal or expression), a component prop the library
+documents, or slot content the component renders into its own `<label>`.
+An `<input type="text">` standing on its own, a self-closed
+`<NcCheckboxRadioSwitch />` with no prop and no slot, and a `<label>` whose
+`for` matches no control are all still findings. See
+``test_check_form_labels.py``, where each relaxation ships with the
+true-positive case it must not swallow.
+
+Usage:
+    check_form_labels.py <file.vue>...        # findings on stdout
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# Native controls that need a name. `select` is deliberately absent: it is
+# gate-12 (nc-input-labels)' subject, and widening this gate's remit while
+# fixing its false-positive rate would make the two numbers incomparable.
+NATIVE = {'input', 'textarea'}
+# Nextcloud components whose published API takes the name as a prop.
+# `NcSelect` belongs to gate-12, same reason.
+NC_PROP_COMPONENTS = {'nctextfield', 'ncinputfield', 'ncrichcontenteditable',
+                      'nccheckboxradioswitch'}
+# ...of which these ALSO accept the name as default-slot content, because
+# they render that slot inside their own <label> element.
+NC_SLOT_COMPONENTS = {'nccheckboxradioswitch'}
+
+# `type=` values that carry their own name or take none.
+EXEMPT_INPUT_TYPES = {'hidden', 'submit', 'button', 'reset', 'image'}
+
+TAG = re.compile(
+    r'<(/?)([A-Za-z][A-Za-z0-9._:-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/?)>',
+    re.DOTALL,
+)
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+TEMPLATE = re.compile(r'<template\b[^>]*>(.*)</template\s*>', re.DOTALL | re.IGNORECASE)
+
+ARIA = re.compile(r'(^|\s)(:|v-bind:)?(aria-label|aria-labelledby)\s*=')
+NC_LABEL_PROP = re.compile(
+    r'(^|\s)(:|v-bind:)?(label|input-label|inputLabel|aria-label-combobox|ariaLabelCombobox)\s*=')
+
+
+def _attr(attrs: str, name: str) -> str | None:
+    """Value of *name* (or its bound `:name` form) as written, or None."""
+    m = re.search(
+        r'(?:^|\s)(?::|v-bind:)?' + re.escape(name) + r'\s*=\s*("([^"]*)"|\'([^\']*)\')',
+        attrs)
+    if not m:
+        return None
+    return m.group(2) if m.group(2) is not None else m.group(3)
+
+
+def _norm_expr(value: str) -> str:
+    """Normalise a `for`/`id` value so a literal and a bound expression that
+    denote the same thing compare equal. Whitespace-insensitive; quotes
+    unified. `` `f-${id}` `` from a `:for` and from an `:id` match."""
+    return re.sub(r'\s+', '', value).replace('"', "'")
+
+
+def _strip_noise(src: str) -> str:
+    """Template region only, comments and script/style blocks removed.
+
+    Order matters: comments first, because a commented-out `</script>`
+    would otherwise end the block early.
+    """
+    body = COMMENT.sub(' ', src)
+    m = TEMPLATE.search(body)
+    if m:
+        body = m.group(1)
+    return BLOCK.sub(' ', body)
+
+
+class _El:
+    __slots__ = ('name', 'attrs', 'start', 'text_start')
+
+    def __init__(self, name: str, attrs: str, start: int, text_start: int):
+        self.name = name
+        self.attrs = attrs
+        self.start = start
+        self.text_start = text_start
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    """Return finding lines for one component source."""
+    body = _strip_noise(src)
+
+    # Pass 1 — every `for=` / `:for=` a <label> declares, normalised.
+    label_for: set[str] = set()
+    for m in TAG.finditer(body):
+        closing, name, attrs, _self = m.group(1), m.group(2).lower(), m.group(3), m.group(4)
+        if closing or name != 'label':
+            continue
+        v = _attr(attrs, 'for')
+        if v:
+            label_for.add(_norm_expr(v))
+
+    findings: list[str] = []
+    stack: list[_El] = []
+    label_depth = 0
+
+    def _named_by_attrs(name: str, attrs: str) -> bool:
+        if ARIA.search(attrs):
+            return True
+        if name in NC_PROP_COMPONENTS and NC_LABEL_PROP.search(attrs):
+            return True
+        if name in NATIVE:
+            v = _attr(attrs, 'id')
+            if v and _norm_expr(v) in label_for:
+                return True
+        return False
+
+    def _report(name: str, attrs: str, rule: str) -> None:
+        rendered = re.sub(r'\s+', ' ', f'<{name}{attrs}>').strip()
+        if len(rendered) > 200:
+            rendered = rendered[:197] + '...'
+        findings.append(f'{fname}: {rendered} rule={rule}')
+
+    for m in TAG.finditer(body):
+        closing, raw_name, attrs, self_close = m.group(1), m.group(2), m.group(3), m.group(4)
+        name = raw_name.lower()
+        void = name in {'input', 'img', 'br', 'hr', 'meta', 'link', 'source', 'area'}
+
+        if closing:
+            # Pop back to the matching open tag, tolerating unbalanced markup.
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i].name == name:
+                    el = stack[i]
+                    inner = body[el.text_start:m.start()]
+                    if el.name in NC_SLOT_COMPONENTS:
+                        _decide_slot_component(el, inner, _report)
+                    del stack[i:]
+                    break
+            label_depth = sum(1 for e in stack if e.name == 'label')
+            continue
+
+        is_void = void or bool(self_close)
+
+        if name == 'input':
+            t = (_attr(attrs, 'type') or 'text').strip().lower()
+            if t not in EXEMPT_INPUT_TYPES:
+                if not (_named_by_attrs(name, attrs) or label_depth > 0):
+                    _report(raw_name, attrs, 'input-without-label')
+        elif name == 'textarea':
+            if not (_named_by_attrs(name, attrs) or label_depth > 0):
+                _report(raw_name, attrs, f'{name}-without-label')
+        elif name in NC_PROP_COMPONENTS:
+            named = _named_by_attrs(name, attrs) or label_depth > 0
+            if named:
+                pass
+            elif name in NC_SLOT_COMPONENTS and not is_void:
+                # Defer: the default slot may supply the label. Decided when
+                # the closing tag is reached.
+                pass
+            else:
+                _report(raw_name, attrs, f'{name}-without-label-prop')
+
+        if not is_void:
+            stack.append(_El(name, attrs, m.start(), m.end()))
+            if name == 'label':
+                label_depth += 1
+
+    # Unclosed slot components: no closing tag was ever seen, so no slot
+    # content was proved. Report rather than silently accept.
+    for el in stack:
+        if el.name in NC_SLOT_COMPONENTS and not (
+                ARIA.search(el.attrs) or NC_LABEL_PROP.search(el.attrs)):
+            _report(el.name, el.attrs, f'{el.name}-without-label-prop')
+
+    return findings
+
+
+def _decide_slot_component(el: _El, inner: str, report) -> None:
+    """A slot-labelling component is named iff its default slot renders
+    something. Whitespace, and nothing else, is not a name."""
+    if ARIA.search(el.attrs) or NC_LABEL_PROP.search(el.attrs):
+        return
+    # Strip nested tags; what remains is the text the user would read. A
+    # `{{ t('app', 'Installed apps only') }}` interpolation counts — it is
+    # the translated visible label.
+    text = TAG.sub(' ', inner)
+    if text.strip():
+        return
+    report(el.name, el.attrs, f'{el.name}-without-label-prop')
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_license_triangle.py
+++ b/hydra-gates/scripts/lib/check_license_triangle.py
@@ -76,7 +76,13 @@ DECL = re.compile(
 # as `lib` and the path guard below never fired — the malfunction would have
 # been reported as an ordinary licence drift, sending someone to edit a
 # header that was already correct. The terminator is stripped instead.
-_TRAILING_COMMENT = re.compile(r'(?:\*/|-->)+$')
+#
+# `--!>` as well as `-->`: HTML5 treats both as a comment terminator, and a
+# pattern that knows only one of them is `py/bad-tag-filter`. Nothing here
+# sanitises markup — this only trims a terminator off a licence identifier —
+# but a half-known comment syntax is a half-known comment syntax, and the
+# narrower pattern would silently leave `EUPL-1.2--!` as the "licence".
+_TRAILING_COMMENT = re.compile(r'(?:\*/|--!?>)+$')
 
 
 def _looks_like_a_path(value: str) -> bool:

--- a/hydra-gates/scripts/lib/check_license_triangle.py
+++ b/hydra-gates/scripts/lib/check_license_triangle.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-28 license-triangle — every licence a file declares must agree with
+the licence the package declares, and with the OTHER declarations in the
+same file.
+
+WHY THIS WAS REWRITTEN (ConductionNL/.github#171)
+-------------------------------------------------
+The shell implementation this replaces did:
+
+    grep -oE '^[[:space:]]*\\*[[:space:]]*@license[[:space:]]+[^[:space:]*]+' \\
+        "${_php}" | head -1 | awk '{print $3}'
+
+Two defects, both of which made a GREEN gate-28 mean nothing.
+
+1. **It read only the FIRST `@license` tag and never looked at
+   `SPDX-License-Identifier:` at all.** A fleet sweep found **174 files
+   declaring BOTH `EUPL-1.2` and an AGPL licence in the same file** —
+   launchpad 123, openregister 47, openconnector 4 — and most of them were
+   PASSING, because the EUPL tag came first and the SPDX line was invisible.
+   Disagreement *within* one file is the stronger signal of the two: it
+   means someone edited one declaration and not the other.
+
+2. **A single NUL byte turned a real PASS into a false RED.**
+   `shillinq/lib/Service/InventoryValuationReportService.php` carried a raw
+   0x00 inside a PHPDoc describing a `sku\\0warehouse` composite key. `file`
+   then reported the PHP source as `data`, `grep` switched to binary mode
+   and printed `Binary file … matches` instead of the line, and `awk
+   '{print $3}'` over THAT read **the file path** as the licence value. The
+   header was correct all along. The same idiom is live in
+   `doriath/src/import/model.js:117` and
+   `openbuild/src/services/manifestValidation/documentAttachments.js:136`,
+   so it would have recurred.
+
+   Reading the bytes in Python with `errors='replace'` removes the class:
+   there is no binary-mode switch to trip. The `_looks_like_a_path` guard
+   below stays anyway, because a "licence value" that is a path is a
+   parser malfunction and must be reported as one rather than as a licence
+   finding — a wrong answer that names itself is recoverable, a wrong
+   answer wearing the right shape is not.
+
+WHAT IS *NOT* A DECLARATION
+---------------------------
+A licence identifier inside a string literal is test data, not a claim.
+nldesign's `MarianneFontTest.php` and `ClaimAccuracyTest.php` assert on
+non-EUPL identifiers; "fixing" them breaks the tests. A declaration is
+therefore only counted when nothing but comment syntax and whitespace
+precedes it on its line — which is true of every real header and false of
+every assertion string.
+
+Usage:
+    check_license_triangle.py <composer-license-set> <file>...
+
+`<composer-license-set>` is pipe-joined (`EUPL-1.2` or `EUPL-1.2|MIT`),
+matching what the runner already computes from composer.json.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# A declaration line: only comment syntax and whitespace may precede the tag.
+# `* @license EUPL-1.2`, `// SPDX-License-Identifier: EUPL-1.2`,
+# `# SPDX-License-Identifier: EUPL-1.2`, `/** @license EUPL-1.2` all count.
+# `$this->assertSame('SPDX-License-Identifier: MIT', $x)` does not: a quote
+# precedes the tag.
+DECL = re.compile(
+    r'^[\s]*(?:/\*+|\*+/?|//+|#+|<!--)?[\s]*'
+    r'(?:@license|SPDX-License-Identifier:)[\s]+'
+    r'([^\s*\'"`;,)\]]+)',
+    re.MULTILINE,
+)
+# `/` is deliberately ALLOWED in the captured value. Excluding it (to stop
+# `@license EUPL-1.2*/` capturing the comment terminator) also truncated a
+# path-shaped value to its first segment, so `lib/Service/Thing.php` arrived
+# as `lib` and the path guard below never fired — the malfunction would have
+# been reported as an ordinary licence drift, sending someone to edit a
+# header that was already correct. The terminator is stripped instead.
+_TRAILING_COMMENT = re.compile(r'(?:\*/|-->)+$')
+
+
+def _looks_like_a_path(value: str) -> bool:
+    """A licence value that is a path is a parse failure, not a licence."""
+    return ('/' in value
+            or value.endswith(('.php', '.js', '.ts', '.vue', '.json'))
+            or value.startswith('.'))
+
+
+def declarations(src: str) -> list[str]:
+    """Every licence identifier this source DECLARES, in order, deduplicated
+    while preserving first-seen order."""
+    seen: list[str] = []
+    for m in DECL.finditer(src):
+        v = _TRAILING_COMMENT.sub('', m.group(1).strip()).strip().rstrip('.,;')
+        if not v or v in seen:
+            continue
+        seen.append(v)
+    return seen
+
+
+def read_text(path: str) -> str | None:
+    """Read a source file as text, immune to embedded NUL bytes.
+
+    Binary mode + `errors='replace'` is the whole fix for defect 2: there is
+    no heuristic here that a 0x00 can flip.
+    """
+    try:
+        with open(path, 'rb') as f:
+            return f.read().decode('utf-8', errors='replace')
+    except OSError:
+        return None
+
+
+def scan_file(path: str, allowed: set[str]) -> list[str]:
+    src = read_text(path)
+    if src is None:
+        return []
+    decls = declarations(src)
+    if not decls:
+        return []
+
+    findings: list[str] = []
+    bogus = [d for d in decls if _looks_like_a_path(d)]
+    for d in bogus:
+        findings.append(
+            f"{path} file_license={d} rule=license-value-is-a-path "
+            f"(parser malfunction, not a licence claim — report, do not 'fix' the header)")
+    real = [d for d in decls if not _looks_like_a_path(d)]
+
+    # The stronger signal first: the file disagrees with ITSELF.
+    if len(set(real)) > 1:
+        findings.append(
+            f"{path} file_licenses={','.join(real)} rule=license-internal-conflict "
+            f"(one file declares more than one licence — a green gate here was never evidence)")
+
+    for d in real:
+        if d not in allowed:
+            findings.append(
+                f"{path} file_license={d} composer_license={'|'.join(sorted(allowed))} "
+                f"rule=license-triangle-drift")
+    return findings
+
+
+def scan_files(files: list[str], composer_license: str) -> list[str]:
+    allowed = {p.strip() for p in composer_license.split('|') if p.strip()}
+    if not allowed:
+        return []
+    out: list[str] = []
+    for path in files:
+        out.extend(scan_file(path, allowed))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_license_triangle.py <composer-license-set> <file>...",
+              file=sys.stderr)
+        return 2
+    for line in scan_files(argv[2:], argv[1]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -453,6 +453,68 @@ _STRICT_GUARD_BODY_RE = re.compile(
     r"|(?:getUser|getUID|currentUid|getCurrentUserId)\s*\(\s*\)\s*===\s*null"
 )
 
+# ---------------------------------------------------------------------------
+# Pattern 5 — the TENANCY guard (ConductionNL/.github#160)
+#
+# `_STRICT_GUARD_BODY_RE` above deliberately excludes a bare `throw` and a
+# 404, on the reasoning that "NotFoundException is not an authorisation
+# guard". For a MULTI-TENANT codebase that reasoning inverts, and gate-7
+# ended up ANTI-CORRELATED with the property it checks.
+#
+# OpenRegister's FlowService says why, in its own comment:
+#
+#     A flow the caller may not see raises the SAME exception as a flow that
+#     does not exist. Distinguishing them would turn every read into an
+#     oracle for enumerating other tenants' flow ids.
+#
+#     public function find(string $uuid): Flow {
+#         $flow = $this->mapper->findByUuid($uuid);
+#         if ($flow->belongsTo($this->activeOrganisation()) === false) {
+#             throw new DoesNotExistException('No such flow');
+#         }
+#         return $flow;
+#     }
+#
+# THAT IS THE GUARD. It is indistinguishable from a 404 on purpose, because
+# a 403 here leaks the existence of another tenant's object. So gate-7
+# flagged exactly the code that got tenancy right — and would have gone
+# GREEN if the 404 were replaced with a 403, i.e. if the code were made to
+# leak. `FlowController::state()` WAS a real IDOR, was fixed by routing
+# through `FlowService::find()`, and gate-7 reported it identically before
+# and after. A verdict that does not move when the defect does is not
+# measuring the defect.
+#
+# The signal below is evidence-based in the same way Pattern 4a is: the
+# collaborator's SOURCE is parsed, and what clears it is a comparison
+# against a SESSION-DERIVED scope followed by a refusal. Both halves are
+# required. A body that merely mentions `belongsTo` and never refuses is
+# not a guard; a body that throws with no tenancy comparison is not seeded
+# by THIS rule (it may still be seeded by the strict one, which is correct).
+_TENANCY_SCOPE_RE = re.compile(
+    r"->\s*belongsTo[A-Za-z0-9_]*\s*\("
+    r"|->\s*(?:getActiveOrganisation|activeOrganisation|getActiveTenant"
+    r"|activeTenant|currentOrganisation|currentTenant)\s*\("
+    r"|->\s*apply(?:Organisation|Organization|Tenant)Filter\s*\("
+    r"|\bMultiTenancyTrait\b"
+)
+
+# The refusal half. A tenancy comparison that leads to nothing is not a
+# guard — it is a computed value nobody acted on.
+_TENANCY_REFUSAL_RE = re.compile(
+    r"\bthrow\b"
+    r"|DoesNotExistException"
+    r"|NotFoundException"
+    r"|return\s*\[\s*\]"
+    r"|return\s+null\b"
+)
+
+
+def _has_tenancy_guard(body: str) -> bool:
+    """True when *body* compares against a session-derived tenant scope AND
+    refuses on mismatch. Both halves required — see Pattern 5 above."""
+    return bool(_TENANCY_SCOPE_RE.search(body) and _TENANCY_REFUSAL_RE.search(body))
+
+
 # Typed property declarations and constructor-promoted properties:
 #   private readonly ParticipationResponder $responder,
 #   protected ?FooGuard $guard;
@@ -536,6 +598,8 @@ def _strict_guard_methods(cleaned: str, src: str) -> set:
         if _GUARD_HELPER_NAME_RE.match(name):
             known.add(name)
         elif _STRICT_GUARD_BODY_RE.search(src[body_start:body_end]):
+            known.add(name)
+        elif _has_tenancy_guard(src[body_start:body_end]):
             known.add(name)
     changed = True
     while changed:

--- a/hydra-gates/scripts/lib/check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/check_semantic_auth.py
@@ -200,10 +200,56 @@ _ADMIN_GATE_BODY_RE = re.compile(
 _FORBIDDEN_TOKEN_RE = re.compile(
     r"STATUS_FORBIDDEN|OCSForbiddenException|\b403\b",
 )
-_PUBLIC_BODY_AUTH_RE = re.compile(
+# A #[PublicPage] method that depends on the SESSION is the real mismatch:
+# NC middleware lets the request through without one, so the body's session
+# test can only ever fail. This is the decidesk defect the rule was built for
+# (`SettingsController::load()` annotated #[NoAdminRequired] while its body
+# called `requireAdmin()`).
+_PUBLIC_SESSION_AUTH_RE = re.compile(
     r"\brequireAdmin\s*\(|"
-    r"userSession\s*->\s*getUser\s*\(\s*\)\s*===\s*null|"
-    r"Http::STATUS_(UNAUTHORIZED|FORBIDDEN)",
+    r"userSession\s*->\s*getUser\s*\(\s*\)\s*===\s*null",
+)
+
+# Returning 401/403 is NOT, on its own, evidence of a session dependency.
+# It is what a correctly self-authenticating public endpoint does when the
+# credential in the REQUEST is missing, invalid or revoked.
+_PUBLIC_DENY_STATUS_RE = re.compile(r"Http::STATUS_(UNAUTHORIZED|FORBIDDEN)")
+
+# "The credential is in the request, not the session."
+#
+# This is Nextcloud's own idiom for public share links, and the fleet's for
+# webhooks and portal endpoints: #[PublicPage] BECAUSE the caller is a remote
+# server or an unauthenticated portal visitor with no local session, and the
+# body authenticates the caller itself from a route token, a bearer header or
+# an HMAC signature. 36 of gate-9's 39 fleet findings were this shape, every
+# one of them correct code:
+#
+#   openconnector PaymentsController::webhook  — HMAC verify, constant-time
+#                                                compare, timestamp tolerance
+#   portaliq ContributionController::inbox +9  — portal subject() resolution
+#   openregister FederationController ×6       — bearer share token in the URL
+#   doriath, hermiq, launchpad, procest, …     — same
+#
+# There was NO correct action a developer could take on those findings. The
+# advice said "remove #[PublicPage] or remove the body auth check": the first
+# breaks the endpoint (middleware rejects the caller before the controller
+# runs), the second removes its only authentication. A gate that can be
+# closed only by weakening the code is worse than no gate.
+_SELF_AUTH_RE = re.compile(
+    r"hash_hmac\s*\(|"
+    r"hash_equals\s*\(|"
+    r"\bBearer\b|"
+    r"->\s*getHeader\s*\(|"
+    r"\$_SERVER\s*\[\s*['\"]HTTP_|"
+    r"\bsignature\b|"
+    r"\bhmac\b|"
+    r"[Tt]oken\s*\)|"
+    r"\$\w*[Tt]oken\b|"
+    r"->\s*(resolve|validate|verify|find|get)\w*[Tt]oken\s*\(|"
+    r"->\s*subject\s*\(|"
+    r"->\s*findByToken\s*\(|"
+    r"[Cc]apability\s*[Tt]oken",
+    re.IGNORECASE,
 )
 
 
@@ -280,11 +326,32 @@ def scan_file(path: str) -> int:
                 )
                 violations += 1
         if _PUBLIC_PAGE_HEAD_RE.search(head):
-            if _PUBLIC_BODY_AUTH_RE.search(body):
+            # Session-derived check under #[PublicPage] — the real mismatch.
+            if _PUBLIC_SESSION_AUTH_RE.search(body):
                 print(
                     f"{path}:{line_no} method={name} "
-                    f"rule=public-page-annotation-with-auth-body — "
-                    f"remove #[PublicPage] or remove body auth check"
+                    f"rule=public-page-annotation-with-session-auth-body — "
+                    f"this method is #[PublicPage], so Nextcloud middleware admits the "
+                    f"request WITHOUT a session, yet the body tests the session "
+                    f"(requireAdmin()/IUserSession). That test can only ever fail for the "
+                    f"callers the annotation admits. Decide which is true: if the endpoint "
+                    f"needs a logged-in user, drop #[PublicPage] and keep the check; if it "
+                    f"is genuinely public, authenticate the caller from the REQUEST "
+                    f"(route token, bearer header, HMAC signature) instead of the session. "
+                    f"Do NOT simply delete the check."
+                )
+                violations += 1
+            elif _PUBLIC_DENY_STATUS_RE.search(body) and not _SELF_AUTH_RE.search(head + body):
+                print(
+                    f"{path}:{line_no} method={name} "
+                    f"rule=public-page-annotation-with-unsourced-denial — "
+                    f"this method is #[PublicPage] and returns 401/403, but nothing in it "
+                    f"resolves a credential from the request (no route token, bearer header, "
+                    f"HMAC signature or portal subject). Either it is denying on something "
+                    f"the annotation guarantees is absent, or the credential it checks is "
+                    f"not visible here. Name the credential the endpoint authenticates "
+                    f"with. Do NOT remove #[PublicPage] (middleware would reject the "
+                    f"caller before the controller runs) and do NOT remove the denial."
                 )
                 violations += 1
     return violations

--- a/hydra-gates/scripts/lib/check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/check_spec_anchors.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-46 spec-anchor-existence — does the `@spec` tag point at something real?
+
+Gate-16 checks that a `@spec` tag is PRESENT. This gate checks that its
+target RESOLVES: the file exists, and — when the tag carries a `#fragment`
+— that the fragment names a heading or task item that actually exists in
+that file. Observed 2026-04-27 on opencatalogi#85 where
+`@spec openspec/specs/federation/spec.md#requirement-directory-self-detection`
+pointed at a requirement nobody had written.
+
+WHY THIS LIVES IN A FILE
+------------------------
+It used to be a ~140-line heredoc inside ``run-hydra-gates.sh``. A gate with
+no test suite of its own is a gate whose false-positive rate nobody can
+measure, and this one's rate was 56%. Moving it here puts it under
+``tests/run-helper-suites.sh``, which discovers every ``scripts/lib/test_*``
+automatically — see ``test_check_spec_anchors.py``.
+
+WHAT A FRAGMENT IS ALLOWED TO NAME
+----------------------------------
+A repository's `@spec` tags are written by humans and by three generations
+of retrofit tooling, so the same requirement is addressed several ways. All
+of these name a requirement that EXISTS, and none of them is a dangling
+reference:
+
+  heading, kebab-cased      `## Requirement: Foo Bar`      ← `#requirement-foo-bar`
+  heading, GitHub's own     `## A subscription's retry`    ← `#a-subscriptions-retry`
+  heading prefix            `### Task 8 — long title`      ← `#task-8`
+  the `:` tail              `### Requirement: Foo Bar`     ← `#foo-bar`
+  the `:` tail's own head   `### Requirement: REQ-001: …`  ← `#REQ-001`   (A)
+  a delimited id token      `### Requirement: Foo (REQ-5)` ← `#REQ-5`     (B)
+  a task item id            `- [x] 2.3 Add the thing`      ← `#task-2.3`
+  the Nth checkbox item     (positional retrofit tags)     ← `#task-4`
+
+(A) and (B) are the two shapes that produced 1,295 of the fleet's 1,995
+gate-46 findings. Both were rejected for the same structural reason: the
+full-heading rule accepted a PREFIX match (`heading.startswith(frag + '-')`)
+but the `:`-tail rule accepted only EQUALITY, and nothing looked inside
+parentheses at all. Neither rejection was evidence about the requirement —
+in every sampled case the requirement was right there in the heading.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+A fragment naming an id that appears NOWHERE in the file still fails. The
+relaxations above are all anchored to text the heading actually contains:
+(B) requires the id to be a *delimited token* (inside `(…)`/`[…]`), not a
+substring, and (A) requires it to be the tail's own leading `:`-segment. A
+tag that invents `#REQ-999` against a file whose headings stop at REQ-007
+resolves to nothing and is reported — that is the case this gate exists for,
+and ``test_check_spec_anchors.py`` proves it still fires for every rule that
+was loosened.
+
+Usage:
+    check_spec_anchors.py <log-path> <file>...
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+# Match `@spec openspec/...` but NOT `@spec exclude ...`
+TAG = re.compile(r'@spec\s+(openspec/[^\s`\'"]+)')
+DATE = re.compile(r'\b\d{4}-\d{2}-\d{2}\b')
+HEADING = re.compile(r'^\s*#{1,6}\s+(.+?)\s*$')
+
+# Any single-character checkbox marker, not just ` `/`x`/`X`.
+#
+# OpenSpec task lists use `- [~]` for "partially done" and `- [-]` for
+# "dropped". The old `[ xX]` class saw neither. That cost twice: the item's
+# own id became unaddressable, AND every positional `#task-N` after it in
+# the file silently resolved to the wrong item, because the counter never
+# incremented for the skipped line. A wrong positional resolution is worse
+# than a missing one — it can report PASS against a different task.
+CHECKBOX = re.compile(r'^\s*-\s*\[.\]')
+CHECKBOX_ID = re.compile(r'^\s*-\s*\[.\]\s*(?:\*\*)?([A-Za-z0-9][A-Za-z0-9.\-]*)')
+
+# `(REQ-PAY-001)`, `[REQ-005]`, `(REQ-PAY-001, REQ-PAY-003)`
+DELIMITED = re.compile(r'[(\[]([^)\]]{1,120})[)\]]')
+
+# An "id-like" token: something that could be a requirement/task identifier
+# rather than a word of prose. It must contain a digit — `REQ-BIE-004-01`,
+# `2.3`, `T01`, `5.2` do; `retry`, `policy`, `Requirement` do not. Requiring a
+# digit is what stops "lift the tokens out of the heading" from degenerating
+# into "match any word in any heading", which would be a blind gate.
+IDLIKE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._\-]*$')
+
+
+def slugify(text: str) -> str:
+    """Kebab-case the visible heading text.
+
+    Every non-alphanumeric run becomes a single `-`, so an apostrophe or a
+    slash becomes a separator rather than vanishing. This is the shape the
+    fleet's own retrofit tooling emits.
+    """
+    t = text.strip().lower()
+    t = re.sub(r'[^a-z0-9]+', '-', t).strip('-')
+    return t
+
+
+def gh_slugify(text: str) -> str:
+    """GitHub's own heading-anchor rule.
+
+    Drop every character that is not alphanumeric, dash, underscore or
+    space, then collapse spaces to dashes. It parts company with
+    ``slugify`` on punctuation *inside* a word: GitHub publishes
+    "A subscription's retry/backoff policy" as
+    ``#a-subscriptions-retrybackoff-policy`` where ``slugify`` produces
+    ``#a-subscription-s-retry-backoff-policy``.
+
+    Both shapes are accepted rather than one replacing the other: a tag
+    written to satisfy the kebab rule still resolves, a tag written against
+    the anchor a reader's browser actually lands on still resolves, and
+    either way the heading has to EXIST — which is what this gate is for.
+    Observed 2026-08-05 on openconnector: 137 findings, none of them real.
+    """
+    t = text.strip().lower()
+    t = re.sub(r'[^a-z0-9\-_ ]+', '', t)
+    return re.sub(r'\s+', '-', t).strip('-')
+
+
+def dedate(name: str) -> str:
+    """`retrofit-2026-04-28-b2b-crossrefs` and `retrofit-b2b-crossrefs-2026-04-28`
+    both normalise to `retrofit-b2b-crossrefs`: archiving moves the date token."""
+    return re.sub(r'-+', '-', DATE.sub('', name)).strip('-')
+
+
+def _both(text: str) -> set[str]:
+    """Both slug dialects for one piece of text, empties dropped."""
+    return {s for s in (slugify(text), gh_slugify(text)) if s}
+
+
+def _idlike_tokens(text: str) -> set[str]:
+    """Slugs of the id-shaped whitespace tokens inside *text*.
+
+    `Scenario REQ-BIE-004-01` yields `req-bie-004-01` and drops `scenario`;
+    `Task 2.3 of giant` yields `2-3` and drops `task`, `of`, `giant`. The
+    digit requirement is the whole safety property here.
+
+    Only the kebab dialect is emitted, deliberately. ``gh_slugify`` drops the
+    dot, so `Task 2.3` would also yield `23` — which a positional `#task-23`
+    tag would then resolve against. Whole-heading GitHub anchors are already
+    covered by the long aliases; a lifted token does not need a second
+    dialect, and giving it one manufactures collisions.
+    """
+    out: set[str] = set()
+    for tok in text.split():
+        tok = tok.strip('.,;:*_`"\'')
+        if not tok or not any(c.isdigit() for c in tok):
+            continue
+        if IDLIKE.match(tok):
+            s = slugify(tok)
+            if s:
+                out.add(s)
+    return out
+
+
+def heading_aliases(head: str) -> tuple[set[str], set[str]]:
+    """Split a heading into (long_aliases, token_aliases).
+
+    ``long_aliases`` are full titles — a fragment may match them by equality
+    OR by being a dash-delimited PREFIX of them (`#task-8` ← `### Task 8 —
+    long title`). ``token_aliases`` are short identifiers lifted out of the
+    heading (`REQ-PAY-001`); those require EQUALITY, because prefix-matching a
+    short id would let `#req` resolve against `REQ-PAY-001` and that really
+    would be a blind gate.
+    """
+    long_aliases: set[str] = set(_both(head))
+    token_aliases: set[str] = set()
+
+    # The heading with its parenthesised/bracketed suffix removed.
+    # `## Webhooks (Task 2.9 of giant)` is addressed as `#webhooks` — the
+    # bracket carries provenance, not title. Without this the only way
+    # `#webhooks` could resolve is by prefix, and single-segment prefix
+    # matching is exactly what makes `#scenario` resolve everywhere.
+    bare = DELIMITED.sub(' ', head).strip()
+    if bare and bare != head:
+        long_aliases |= _both(bare)
+
+    if ':' in head:
+        lead, tail = head.split(':', 1)
+        long_aliases |= _both(tail)
+        bare_tail = DELIMITED.sub(' ', tail).strip()
+        if bare_tail and bare_tail != tail:
+            long_aliases |= _both(bare_tail)
+        # `### Requirement: REQ-001: List and search zaken` — the tail's own
+        # leading `:`-segment is the requirement id.
+        if ':' in tail:
+            token_aliases |= _both(tail.split(':', 1)[0])
+        # `#### Scenario REQ-BIE-004-01: Cron triggers export run creation` —
+        # the id sits in the segment BEFORE the colon, as its own token.
+        token_aliases |= _idlike_tokens(lead)
+
+    # `#### 5.2 Foo` ← `#5.2`.
+    #
+    # Restricted to an id-shaped lead. Taking the first word unconditionally
+    # made `#scenario` resolve against every `#### Scenario …` heading and
+    # `#requirement` against every `### Requirement: …` — the gate would
+    # accept a tag that names a heading LEVEL rather than a requirement.
+    token_aliases |= _idlike_tokens(head.split()[0] if head.split() else '')
+
+    # `### Requirement: Foo (REQ-PAY-001)` / `[REQ-005]` / `(REQ-A-1, REQ-A-2)`
+    # / `## BlastService (Task 2.3 of giant)`
+    for m in DELIMITED.finditer(head):
+        for piece in re.split(r'[,;/]', m.group(1)):
+            piece = piece.strip()
+            if piece:
+                token_aliases |= _both(piece)
+                token_aliases |= _idlike_tokens(piece)
+
+    return long_aliases, token_aliases
+
+
+def _matches(long_aliases: set[str], token_aliases: set[str], frags: tuple[str, ...]) -> bool:
+    live = tuple(f for f in frags if f)
+    if not live:
+        return False
+    if any(a in live for a in long_aliases):
+        return True
+    if any(a in live for a in token_aliases):
+        return True
+    # `-` boundary on the prefix rule keeps `#task-8` from matching `Task 89`.
+    #
+    # A SINGLE-SEGMENT fragment is excluded from prefix matching. `#task-8`
+    # against `### Task 8 — long title` is the case the prefix rule exists
+    # for and it has two segments. A one-word fragment prefix-matches on the
+    # first word of a sentence-shaped title — `#scenario` against every
+    # `#### Scenario …` in the repo, `#cron` against
+    # `#### … Cron triggers export run creation` — which is evidence about
+    # nothing.
+    #
+    # `#webhooks` against `## Webhooks (Task 2.9 of giant)` is a real
+    # anchor and is NOT lost by this: the parenthesised suffix is stripped
+    # in `heading_aliases`, so it resolves by EQUALITY instead.
+    return any(
+        a.startswith(f + '-')
+        for a in long_aliases
+        for f in live
+        if '-' in f
+    )
+
+
+def has_anchor(md_path: str, fragment: str) -> bool:
+    """True when *fragment* names a heading or task item in *md_path*."""
+    frag_slug = slugify(fragment)
+    frag_alt = slugify(re.sub(r'^task-', '', fragment))
+    frags = (frag_slug, frag_alt)
+    pos_m = re.fullmatch(r'(?:task-)?(\d+)', fragment)
+    positional = int(pos_m.group(1)) if pos_m else None
+    item_count = 0
+    try:
+        with open(md_path, encoding='utf-8', errors='replace') as f:
+            for line in f:
+                m = HEADING.match(line)
+                if m:
+                    long_aliases, token_aliases = heading_aliases(m.group(1))
+                    if _matches(long_aliases, token_aliases, frags):
+                        return True
+                    continue
+                if CHECKBOX.match(line):
+                    item_count += 1
+                    # Positional convention used by reverse-spec retrofits:
+                    # `#task-N` / `#N` addresses the Nth top-level checkbox.
+                    if positional is not None and item_count == positional:
+                        return True
+                t = CHECKBOX_ID.match(line)
+                if t and slugify(t.group(1).rstrip('.:')) in frags:
+                    return True
+        return False
+    except OSError:
+        return False
+
+
+def find_repo_root(start: str | None = None) -> str | None:
+    p = start or os.getcwd()
+    while p and p != '/':
+        if os.path.isdir(os.path.join(p, 'openspec')):
+            return p
+        p = os.path.dirname(p)
+    return None
+
+
+def build_archive_index(root: str) -> dict[str, list[str]]:
+    """Archiving moves `openspec/changes/<name>/` to
+    `openspec/changes/archive/<date>-<name>/` (or legacy
+    `openspec/archive/<name>`, sometimes with the date token reshuffled).
+    Tags keep pointing at the original path; resolve through this index
+    rather than forcing a repo-wide retag."""
+    index: dict[str, list[str]] = {}
+    for pattern in ('openspec/changes/archive/*', 'openspec/archive/*'):
+        for d in glob.glob(os.path.join(root, pattern)):
+            if os.path.isdir(d):
+                index.setdefault(dedate(os.path.basename(d)), []).append(d)
+    return index
+
+
+def _path_shapes(path: str) -> list[str]:
+    """The equivalent spellings of one spec path.
+
+    `openspec/specs/task-collaboration.md` and
+    `openspec/specs/task-collaboration/spec.md` are the same spec — OpenSpec
+    moved from the flat file to the directory form, and tags written before
+    the move keep the old spelling. Reporting the old spelling as "target
+    file not found" says the requirement is missing when the requirement is
+    right there under the other name.
+    """
+    shapes = [path]
+    if path.endswith('/spec.md'):
+        shapes.append(path[: -len('/spec.md')] + '.md')
+    elif path.endswith('.md'):
+        shapes.append(path[: -len('.md')] + '/spec.md')
+    return shapes
+
+
+def resolve(path: str, root: str, archive_index: dict[str, list[str]]) -> list[str]:
+    """Existing candidate files for a tag path: the literal path, its
+    flat/directory counterpart, and archived counterparts of both.
+
+    Several archived dirs can share a de-dated key (e.g. two
+    annotate-openregister retrofits from different dates), so candidates
+    carrying the tag's own date token are tried first and ALL existing
+    candidates are returned — the anchor check accepts a fragment found in
+    any of them."""
+    cands: list[str] = []
+    for shape in _path_shapes(path):
+        abs_path = os.path.join(root, shape)
+        if os.path.exists(abs_path) and abs_path not in cands:
+            cands.append(abs_path)
+        m = re.match(r'openspec/(?:changes|archive)/([^/]+)/(.*)$', shape)
+        if not m or m.group(1) == 'archive':
+            continue
+        name = m.group(1)
+        dates = DATE.findall(name)
+        dirs = archive_index.get(dedate(name), [])
+        dirs = sorted(dirs, key=lambda d: 0 if any(t in os.path.basename(d) for t in dates) else 1)
+        for d in dirs:
+            cand = os.path.join(d, m.group(2))
+            if os.path.exists(cand) and cand not in cands:
+                cands.append(cand)
+    return cands
+
+
+def scan_files(files: list[str], root: str | None = None) -> list[str]:
+    """Return one finding line per unresolved `@spec` target."""
+    root = root or find_repo_root() or os.getcwd()
+    archive_index = build_archive_index(root)
+    findings: list[str] = []
+    for fp in files:
+        try:
+            with open(fp, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        for m in TAG.finditer(src):
+            target = m.group(1)
+            if '#' in target:
+                path, frag = target.split('#', 1)
+            else:
+                path, frag = target, None
+            candidates = resolve(path, root, archive_index)
+            if not candidates:
+                findings.append(f"{fp}: @spec target file not found → {target}")
+                continue
+            if frag and path.endswith('.md'):
+                if not any(has_anchor(c, frag) for c in candidates):
+                    findings.append(f"{fp}: @spec anchor not found in {path} → #{frag}")
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_spec_anchors.py <log-path> <file>...", file=sys.stderr)
+        return 2
+    log_path, files = argv[1], argv[2:]
+    findings = scan_files(files)
+    with open(log_path, 'a', encoding='utf-8') as g:
+        for line in findings:
+            g.write(line + "\n")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_form_labels.py
+++ b/hydra-gates/scripts/lib/test_check_form_labels.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_form_labels (gate-40). Run with:
+
+    python3 scripts/lib/test_check_form_labels.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+Gate-40 was measured at 1,211 findings across 21 repos, 57% of them false.
+The false positives were not merely noise: the ONLY way to clear the
+`NcCheckboxRadioSwitch` shape under the old implementation was to add
+`aria-label` to a control that already names itself from its default slot,
+and `aria-label` OVERRIDES the visible text. Clearing the gate meant
+shipping an accessibility regression to satisfy an accessibility gate.
+
+So every relaxation below is paired, in the same class, with the case it
+must NOT swallow. The fixtures are the real fleet markup: app-versions'
+`<label>`-wrapped safe-mode checkbox, docudesk's self-closed anonymiser
+switch (a genuine unnamed control, still flagged), decidesk's
+`<label><span>…</span><input></label>` publication settings.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_form_labels as cfl  # noqa: E402
+
+
+def rules(markup: str) -> list[str]:
+    """Rule names reported for a `<template>` body."""
+    src = "<template>\n" + markup + "\n</template>\n"
+    return [line.rsplit("rule=", 1)[1]
+            for line in cfl.scan_source("Component.vue", src)]
+
+
+# --------------------------------------------------------------------------
+# Mode 1 — implicit <label> wrapping. 268 fleet findings.
+# --------------------------------------------------------------------------
+class ImplicitLabelWrapping(unittest.TestCase):
+    def test_fp_a_wrapped_checkbox_is_named(self):
+        # app-versions/src/App.vue, verbatim shape.
+        self.assertEqual(rules("""
+            <label :class="$style.safeMode">
+                <input v-model="safeModeEnabled" type="checkbox" :disabled="busy">
+                <span>Safe mode (block downgrades)</span>
+            </label>
+        """), [])
+
+    def test_fp_label_text_before_the_input_also_counts(self):
+        # decidesk/src/views/settings/PublicationSettings.vue shape.
+        self.assertEqual(rules("""
+            <label class="field">
+                <span>{{ t('decidesk', 'Target OpenCatalogi catalog') }}</span>
+                <input v-model="config.catalog" type="text">
+            </label>
+        """), [])
+
+    def test_tp_an_unwrapped_input_is_still_reported(self):
+        self.assertEqual(rules('<div><input v-model="x" type="checkbox"></div>'),
+                         ["input-without-label"])
+
+    def test_tp_an_input_after_the_label_closes_is_still_reported(self):
+        # The wrap must be real containment, not adjacency.
+        self.assertEqual(rules("""
+            <label><span>Safe mode</span></label>
+            <input v-model="x" type="checkbox">
+        """), ["input-without-label"])
+
+    def test_tp_a_label_whose_for_matches_nothing_does_not_name_an_input(self):
+        self.assertEqual(rules("""
+            <label for="other-field">Name</label>
+            <input v-model="x" type="text" id="this-field">
+        """), ["input-without-label"])
+
+    def test_tp_wrapping_does_not_leak_to_the_next_sibling(self):
+        self.assertEqual(rules("""
+            <label><input type="text"><span>A</span></label>
+            <label><input type="text"><span>B</span></label>
+            <input type="text">
+        """), ["input-without-label"])
+
+
+# --------------------------------------------------------------------------
+# Mode 2 — NcCheckboxRadioSwitch default-slot labels. 463 fleet findings,
+# and the one whose remediation advice was an a11y regression.
+# --------------------------------------------------------------------------
+class CheckboxRadioSwitchDefaultSlot(unittest.TestCase):
+    def test_fp_default_slot_text_is_the_label(self):
+        # app-versions/src/components/DiscoverPanel.vue, verbatim.
+        self.assertEqual(rules("""
+            <NcCheckboxRadioSwitch v-model="installedOnly" data-testid="discover-installed-only">
+                {{ t('app_versions', 'Installed apps only') }}
+            </NcCheckboxRadioSwitch>
+        """), [])
+
+    def test_fp_plain_slot_text_is_the_label(self):
+        self.assertEqual(rules(
+            '<NcCheckboxRadioSwitch v-model="x">Enable OCR</NcCheckboxRadioSwitch>'), [])
+
+    def test_tp_a_self_closed_switch_with_no_slot_is_still_reported(self):
+        # docudesk/src/views/settings/Settings.vue:41 — a real unnamed
+        # control. It must survive the relaxation, or the relaxation has
+        # deleted the gate.
+        self.assertEqual(rules("""
+            <NcCheckboxRadioSwitch
+                :model-value="false"
+                type="switch"
+                @update:modelValue="resetAnonymiserWarning" />
+        """), ["nccheckboxradioswitch-without-label-prop"])
+
+    def test_tp_an_empty_slot_is_not_a_label(self):
+        self.assertEqual(rules(
+            '<NcCheckboxRadioSwitch v-model="x">   </NcCheckboxRadioSwitch>'),
+            ["nccheckboxradioswitch-without-label-prop"])
+
+    def test_tp_an_unclosed_switch_is_reported_not_assumed_labelled(self):
+        # An open tag with no closing tag proves NOTHING about its slot.
+        # Assuming it labelled would make malformed markup the cheapest way
+        # to silence the gate.
+        self.assertEqual(rules('<NcCheckboxRadioSwitch v-model="x">'),
+                         ["nccheckboxradioswitch-without-label-prop"])
+
+    def test_regression_the_label_prop_still_satisfies_it(self):
+        self.assertEqual(rules(
+            '<NcCheckboxRadioSwitch v-model="x" :label="t(\'app\', \'OCR\')" />'), [])
+
+
+# --------------------------------------------------------------------------
+# Mode 3 — dynamic :id / :for. 56 fleet findings.
+# --------------------------------------------------------------------------
+class DynamicIdForPairs(unittest.TestCase):
+    def test_fp_matching_bound_expressions_associate(self):
+        self.assertEqual(rules("""
+            <label :for="`field-${row.id}`">{{ row.name }}</label>
+            <input :id="`field-${row.id}`" v-model="row.value" type="text">
+        """), [])
+
+    def test_fp_whitespace_differences_do_not_break_the_pair(self):
+        self.assertEqual(rules("""
+            <label :for="'field-' + row.id">{{ row.name }}</label>
+            <input :id="'field-'  +  row.id" v-model="row.value" type="text">
+        """), [])
+
+    def test_tp_a_mismatched_expression_is_still_reported(self):
+        # Same shape, different expression. If the gate matched on "is bound
+        # at all" instead of on the expression, this would go quiet — and
+        # every mis-wired :for/:id pair in the fleet with it.
+        self.assertEqual(rules("""
+            <label :for="`field-${row.id}`">{{ row.name }}</label>
+            <input :id="`other-${row.id}`" v-model="row.value" type="text">
+        """), ["input-without-label"])
+
+    def test_regression_literal_id_for_pairs_still_associate(self):
+        self.assertEqual(rules("""
+            <label for="catalog">Catalog</label>
+            <input id="catalog" type="text">
+        """), [])
+
+
+# --------------------------------------------------------------------------
+# Mode 4 — markup that does not ship.
+# --------------------------------------------------------------------------
+class NonShippingMarkup(unittest.TestCase):
+    def test_fp_a_commented_out_input_is_not_a_control(self):
+        self.assertEqual(rules('<!-- <input v-model="x" type="text"> -->'), [])
+
+    def test_tp_the_same_input_outside_a_comment_is_reported(self):
+        self.assertEqual(rules('<input v-model="x" type="text">'),
+                         ["input-without-label"])
+
+    def test_fp_markup_inside_a_string_in_script_is_not_a_control(self):
+        src = ("<template>\n<div />\n</template>\n"
+               "<script>\nconst tpl = '<input type=\"text\">'\n</script>\n")
+        self.assertEqual(cfl.scan_source("Component.vue", src), [])
+
+    def test_tp_the_template_block_is_still_scanned(self):
+        src = ('<template>\n<input type="text">\n</template>\n'
+               "<script>\nexport default {}\n</script>\n")
+        self.assertEqual(len(cfl.scan_source("Component.vue", src)), 1)
+
+
+# --------------------------------------------------------------------------
+# Behaviour that must survive every relaxation above.
+# --------------------------------------------------------------------------
+class PreservedBehaviour(unittest.TestCase):
+    def test_hidden_and_button_inputs_are_exempt(self):
+        for t in ("hidden", "submit", "button", "reset", "image"):
+            with self.subTest(type=t):
+                self.assertEqual(rules(f'<input type="{t}" value="x">'), [])
+
+    def test_a_type_less_input_defaults_to_text_and_is_checked(self):
+        self.assertEqual(rules('<input v-model="x">'), ["input-without-label"])
+
+    def test_aria_label_still_satisfies_it(self):
+        self.assertEqual(rules('<input type="text" aria-label="Search">'), [])
+        self.assertEqual(rules('<input type="text" :aria-label="t(\'a\',\'b\')">'), [])
+        self.assertEqual(rules('<input type="text" aria-labelledby="h1">'), [])
+
+    def test_nctextfield_needs_its_label_prop(self):
+        self.assertEqual(rules('<NcTextField v-model="x" />'),
+                         ["nctextfield-without-label-prop"])
+        self.assertEqual(rules('<NcTextField v-model="x" :label="l" />'), [])
+        # NcTextField has no default-slot label: slot content must NOT excuse it.
+        self.assertEqual(rules('<NcTextField v-model="x">Name</NcTextField>'),
+                         ["nctextfield-without-label-prop"])
+
+    def test_textarea_is_checked_and_wrapping_names_it(self):
+        self.assertEqual(rules('<textarea v-model="x"></textarea>'),
+                         ["textarea-without-label"])
+        self.assertEqual(rules(
+            '<label><span>Notes</span><textarea v-model="x"></textarea></label>'), [])
+
+    def test_an_attribute_value_containing_a_gt_does_not_split_the_tag(self):
+        # `:class="a > b"` used to terminate the tag early for the old
+        # flatten-and-regex implementation, corrupting the attribute set.
+        self.assertEqual(rules(
+            '<input type="text" :class="count > 3 ? \'a\' : \'b\'" aria-label="N">'), [])
+
+
+class GateIsNotBlind(unittest.TestCase):
+    """A directly-asserted floor: a template full of genuinely unnamed
+    controls must produce one finding per control. If a future change makes
+    the scanner return early — an exception swallowed, a regex that stops
+    matching, a template block it fails to find — every ``assertEqual([])``
+    above still passes and only this test fails."""
+
+    def test_unnamed_controls_are_all_reported(self):
+        found = rules("""
+            <div>
+                <input v-model="a" type="text">
+                <input v-model="b" type="email">
+                <textarea v-model="c"></textarea>
+                <NcTextField v-model="d" />
+                <NcInputField v-model="e" />
+                <NcCheckboxRadioSwitch v-model="f" />
+            </div>
+        """)
+        self.assertEqual(sorted(found), sorted([
+            "input-without-label",
+            "input-without-label",
+            "textarea-without-label",
+            "nctextfield-without-label-prop",
+            "ncinputfield-without-label-prop",
+            "nccheckboxradioswitch-without-label-prop",
+        ]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_license_triangle.py
+++ b/hydra-gates/scripts/lib/test_check_license_triangle.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_license_triangle (gate-28). Run with:
+
+    python3 scripts/lib/test_check_license_triangle.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+gate-28 passed in all 28 app repos, which is exactly why its two defects
+mattered: 174 files carried an AGPL claim behind that green. Each fix below
+ships with the case it must not swallow — an actually-drifted header still
+fails, and a file whose ONLY non-EUPL identifiers are test data still
+passes.
+
+The NUL fixture is a real 0x00 byte, not the two characters `\\0`. Writing
+the escape instead of the byte is how this defect stayed invisible: the
+escape parses fine and proves nothing.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_license_triangle as clt  # noqa: E402
+
+EUPL = "EUPL-1.2"
+
+CLEAN = """<?php
+/**
+ * Inventory valuation report service.
+ *
+ * @copyright Copyright (c) 2026 Conduction B.V.
+ * @license   EUPL-1.2
+ */
+namespace OCA\\Shillinq\\Service;
+"""
+
+BOTH_LICENCES = """<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * @copyright Copyright (c) 2026 Conduction B.V.
+ * @license   EUPL-1.2
+ */
+namespace OCA\\Launchpad\\Service;
+"""
+
+DRIFTED = """<?php
+/**
+ * @license MIT
+ */
+namespace OCA\\Thing\\Service;
+"""
+
+# nldesign/tests/.../MarianneFontTest.php shape: identifiers as ASSERTION
+# DATA, in string literals. Changing them breaks the tests.
+TEST_DATA = """<?php
+/**
+ * @license EUPL-1.2
+ */
+class MarianneFontTest extends TestCase
+{
+    public function testRejectsProprietaryFont(): void
+    {
+        $this->assertSame('SPDX-License-Identifier: LicenseRef-Marianne', $meta);
+        $this->assertStringContainsString('@license AGPL-3.0-or-later', $body);
+    }
+}
+"""
+
+
+def _scan(body: str, composer: str = EUPL, name: str = "Service.php") -> list[str]:
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / name
+        p.write_text(body, encoding="utf-8")
+        return clt.scan_files([str(p)], composer)
+
+
+def _scan_bytes(body: bytes, composer: str = EUPL) -> list[str]:
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "Service.php"
+        p.write_bytes(body)
+        return clt.scan_files([str(p)], composer)
+
+
+def _rules(findings: list[str]) -> list[str]:
+    return [f.rsplit("rule=", 1)[1].split()[0] for f in findings]
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — only the FIRST @license was read; SPDX was invisible.
+# --------------------------------------------------------------------------
+class SecondLicenceInTheSameFile(unittest.TestCase):
+    def test_tp_a_file_declaring_eupl_and_agpl_is_now_reported(self):
+        rules = _rules(_scan(BOTH_LICENCES))
+        self.assertIn("license-internal-conflict", rules)
+        self.assertIn("license-triangle-drift", rules)
+
+    def test_tp_the_agpl_value_is_named_in_the_finding(self):
+        self.assertTrue(any("AGPL-3.0-or-later" in f for f in _scan(BOTH_LICENCES)))
+
+    def test_the_old_implementation_would_have_passed_this_file(self):
+        # The reason this class exists: the FIRST declaration in reading
+        # order is the SPDX line, but the old grep only matched the PHPDoc
+        # `* @license` shape and took its head -1 — so it saw EUPL-1.2 and
+        # stopped. Asserting the ordering makes the regression visible if
+        # anyone reintroduces a first-match-wins read.
+        self.assertEqual(clt.declarations(BOTH_LICENCES),
+                         ["AGPL-3.0-or-later", "EUPL-1.2"])
+
+    def test_fp_a_clean_file_still_passes(self):
+        self.assertEqual(_scan(CLEAN), [])
+
+    def test_fp_matching_spdx_and_license_tags_agree(self):
+        body = ("<?php\n// SPDX-License-Identifier: EUPL-1.2\n"
+                "/**\n * @license EUPL-1.2\n */\n")
+        self.assertEqual(_scan(body), [])
+
+    def test_tp_a_drifted_single_declaration_still_fails(self):
+        self.assertEqual(_rules(_scan(DRIFTED)), ["license-triangle-drift"])
+
+    def test_a_dual_licensed_package_accepts_either(self):
+        self.assertEqual(_scan(DRIFTED, composer="EUPL-1.2|MIT"), [])
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — a raw NUL byte made grep go binary and the gate read the FILE
+# PATH as the licence value: a false RED on a correct file.
+# --------------------------------------------------------------------------
+class NulByteInSource(unittest.TestCase):
+    def test_fp_a_correct_header_with_an_embedded_nul_passes(self):
+        # shillinq/lib/Service/InventoryValuationReportService.php:515.
+        body = CLEAN.encode() + b"\n// composite key: sku\x00warehouse\n"
+        self.assertEqual(_scan_bytes(body), [])
+
+    def test_tp_a_drifted_header_with_an_embedded_nul_still_fails(self):
+        # The pairing that matters: NUL-tolerance must not become
+        # NUL-blindness. A file that is BOTH binary-ish AND wrong is still
+        # wrong.
+        body = DRIFTED.encode() + b"\n// composite key: sku\x00warehouse\n"
+        self.assertEqual(_rules(_scan_bytes(body)), ["license-triangle-drift"])
+
+    def test_a_nul_immediately_before_the_tag_does_not_hide_it(self):
+        body = b"<?php\n/**\n * key: a\x00b\n * @license MIT\n */\n"
+        self.assertEqual(_rules(_scan_bytes(body)), ["license-triangle-drift"])
+
+    def test_a_path_shaped_licence_value_is_reported_as_a_parser_fault(self):
+        body = "<?php\n/**\n * @license lib/Service/Thing.php\n */\n"
+        rules = _rules(_scan(body))
+        self.assertEqual(rules, ["license-value-is-a-path"])
+        # ...and NOT as a licence drift, which would send someone to edit a
+        # header that is already correct.
+        self.assertNotIn("license-triangle-drift", rules)
+
+    def test_looks_like_a_path_directly(self):
+        self.assertTrue(clt._looks_like_a_path("lib/Service/Thing.php"))
+        self.assertTrue(clt._looks_like_a_path("./Thing.php"))
+        self.assertFalse(clt._looks_like_a_path("EUPL-1.2"))
+        self.assertFalse(clt._looks_like_a_path("AGPL-3.0-or-later"))
+
+
+# --------------------------------------------------------------------------
+# The documented exception: identifiers as test DATA.
+# --------------------------------------------------------------------------
+class LicenceIdentifiersAsTestData(unittest.TestCase):
+    def test_fp_assertion_strings_are_not_declarations(self):
+        self.assertEqual(_scan(TEST_DATA, name="MarianneFontTest.php"), [])
+
+    def test_declarations_ignores_quoted_identifiers(self):
+        self.assertEqual(clt.declarations(TEST_DATA), ["EUPL-1.2"])
+
+    def test_tp_a_real_header_in_a_test_file_is_still_judged(self):
+        # The exception is about STRING LITERALS, not about the tests/
+        # directory. A test file whose own header drifted still fails.
+        body = TEST_DATA.replace("@license EUPL-1.2", "@license AGPL-3.0-or-later")
+        self.assertEqual(_rules(_scan(body, name="MarianneFontTest.php")),
+                         ["license-triangle-drift"])
+
+
+class GateIsNotBlind(unittest.TestCase):
+    """A direct floor. If `declarations()` ever returns nothing — a regex
+    that stops matching, a read that silently fails — every `assertEqual([])`
+    above passes and only this fails."""
+
+    def test_every_declaration_shape_is_seen(self):
+        for body, expected in (
+            ("<?php\n/**\n * @license EUPL-1.2\n */\n", ["EUPL-1.2"]),
+            ("<?php\n// SPDX-License-Identifier: EUPL-1.2\n", ["EUPL-1.2"]),
+            ("<?php\n# SPDX-License-Identifier: EUPL-1.2\n", ["EUPL-1.2"]),
+            ("/* SPDX-License-Identifier: EUPL-1.2 */\n", ["EUPL-1.2"]),
+            ("<!-- SPDX-License-Identifier: EUPL-1.2 -->\n", ["EUPL-1.2"]),
+            ("<?php\n/** @license   MIT */\n", ["MIT"]),
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(clt.declarations(body), expected)
+
+    def test_a_wrong_licence_is_reported_in_every_declaration_shape(self):
+        for body in (
+            "<?php\n/**\n * @license AGPL-3.0-or-later\n */\n",
+            "<?php\n// SPDX-License-Identifier: AGPL-3.0-or-later\n",
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(_rules(_scan(body)), ["license-triangle-drift"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_license_triangle.py
+++ b/hydra-gates/scripts/lib/test_check_license_triangle.py
@@ -155,6 +155,23 @@ class NulByteInSource(unittest.TestCase):
         # header that is already correct.
         self.assertNotIn("license-triangle-drift", rules)
 
+    def test_a_comment_terminator_is_trimmed_off_the_value(self):
+        # Both HTML5 terminators, and the C-style one. A pattern that knows
+        # only `-->` leaves `EUPL-1.2--!` as the licence and reports drift on
+        # a correct header.
+        for body, expected in (
+            ("<?php\n/** @license EUPL-1.2*/\n", ["EUPL-1.2"]),
+            ("<!--SPDX-License-Identifier: EUPL-1.2-->\n", ["EUPL-1.2"]),
+            ("<!--SPDX-License-Identifier: EUPL-1.2--!>\n", ["EUPL-1.2"]),
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(clt.declarations(body), expected)
+                self.assertEqual(_scan(body), [])
+
+    def test_a_wrong_licence_is_still_wrong_after_trimming(self):
+        self.assertEqual(_rules(_scan("<!--SPDX-License-Identifier: MIT--!>\n")),
+                         ["license-triangle-drift"])
+
     def test_looks_like_a_path_directly(self):
         self.assertTrue(clt._looks_like_a_path("lib/Service/Thing.php"))
         self.assertTrue(clt._looks_like_a_path("./Thing.php"))

--- a/hydra-gates/scripts/lib/test_check_manifest.sh
+++ b/hydra-gates/scripts/lib/test_check_manifest.sh
@@ -25,6 +25,12 @@
 #
 # Run twice: once with Ajv available (full schema path) and once with Ajv
 # forced unavailable (structural-lint fallback), so both code paths are covered.
+
+# Private per-invocation log. A fixed /tmp path made this suite fail under
+# the helper-suite harness when two runs overlapped: the second run
+# truncated the first run's validator output between the write and the grep.
+_TCM_LOG="$(mktemp "${TMPDIR:-/tmp}/hydra-tcm.XXXXXXXX.log")"
+
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -47,22 +53,22 @@ done
 _assert() { # <expected-rc> <fixture> <label> [extra args...]
 	local want="$1" fixture="$2" label="$3" rc
 	shift 3
-	node "${VALIDATOR}" "${FIX}/${fixture}" "$@" >/tmp/_tcm.log 2>&1
+	node "${VALIDATOR}" "${FIX}/${fixture}" "$@" >${_TCM_LOG} 2>&1
 	rc=$?
 	if [ "${rc}" -eq "${want}" ]; then
 		_ok "${label} (rc=${rc})"
 	else
 		_no "${label}: expected rc=${want}, got ${rc}"
-		sed 's/^/    /' /tmp/_tcm.log
+		sed 's/^/    /' ${_TCM_LOG}
 	fi
 }
 
 _assert_log() { # <grep-ere> <label>
-	if grep -qE "$1" /tmp/_tcm.log; then
+	if grep -qE "$1" ${_TCM_LOG}; then
 		_ok "$2"
 	else
 		_no "$2 (pattern not found: $1)"
-		sed 's/^/    /' /tmp/_tcm.log
+		sed 's/^/    /' ${_TCM_LOG}
 	fi
 }
 

--- a/hydra-gates/scripts/lib/test_check_manifest.sh
+++ b/hydra-gates/scripts/lib/test_check_manifest.sh
@@ -53,22 +53,22 @@ done
 _assert() { # <expected-rc> <fixture> <label> [extra args...]
 	local want="$1" fixture="$2" label="$3" rc
 	shift 3
-	node "${VALIDATOR}" "${FIX}/${fixture}" "$@" >${_TCM_LOG} 2>&1
+	node "${VALIDATOR}" "${FIX}/${fixture}" "$@" >"${_TCM_LOG}" 2>&1
 	rc=$?
 	if [ "${rc}" -eq "${want}" ]; then
 		_ok "${label} (rc=${rc})"
 	else
 		_no "${label}: expected rc=${want}, got ${rc}"
-		sed 's/^/    /' ${_TCM_LOG}
+		sed 's/^/    /' "${_TCM_LOG}"
 	fi
 }
 
 _assert_log() { # <grep-ere> <label>
-	if grep -qE "$1" ${_TCM_LOG}; then
+	if grep -qE "$1" "${_TCM_LOG}"; then
 		_ok "$2"
 	else
 		_no "$2 (pattern not found: $1)"
-		sed 's/^/    /' ${_TCM_LOG}
+		sed 's/^/    /' "${_TCM_LOG}"
 	fi
 }
 

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -1478,5 +1478,129 @@ class TestController {
         self.assertIn("method=showThing", out[0])
 
 
+# ---------------------------------------------------------------------------
+# Pattern 5 — the TENANCY guard (ConductionNL/.github#160)
+#
+# gate-7 was ANTI-CORRELATED with the property it checks on a multi-tenant
+# codebase: it stayed red on the correct fix and would have gone green if the
+# code were made to leak. The fixtures below are OpenRegister's real shapes.
+#
+# Both ways, in the same class: the tenancy-scoped service must clear its
+# caller, and a service that loads by client-supplied id with NO tenancy
+# comparison must still be flagged.
+# ---------------------------------------------------------------------------
+
+# The exact shape from OpenRegister's FlowService, comment and all. A flow the
+# caller may not see raises the SAME exception as one that does not exist.
+_FLOW_SERVICE = """<?php
+namespace OCA\\\\OpenRegister\\\\Service;
+
+class FlowService
+{
+    /**
+     * A flow the caller may not see raises the SAME exception as a flow that
+     * does not exist. Distinguishing them would turn every read into an
+     * oracle for enumerating other tenants' flow ids.
+     */
+    public function find(string $uuid): Flow
+    {
+        $flow = $this->mapper->findByUuid($uuid);
+        if ($flow->belongsTo($this->activeOrganisation()) === false) {
+            throw new DoesNotExistException('No such flow');
+        }
+        return $flow;
+    }
+
+    public function findAll(): array
+    {
+        $org = $this->activeOrganisation();
+        if ($org === null) {
+            return [];
+        }
+        return $this->mapper->findAllForOrganisation($org);
+    }
+}
+"""
+
+# Same surface, NO tenancy comparison: the client-supplied uuid goes straight
+# to an unscoped mapper. This is what FlowController::state() actually did
+# before it was fixed.
+_UNSCOPED_SERVICE = """<?php
+namespace OCA\\\\OpenRegister\\\\Service;
+
+class FlowService
+{
+    public function find(string $uuid): Flow
+    {
+        return $this->mapper->findByUuid($uuid);
+    }
+
+    public function findAll(): array
+    {
+        return $this->mapper->findAll();
+    }
+}
+"""
+
+_FLOW_CONTROLLER = """<?php
+namespace OCA\\\\OpenRegister\\\\Controller;
+
+class TestController extends Controller
+{
+    private FlowService $flows;
+
+    /**
+     * @NoAdminRequired
+     */
+    public function state(string $uuid) {
+        return new JSONResponse($this->flows->find($uuid)->getState());
+    }
+}
+"""
+
+
+class TenancyGuardTest(unittest.TestCase):
+    def test_fp_org_scoped_service_clears_its_caller(self):
+        # THE demonstration from #160: FlowController::state() was a real
+        # IDOR, was fixed by routing through FlowService::find(), and gate-7
+        # reported it identically before and after. It must now clear.
+        self.assertEqual(_scan_app(_FLOW_CONTROLLER, {"FlowService": _FLOW_SERVICE}), [])
+
+    def test_tp_the_same_controller_over_an_UNSCOPED_service_is_still_flagged(self):
+        # The pairing that proves this is not a mute. Identical controller,
+        # identical service NAME and signature — only the tenancy comparison
+        # differs, and that is the whole property gate-7 exists to measure.
+        out = _scan_app(_FLOW_CONTROLLER, {"FlowService": _UNSCOPED_SERVICE})
+        self.assertEqual(len(out), 1)
+        self.assertIn("method=state", out[0])
+
+    def test_a_tenancy_comparison_with_no_refusal_is_not_a_guard(self):
+        self.assertFalse(cni._has_tenancy_guard(
+            "$org = $this->activeOrganisation(); $out = $flow->belongsTo($org); return $flow;"))
+
+    def test_a_refusal_with_no_tenancy_comparison_is_not_a_tenancy_guard(self):
+        self.assertFalse(cni._has_tenancy_guard(
+            "$flow = $this->mapper->findByUuid($uuid); if ($flow === null) { throw new DoesNotExistException(); } return $flow;"))
+
+    def test_both_halves_together_are_a_guard(self):
+        self.assertTrue(cni._has_tenancy_guard(
+            "if ($flow->belongsTo($this->activeOrganisation()) === false) { throw new DoesNotExistException(); }"))
+
+    def test_silent_narrowing_to_an_empty_list_counts(self):
+        self.assertTrue(cni._has_tenancy_guard(
+            "$org = $this->activeOrganisation(); if ($org === null) { return []; }"))
+
+    def test_a_mapper_applying_the_organisation_filter_counts(self):
+        self.assertTrue(cni._has_tenancy_guard(
+            "$qb = $this->applyOrganisationFilter($qb); if ($rows === []) { return []; }"))
+
+    def test_a_plain_getter_named_getOrganisation_is_not_a_scope_signal(self):
+        # `->getOrganisation()` is an ordinary accessor all over the fleet.
+        # Only the ACTIVE/CURRENT forms are session-derived, and only a
+        # session-derived value makes the comparison an authorisation check.
+        self.assertFalse(cni._has_tenancy_guard(
+            "$org = $entity->getOrganisation(); if ($org === null) { throw new DoesNotExistException(); }"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/test_check_semantic_auth.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_semantic_auth (gate-9). Run with:
+
+    python3 scripts/lib/test_check_semantic_auth.py
+
+WHY THIS SUITE EXISTS
+---------------------
+gate-9 shipped with NO tests. Its `public-page-annotation-with-auth-body`
+rule produced 39 fleet findings of which 36 were false, and its remediation
+text — *"remove `#[PublicPage]` or remove body auth check"* — would have
+INTRODUCED a vulnerability in every one of those 36: the first half breaks
+the endpoint (Nextcloud middleware rejects the remote caller before the
+controller runs), the second half deletes its only authentication.
+
+The fixtures below are the real call shapes, verbatim in structure:
+openconnector's HMAC webhook, portaliq's portal `subject()` inbox,
+openregister's bearer-share-token federation reader — against decidesk's
+actual defect, a `#[PublicPage]` method that tests the SESSION.
+
+Both ways, in the same class: the self-authenticating shapes must go quiet,
+and the session-dependent shape must still fire.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_semantic_auth as csa  # noqa: E402
+
+
+def _scan(php: str) -> list[str]:
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "Controller.php"
+        p.write_text(php, encoding="utf-8")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            csa.scan_file(str(p))
+    return [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+
+
+def _rules(findings: list[str]) -> list[str]:
+    return [f.split("rule=", 1)[1].split(" ", 1)[0] for f in findings]
+
+
+CLASS = """<?php
+namespace OCA\\Thing\\Controller;
+
+class ThingController extends Controller
+{
+%s
+}
+"""
+
+HMAC_WEBHOOK = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function webhook(): JSONResponse
+    {
+        $signature = $this->request->getHeader('X-Mollie-Signature');
+        $expected = hash_hmac('sha256', $this->request->getContent(), $this->secret);
+        if (hash_equals($expected, $signature) === false) {
+            return new JSONResponse(['error' => 'bad signature'], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+"""
+
+PORTAL_INBOX = CLASS % """
+    #[PublicPage]
+    public function inbox(): JSONResponse
+    {
+        $subject = $this->portal->subject();
+        if ($subject === null) {
+            return new JSONResponse(['error' => 'no portal session'], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse($this->service->listFor($subject));
+    }
+"""
+
+FEDERATION_BEARER = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function objects(string $shareToken): JSONResponse
+    {
+        $share = $this->shares->findByToken($shareToken);
+        if ($share === null || $share->isRevoked()) {
+            return new JSONResponse(['error' => 'unknown share'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse($this->service->objectsFor($share));
+    }
+"""
+
+# decidesk's real defect shape: annotated public, but the body tests the
+# SESSION — a test that can only ever fail for the callers the annotation
+# admits.
+SESSION_DEPENDENT = CLASS % """
+    #[PublicPage]
+    public function load(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse($this->settings->all());
+    }
+"""
+
+SESSION_NULL_CHECK = CLASS % """
+    #[PublicPage]
+    public function mine(): JSONResponse
+    {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse($this->service->forCurrentUser());
+    }
+"""
+
+# 401 with no credential source anywhere: the shape that remains worth
+# reporting, because nothing in the method says what it authenticates with.
+UNSOURCED_DENIAL = CLASS % """
+    #[PublicPage]
+    public function report(): JSONResponse
+    {
+        if ($this->flags->closed()) {
+            return new JSONResponse(['error' => 'closed'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse($this->service->report());
+    }
+"""
+
+
+class SelfAuthenticatingPublicEndpoints(unittest.TestCase):
+    """The 36 false positives."""
+
+    def test_fp_hmac_signed_webhook_is_not_a_finding(self):
+        self.assertEqual(_scan(HMAC_WEBHOOK), [])
+
+    def test_fp_portal_subject_resolution_is_not_a_finding(self):
+        self.assertEqual(_scan(PORTAL_INBOX), [])
+
+    def test_fp_bearer_share_token_is_not_a_finding(self):
+        self.assertEqual(_scan(FEDERATION_BEARER), [])
+
+
+class SessionDependentPublicPage(unittest.TestCase):
+    """The 3 true positives — these MUST still fire."""
+
+    def test_tp_require_admin_under_public_page_still_fires(self):
+        self.assertEqual(_rules(_scan(SESSION_DEPENDENT)),
+                         ["public-page-annotation-with-session-auth-body"])
+
+    def test_tp_user_session_null_check_under_public_page_still_fires(self):
+        self.assertEqual(_rules(_scan(SESSION_NULL_CHECK)),
+                         ["public-page-annotation-with-session-auth-body"])
+
+    def test_tp_a_session_check_fires_even_alongside_a_token(self):
+        # Self-authentication excuses an UNSOURCED denial, never a session
+        # test. A method that reads a token AND requires a session is still
+        # contradicting its own annotation.
+        php = CLASS % """
+    #[PublicPage]
+    public function mixed(string $shareToken): JSONResponse
+    {
+        $share = $this->shares->findByToken($shareToken);
+        $this->requireAdmin();
+        return new JSONResponse($share);
+    }
+"""
+        self.assertEqual(_rules(_scan(php)),
+                         ["public-page-annotation-with-session-auth-body"])
+
+    def test_tp_a_denial_with_no_credential_source_is_reported(self):
+        self.assertEqual(_rules(_scan(UNSOURCED_DENIAL)),
+                         ["public-page-annotation-with-unsourced-denial"])
+
+
+class RemediationTextIsSafe(unittest.TestCase):
+    """The advice itself is part of the gate. If it tells a developer to open
+    the endpoint, the gate is a vulnerability generator regardless of its
+    precision. These assertions are on the STRING, deliberately."""
+
+    def _advice(self, php: str) -> str:
+        found = _scan(php)
+        self.assertTrue(found, "expected a finding to inspect the advice of")
+        return found[0]
+
+    def test_advice_never_says_to_remove_the_public_page_annotation(self):
+        for php in (SESSION_DEPENDENT, SESSION_NULL_CHECK, UNSOURCED_DENIAL):
+            with self.subTest(php=php[:60]):
+                advice = self._advice(php)
+                self.assertNotIn("remove #[PublicPage] or", advice)
+
+    def test_advice_never_says_to_remove_the_auth_check(self):
+        for php in (SESSION_DEPENDENT, SESSION_NULL_CHECK, UNSOURCED_DENIAL):
+            with self.subTest(php=php[:60]):
+                advice = self._advice(php)
+                self.assertNotIn("remove body auth check", advice)
+                self.assertIn("Do NOT", advice)
+
+    def test_advice_names_the_request_borne_alternative(self):
+        advice = self._advice(SESSION_DEPENDENT)
+        self.assertIn("route token", advice)
+
+
+class NoAdminRequiredRuleUnchanged(unittest.TestCase):
+    """The rule gate-9 was actually built for. It was RIGHT — 3 of 3 real —
+    and nothing above may weaken it."""
+
+    def test_tp_no_admin_required_with_an_admin_body_still_fires(self):
+        php = CLASS % """
+    #[NoAdminRequired]
+    public function load(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse($this->settings->all());
+    }
+"""
+        self.assertEqual(_rules(_scan(php)),
+                         ["no-admin-required-annotation-with-admin-body"])
+
+    def test_fp_a_plain_no_admin_required_method_is_clean(self):
+        php = CLASS % """
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse($this->service->listForCurrentUser());
+    }
+"""
+        self.assertEqual(_scan(php), [])
+
+
+class GateIsNotBlind(unittest.TestCase):
+    def test_the_scanner_still_reads_methods_at_all(self):
+        # If `_find_method_bodies` ever returns nothing, every `assertEqual([])`
+        # above passes. This asserts the floor directly.
+        php = CLASS % """
+    #[PublicPage]
+    public function a(): JSONResponse { $this->requireAdmin(); return new JSONResponse([]); }
+
+    #[PublicPage]
+    public function b(): JSONResponse { $this->requireAdmin(); return new JSONResponse([]); }
+"""
+        self.assertEqual(len(_scan(php)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/test_check_spec_anchors.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_spec_anchors (gate-46). Run with:
+
+    python3 scripts/lib/test_check_spec_anchors.py
+
+or via pytest:
+
+    python3 -m pytest scripts/lib/test_check_spec_anchors.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+Gate-46 was measured at 1,995 findings across 21 repos, 54% of them false.
+Every relaxation below was written to clear a specific false-positive shape,
+and every one of them ships PAIRED with a case that must still FAIL. A gate
+that stops flagging is not a fixed gate, it is a dead one — and a dead gate
+is indistinguishable from a passing repository, which is the defect this
+whole package has spent a week fighting.
+
+So each ``...Relaxed`` test class has a sibling assertion in the same class:
+
+  * the false-positive input now resolves, AND
+  * an input that differs only in the part the gate is supposed to check
+    still does not resolve.
+
+The fixtures are copied from real fleet specs (pipelinq's
+``pos-payment-provider-adapter``, zaakafhandelapp's ``zgw-zaak-management``,
+pipelinq's ``bi-export-and-data-warehouse-sink``) rather than written to
+mirror the implementation's own regexes back at it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_spec_anchors as csa  # noqa: E402
+
+
+def _anchor(md: str, fragment: str) -> bool:
+    """Write *md* to a throwaway file and ask whether *fragment* resolves."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "spec.md"
+        p.write_text(md, encoding="utf-8")
+        return csa.has_anchor(str(p), fragment)
+
+
+def _scan(tree: dict[str, str], source_rel: str, source_src: str) -> list[str]:
+    """Materialise an openspec tree plus one annotated source file and scan."""
+    with tempfile.TemporaryDirectory() as root:
+        for rel, body in tree.items():
+            p = Path(root) / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        src = Path(root) / source_rel
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(source_src, encoding="utf-8")
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            return csa.scan_files([source_rel], root=root)
+        finally:
+            os.chdir(cwd)
+
+
+# --------------------------------------------------------------------------
+# Mode 1 — the `:`-tail rule accepted only EQUALITY where the full-heading
+# rule accepted a PREFIX. 351 fleet findings.
+# --------------------------------------------------------------------------
+ZGW = """# ZGW Zaak Management
+
+## Requirements
+
+### Requirement: REQ-001: List and search zaken
+
+### Requirement: REQ-005: Manage case-bound sub-resources
+"""
+
+
+class ColonTailPrefixParity(unittest.TestCase):
+    def test_fp_the_id_before_the_second_colon_now_resolves(self):
+        self.assertTrue(_anchor(ZGW, "REQ-001"))
+        self.assertTrue(_anchor(ZGW, "REQ-005"))
+
+    def test_tp_an_id_that_is_in_no_heading_still_fails(self):
+        # REQ-002/3/4 exist in the real file; this fixture stops at 005.
+        self.assertFalse(_anchor(ZGW, "REQ-002"))
+        self.assertFalse(_anchor(ZGW, "REQ-999"))
+
+    def test_tp_the_prefix_rule_still_respects_the_dash_boundary(self):
+        # `#REQ-00` must not resolve against `REQ-001`: prefix matching is
+        # only allowed to consume WHOLE dash-delimited segments.
+        self.assertFalse(_anchor(ZGW, "REQ-00"))
+
+    def test_regression_the_long_tail_still_resolves_by_prefix(self):
+        head = "### Task 8 — implement the retry ladder\n"
+        self.assertTrue(_anchor(head, "task-8"))
+        self.assertFalse(_anchor(head, "task-89"))
+
+
+# --------------------------------------------------------------------------
+# Mode 2 — a requirement id in trailing parentheses. 944 fleet findings.
+# --------------------------------------------------------------------------
+POS_PAYMENT = """# POS Pluggable Payment Provider Specification
+
+## ADDED Requirements
+
+### Requirement: Payment Provider Adapter Interface (REQ-PAY-001)
+
+#### Scenario: MollieAdapter implements PaymentProviderInterface
+
+### Requirement: Provider Credential Storage & Encryption (REQ-PAY-002)
+
+### Requirement: Refund and capture flows [REQ-PAY-003, REQ-PAY-004]
+"""
+
+
+class ParenthesisedRequirementIds(unittest.TestCase):
+    def test_fp_a_parenthesised_id_now_resolves(self):
+        self.assertTrue(_anchor(POS_PAYMENT, "REQ-PAY-001"))
+        self.assertTrue(_anchor(POS_PAYMENT, "REQ-PAY-002"))
+
+    def test_fp_a_bracketed_comma_list_resolves_each_member(self):
+        self.assertTrue(_anchor(POS_PAYMENT, "REQ-PAY-003"))
+        self.assertTrue(_anchor(POS_PAYMENT, "REQ-PAY-004"))
+
+    def test_tp_an_id_no_heading_declares_still_fails(self):
+        self.assertFalse(_anchor(POS_PAYMENT, "REQ-PAY-005"))
+        self.assertFalse(_anchor(POS_PAYMENT, "REQ-CARD-001"))
+
+    def test_tp_a_short_id_is_matched_by_equality_not_prefix(self):
+        # This is the anti-blindness assertion for mode 2. If lifted tokens
+        # were prefix-matched like full headings, `#REQ` would resolve
+        # against REQ-PAY-001 and the gate would accept any tag beginning
+        # with a live id's first segment.
+        self.assertFalse(_anchor(POS_PAYMENT, "REQ"))
+        self.assertFalse(_anchor(POS_PAYMENT, "REQ-PAY"))
+
+    def test_regression_the_full_github_anchor_still_resolves(self):
+        self.assertTrue(_anchor(
+            POS_PAYMENT,
+            "requirement-payment-provider-adapter-interface-req-pay-001",
+        ))
+
+
+# --------------------------------------------------------------------------
+# Mode 3 — `- [~]` / `- [-]` checkboxes were invisible, which ALSO shifted
+# every positional `#task-N` after them. 28 fleet findings, plus a silent
+# mis-resolution class that produced no finding at all.
+# --------------------------------------------------------------------------
+TASKS = """# Tasks
+
+- [x] 1.1 Write the mapper
+- [~] 1.2 Wire the controller
+- [ ] 1.3 Add the route
+- [-] 1.4 Dropped: the legacy shim
+"""
+
+
+class PartialAndDroppedCheckboxes(unittest.TestCase):
+    def test_fp_a_partial_item_id_now_resolves(self):
+        self.assertTrue(_anchor(TASKS, "task-1.2"))
+
+    def test_fp_a_dropped_item_id_now_resolves(self):
+        self.assertTrue(_anchor(TASKS, "task-1.4"))
+
+    def test_positional_resolution_counts_every_checkbox(self):
+        # The important half: `#task-3` must land on 1.3, the THIRD item.
+        # With `[~]` invisible the counter never incremented for 1.2, so
+        # `#task-3` silently resolved to 1.4 — a wrong answer that reported
+        # PASS, which is worse than the missing anchor it replaced.
+        #
+        # Proved by deleting the third item: `#task-3` must then fail.
+        self.assertTrue(_anchor(TASKS, "task-3"))
+        three_items = "\n".join(
+            ln for ln in TASKS.splitlines() if "1.3" not in ln and "1.4" not in ln
+        )
+        self.assertFalse(_anchor(three_items, "task-3"))
+
+    def test_tp_a_task_number_past_the_end_still_fails(self):
+        self.assertFalse(_anchor(TASKS, "task-5"))
+        self.assertFalse(_anchor(TASKS, "task-9.9"))
+
+
+# --------------------------------------------------------------------------
+# Mode 4 — apostrophes and slashes. GitHub DROPS them; the fleet's retrofit
+# tooling turns them into `-`. Both spellings name the same heading, and an
+# anchor built by dropping the character misses by exactly one and looks
+# identical to a dangling reference.
+# --------------------------------------------------------------------------
+PUNCT = "## A subscription's retry/backoff policy\n"
+
+
+class SlugPunctuation(unittest.TestCase):
+    def test_fp_github_spelling_resolves(self):
+        self.assertTrue(_anchor(PUNCT, "a-subscriptions-retrybackoff-policy"))
+
+    def test_fp_kebab_spelling_resolves(self):
+        self.assertTrue(_anchor(PUNCT, "a-subscription-s-retry-backoff-policy"))
+
+    def test_tp_a_heading_that_does_not_exist_still_fails(self):
+        self.assertFalse(_anchor(PUNCT, "a-subscriptions-retry-policy"))
+        self.assertFalse(_anchor(PUNCT, "a-subscriptions-backoff-policy"))
+
+    def test_slugify_turns_punctuation_into_a_separator(self):
+        self.assertEqual(csa.slugify("A subscription's retry/backoff policy"),
+                         "a-subscription-s-retry-backoff-policy")
+
+    def test_gh_slugify_drops_punctuation_inside_a_word(self):
+        self.assertEqual(csa.gh_slugify("A subscription's retry/backoff policy"),
+                         "a-subscriptions-retrybackoff-policy")
+
+
+# --------------------------------------------------------------------------
+# Mode 5 — the flat/directory spec path shapes.
+# --------------------------------------------------------------------------
+SRC_TAG = """<?php
+/**
+ * @spec openspec/specs/task-collaboration.md#requirement-assign-a-task
+ */
+class Foo {}
+"""
+SRC_TAG_MISSING = """<?php
+/**
+ * @spec openspec/specs/no-such-capability.md#requirement-assign-a-task
+ */
+class Foo {}
+"""
+COLLAB = "# Task collaboration\n\n### Requirement: Assign a task\n"
+
+
+class SpecPathShapes(unittest.TestCase):
+    def test_fp_flat_tag_resolves_against_the_directory_form(self):
+        findings = _scan(
+            {"openspec/specs/task-collaboration/spec.md": COLLAB},
+            "lib/Service/Foo.php", SRC_TAG,
+        )
+        self.assertEqual(findings, [])
+
+    def test_fp_directory_tag_resolves_against_the_flat_form(self):
+        src = SRC_TAG.replace("task-collaboration.md",
+                              "task-collaboration/spec.md")
+        findings = _scan(
+            {"openspec/specs/task-collaboration.md": COLLAB},
+            "lib/Service/Foo.php", src,
+        )
+        self.assertEqual(findings, [])
+
+    def test_tp_a_spec_that_exists_in_neither_shape_still_fails(self):
+        findings = _scan(
+            {"openspec/specs/task-collaboration/spec.md": COLLAB},
+            "lib/Service/Foo.php", SRC_TAG_MISSING,
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("target file not found", findings[0])
+
+    def test_tp_the_shape_fallback_does_not_excuse_a_bad_anchor(self):
+        # The file is found via the other shape; the fragment still has to
+        # exist in it.
+        src = SRC_TAG.replace("requirement-assign-a-task",
+                              "requirement-delete-a-task")
+        findings = _scan(
+            {"openspec/specs/task-collaboration/spec.md": COLLAB},
+            "lib/Service/Foo.php", src,
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("anchor not found", findings[0])
+
+
+# --------------------------------------------------------------------------
+# The id-like-token rule — `#### Scenario REQ-BIE-004-01: Cron triggers …`
+# puts the id BEFORE the colon, as its own token.
+# --------------------------------------------------------------------------
+BI_EXPORT = """# BI export
+
+#### Scenario REQ-BIE-004-01: Cron triggers export run creation
+
+#### Scenario REQ-BIE-004-02: Worker picks up pending runs within 60 seconds
+
+## BlastService (Task 2.3 of giant)
+"""
+
+
+class IdLikeTokensInHeadings(unittest.TestCase):
+    def test_fp_a_pre_colon_id_token_resolves(self):
+        self.assertTrue(_anchor(BI_EXPORT, "REQ-BIE-004-01"))
+        self.assertTrue(_anchor(BI_EXPORT, "REQ-BIE-004-02"))
+
+    def test_fp_an_id_inside_prose_parentheses_resolves(self):
+        self.assertTrue(_anchor(BI_EXPORT, "task-2.3"))
+
+    def test_tp_an_id_absent_from_every_heading_still_fails(self):
+        self.assertFalse(_anchor(BI_EXPORT, "REQ-BIE-004-03"))
+        self.assertFalse(_anchor(BI_EXPORT, "REQ-BIE-005-01"))
+        self.assertFalse(_anchor(BI_EXPORT, "task-2.4"))
+
+    def test_tp_prose_words_are_not_lifted_as_ids(self):
+        # The anti-blindness assertion for this rule. Without the
+        # digit requirement, every word of every heading before a colon
+        # would become an anchor and the gate would resolve anything.
+        self.assertFalse(_anchor(BI_EXPORT, "scenario"))
+        self.assertFalse(_anchor(BI_EXPORT, "requirement"))
+        self.assertFalse(_anchor(BI_EXPORT, "cron"))
+        # `#blastservice` DOES resolve — `## BlastService (Task 2.3 of
+        # giant)` is a real topic heading whose bracket carries provenance,
+        # not title. That is the same class as `#webhooks` below.
+        self.assertTrue(_anchor(BI_EXPORT, "blastservice"))
+        self.assertFalse(_anchor(BI_EXPORT, "giant"))
+        # ...but a fragment that names a real TOPIC heading still resolves:
+        # `#webhooks` against `## Webhooks (Task 2.9 of giant)` is a working
+        # anchor, so the structural-keyword exclusion is a keyword list and
+        # not a ban on short fragments.
+        self.assertTrue(_anchor("## Webhooks (Task 2.9 of giant)\n", "webhooks"))
+        self.assertFalse(_anchor("### The retry and backoff policy: details\n",
+                                 "retry"))
+        self.assertFalse(_anchor("### The retry and backoff policy: details\n",
+                                 "backoff"))
+
+    def test_idlike_tokens_directly(self):
+        self.assertEqual(csa._idlike_tokens("Scenario REQ-BIE-004-01"),
+                         {"req-bie-004-01"})
+        self.assertEqual(csa._idlike_tokens("Task 2.3 of giant"), {"2-3"})
+        self.assertEqual(csa._idlike_tokens("The retry and backoff policy"),
+                         set())
+
+
+# --------------------------------------------------------------------------
+# Behaviour that must survive every relaxation above.
+# --------------------------------------------------------------------------
+class PreservedBehaviour(unittest.TestCase):
+    def test_a_missing_target_file_is_reported(self):
+        findings = _scan(
+            {"openspec/specs/other/spec.md": "# Other\n"},
+            "lib/Foo.php",
+            "<?php\n/** @spec openspec/specs/ghost/spec.md */\n",
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("target file not found", findings[0])
+
+    def test_an_archived_change_still_resolves(self):
+        findings = _scan(
+            {
+                "openspec/changes/archive/2026-06-14-pos-payment-provider-adapter"
+                "/specs/pos-payment-provider-adapter/spec.md": POS_PAYMENT,
+            },
+            "lib/Foo.php",
+            "<?php\n/** @spec openspec/changes/pos-payment-provider-adapter"
+            "/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-001 */\n",
+        )
+        self.assertEqual(findings, [])
+
+    def test_a_tag_with_no_fragment_only_needs_the_file(self):
+        findings = _scan(
+            {"openspec/specs/thing/spec.md": "# Thing\n"},
+            "lib/Foo.php",
+            "<?php\n/** @spec openspec/specs/thing/spec.md */\n",
+        )
+        self.assertEqual(findings, [])
+
+    def test_spec_exclude_is_not_a_target(self):
+        findings = _scan(
+            {"openspec/specs/thing/spec.md": "# Thing\n"},
+            "lib/Foo.php",
+            "<?php\n/** @spec exclude pure DTO, no behaviour */\n",
+        )
+        self.assertEqual(findings, [])
+
+    def test_a_wholly_invented_fragment_is_still_reported(self):
+        findings = _scan(
+            {"openspec/specs/thing/spec.md": ZGW},
+            "lib/Foo.php",
+            "<?php\n/** @spec openspec/specs/thing/spec.md"
+            "#requirement-teleport-the-zaak */\n",
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("anchor not found", findings[0])
+
+
+class GateIsNotBlind(unittest.TestCase):
+    """One consolidated demonstration that the gate still has teeth.
+
+    If a future relaxation makes ``has_anchor`` return True unconditionally,
+    every ``assertFalse`` above goes green individually only if someone
+    deletes them. This test asserts the property directly: a spec file with
+    real content must reject a fragment built from words that appear
+    nowhere in it.
+    """
+
+    def test_random_fragments_do_not_resolve_against_a_real_spec(self):
+        for frag in (
+            "requirement-nonexistent",
+            "REQ-ZZZ-999",
+            "task-12345",
+            "scenario-the-server-catches-fire",
+            "zzzz",
+            "",
+        ):
+            with self.subTest(frag=frag):
+                self.assertFalse(_anchor(POS_PAYMENT, frag))
+                self.assertFalse(_anchor(ZGW, frag))
+                self.assertFalse(_anchor(BI_EXPORT, frag))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_gate_route_auth.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_auth.sh
@@ -56,14 +56,24 @@ _bad()  { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
 _OUT=""
 _UNRES=""
 _RRLOG=""
+_LOGDIR=""
 _run() {
     local _dir="$1"; shift
-    _OUT="$(bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
-    # The gates write their detail logs to fixed /tmp paths, which a
-    # concurrently running gate suite would truncate. Snapshot them straight
-    # away and assert against the snapshot.
-    _UNRES="$(cat /tmp/hydra-gate-route-auth-unresolved.log 2>/dev/null || true)"
-    _RRLOG="$(cat /tmp/hydra-gate-route-reachability.log 2>/dev/null || true)"
+    # Give THIS invocation its own findings directory.
+    #
+    # These assertions used to read fixed /tmp/hydra-gate-*.log paths and
+    # carried a comment saying a concurrent run "would truncate" them — with
+    # a snapshot taken after the run as the mitigation. A snapshot cannot
+    # help: the truncation happens DURING the run, between the gate's write
+    # and its own `wc -l`. Run under the helper-suite harness this suite
+    # reported 7 failures while reporting 0 standalone, which is the shape
+    # of a measurement contaminated by another process, not of a defect.
+    local _logdir
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-test.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    _UNRES="$(cat "${_logdir}/hydra-gate-route-auth-unresolved.log" 2>/dev/null || true)"
+    _RRLOG="$(cat "${_logdir}/hydra-gate-route-reachability.log" 2>/dev/null || true)"
+    _LOGDIR="${_logdir}"
     if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
         _bad "run in ${_dir} ABORTED before the summary — verdicts above it are not a result"
         printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
@@ -121,7 +131,7 @@ if _run "${FIXTURES}/unguarded"; then
     _expect_gate 5 FAIL "unguarded fixture: a routed, attribute-less write still FAILS gate-5"
     _expect_out 'gate-5\] route-auth: FAIL — 2 routed method' \
         "unguarded fixture: exactly TWO findings (the guarded sibling method is not reported)"
-    _RALOG="$(cat /tmp/hydra-gate-route-auth.log 2>/dev/null || true)"
+    _RALOG="$(cat "${_LOGDIR}/hydra-gate-route-auth.log" 2>/dev/null || true)"
     _expect_log "${_RALOG}" 'WidgetController.php:[0-9]+ method=update' \
         "unguarded fixture: the snake/lowercase slug's unguarded method is named"
     # camelCase slug. Invisible to gate-5's old `'[a-z_]+#…'` regex.

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -50,7 +50,9 @@
 #
 # Output shape (stdout):
 #   [gate-N] <gate-name>: PASS | FAIL[<reasons>]
-# Gates that FAIL write details to /tmp/hydra-gate-<name>.log for debugging;
+# Gates that FAIL write details to <log-dir>/hydra-gate-<name>.log for debugging,
+# where <log-dir> is a PRIVATE per-invocation directory printed on the first
+# line of output (see HYDRA_GATE_LOG_DIR below);
 # a short summary is emitted on stdout so the wrapper can relay it to the
 # builder's focused fix pass.
 #
@@ -72,6 +74,47 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 # coverage assertion measured against a stale inventory is the very defect the
 # assertion exists to catch.
 RUNNER_SELF="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]:-$0}")"
+
+# ---------------------------------------------------------------------------
+# ONE PRIVATE LOG DIRECTORY PER INVOCATION.
+#
+# Every gate below writes its findings to a file and then derives its verdict
+# from `wc -l` on that file. Until now ~61 of those paths were hardcoded
+# `${HYDRA_GATE_LOG_DIR}/hydra-gate-<name>.log`, shared by every concurrent run on the host.
+# Exactly one gate — gate-6 — used `mktemp`, and its comment said why.
+#
+# The consequence is not noise, it is NON-DETERMINISM IN BOTH DIRECTIONS.
+# Two runs of the same commit on the same host, minutes apart, with other
+# runs active:
+#
+#     run A:  gate-7  FAIL 18   gate-28 FAIL  6   gate-39 PASS     gate-45 FAIL 30
+#     run B:  gate-7  FAIL 25   gate-28 FAIL 32   gate-39 FAIL 7   gate-45 FAIL 29
+#
+# gate-39 flipped PASS<->FAIL. A log another process truncated between the
+# write and the count reports a number describing neither run, and a
+# truncated-to-empty log reports PASS — a falsely-green gate, manufactured
+# by the runner's own plumbing. Measured five times across fleet sweeps: a
+# repo was credited with another repo's findings, and vice versa.
+#
+# TMPDIR is honoured so a caller can place the logs somewhere it can collect
+# them; the directory is PRINTED once so the paths in the summary stay
+# greppable, and is deliberately NOT deleted on exit — the whole point of a
+# findings log is that you read it after the run.
+# ---------------------------------------------------------------------------
+HYDRA_GATE_LOG_DIR="${HYDRA_GATE_LOG_DIR:-}"
+if [ -z "${HYDRA_GATE_LOG_DIR}" ]; then
+    HYDRA_GATE_LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gates.XXXXXXXX" 2>/dev/null || true)"
+fi
+if [ -z "${HYDRA_GATE_LOG_DIR}" ] || [ ! -d "${HYDRA_GATE_LOG_DIR}" ]; then
+    # Refuse rather than silently fall back to the shared path. A run whose
+    # logs land somewhere another run can truncate is a run whose verdicts
+    # cannot be trusted, and "cannot be trusted" must not look like "green".
+    echo "[hydra-gates] ERROR: could not create a private log directory under ${TMPDIR:-/tmp}." >&2
+    echo "[hydra-gates]        Refusing to run: shared log paths make gate verdicts non-deterministic." >&2
+    exit 97
+fi
+mkdir -p "${HYDRA_GATE_LOG_DIR}" 2>/dev/null || true
+echo "[hydra-gates] findings logs: ${HYDRA_GATE_LOG_DIR}"
 
 SCOPE_TO_DIFF=0
 BASE_REF="origin/development"
@@ -149,16 +192,86 @@ if [ "${SCOPE_TO_DIFF}" = "1" ]; then
         fi
     fi
 
+    # A RESOLVING BASE IS NOT A USABLE BASE (third vacuous-pass shape).
+    #
+    # The check above proves `${BASE_REF}` names a commit. It does NOT prove
+    # the two histories share one. On a SHALLOW checkout — `actions/checkout`
+    # with the default `fetch-depth: 1`, which is most of the fleet —
+    # `origin/development` exists as a ref while its history is truncated, so
+    # `git diff ${BASE_REF}...HEAD` fails outright. The old `|| … || true`
+    # chain swallowed that failure and left CHANGED_FILES empty, and an empty
+    # scope makes EVERY gate iterate nothing and report PASS.
+    #
+    # Measured on shillinq: a `development` run finished in 22 SECONDS with
+    # all 63 gates green. Unscoped, the same commit fails 18. Twenty-two
+    # seconds is itself the tell — but nothing in the output said so, and a
+    # green run is not read twice.
+    #
+    # So: require a merge base, and read the diff's exit status DIRECTLY
+    # rather than through a `||` chain that cannot tell "no changes" from
+    # "the command could not run".
+    # THE BASE IS THE SAME COMMIT AS HEAD.
+    #
+    # This is the shape that actually produced shillinq's 22-second all-green
+    # run, and it is not a shallow-history failure: on a push to
+    # `development`, `origin/development` and `HEAD` ARE the same commit. The
+    # diff is then legitimately empty, git succeeds, and every gate iterates
+    # nothing and reports PASS. Verified: shillinq `development`
+    # c64e9fe — `git rev-parse HEAD` and `origin/development` identical,
+    # `git diff origin/development...HEAD` = 0 files, 52 gates PASS. Run
+    # UNSCOPED the same commit fails 18.
+    #
+    # So EVERY diff-scoped run on a mainline branch is vacuous by
+    # construction. That is a configuration error in the caller (a scoped run
+    # only makes sense for a PR), not an empty PR, and it must not wear the
+    # same green as a run that inspected something.
+    _base_sha=$(git -c safe.directory='*' rev-parse --verify --quiet "${BASE_REF}^{commit}" 2>/dev/null || true)
+    _head_sha=$(git -c safe.directory='*' rev-parse --verify --quiet 'HEAD^{commit}' 2>/dev/null || true)
+    if [ -n "${_base_sha}" ] && [ "${_base_sha}" = "${_head_sha}" ]; then
+        echo "[hydra-gates] ERROR: diff base '${BASE_REF}' IS HEAD (${_head_sha})." >&2
+        echo "[hydra-gates] A scoped run against itself inspects nothing, and every gate" >&2
+        echo "[hydra-gates] would report PASS over an empty file set. Refusing." >&2
+        echo "[hydra-gates] Run WITHOUT --scope-to-diff on a mainline branch, or pass a" >&2
+        echo "[hydra-gates] --base that is actually behind HEAD." >&2
+        exit 99
+    fi
+
+    if ! git -c safe.directory='*' merge-base "${BASE_REF}" HEAD > /dev/null 2>&1; then
+        echo "[hydra-gates] ERROR: '${BASE_REF}' resolves, but shares NO history with HEAD." >&2
+        echo "[hydra-gates] This is what a SHALLOW checkout looks like (fetch-depth: 1)." >&2
+        echo "[hydra-gates] The diff would be empty and every gate would pass having read" >&2
+        echo "[hydra-gates] nothing. Refusing. Fix: fetch-depth: 0, or a deeper fetch of" >&2
+        echo "[hydra-gates] '${BASE_REF}', or run unscoped." >&2
+        exit 99
+    fi
+
+    # `&& _diff_rc=0 || _diff_rc=$?` and NOT `set -e` / `set +e`.
+    #
+    # This script runs under `set -u` only — errexit is deliberately OFF,
+    # because a gate returning non-zero is normal. An earlier draft of this
+    # block used `set +e … set -e`, which does not restore the previous
+    # state, it turns errexit ON for the remaining 3,700 lines. The run then
+    # ABORTED right after this block, and the abort banner said only
+    # "GATE COVERAGE IS INCOMPLETE" — caught by
+    # scripts/lib/test_gate_route_auth.sh, which is why that suite exists.
     CHANGED_FILES=$(git -c safe.directory='*' diff --name-only \
-        --diff-filter=ACMR "${BASE_REF}...HEAD" 2>/dev/null \
-        || git -c safe.directory='*' diff --name-only \
-            --diff-filter=ACMR "${BASE_REF}" 2>/dev/null \
-        || true)
+        --diff-filter=ACMR "${BASE_REF}...HEAD" 2>/dev/null) && _diff_rc=0 || _diff_rc=$?
+    if [ "${_diff_rc}" -ne 0 ]; then
+        # Fall back to the two-dot form, still reading the code directly.
+        CHANGED_FILES=$(git -c safe.directory='*' diff --name-only \
+            --diff-filter=ACMR "${BASE_REF}" 2>/dev/null) && _diff_rc=0 || _diff_rc=$?
+    fi
+    if [ "${_diff_rc}" -ne 0 ]; then
+        echo "[hydra-gates] ERROR: computing the diff against '${BASE_REF}' FAILED (git exit ${_diff_rc})." >&2
+        echo "[hydra-gates] An unobtainable scope is not an empty one. Refusing rather than" >&2
+        echo "[hydra-gates] reporting a green run over zero inspected files." >&2
+        exit 99
+    fi
     _cf_count=$(printf '%s' "${CHANGED_FILES}" | grep -c . 2>/dev/null || true)
     if [ "${_cf_count:-0}" = "0" ]; then
         # Genuinely zero changed files is a legitimate outcome, but it must be
         # stated as such rather than looking like a scoped run that found nothing.
-        echo "[hydra-gates] Scope: diff vs ${BASE_REF} — 0 changed file(s). Base resolves; this PR changes nothing."
+        echo "[hydra-gates] Scope: diff vs ${BASE_REF} — 0 changed file(s). Base resolves, histories join, git succeeded; this PR changes nothing."
     else
         echo "[hydra-gates] Scope: diff vs ${BASE_REF} — ${_cf_count} changed file(s)"
     fi
@@ -263,7 +376,7 @@ _enum_tracked() {
 # newline. That is how gate-22 came to print
 #
 #     [gate-22] manifest-validation: FAIL — 0
-#     1 schema violation(s) in src/manifest.json — see /tmp/…
+#     1 schema violation(s) in src/manifest.json — see ${HYDRA_GATE_LOG_DIR}/…
 #
 # on opencatalogi: a real finding sat in the log, the count line read "0", and
 # the rest of the message was orphaned onto a second line that no `^\[gate-`
@@ -485,9 +598,9 @@ trap '_rc=$?; if [ "${_SUMMARY_REACHED}" -eq 0 ]; then
 # Resolve the lib/ dir that ships the gate helpers. Local repo layout is
 # scripts/run-hydra-gates.sh + scripts/lib/*.py; container layout flattens
 # everything into /usr/local/lib/hydra/. Probe both.
-_gate_helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd || true)"
+_gate_helper_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd || true)"
 if [ ! -f "${_gate_helper_dir}/filter_preexisting_methods.py" ]; then
-    _gate_helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
+    _gate_helper_dir="${SCRIPT_DIR}"
 fi
 
 # Provenance filter — for method-based gates, distinguish PR-introduced
@@ -527,7 +640,7 @@ if [ -d lib ]; then
         {
             [ "${_ml}" -gt 0 ] && { echo "Missing @license:"; echo "${_missing_license}" | sed 's/^/  /'; }
             [ "${_mc}" -gt 0 ] && { echo "Missing @copyright:"; echo "${_missing_copyright}" | sed 's/^/  /'; }
-        } > /tmp/hydra-gate-spdx-headers.log
+        } > ${HYDRA_GATE_LOG_DIR}/hydra-gate-spdx-headers.log
         _fail 1 "spdx-headers" "${_ml} missing @license, ${_mc} missing @copyright"
     fi
 fi
@@ -536,14 +649,14 @@ fi
 # Gate 2: Forbidden debug helpers in lib/
 # ---------------------------------------------------------------------------
 if [ -d lib ]; then
-    : > /tmp/hydra-gate-forbidden-patterns.log
+    : > ${HYDRA_GATE_LOG_DIR}/hydra-gate-forbidden-patterns.log
     _forbidden=0
     for pattern in var_dump die error_log print_r dd dump; do
         _hits=$(grep -rnE "\\b${pattern}\\(" lib/ 2>/dev/null | grep -v 'vendor/' | _filter_grep_by_scope || true)
         if [ -n "${_hits}" ]; then
             _n=$(echo "${_hits}" | wc -l)
-            echo "${_n}x ${pattern}(" >> /tmp/hydra-gate-forbidden-patterns.log
-            echo "${_hits}" | head -3 | sed 's/^/  /' >> /tmp/hydra-gate-forbidden-patterns.log
+            echo "${_n}x ${pattern}(" >> ${HYDRA_GATE_LOG_DIR}/hydra-gate-forbidden-patterns.log
+            echo "${_hits}" | head -3 | sed 's/^/  /' >> ${HYDRA_GATE_LOG_DIR}/hydra-gate-forbidden-patterns.log
             _forbidden=$((_forbidden + _n))
         fi
     done
@@ -557,7 +670,7 @@ fi
 # ---------------------------------------------------------------------------
 # Gate 3: Stub scan
 # ---------------------------------------------------------------------------
-_stub_log=/tmp/hydra-gate-stub-scan.log
+_stub_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-stub-scan.log
 : > "${_stub_log}"
 grep -rn "In a complete implementation" lib/ src/ 2>/dev/null | _filter_grep_by_scope | head -5 >> "${_stub_log}" || true
 if [ -d lib/BackgroundJob ]; then
@@ -671,7 +784,7 @@ if [ -f composer.json ] && command -v composer >/dev/null 2>&1; then
         _skip 4 "composer-audit" na "neither composer.json nor composer.lock is in this diff — under ADR-020 diff scoping the dependency tree is unchanged from the base branch, so this PR introduces no dependency change to audit."
     fi
     if [ "${_run_audit}" = "1" ]; then
-        _ca_log=/tmp/hydra-gate-composer-audit.log
+        _ca_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-composer-audit.log
         if [ -f composer.lock ]; then
             _ca_mode="--locked"
         else
@@ -731,8 +844,8 @@ fi
 #     route is exactly when its auth posture must be re-checked).
 # ---------------------------------------------------------------------------
 if [ -f appinfo/routes.php ]; then
-    _ra_fail=0 _ra_log=/tmp/hydra-gate-route-auth.log
-    _ra_unresolved_log=/tmp/hydra-gate-route-auth-unresolved.log
+    _ra_fail=0 _ra_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-route-auth.log
+    _ra_unresolved_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-route-auth-unresolved.log
     : > "${_ra_log}"
     : > "${_ra_unresolved_log}"
     # Touching appinfo/routes.php puts every routed method back in scope.
@@ -821,10 +934,10 @@ fi
 # count (a public helper called from a sibling method is legit).
 #
 # The findings log uses a mktemp path (not the fixed
-# /tmp/hydra-gate-orphan-auth.log) so parallel gate runs across multiple
+# ${HYDRA_GATE_LOG_DIR}/hydra-gate-orphan-auth.log) so parallel gate runs across multiple
 # apps can't clobber each other's counts. See hydra#110.
 # ---------------------------------------------------------------------------
-_oa_log="$(mktemp "${TMPDIR:-/tmp}/hydra-gate-orphan-auth.XXXXXX.log")"
+_oa_log="$(mktemp "${HYDRA_GATE_LOG_DIR}/hydra-gate-orphan-auth.XXXXXX.log")"
 : > "${_oa_log}"
 _oa_files=()
 while IFS= read -r f; do
@@ -844,9 +957,9 @@ if [ "${#_oa_files[@]}" -eq 0 ]; then
     _skip 6 "orphan-auth" na "scope was empty — 0 lib/Service or lib/Controller PHP file(s) in this diff, so NOTHING was inspected; orphaned (defined-but-never-called) authorization methods are UNVERIFIED by this run."
 fi
 if [ "${#_oa_files[@]}" -gt 0 ]; then
-    _oa_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _oa_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_oa_lib_dir}/check_orphan_auth.py" ]; then
-        _oa_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _oa_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_oa_lib_dir}/check_orphan_auth.py" ]; then
         python3 "${_oa_lib_dir}/check_orphan_auth.py" "${_oa_files[@]}" \
@@ -905,7 +1018,7 @@ fi
 # properly scopes @NoAdminRequired look-back to the current method's
 # docblock — avoiding false positives from preceding method annotations.
 # ---------------------------------------------------------------------------
-_idor_log=/tmp/hydra-gate-no-admin-idor.log
+_idor_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-no-admin-idor.log
 : > "${_idor_log}"
 _idor_files=()
 while IFS= read -r f; do
@@ -922,9 +1035,9 @@ if [ "${#_idor_files[@]}" -eq 0 ]; then
     _skip 7 "no-admin-idor" na "scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run."
 fi
 if [ "${#_idor_files[@]}" -gt 0 ]; then
-    _gate_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _gate_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_gate_lib_dir}/check_no_admin_idor.py" ]; then
-        _gate_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _gate_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_gate_lib_dir}/check_no_admin_idor.py" ]; then
         python3 "${_gate_lib_dir}/check_no_admin_idor.py" "${_idor_files[@]}" \
@@ -948,7 +1061,7 @@ fi
 # Gate 8: Unsafe-auth-resolver — no `catch (\Throwable) { return null; }`
 # in methods whose name contains Auth/Authorization/Permission/Role/Guard.
 # ---------------------------------------------------------------------------
-_uar_log=/tmp/hydra-gate-unsafe-auth-resolver.log
+_uar_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-unsafe-auth-resolver.log
 : > "${_uar_log}"
 while IFS= read -r f; do
     [ -f "$f" ] || continue
@@ -1009,7 +1122,7 @@ fi
 # See ADR-005 (security — attribute must match actual requirement) and
 # ADR-016 (routes — gate-5 syntactic, gate-9 semantic).
 # ---------------------------------------------------------------------------
-_sem_log=/tmp/hydra-gate-semantic-auth.log
+_sem_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-semantic-auth.log
 : > "${_sem_log}"
 
 # W28 (2026-04-24 warnings list) — gate-9 was a flat-regex implementation
@@ -1033,8 +1146,8 @@ if [ "${#_sem_files[@]}" -gt 0 ]; then
     # because the path resolution only checked the lib/ subdir variant.
     _sem_helper=""
     for _candidate in \
-        "$(dirname "${BASH_SOURCE[0]:-$0}")/lib/check_semantic_auth.py" \
-        "$(dirname "${BASH_SOURCE[0]:-$0}")/check_semantic_auth.py"; do
+        "${SCRIPT_DIR}/lib/check_semantic_auth.py" \
+        "${SCRIPT_DIR}/check_semantic_auth.py"; do
         if [ -f "${_candidate}" ]; then
             _sem_helper="${_candidate}"
             break
@@ -1045,7 +1158,7 @@ if [ "${#_sem_files[@]}" -gt 0 ]; then
             >> "${_sem_log}" 2>/dev/null || true
     else
         _sem_ran=0
-        _skip 9 "semantic-auth" wiring "check_semantic_auth.py not found near $(dirname "${BASH_SOURCE[0]:-$0}") — ${#_sem_files[@]} controller file(s) were in scope and NONE were inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run."
+        _skip 9 "semantic-auth" wiring "check_semantic_auth.py not found near ${SCRIPT_DIR} — ${#_sem_files[@]} controller file(s) were in scope and NONE were inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run."
     fi
 fi
 if [ "${_sem_ran}" -eq 1 ]; then
@@ -1065,7 +1178,7 @@ fi
 # `loadState('doriath', 'version', 'Unknown')`. ADR-004 hard rule.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _is_log=/tmp/hydra-gate-initial-state.log
+    _is_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-initial-state.log
     : > "${_is_log}"
     grep -rnE "getElementById\s*\([^)]+\)[^.]*\.dataset\b" src/ \
         --include='*.vue' --include='*.js' --include='*.ts' 2>/dev/null \
@@ -1085,7 +1198,7 @@ fi
 # framework enforces. ADR-004 hard rule. Observed 2026-04-30 on doriath
 # (commit c7c72e9 removed the dangerous /settings → AdminRoot route).
 # ---------------------------------------------------------------------------
-_ar_log=/tmp/hydra-gate-admin-router.log
+_ar_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-admin-router.log
 : > "${_ar_log}"
 for f in src/router/index.js src/router/index.ts src/router.js src/router.ts; do
     [ -f "$f" ] || continue
@@ -1111,7 +1224,7 @@ fi
 # rule. Observed 2026-04-30 on doriath.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _il_log=/tmp/hydra-gate-nc-input-labels.log
+    _il_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-nc-input-labels.log
     : > "${_il_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -1139,7 +1252,7 @@ fi
 # components. ADR-004 hard rule. Observed 2026-04-30 on doriath.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _mi_log=/tmp/hydra-gate-modal-isolation.log
+    _mi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-modal-isolation.log
     : > "${_mi_log}"
     while IFS= read -r vue; do
         case "${vue}" in
@@ -1181,7 +1294,7 @@ fi
 # analysis; owned by code-review runtime semantics + ADR-005.
 # ---------------------------------------------------------------------------
 if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
-    _rr_log=/tmp/hydra-gate-route-reachability.log
+    _rr_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-route-reachability.log
     : > "${_rr_log}"
 
     # Touching appinfo/routes.php puts every routed entry back in scope for
@@ -1327,12 +1440,12 @@ fi
 # slicer + manifest walker.
 # ---------------------------------------------------------------------------
 if [ -f src/manifest.json ]; then
-    _da_log=/tmp/hydra-gate-dashboard-antipattern.log
+    _da_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-dashboard-antipattern.log
     : > "${_da_log}"
     _da_ran=1
-    _da_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _da_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_da_lib_dir}/check_dashboard_antipattern.py" ]; then
-        _da_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _da_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_da_lib_dir}/check_dashboard_antipattern.py" ]; then
         # The helper exits with the number of violations and prints one
@@ -1379,12 +1492,12 @@ fi
 # See scripts/lib/check_spec_coverage.py for the parse + scope logic.
 # ---------------------------------------------------------------------------
 if [ -d lib ] || [ -d src ]; then
-    _sc_log=/tmp/hydra-gate-spec-coverage.log
+    _sc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-coverage.log
     : > "${_sc_log}"
     _sc_ran=1
-    _sc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _sc_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_sc_lib_dir}/check_spec_coverage.py" ]; then
-        _sc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _sc_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_sc_lib_dir}/check_spec_coverage.py" ]; then
         # The helper self-scopes to the PR diff; feed it our --base so a
@@ -1430,8 +1543,18 @@ fi
 # 4 MeetingService CRUD methods, ~260 lines, never called from the
 # frontend. Deleted in 2026-04-28 retrofit. This gate prevents the same
 # pattern from recurring.
-_redundant_log=/tmp/hydra-gate-redundant-controller.log
-SCRIPT_DIR_REDUNDANT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_redundant_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-redundant-controller.log
+# ${SCRIPT_DIR}, resolved once at the top BEFORE the `cd "${APP_DIR}"`.
+#
+# This line used to re-resolve `dirname "${BASH_SOURCE[0]}"` HERE, which is
+# relative to the APP directory by the time it runs. Invoked by a relative
+# path — `bash dotgithub/hydra-gates/scripts/run-hydra-gates.sh /some/app`,
+# which is how a human runs it — the `cd` failed and, under the `&&`, the
+# whole runner ABORTED at gate 17. The remaining ~46 gates never executed.
+# The run does announce "ABORTED before the summary", so it is not silently
+# green, but it is a whole-suite outage triggered by nothing worse than the
+# caller's choice of path spelling.
+SCRIPT_DIR_REDUNDANT="${SCRIPT_DIR}"
 # Use a bash array so the multi-line `${CHANGED_FILES}` (newline-separated by
 # `git diff --name-only`) stays a single argument. Previously the unquoted
 # `${_changed_files_arg}` expansion word-split on newlines/spaces, causing
@@ -1499,7 +1622,7 @@ fi
 #
 # See ADR-031 "The x-openregister-notifications dialect (canonical)".
 # ---------------------------------------------------------------------------
-_nd_log=/tmp/hydra-gate-notification-dialect.log
+_nd_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect.log
 : > "${_nd_log}"
 # OpenRegister engine marker — only the engine app ships this dispatcher.
 # Its presence suppresses check (b) entirely (the engine legitimately calls
@@ -1536,7 +1659,7 @@ fi
 _nd_fail=$(wc -l < "${_nd_log}" 2>/dev/null || echo 0)
 
 # ---- (b) Imperative dispatch in a leaf app — WARNING only (not a failure).
-_nd_warn_log=/tmp/hydra-gate-notification-dialect-warn.log
+_nd_warn_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect-warn.log
 : > "${_nd_warn_log}"
 if [ "${_nd_is_engine}" = "0" ] && [ -d lib ]; then
     # NotificationService-named classes.
@@ -1591,12 +1714,12 @@ fi
 # See .claude/skills/hydra-gate-e2e-coverage/SKILL.md for the fix action.
 # ---------------------------------------------------------------------------
 if [ -d openspec/specs ] || [ -d tests/e2e ]; then
-    _e2e_log=/tmp/hydra-gate-e2e-coverage.log
+    _e2e_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-coverage.log
     : > "${_e2e_log}"
     _e2e_ran=1
-    _e2e_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _e2e_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_e2e_lib_dir}/check_e2e_coverage.py" ]; then
-        _e2e_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _e2e_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_e2e_lib_dir}/check_e2e_coverage.py" ]; then
         # check_e2e_coverage.py exits with the uncovered-scenario count (0 = PASS).
@@ -1641,7 +1764,7 @@ fi
 # Scoped to PHP files under lib/, diff-aware when --scope-to-diff is on.
 # ---------------------------------------------------------------------------
 if [ -d lib ]; then
-    _or_log=/tmp/hydra-gate-or-objectservice-api.log
+    _or_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-or-objectservice-api.log
     : > "${_or_log}"
     _or_hits=0
     # Method-call style only — `->findObjects(` etc — to avoid matching
@@ -1693,7 +1816,7 @@ fi
 # line + at least 7 chars + space, which is git's canonical conflict
 # marker shape and unlikely to collide with prose / code.
 # ---------------------------------------------------------------------------
-_cm_log=/tmp/hydra-gate-conflict-markers.log
+_cm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-conflict-markers.log
 : > "${_cm_log}"
 _cm_hits=0
 # Match git's exact marker shapes: `<<<<<<< ` / `======= ` (end of line OK) / `>>>>>>> `
@@ -1769,7 +1892,7 @@ fi
 # Spec: openspec/changes/adopt-app-manifest/specs/adopt-app-manifest/spec.md
 # ---------------------------------------------------------------------------
 if [ -f src/manifest.json ]; then
-    _mv_log=/tmp/hydra-gate-manifest-validation.log
+    _mv_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-manifest-validation.log
     : > "${_mv_log}"
     _mv_validator="${SCRIPT_DIR}/lib/check_manifest.js"
     # Diff-scope: when --scope-to-diff is set and src/manifest.json was NOT
@@ -1840,7 +1963,7 @@ fi
 #   - openspec/changes/consume-or-workflow-engine-fleet-wide/tasks.md HYDRA-1.2
 #   - openspec/changes/shared-pdok-via-openconnector/tasks.md
 # ---------------------------------------------------------------------------
-_or_abs_log=/tmp/hydra-gate-or-abstraction-anti-patterns.log
+_or_abs_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-or-abstraction-anti-patterns.log
 : > "${_or_abs_log}"
 # Skip when lib/ is absent (frontend-only repo).
 if [ -d lib ]; then
@@ -1932,7 +2055,7 @@ fi
 # was absent: no scripts/check-integration-parity.sh → no output at all. It was
 # measured absent in MOST fleet repos on 2026-08-03, which is why fleet coverage
 # was never the declared gate count anywhere. It now says so.
-_parity_log=/tmp/hydra-gate-integration-parity.log
+_parity_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-integration-parity.log
 : > "${_parity_log}"
 #
 # COVERAGE CLASSIFICATION (gate-24). "No parity script" was one message for two
@@ -2005,12 +2128,12 @@ fi
 # See .claude/skills/hydra-gate-contract-coverage/SKILL.md for the fix action.
 # ---------------------------------------------------------------------------
 if [ -f appinfo/routes.php ]; then
-    _cc_log=/tmp/hydra-gate-contract-coverage.log
+    _cc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-contract-coverage.log
     : > "${_cc_log}"
     _cc_ran=1
-    _cc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _cc_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_cc_lib_dir}/check_contract_coverage.py" ]; then
-        _cc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _cc_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_cc_lib_dir}/check_contract_coverage.py" ]; then
         # The helper exits with the uncovered-endpoint count (0 = PASS). Capture
@@ -2052,12 +2175,12 @@ fi
 # See .claude/skills/hydra-gate-visual-coverage/SKILL.md for the fix action.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _vc_log=/tmp/hydra-gate-visual-coverage.log
+    _vc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-visual-coverage.log
     : > "${_vc_log}"
     _vc_ran=1
-    _vc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _vc_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_vc_lib_dir}/check_visual_coverage.py" ]; then
-        _vc_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _vc_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_vc_lib_dir}/check_visual_coverage.py" ]; then
         set +e
@@ -2112,7 +2235,7 @@ fi
 # See .claude/skills/hydra-gate-no-phantom-cross-app-rpc/SKILL.md for the
 # detection algorithm and the fix action (the event-contract recipe).
 # ---------------------------------------------------------------------------
-_pcar_log=/tmp/hydra-gate-no-phantom-cross-app-rpc.log
+_pcar_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-no-phantom-cross-app-rpc.log
 : > "${_pcar_log}"
 _pcar_files=()
 # Audit lib/ PHP (the command-dispatch site) and src/ JS/Vue/TS (a phantom
@@ -2126,9 +2249,9 @@ done < <(find lib src \( -name '*.php' -o -name '*.vue' -o -name '*.js' -o -name
     -not -path '*/dist/*' -not -path '*/build/*' 2>/dev/null)
 _pcar_ran=1
 if [ "${#_pcar_files[@]}" -gt 0 ]; then
-    _pcar_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/lib" 2>/dev/null && pwd)"
+    _pcar_lib_dir="$(cd "${SCRIPT_DIR}/lib" 2>/dev/null && pwd)"
     if [ ! -f "${_pcar_lib_dir}/check_phantom_cross_app_rpc.py" ]; then
-        _pcar_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)/lib"
+        _pcar_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_pcar_lib_dir}/check_phantom_cross_app_rpc.py" ]; then
         python3 "${_pcar_lib_dir}/check_phantom_cross_app_rpc.py" "${_pcar_files[@]}" \
@@ -2167,7 +2290,7 @@ fi
 # pre-dates EUPL); per ADR-014 we accept that drift on info.xml ONLY. composer
 # .json and per-file headers must agree.
 # ---------------------------------------------------------------------------
-_lt_log=/tmp/hydra-gate-license-triangle.log
+_lt_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-license-triangle.log
 : > "${_lt_log}"
 _composer_lic=""
 if [ -f composer.json ]; then
@@ -2187,28 +2310,36 @@ except Exception:
     print('')
 " 2>/dev/null)
 fi
-if [ -n "${_composer_lic}" ] && [ -d lib ]; then
-    # Collect every distinct @license value in lib/**/*.php files in scope
+_lt_ran=1
+_lt_helper="${SCRIPT_DIR}/lib/check_license_triangle.py"
+if [ -z "${_composer_lic}" ] || [ ! -d lib ]; then
+    _lt_ran=0
+    _skip 28 "license-triangle" na "no composer.json \`license\` field, or no lib/ — there is no declared package licence to compare against."
+else
+    _lt_files=()
     while IFS= read -r _php; do
         [ -z "${_php}" ] && continue
         _in_scope "${_php}" || continue
-        _file_lic=$(grep -oE '^[[:space:]]*\*[[:space:]]*@license[[:space:]]+[^[:space:]*]+' "${_php}" 2>/dev/null \
-            | head -1 | awk '{print $3}')
-        if [ -z "${_file_lic}" ]; then continue; fi
-        # Member-of check against the pipe-joined composer license set.
-        case "|${_composer_lic}|" in
-            *"|${_file_lic}|"*) ;;   # file license is in the allowed set
-            *)
-                echo "${_php} file_license=${_file_lic} composer_license=${_composer_lic} rule=license-triangle-drift" >> "${_lt_log}"
-                ;;
-        esac
+        _lt_files+=("${_php}")
     done < <(_enum_tracked '\.php$' lib)
+    if [ "${#_lt_files[@]}" -eq 0 ]; then
+        _lt_ran=0
+        _skip 28 "license-triangle" na "scope was empty — 0 lib/**.php file(s) in this diff, so NO licence declaration was compared."
+    elif [ ! -f "${_lt_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _lt_ran=0
+        _skip 28 "license-triangle" wiring "check_license_triangle.py not found at ${_lt_helper} — ${#_lt_files[@]} PHP file(s) were in scope and NONE had their licence declarations read; licence drift is UNVERIFIED by this run."
+    else
+        python3 "${_lt_helper}" "${_composer_lic}" "${_lt_files[@]}" >> "${_lt_log}" 2>/dev/null || true
+    fi
 fi
 _lt_fail=$(wc -l < "${_lt_log}" 2>/dev/null || echo 0)
-if [ "${_lt_fail}" -eq 0 ]; then
-    _pass 28 "license-triangle"
-else
-    _fail 28 "license-triangle" "${_lt_fail} file(s) with @license != composer.json — see ${_lt_log}"
+if [ "${_lt_ran}" -eq 1 ]; then
+    if [ "${_lt_fail}" -eq 0 ]; then
+        _pass 28 "license-triangle"
+    else
+        _fail 28 "license-triangle" "${_lt_fail} licence declaration(s) disagreeing with composer.json or with each other — see ${_lt_log}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -2219,7 +2350,7 @@ fi
 # alongside a new .phpunit.cache/ ignore rule). Only fires under --scope-to-diff
 # because the check is intrinsically diff-relative.
 # ---------------------------------------------------------------------------
-_gi_log=/tmp/hydra-gate-gitignore-then-commit.log
+_gi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-gitignore-then-commit.log
 : > "${_gi_log}"
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -f .gitignore ]; then
     # Lines newly added to .gitignore in this PR (excluding blanks + comments)
@@ -2262,7 +2393,7 @@ fi
 # only verifies SOME annotation is present — this gate verifies the right one
 # is present for monitoring callers.
 # ---------------------------------------------------------------------------
-_pm_log=/tmp/hydra-gate-public-monitoring.log
+_pm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-public-monitoring.log
 : > "${_pm_log}"
 if [ -f appinfo/routes.php ] && [ -d lib/Controller ]; then
     # Find route entries whose `name` looks like `<monitoring-word>#<method>`
@@ -2312,7 +2443,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 1.1.1
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _ia_log=/tmp/hydra-gate-img-alt.log
+    _ia_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt.log
     : > "${_ia_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2360,7 +2491,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 2.1.1, 4.1.2
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _sc_log=/tmp/hydra-gate-semantic-controls.log
+    _sc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-semantic-controls.log
     : > "${_sc_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2499,7 +2630,7 @@ if [ ! -f "${_axe_report}" ]; then
     fi
 fi
 if [ -f "${_axe_report}" ]; then
-    _axe_log=/tmp/hydra-gate-axe.log
+    _axe_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-axe.log
     : > "${_axe_log}"
     # Parse with python so we don't add a jq dependency. Counts violations
     # by impact and emits one line per serious/critical violation for the
@@ -2545,7 +2676,7 @@ fi
 # role to assistive tech that matches the surrounding NC shell.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _wc_log=/tmp/hydra-gate-window-confirm.log
+    _wc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-window-confirm.log
     : > "${_wc_log}"
     grep -rnE '\bwindow\.(confirm|alert|prompt)\s*\(' src/ \
         --include='*.vue' --include='*.js' --include='*.ts' 2>/dev/null \
@@ -2575,7 +2706,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 1.1.1 (Non-text Content)
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _iae_log=/tmp/hydra-gate-img-alt-empty-only.log
+    _iae_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt-empty-only.log
     : > "${_iae_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2620,7 +2751,7 @@ fi
 #     `tabindex='-1'`. Positive integer values are very rarely useful."
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _tp_log=/tmp/hydra-gate-tabindex-positive.log
+    _tp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-tabindex-positive.log
     : > "${_tp_log}"
     # Match tabindex with quoted positive integer. Allow whitespace
     # inside the quotes. Excludes tabindex="0", tabindex="-1", and any
@@ -2653,7 +2784,7 @@ fi
 #   - axe-core rule `aria-hidden-focus` (impact: serious)
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _ahf_log=/tmp/hydra-gate-aria-hidden-focusable.log
+    _ahf_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-aria-hidden-focusable.log
     : > "${_ahf_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2726,7 +2857,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 2.4.1
 # ---------------------------------------------------------------------------
 if [ -d src ] || [ -d templates ]; then
-    _sl_log=/tmp/hydra-gate-skip-link.log
+    _sl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-skip-link.log
     : > "${_sl_log}"
     _sl_check() {
         local _f="$1"
@@ -2779,7 +2910,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 4.1.2
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _bn_log=/tmp/hydra-gate-button-name.log
+    _bn_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-button-name.log
     : > "${_bn_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2825,66 +2956,61 @@ fi
 # Pass conditions for an input element:
 #   (a) has aria-label / :aria-label / aria-labelledby, OR
 #   (b) has an `id=` attribute paired with some `<label for=>` in the file
-#       referencing the same id (heuristic), OR
-#   (c) for the NC* components: has a `label` / `:label` / `inputLabel`
+#       referencing the same id — literal OR bound expression, so
+#       `:for="`f-${id}`"` + `:id="`f-${id}`"` associates, OR
+#   (c) it is a DESCENDANT of a `<label>` element (implicit association —
+#       `<label><input><span>Safe mode</span></label>` needs no id at all), OR
+#   (d) for the NC* components: has a `label` / `:label` / `inputLabel`
 #       prop (their published API), OR
-#   (d) input `type` is `hidden` / `submit` / `button` / `reset` / `image`.
+#   (e) for NcCheckboxRadioSwitch: has non-empty DEFAULT SLOT content, which
+#       nc-vue renders into its own <label>. This one is load-bearing: the
+#       only way to satisfy the previous implementation was to add
+#       `aria-label`, and `aria-label` OVERRIDES the visible text — an
+#       accessibility REGRESSION demanded by an accessibility gate. 463 of
+#       the fleet's 1,211 findings were this shape, and two burn-down PRs
+#       (opencatalogi#808, docudesk#385) were stuck un-mergeable on it, OR
+#   (f) input `type` is `hidden` / `submit` / `button` / `reset` / `image`.
+#
+# Comments and <script>/<style> blocks are excluded: markup that does not
+# ship is not a control.
+#
+# Implementation: scripts/lib/check_form_labels.py, with both-ways tests in
+# scripts/lib/test_check_form_labels.py — every relaxation above ships with
+# the true-positive case it must not swallow.
 #
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 1.3.1, 3.3.2
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _fl_log=/tmp/hydra-gate-form-label-association.log
+    _fl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-form-label-association.log
     : > "${_fl_log}"
+    _fl_ran=1
+    _fl_helper="${SCRIPT_DIR}/lib/check_form_labels.py"
+    _fl_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYFL' >> "${_fl_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    src = open(fname).read()
-except Exception:
-    sys.exit(0)
-txt = src.replace('\n', ' ')
-labelled_for = set(m.group(1) for m in re.finditer(r'<label\b[^>]*\bfor\s*=\s*"([^"]+)"', txt, re.IGNORECASE))
-
-def has_aria(attrs):
-    return bool(re.search(r'(^|\s)(:?aria-label|aria-labelledby|v-bind:aria-label)\s*=', attrs))
-
-def has_for_match(attrs):
-    m = re.search(r'(^|\s)id\s*=\s*"([^"]+)"', attrs)
-    return m and m.group(2) in labelled_for
-
-def has_nc_label_prop(attrs):
-    return bool(re.search(r'(^|\s)(:?label|input-label|:input-label|inputLabel)\s*=', attrs))
-
-for m in re.finditer(r'<input\b([^>]*)>', txt, re.IGNORECASE):
-    attrs = m.group(1) or ''
-    type_m = re.search(r'(^|\s)type\s*=\s*"(hidden|submit|button|reset|image)"', attrs, re.IGNORECASE)
-    if type_m: continue
-    if has_aria(attrs): continue
-    if has_for_match(attrs): continue
-    print(f'{fname}: {m.group(0)} rule=input-without-label')
-
-for m in re.finditer(r'<(NcTextField|NcCheckboxRadioSwitch|NcRichContenteditable|NcInputField)\b([^>]*)/?>', txt, re.IGNORECASE):
-    tag = m.group(1)
-    attrs = m.group(2) or ''
-    if has_aria(attrs): continue
-    if has_nc_label_prop(attrs): continue
-    print(f'{fname}: <{tag} ...> rule={tag.lower()}-without-label-prop')
-
-for m in re.finditer(r'<textarea\b([^>]*)>', txt, re.IGNORECASE):
-    attrs = m.group(1) or ''
-    if has_aria(attrs): continue
-    if has_for_match(attrs): continue
-    print(f'{fname}: <textarea ...> rule=textarea-without-label')
-PYFL
+        _fl_files+=("${vue}")
     done < <(find src -name '*.vue' 2>/dev/null)
-    _fl_fail=$(wc -l < "${_fl_log}" 2>/dev/null || echo 0)
-    if [ "${_fl_fail}" -eq 0 ]; then
-        _pass 40 "form-label-association"
+    if [ "${#_fl_files[@]}" -eq 0 ]; then
+        _fl_ran=0
+        _skip 40 "form-label-association" na "scope was empty — 0 .vue file(s) in this diff, so NO form control was inspected."
+    elif [ ! -f "${_fl_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _fl_ran=0
+        _skip 40 "form-label-association" wiring "check_form_labels.py not found at ${_fl_helper} — ${#_fl_files[@]} .vue file(s) were in scope and NONE were inspected; unlabelled form controls (WCAG 1.3.1 / 3.3.2) are UNVERIFIED by this run."
     else
-        _fail 40 "form-label-association" "${_fl_fail} form input(s) without an associated label — see ${_fl_log}"
+        # ONE python process for the whole file set, not one per file. The
+        # per-file heredoc this replaced took over two minutes on a 21-repo
+        # sweep, almost all of it interpreter startup.
+        python3 "${_fl_helper}" "${_fl_files[@]}" >> "${_fl_log}" 2>/dev/null || true
+    fi
+    _fl_fail=$(wc -l < "${_fl_log}" 2>/dev/null || echo 0)
+    if [ "${_fl_ran}" -eq 1 ]; then
+        if [ "${_fl_fail}" -eq 0 ]; then
+            _pass 40 "form-label-association"
+        else
+            _fail 40 "form-label-association" "${_fl_fail} form input(s) without an associated label — see ${_fl_log}"
+        fi
     fi
 fi
 
@@ -2903,7 +3029,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 3.1.1
 # ---------------------------------------------------------------------------
 if [ -d templates ] || [ -d appinfo/templates ]; then
-    _hl_log=/tmp/hydra-gate-html-lang.log
+    _hl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-html-lang.log
     : > "${_hl_log}"
     while IFS= read -r _f; do
         [ -z "$_f" ] && continue
@@ -2943,7 +3069,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 2.4.4
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _lq_log=/tmp/hydra-gate-link-text-quality.log
+    _lq_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-link-text-quality.log
     : > "${_lq_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -2997,7 +3123,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 1.3.1
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _th_log=/tmp/hydra-gate-table-headers.log
+    _th_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-table-headers.log
     : > "${_th_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -3037,7 +3163,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 1.3.5
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _ac_log=/tmp/hydra-gate-autocomplete-attr.log
+    _ac_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-autocomplete-attr.log
     : > "${_ac_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -3081,7 +3207,7 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 2.3.3 (AAA, audit-common)
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
-    _rm_log=/tmp/hydra-gate-prefers-reduced-motion.log
+    _rm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-prefers-reduced-motion.log
     : > "${_rm_log}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
@@ -3121,7 +3247,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-spec-anchor-existence/SKILL.md
 # ---------------------------------------------------------------------------
-_sae_log=/tmp/hydra-gate-spec-anchor-existence.log
+_sae_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-anchor-existence.log
 : > "${_sae_log}"
 _sae_files=()
 while IFS= read -r f; do
@@ -3131,158 +3257,31 @@ while IFS= read -r f; do
 done < <(find lib src \( -name '*.php' -o -name '*.vue' -o -name '*.js' -o -name '*.ts' -o -name '*.md' \) \
     -not -path '*/vendor/*' -not -path '*/node_modules/*' \
     -not -path '*/dist/*' -not -path '*/build/*' 2>/dev/null)
-if [ "${#_sae_files[@]}" -gt 0 ]; then
-    python3 - "${_sae_log}" "${_sae_files[@]}" << 'PY'
-import glob, os, re, sys
-log_path = sys.argv[1]
-files = sys.argv[2:]
-# Match `@spec openspec/...` but NOT `@spec exclude ...`
-TAG = re.compile(r'@spec\s+(openspec/[^\s`\'"]+)')
-DATE = re.compile(r'\b\d{4}-\d{2}-\d{2}\b')
-def slugify(text):
-    # kebab-case the visible-heading text so #requirement-foo-bar matches "## Requirement: Foo Bar"
-    t = text.strip().lower()
-    t = re.sub(r'[^a-z0-9]+', '-', t).strip('-')
-    return t
-def gh_slugify(text):
-    # GitHub's own heading-anchor rule: drop every character that is not
-    # alphanumeric, dash, underscore or space, then collapse spaces to dashes.
-    #
-    # It parts company with slugify() on punctuation *inside* a word. GitHub
-    # publishes "A subscription's retry/backoff policy" as
-    # #a-subscriptions-retrybackoff-policy; slugify() produces
-    # #a-subscription-s-retry-backoff-policy. Tags are written against the
-    # anchor GitHub actually serves — that is the link a reader clicks — so
-    # without this the gate reports a correct, working anchor as unresolved.
-    # Observed 2026-08-05 on openconnector: 137 findings, none of them real.
-    #
-    # Both shapes are accepted rather than one replacing the other: a tag
-    # written to satisfy the old kebab rule still resolves, and either way
-    # the heading has to exist, which is what this gate is for.
-    t = text.strip().lower()
-    t = re.sub(r'[^a-z0-9\-_ ]+', '', t)
-    return re.sub(r'\s+', '-', t).strip('-')
-def dedate(name):
-    # `retrofit-2026-04-28-b2b-crossrefs` and `retrofit-b2b-crossrefs-2026-04-28`
-    # both normalise to `retrofit-b2b-crossrefs`: archiving moves the date token.
-    return re.sub(r'-+', '-', DATE.sub('', name)).strip('-')
-def has_anchor(md_path, fragment):
-    # A fragment resolves when it matches (kebab-cased) a heading, a heading's
-    # leading token (`#### 5.2 Foo` ← `#5.2`), a task-list item id
-    # (`- [x] task-18: ...` ← `#task-18`, `- [x] 5.2 Add ...` ← `#5.2`,
-    # optionally with a `task-` prefix in the tag), or — for `#task-N` /
-    # `#N` on files whose checkbox items carry no ids — the Nth top-level
-    # checkbox item (positional convention used by reverse-spec retrofits).
-    frag_slug = slugify(fragment)
-    frag_alt = slugify(re.sub(r'^task-', '', fragment))
-    pos_m = re.fullmatch(r'(?:task-)?(\d+)', fragment)
-    positional = int(pos_m.group(1)) if pos_m else None
-    item_count = 0
-    try:
-        with open(md_path, encoding='utf-8', errors='replace') as f:
-            for line in f:
-                m = re.match(r'^\s*#{1,6}\s+(.+?)\s*$', line)
-                if m:
-                    head = m.group(1)
-                    hslugs = (slugify(head), gh_slugify(head))
-                    frags = (frag_slug, frag_alt)
-                    if any(h in frags for h in hslugs):
-                        return True
-                    # `### Task 8 — long title` resolves `#task-8`; the `-`
-                    # boundary keeps `#task-8` from matching `Task 89`.
-                    if any(h.startswith(f + '-') for h in hslugs for f in frags if f):
-                        return True
-                    # `### Requirement: Foo bar` resolves `#foo-bar` (tags
-                    # often omit the `requirement-`/`scenario-` prefix).
-                    if ':' in head:
-                        tail = head.split(':', 1)[1]
-                        if slugify(tail) in frags or gh_slugify(tail) in frags:
-                            return True
-                    lead = head.split()[0].rstrip('.:') if head.split() else ''
-                    if lead and slugify(lead) in frags:
-                        return True
-                    continue
-                if re.match(r'^-\s*\[[ xX]\]', line):
-                    item_count += 1
-                    if positional is not None and item_count == positional:
-                        return True
-                t = re.match(r'^\s*-\s*\[[ xX]\]\s*(?:\*\*)?([A-Za-z0-9][A-Za-z0-9.\-]*)', line)
-                if t and slugify(t.group(1).rstrip('.:')) in (frag_slug, frag_alt):
-                    return True
-        return False
-    except OSError:
-        return False
-def find_repo_root():
-    p = os.getcwd()
-    while p and p != '/':
-        if os.path.isdir(os.path.join(p, 'openspec')):
-            return p
-        p = os.path.dirname(p)
-    return None
-root = find_repo_root() or os.getcwd()
-# Archived-change index: archiving moves `openspec/changes/<name>/` to
-# `openspec/changes/archive/<date>-<name>/` (or legacy `openspec/archive/<name>`,
-# sometimes with the date token reshuffled). Tags keep pointing at the original
-# path; resolve them through this index instead of forcing a repo-wide retag.
-archive_index = {}
-for pattern in ('openspec/changes/archive/*', 'openspec/archive/*'):
-    for d in glob.glob(os.path.join(root, pattern)):
-        if os.path.isdir(d):
-            archive_index.setdefault(dedate(os.path.basename(d)), []).append(d)
-def resolve(path):
-    # Returns the list of existing candidate files for the tag path: the
-    # literal path plus archived counterparts. Several archived dirs can
-    # share a de-dated key (e.g. two annotate-openregister retrofits from
-    # different dates), so candidates carrying the tag's own date token are
-    # tried first and ALL existing candidates are returned — the anchor
-    # check accepts a fragment found in any of them.
-    cands = []
-    abs_path = os.path.join(root, path)
-    if os.path.exists(abs_path):
-        cands.append(abs_path)
-    m = re.match(r'openspec/(?:changes|archive)/([^/]+)/(.*)$', path)
-    if m and m.group(1) != 'archive':
-        name = m.group(1)
-        dates = DATE.findall(name)
-        dirs = archive_index.get(dedate(name), [])
-        dirs = sorted(dirs, key=lambda d: 0 if any(t in os.path.basename(d) for t in dates) else 1)
-        for d in dirs:
-            cand = os.path.join(d, m.group(2))
-            if os.path.exists(cand) and cand not in cands:
-                cands.append(cand)
-    return cands
-for fp in files:
-    try:
-        with open(fp, encoding='utf-8', errors='replace') as f:
-            src = f.read()
-    except OSError:
-        continue
-    for m in TAG.finditer(src):
-        target = m.group(1)
-        # Split path#fragment
-        if '#' in target:
-            path, frag = target.split('#', 1)
-        else:
-            path, frag = target, None
-        candidates = resolve(path)
-        if not candidates:
-            with open(log_path, 'a', encoding='utf-8') as g:
-                g.write(f"{fp}: @spec target file not found → {target}\n")
-            continue
-        if frag and path.endswith('.md'):
-            if not any(has_anchor(c, frag) for c in candidates):
-                with open(log_path, 'a', encoding='utf-8') as g:
-                    g.write(f"{fp}: @spec anchor not found in {path} → #{frag}\n")
-PY
+_sae_ran=1
+_sae_helper="${SCRIPT_DIR}/lib/check_spec_anchors.py"
+if [ "${#_sae_files[@]}" -eq 0 ]; then
+    _sae_ran=0
+    _skip 46 "spec-anchor-existence" na "scope was empty — 0 annotated source file(s) in this diff, so NO @spec target was resolved."
+elif [ ! -f "${_sae_helper}" ]; then
+    # A MISSING HELPER MUST NOT REPORT PASS (#147). The gate previously
+    # carried its resolver inline, so "the helper is absent" was not a
+    # reachable state; now that it lives in scripts/lib it is, and an absent
+    # resolver looks exactly like a repository with no dangling anchors.
+    _sae_ran=0
+    _skip 46 "spec-anchor-existence" wiring "check_spec_anchors.py not found at ${_sae_helper} — ${#_sae_files[@]} file(s) were in scope and NONE had their @spec targets resolved; dangling spec references are UNVERIFIED by this run."
+else
+    python3 "${_sae_helper}" "${_sae_log}" "${_sae_files[@]}" || true
 fi
 set +e
 _sae_fail=$(wc -l < "${_sae_log}" 2>/dev/null | tr -d ' ')
 set -e
 [ -z "${_sae_fail}" ] && _sae_fail=0
-if [ "${_sae_fail}" -eq 0 ]; then
-    _pass 46 "spec-anchor-existence"
-else
-    _fail 46 "spec-anchor-existence" "${_sae_fail} unresolved @spec target(s) — see ${_sae_log}"
+if [ "${_sae_ran}" -eq 1 ]; then
+    if [ "${_sae_fail}" -eq 0 ]; then
+        _pass 46 "spec-anchor-existence"
+    else
+        _fail 46 "spec-anchor-existence" "${_sae_fail} unresolved @spec target(s) — see ${_sae_log}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -3298,7 +3297,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-security-change-has-tests/SKILL.md
 # ---------------------------------------------------------------------------
-_scht_log=/tmp/hydra-gate-security-change-has-tests.log
+_scht_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-security-change-has-tests.log
 : > "${_scht_log}"
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
     _scht_changed=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)
@@ -3351,7 +3350,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-csrf-cochange/SKILL.md
 # ---------------------------------------------------------------------------
-_csrf_log=/tmp/hydra-gate-csrf-cochange.log
+_csrf_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-cochange.log
 : > "${_csrf_log}"
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
     # Find removed @NoCSRFRequired lines in changed PHP files
@@ -3406,7 +3405,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-controller-exception-translation/SKILL.md
 # ---------------------------------------------------------------------------
-_cxt_log=/tmp/hydra-gate-controller-exception-translation.log
+_cxt_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-controller-exception-translation.log
 : > "${_cxt_log}"
 _cxt_files=()
 while IFS= read -r f; do
@@ -3517,7 +3516,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-security-config-fail-mode/SKILL.md
 # ---------------------------------------------------------------------------
-_scfm_log=/tmp/hydra-gate-security-config-fail-mode.log
+_scfm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-security-config-fail-mode.log
 : > "${_scfm_log}"
 _scfm_files=()
 while IFS= read -r f; do
@@ -3602,7 +3601,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-schema-property-titles/SKILL.md
 # ---------------------------------------------------------------------------
-_spt_log=/tmp/hydra-gate-schema-property-titles.log
+_spt_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-schema-property-titles.log
 : > "${_spt_log}"
 _spt_files=()
 while IFS= read -r f; do
@@ -3672,7 +3671,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-custom-widget-ratchet/SKILL.md
 # ---------------------------------------------------------------------------
-_cwr_log=/tmp/hydra-gate-custom-widget-ratchet.log
+_cwr_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-custom-widget-ratchet.log
 : > "${_cwr_log}"
 _cwr_files=()
 while IFS= read -r f; do
@@ -3757,7 +3756,7 @@ fi
 # Spec:  openspec/changes/gate-53-effective-manifest-crossref/specs/gate-effective-manifest-crossref/spec.md
 # ---------------------------------------------------------------------------
 if [ -f src/manifest.json ]; then
-    _em_log=/tmp/hydra-gate-effective-manifest-crossref.log
+    _em_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-effective-manifest-crossref.log
     : > "${_em_log}"
     _em_builder="${SCRIPT_DIR}/lib/build_effective_manifest.js"
     _em_crossref="${SCRIPT_DIR}/lib/check_manifest_crossref.js"
@@ -3811,7 +3810,7 @@ if [ -f src/manifest.json ]; then
         _em_scope_file=""
         _em_scoper="${SCRIPT_DIR}/lib/manifest_diff_scope.py"
         if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -f "${_em_scoper}" ]; then
-            _em_scope_file=$(mktemp /tmp/hydra-gate53-scope.XXXXXX 2>/dev/null || true)
+            _em_scope_file=$(mktemp ${HYDRA_GATE_LOG_DIR}/hydra-gate53-scope.XXXXXX 2>/dev/null || true)
             if [ -n "${_em_scope_file}" ]; then
                 _em_inputs=()
                 while IFS= read -r _em_f; do
@@ -3853,7 +3852,7 @@ if [ -f src/manifest.json ]; then
             _em_scope_val="${_em_scope_file}"
         fi
 
-        _em_tmp=$(mktemp /tmp/hydra-gate53-effective.XXXXXX.json 2>/dev/null || true)
+        _em_tmp=$(mktemp ${HYDRA_GATE_LOG_DIR}/hydra-gate53-effective.XXXXXX.json 2>/dev/null || true)
         _em_reason=""
         if [ -z "${_em_tmp}" ]; then
             # Temp-file handoff failed — fail-closed, never skipped.
@@ -3929,7 +3928,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-relation-dialect/SKILL.md
 # ---------------------------------------------------------------------------
-_rd_log=/tmp/hydra-gate-relation-dialect.log
+_rd_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-relation-dialect.log
 : > "${_rd_log}"
 _rd_files=()
 while IFS= read -r f; do
@@ -3988,7 +3987,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-detail-page-discipline/SKILL.md
 # ---------------------------------------------------------------------------
-_dpd_log=/tmp/hydra-gate-detail-page-discipline.log
+_dpd_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-detail-page-discipline.log
 : > "${_dpd_log}"
 _dpd_files=()
 while IFS= read -r f; do
@@ -4050,7 +4049,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-register-handler-resolution/SKILL.md
 # ---------------------------------------------------------------------------
-_rhr_log=/tmp/hydra-gate-register-handler-resolution.log
+_rhr_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-register-handler-resolution.log
 : > "${_rhr_log}"
 _rhr_files=()
 while IFS= read -r f; do
@@ -4106,7 +4105,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-orphaned-write-capability/SKILL.md
 # ---------------------------------------------------------------------------
-_owc_log=/tmp/hydra-gate-orphaned-write-capability.log
+_owc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-orphaned-write-capability.log
 : > "${_owc_log}"
 _owc_files=()
 while IFS= read -r f; do
@@ -4164,7 +4163,7 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-e2e-networkidle/SKILL.md
 # ---------------------------------------------------------------------------
-_nwi_log=/tmp/hydra-gate-e2e-networkidle.log
+_nwi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-networkidle.log
 : > "${_nwi_log}"
 while IFS= read -r f; do
     [ -f "$f" ] || continue
@@ -4203,7 +4202,7 @@ fi
 # Suppress with a comment containing `unclosable-gate exclude <reason>`.
 # Skill: .claude/skills/hydra-gate-unclosable-gate/SKILL.md
 # ---------------------------------------------------------------------------
-_ucg_log=/tmp/hydra-gate-unclosable-gate.log
+_ucg_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-unclosable-gate.log
 : > "${_ucg_log}"
 if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; then
     set +e
@@ -4243,7 +4242,7 @@ fi
 #
 # Spec: openspec/architecture/adr-077-semantic-icon-vocabulary.md
 # ---------------------------------------------------------------------------
-_iv_log=/tmp/hydra-gate-icon-vocabulary.log
+_iv_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-icon-vocabulary.log
 : > "${_iv_log}"
 if [ -f src/manifest.json ]; then
     _iv_args=""
@@ -4316,7 +4315,7 @@ fi
 # Spec: openspec/architecture/adr-078-object-event-work-placement.md
 # Skill: .claude/skills/hydra-gate-listener-work-placement/SKILL.md
 # ---------------------------------------------------------------------------
-_lwp_log=/tmp/hydra-gate-listener-work-placement.log
+_lwp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-listener-work-placement.log
 : > "${_lwp_log}"
 if [ -d lib/AppInfo ]; then
     set +e
@@ -4337,7 +4336,7 @@ fi
 # ---------------------------------------------------------------------------
 # Gate 62 — store-plane (ADR-080)
 # ---------------------------------------------------------------------------
-_sp_log=/tmp/hydra-gate-store-plane.log
+_sp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-store-plane.log
 : > "${_sp_log}"
 set +e
 python3 "${SCRIPT_DIR}/lib/check_store_and_settings_surface.py" . --gate store --base "${BASE_REF}" > "${_sp_log}" 2>&1
@@ -4354,7 +4353,7 @@ fi
 # ---------------------------------------------------------------------------
 # Gate 63 — settings-surface (ADR-079)
 # ---------------------------------------------------------------------------
-_ss_log=/tmp/hydra-gate-settings-surface.log
+_ss_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-settings-surface.log
 : > "${_ss_log}"
 set +e
 python3 "${SCRIPT_DIR}/lib/check_store_and_settings_surface.py" . --gate settings --base "${BASE_REF}" > "${_ss_log}" 2>&1

--- a/hydra-gates/tests/run-helper-suites.sh
+++ b/hydra-gates/tests/run-helper-suites.sh
@@ -72,6 +72,15 @@ runner_for() { # <basename> -> interpreter
 	esac
 }
 
+# Per-invocation log directory, for the same reason the gate runner has one:
+# two CI jobs running this harness on one host used to write
+# /tmp/_helper_<name>.log over each other, so the failure output printed for a
+# red suite could belong to a different run entirely.
+LOGDIR="$(mktemp -d "${TMPDIR:-/tmp}/hydra-helper-suites.XXXXXXXX")" || {
+	echo "FAIL — could not create a private log directory; refusing to run."
+	exit 1
+}
+
 if [ ! -d "${LIB}" ]; then
 	echo "FAIL — ${LIB} does not exist; this runner cannot discover anything"
 	exit 1
@@ -107,12 +116,12 @@ for name in "${SUITES[@]}"; do
 		_failed+=("${name}")
 		continue
 	fi
-	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "/tmp/_helper_${name}.log" 2>&1; then
+	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "${LOGDIR}/helper_${name}.log" 2>&1; then
 		echo "PASS — ${name}"
 		_passed=$((_passed + 1))
 	else
 		echo "FAIL — ${name} (exit $?)"
-		sed 's/^/      /' "/tmp/_helper_${name}.log" | tail -40
+		sed 's/^/      /' "${LOGDIR}/helper_${name}.log" | tail -40
 		_failed+=("${name}")
 	fi
 done
@@ -129,7 +138,7 @@ for entry in "${QUARANTINE[@]}"; do
 		continue
 	fi
 	cmd="$(runner_for "${name}")"
-	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "/tmp/_quar_${name}.log" 2>&1; then
+	if ( cd "${PKG_ROOT}" && "${cmd}" "scripts/lib/${name}" ) > "${LOGDIR}/quar_${name}.log" 2>&1; then
 		echo "FAIL — quarantined suite '${name}' now PASSES. Un-quarantine it: delete its"
 		echo "       QUARANTINE entry so CI enforces it from here on."
 		_rot=$((_rot + 1))


### PR DESCRIPTION
## Why

**1,726 real findings across the fleet cannot be burned down until these gates are honest.** The gates are diff- AND file-scoped, so touching a file drags in all of its pre-existing findings — and when the residue is entirely false positives there is no honest way to green the PR. Two burn-down PRs (opencatalogi#808, docudesk#385) are open and stuck in exactly that state.

The sharpest example: clearing gate-40's residue would mean adding `aria-label` to `NcCheckboxRadioSwitch` elements that **already name themselves from their default slot**. `aria-label` overrides the visible label. The only way to close an accessibility gate was to ship an accessibility regression.

## Measured, 21 fleet repos at `origin/development`, baseline = v1.4.0 (`46cc1c8`)

| gate | before | after | Δ |
|---|---:|---:|---:|
| 46 spec-anchor-existence | 1,995 | **918** | −54% |
| 40 form-label-association | 1,211 | **517** | −57% |
| 9 semantic-auth | 45 | **11** | −76% |
| 7 no-admin-idor | 32 | **26** | −19% (partial) |
| 28 license-triangle | 0 | 0 | preventive — see below |

Note these are **not** the 2,630 / 1,365 in #158: those predate `gh_slugify` (#165), which is in v1.4.0 and in no earlier tag. Measured honestly against what `main` actually does today.

## Never make a gate pass by making it blind

Every relaxation ships **paired** with the true-positive case it must not swallow. Four new suites (46, 40, 28, 9) plus 8 new gate-7 cases, all auto-discovered by `tests/run-helper-suites.sh`.

Each relaxed predicate was **mutation-checked in both directions**:

| mutation | result |
|---|---|
| gate-46 `has_anchor` → always True | 18 failures |
| gate-46 digit guard removed | 2 failures |
| gate-40 label check → always True | 10 failures |
| gate-40 slot check → always True | 1 failure |
| gate-40 `:id`/`:for` → "is bound at all" | 2 failures |
| gate-7 tenancy guard → always True | **8** failures |
| gate-7 tenancy guard → always False | **4** failures |

The last pair is the one that matters: the gate-7 suite pins both edges, so neither a mute nor a revert can pass it.

## The runner corrupted its own measurements

61 gates wrote to hardcoded `/tmp/hydra-gate-<name>.log` and derived their verdicts by `wc -l` on them. Exactly one used `mktemp`, and its comment said why.

Two concurrent runs on **different repos**, v1.4.0:

```
petstore:     [gate-46] FAIL — 26 unresolved @spec target(s)
              — see /tmp/hydra-gate-spec-anchor-existence.log   ← 0 lines
app-versions: [gate-46] PASS
petstore:     [gate-40] FAIL — 1     ┐ one file,
app-versions: [gate-40] FAIL — 7     ┘ 7 lines
```

petstore's 26 findings were truncated away by app-versions. **Had the truncation landed before the `wc -l` instead of after, petstore would have reported PASS over 26 real findings.** Same test on this branch: two private directories, each containing exactly what its own run reported (26/0 and 0/1).

The package's own test suite had it too — `test_gate_route_auth.sh` reported **7 failures under the harness and 0 standalone**. Fixed there as well.

## A resolving diff base is not a usable one

shillinq's `development` run finished in **22 seconds, all green**. Not a shallow checkout: on a push to a mainline branch `origin/development` **IS** `HEAD`, so the diff is empty by construction and every gate passes over nothing. Verified at `c64e9fe` — **52 gates PASS scoped, 18 FAIL unscoped**.

Now refused (exit 99), with a merge-base check for genuine shallow checkouts, and the diff's exit code read **directly** rather than through a `||` chain that cannot tell "no changes" from "could not run".

⚠️ **This will turn currently-green fleet runs red.** They are falsely green. Worth knowing before the roll.

## gate-28: the NUL byte is worse than #171 filed

Depending on the grep implementation a raw `0x00` produces **either** outcome:

- GNU grep ≤3.4 prints `Binary file X matches` on **stdout** → `awk '{print $3}'` reads the **file path** as the licence → false RED
- ugrep / GNU grep ≥3.5 print nothing to stdout → the gate `continue`s and **never checks the file** → false GREEN

Verified: an `@license AGPL-3.0-or-later` hidden behind a NUL **passed silently**. Live NULs remain in `doriath/src/import/model.js` and `openbuild/src/services/manifestValidation/documentAttachments.js` (`file` reports both as `data`).

The gate also read only the first `@license` and ignored `SPDX-License-Identifier:` entirely — how 174 files carried an AGPL claim behind a green gate. Now every declaration is collected; identifiers inside string literals stay test data (nldesign's `MarianneFontTest.php`).

## gate-9: the advice would have introduced the vulnerability

> *"remove `#[PublicPage]` or remove body auth check"*

The first breaks the endpoint — NC middleware rejects the remote caller before the controller runs. The second deletes its only authentication. **There was no correct action a developer could take on 34 of 45 findings.** Returning 401/403 is not, on its own, evidence of a session dependency; it is what a self-authenticating public endpoint does.

A `#[PublicPage]` method that tests the **session** still fires, under a rule name that says so, with advice that never tells anyone to open an endpoint. Asserted on the string itself, in `RemediationTextIsSafe`.

## gate-7: anti-correlated with the property it checks

On a multi-tenant codebase the tenancy guard refuses with **404 on purpose**, because a 403 leaks another tenant's object ids. gate-7 excluded bare throws, so it flagged exactly the code that got tenancy right — and `FlowController::state()` reported **identically before and after its real IDOR was fixed**.

Adds a signal requiring **both** a comparison against a session-derived scope **and** a refusal. **Partial**: 6 of ~17 openregister false positives clear. The rest need collaborator-hop work — left for a follow-up rather than guessed at, because this is a security gate.

## Also

- **19 helper lookups** re-resolved `dirname "${BASH_SOURCE[0]}"` *after* the `cd "${APP_DIR}"`, against the warning at the top of the file. One (gate-17) **aborted the whole suite** when the runner was invoked by a relative path — 46 gates never ran.
- Gates 46/40/28 now `_skip(wiring)` when their helper is missing rather than passing over an unread file set (#147).
- gate-40 is ~40× faster: one python process, not one per `.vue`.
- `quality.yml` **floats on `@main` while the package it drives is PINNED**, and executes paths inside it *by name*. That interface broke three times in one day (#168). Pinning both halves from one tag is a **human call** — it changes how 22 repos receive gate fixes. Until then a preflight names the desync instead of letting it surface as an unexplained gate failure. Largest single `run:` step in the file is 8,533 B, well under the ~19 KB limit.

## Verification

```
$ bash hydra-gates/tests/run-helper-suites.sh
   passed: 22   quarantined: 2   failed: 0
```
22 suites green (v1.4.0: 17 passing, 1 failing). 3 concurrent harness runs: 0 failures each — on v1.4.0 one of two overlapping runs failed.

## Release

Ready to tag **v1.5.0**, not v1.4.x. New refusal conditions (exit 97, exit 99 on base==HEAD) turn previously-passing runs into failures, and gates emit new rule names. That must not arrive as a patch. The fleet pins **v1.3.0**, so anyone bumping to a v1.4.x would silently also receive v1.4.0's unrolled `gh_slugify` verdict change — one minor makes the whole delta legible in one release note.

**Not rolled to the fleet.** Reported ready.

Closes #158 (items 2 and 6), closes #171. Partially addresses #160 (items 2 and 3; item 1 partial). Addresses #159's `@main`-vs-pinned split with a named preflight, not a resolution.
