### PR TITLE
fix(gates): four gates that could not be answered truthfully (19, 47, 62, and the vacuous-scope epilogue)

### DIFF
--- a/hydra-gates/bin/hydra-gates
+++ b/hydra-gates/bin/hydra-gates
@@ -339,7 +339,24 @@ fi
 # The single most dangerous shape: a scoped run over an empty diff. Every gate
 # passes having read nothing, and the output is otherwise identical to a real
 # green. The runner states it; we restate it where the verdict is read.
-if [ "${SCOPE_DIFF}" = "1" ] && grep -q "0 changed file(s)" "${_out}"; then
+#
+# READ THE COUNT, DO NOT PATTERN-MATCH THE PROSE.
+#
+# This was `grep -q "0 changed file(s)"`, which is a SUBSTRING match: it is
+# satisfied by `10 changed file(s)`, and by 20, 30, 100. Runs whose header
+# said ten files changed and whose every gate ran still printed the
+# "SCOPE WAS EMPTY" epilogue below — and that epilogue had been adopted
+# fleet-wide as the tell for a vacuous run, so the bug manufactured doubt
+# about runs that were fine while saying nothing new about runs that were
+# not. A report that can contradict its own header is not a report.
+#
+# `SCOPE-FILE-COUNT:` is emitted by the runner exactly once, as a bare
+# integer, for this. Note the epilogue's own prose ("SCOPE WAS EMPTY") also
+# appears in COMMENTS in this file and in run-hydra-gates.sh, so grepping the
+# SOURCE for it finds explanations rather than emissions; grep the OUTPUT, or
+# better, grep `SCOPE-FILE-COUNT: 0`.
+_scope_count="$(sed -n 's/^\[hydra-gates\] SCOPE-FILE-COUNT: //p' "${_out}" 2>/dev/null | head -1)"
+if [ "${SCOPE_DIFF}" = "1" ] && [ "${_scope_count:-}" = "0" ]; then
     echo "[hydra-gates] SCOPE WAS EMPTY: 0 files differ from ${BASE_REF}."
     echo "[hydra-gates] Every gate below passed by inspecting NOTHING. This green describes"
     echo "[hydra-gates] the empty diff, not the repository. If you expected changes here,"

--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -432,12 +432,157 @@ _E2E_SHORT_RE = re.compile(
 )
 
 
+# ---------------------------------------------------------------------------
+# A PERMANENTLY-SKIPPED TEST IS NOT COVERAGE
+#
+# Observed on decidesk: four tests with EMPTY BODIES and a hardcoded
+# `test.skip(true, ...)`. Each carried an `@e2e` tag, each was counted as
+# traceability, and together they asserted NOTHING. That is a dead gate by
+# construction — the tag says a scenario is proven, the test proves nothing,
+# and the gate cannot tell the difference.
+#
+# What is dead:
+#   test.skip('name', ...)      the modifier form — declares a skipped test
+#   it.skip(...) / xit / xtest / test.fixme(...)
+#   describe.skip(...)          takes every test inside it with it
+#   test.skip(true)             an UNCONDITIONAL skip at the top of a body
+#   test.skip()                 argument-less, same thing
+#   an empty body               nothing but whitespace and comments
+#
+# What is NOT dead, and must keep counting:
+#   test.skip(browserName === 'firefox', 'flaky on gecko')
+#   test.skip(!process.env.CI, 'needs a CI fixture')
+#
+# ...because those run somewhere. A RUNTIME CONDITION is a real test with a
+# guard; a literal `true` is a test someone turned off. Conflating them would
+# swap this gate's blindness for a different one — refusing legitimate
+# conditional skips — so the discriminator is the argument, not the call.
+_TEST_DECL_RE = re.compile(
+    r"\b(?P<fn>test|it|describe)"
+    r"(?P<mod>\s*\.\s*(?:skip|fixme|failing))?"
+    r"\s*\(",
+)
+_XTEST_RE = re.compile(r"\b(?:xit|xtest|xdescribe)\s*\(")
+# `test.skip(true)` / `test.skip( 1 )` / `test.skip()` — no runtime condition.
+_UNCONDITIONAL_SKIP_RE = re.compile(
+    r"\b(?:test|it)\s*\.\s*skip\s*\(\s*(?:\)|true\s*[,)]|1\s*[,)])"
+)
+
+
+def _strip_comments(text: str) -> str:
+    """Remove // and /* */ comments so an empty body is not mistaken for a
+    documented one. Crude but sufficient: this only ever decides "is there any
+    executable statement here", never what the statement means."""
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
+    text = re.sub(r"(?m)//.*$", " ", text)
+    return text
+
+
+def _enclosing_block(text: str, pos: int) -> tuple[str, str] | None:
+    """The nearest `test(`/`it(`/`describe(` declaration at or after *pos*, as
+    (declaration_text, body_text).
+
+    An `@e2e` tag conventionally sits in a comment immediately ABOVE the test
+    it annotates, so the search runs forward from the tag.
+    """
+    m = _TEST_DECL_RE.search(text, pos)
+    xm = _XTEST_RE.search(text, pos)
+    if xm and (not m or xm.start() < m.start()):
+        decl_start, open_paren = xm.start(), xm.end() - 1
+    elif m:
+        decl_start, open_paren = m.start(), m.end() - 1
+    else:
+        return None
+    # Walk to the matching close paren of the declaration.
+    depth = 0
+    i = open_paren
+    while i < len(text):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    if i >= len(text):
+        return None
+    whole = text[decl_start:i + 1]
+    # THE BODY IS THE LAST BRACE-BALANCED GROUP, FOUND FROM THE END.
+    #
+    # Not the first `{`: in `test('name', async ({ page }) => { … })` the first
+    # brace opens the fixture DESTRUCTURING, so a forward search returns
+    # `{ page }) => {})` and an empty body then looks non-empty. Scanning back
+    # from the closing paren finds the callback body itself.
+    j = len(whole) - 2                      # skip the final ')'
+    while j >= 0 and whole[j].isspace():
+        j -= 1
+    body = ""
+    if j >= 0 and whole[j] == "}":
+        depth = 0
+        k = j
+        while k >= 0:
+            if whole[k] == "}":
+                depth += 1
+            elif whole[k] == "{":
+                depth -= 1
+                if depth == 0:
+                    break
+            k -= 1
+        if k >= 0:
+            body = whole[k:j + 1]
+    return whole, body
+
+
+def _ref_is_live(text: str, pos: int) -> bool:
+    """Does the test enclosing the `@e2e` tag at *pos* actually assert
+    anything?"""
+    block = _enclosing_block(text, pos)
+    if block is None:
+        # No enclosing test at all — a file-level tag. Treated as live: this
+        # function exists to catch tests that were switched OFF, not to
+        # invent a structural requirement the gate never had.
+        return True
+    decl, body = block
+    head = decl[:decl.find("{") if "{" in decl else len(decl)]
+    if _XTEST_RE.match(decl) or re.match(
+            r"\s*\b(?:test|it|describe)\s*\.\s*(?:skip|fixme|failing)\s*\(", decl):
+        return False
+    stripped = _strip_comments(body)
+    if _UNCONDITIONAL_SKIP_RE.search(stripped):
+        return False
+    inner = stripped.strip()
+    if inner.startswith("{"):
+        inner = inner[1:]
+    if inner.endswith("}"):
+        inner = inner[:-1]
+    if not inner.strip():
+        return False
+    del head
+    return True
+
+
 def collect_covered_refs(app_dir: Path) -> set[str]:
-    """Return the set of ``<spec>::<slug>`` refs found in any e2e test file."""
-    covered: set[str] = set()
+    """Return the set of ``<spec>::<slug>`` refs found in any e2e test file.
+
+    Only refs whose enclosing test actually runs are returned; see
+    ``collect_ref_status`` for the dead ones and why.
+    """
+    live, _dead = collect_ref_status(app_dir)
+    return live
+
+
+def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
+    """(live refs, {dead ref: reason}) across the app's e2e suite.
+
+    A ref is live if ANY test referencing it runs. One skipped copy alongside
+    a real one is not a regression, so the dead map only keeps refs with no
+    live reference at all.
+    """
+    live: set[str] = set()
+    dead: dict[str, str] = {}
     e2e_dir = app_dir / "tests" / "e2e"
     if not e2e_dir.is_dir():
-        return covered
+        return live, dead
     for p in e2e_dir.rglob("*"):
         if not p.is_file():
             continue
@@ -450,11 +595,18 @@ def collect_covered_refs(app_dir: Path) -> set[str]:
             text = p.read_text(encoding="utf-8")
         except OSError:
             continue
-        for m in _E2E_PATH_RE.finditer(text):
-            covered.add(f"{m.group('spec')}::{m.group('slug')}")
-        for m in _E2E_SHORT_RE.finditer(text):
-            covered.add(f"{m.group('spec')}::{m.group('slug')}")
-    return covered
+        for rex in (_E2E_PATH_RE, _E2E_SHORT_RE):
+            for m in rex.finditer(text):
+                ref = f"{m.group('spec')}::{m.group('slug')}"
+                if _ref_is_live(text, m.end()):
+                    live.add(ref)
+                    dead.pop(ref, None)
+                elif ref not in live:
+                    dead[ref] = (
+                        f"referenced only by a test that never runs "
+                        f"({p.relative_to(app_dir)})"
+                    )
+    return live, dead
 
 
 # ---------------------------------------------------------------------------
@@ -562,7 +714,7 @@ def run_gate(app_dir: Path) -> int:
         print(f"[gate-{GATE_NUM}] e2e-coverage: PASS — no spec files in diff")
         return 0
 
-    covered_refs = collect_covered_refs(app_dir)
+    covered_refs, dead_refs = collect_ref_status(app_dir)
 
     findings: list[str] = []
     for rel in sorted(touched):
@@ -579,6 +731,15 @@ def run_gate(app_dir: Path) -> int:
                 findings.append(
                     f"{s['ref']} — @e2e exclude without reason (reason required)"
                 )
+            elif s["ref"] in dead_refs:
+                # Named, but by a test that never runs. Saying "missing @e2e"
+                # here would send someone to add a tag that is already there.
+                findings.append(
+                    f"{s['ref']} — @e2e tag present but the test does not run: "
+                    f"{dead_refs[s['ref']]}. A permanently-skipped or empty test is "
+                    f"not coverage: unskip it, give it a body, or replace the tag "
+                    f"with a reason-bearing `@e2e exclude`."
+                )
             elif s["ref"] not in covered_refs:
                 findings.append(f"{s['ref']} — missing @e2e")
 
@@ -590,7 +751,7 @@ def run_gate(app_dir: Path) -> int:
         print(f"[gate-{GATE_NUM}] e2e-coverage: PASS — {len(covered_refs)} reference(s) in e2e suite")
     else:
         print(
-            f"[gate-{GATE_NUM}] e2e-coverage: FAIL — {count} scenario(s) missing @e2e"
+            f"[gate-{GATE_NUM}] e2e-coverage: FAIL — {count} scenario(s) without a running e2e test"
         )
     return count
 

--- a/hydra-gates/scripts/lib/check_security_cochange.py
+++ b/hydra-gates/scripts/lib/check_security_cochange.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-47 security-change-has-tests — a PR that changes security-sensitive
+code must also touch a test.
+
+WHY THIS WAS REWRITTEN
+----------------------
+The shell implementation this replaces classified a changed file by grepping
+**the whole file**:
+
+    grep -qE "(#\\[NoAdminRequired\\]|…|IUserSession|parse_url|…)" "$f"
+
+So a file was "a security change" if the token appeared ANYWHERE in it — in a
+method the PR never went near, in an import, in a comment. Two agents hit this
+independently on the same day:
+
+  * a PR whose hunks were CSS custom properties and one added chevron column
+    was told to add a CSRF test, because the component file also happens to
+    render something behind `IUserSession`;
+  * a PR that was **provably comment-only** — all 30 changed `lib/` lines
+    inside docblocks — was told to co-change tests.
+
+Neither used the opt-out, which is the tell that matters: developers do not
+reach for an opt-out when they believe the finding is wrong, they argue with
+it or ignore the gate. A gate whose finding cannot be acted on truthfully is
+an unclosable gate, and unclosable gates are how a suite loses its readers.
+
+WHAT CHANGED
+------------
+1. **Classify on the HUNKS, not the file.** Only lines the diff actually adds
+   or removes are examined. `git diff -U0` gives exactly those.
+
+2. **A comment line counts only for an ANNOTATION.** In Nextcloud the docblock
+   forms `@NoAdminRequired` / `@NoCSRFRequired` / `@PublicPage` ARE the auth
+   declaration, so a changed docblock carrying one is a real security change.
+   Prose that merely mentions `IUserSession` is not — it is a sentence. The
+   discriminator is which token, not whether the line is a comment, because
+   collapsing the two is what produced the comment-only false positive.
+
+Path-based classification (`lib/**/Auth/**`, `lib/*Csrf*`, …) is unchanged:
+a file under those paths is security code by location, and any change to it
+qualifies.
+
+WHAT STILL FIRES
+----------------
+A hunk that adds, removes or edits an auth annotation, a CSRF exemption, a
+session lookup, a signature comparison or a URL parse — with no test file in
+the same diff — is still reported, and ``test_check_security_cochange.py``
+proves it for every token in the vocabulary.
+
+Usage:
+    check_security_cochange.py <base-ref> [app-dir]
+    # prints one line per security-touching file with no test co-change
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+# Security code identified by LOCATION. Any change to such a file qualifies —
+# there is no "incidental" edit to lib/Service/Auth/TokenVerifier.php.
+_PATH_PATTERNS = (
+    re.compile(r"^lib/.*Auth[^/]*\.php$"),
+    re.compile(r"^lib/.*Csrf[^/]*\.php$"),
+    re.compile(r"^lib/.*Session[^/]*\.php$"),
+    re.compile(r"^lib/.*/(Auth|Session|Csrf|Rbac|Permission|Authorization)/.*$"),
+)
+
+# Tokens that are a security DECLARATION wherever they appear — including in a
+# docblock, because in Nextcloud the docblock form IS the declaration.
+_ANNOTATION_RE = re.compile(
+    r"#\[NoAdminRequired\]"
+    r"|#\[AuthorizedAdminSetting\("
+    r"|#\[PublicPage\]"
+    r"|#\[NoCSRFRequired\]"
+    r"|@NoAdminRequired\b"
+    r"|@NoCSRFRequired\b"
+    r"|@PublicPage\b"
+)
+
+# Tokens that are security-relevant only as CODE. In prose they are the name
+# of a thing being described, not a change to it.
+_CODE_TOKEN_RE = re.compile(
+    r"\bparse_url\s*\("
+    r"|\bhash_equals\s*\("
+    r"|\bpassword_verify\s*\("
+    r"|\bIUserSession\b"
+    r"|\bgetSecureRandom\s*\("
+    r"|\brequesttoken\b"
+)
+
+_TEST_PATH_RE = re.compile(
+    r"^tests?/|/tests?/|\.spec\.(js|ts|vue|php)$|\.test\.(js|ts|vue)$|Test\.php$"
+)
+
+_CANDIDATE_RE = re.compile(r"^(lib/.*\.php|src/.*\.(vue|js|ts))$")
+
+# Comment shapes, per line, after leading whitespace.
+_COMMENT_LINE_RE = re.compile(r"^\s*(?:\*|//|/\*|\#(?!\[))")
+
+
+def is_test_path(path: str) -> bool:
+    return bool(_TEST_PATH_RE.search(path))
+
+
+def is_security_path(path: str) -> bool:
+    return any(p.match(path) for p in _PATH_PATTERNS)
+
+
+def line_is_security_relevant(line: str) -> bool:
+    """Is this ONE changed line a security change?
+
+    A comment line qualifies only via ``_ANNOTATION_RE``. `#[` is excluded
+    from the `#` comment shape so a PHP 8 attribute is never read as a shell
+    comment.
+    """
+    if _ANNOTATION_RE.search(line):
+        return True
+    if _COMMENT_LINE_RE.match(line):
+        return False
+    return bool(_CODE_TOKEN_RE.search(line))
+
+
+def changed_lines(base_ref: str, path: str, cwd: str) -> list[str]:
+    """The added/removed lines for *path*, without diff framing.
+
+    `-U0` so no context line is mistaken for a change: context is precisely
+    the code the PR did NOT touch, and treating it as touched is the defect
+    this function exists to remove.
+    """
+    proc = subprocess.run(
+        ["git", "-c", "safe.directory=*", "diff", "-U0", "--no-color",
+         f"{base_ref}...HEAD", "--", path],
+        cwd=cwd, capture_output=True, text=True, check=False,
+    )
+    out = proc.stdout
+    if not out.strip():
+        proc = subprocess.run(
+            ["git", "-c", "safe.directory=*", "diff", "-U0", "--no-color",
+             base_ref, "--", path],
+            cwd=cwd, capture_output=True, text=True, check=False,
+        )
+        out = proc.stdout
+    lines: list[str] = []
+    for raw in out.splitlines():
+        if raw.startswith(("+++", "---", "@@", "diff ", "index ",
+                           "new file", "deleted file", "similarity ",
+                           "rename ")):
+            continue
+        if raw.startswith(("+", "-")):
+            lines.append(raw[1:])
+    return lines
+
+
+def changed_files(base_ref: str, cwd: str) -> list[str]:
+    proc = subprocess.run(
+        ["git", "-c", "safe.directory=*", "diff", "--name-only",
+         f"{base_ref}...HEAD"],
+        cwd=cwd, capture_output=True, text=True, check=False,
+    )
+    out = proc.stdout
+    if not out.strip():
+        proc = subprocess.run(
+            ["git", "-c", "safe.directory=*", "diff", "--name-only", base_ref],
+            cwd=cwd, capture_output=True, text=True, check=False,
+        )
+        out = proc.stdout
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def scan(base_ref: str, cwd: str = ".") -> tuple[list[str], bool]:
+    """(security-touching files, whether the diff also touches a test)."""
+    files = changed_files(base_ref, cwd)
+    has_test = any(is_test_path(f) for f in files)
+    security: list[str] = []
+    for f in files:
+        if is_security_path(f):
+            security.append(f)
+            continue
+        if not _CANDIDATE_RE.match(f):
+            continue
+        for line in changed_lines(base_ref, f, cwd):
+            if line_is_security_relevant(line):
+                security.append(f)
+                break
+    return security, has_test
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_security_cochange.py <base-ref> [app-dir]",
+              file=sys.stderr)
+        return 2
+    base_ref = argv[1]
+    cwd = argv[2] if len(argv) > 2 else os.getcwd()
+    security, has_test = scan(base_ref, cwd)
+    if security and not has_test:
+        for f in security:
+            print(f)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/check_store_and_settings_surface.py
@@ -90,7 +90,7 @@ def _pages_by_id(manifests: list[tuple[Path, dict]]) -> dict[str, dict]:
     return pages
 
 
-def check_store(root: Path, manifests, findings) -> None:
+def check_store(root: Path, manifests, findings, changed: set[str] | None = None) -> None:
     """ADR-080: store / templates / catalogue are three distinct concepts."""
     pages = _pages_by_id(manifests)
 
@@ -156,10 +156,26 @@ def check_store(root: Path, manifests, findings) -> None:
                 )
 
     # Decision 3: no app-local re-implementation of store discovery.
+    #
+    # DIFF-SCOPED, like every other half of this gate.
+    #
+    # This scan used to walk the whole lib/ tree unconditionally while the
+    # manifest half above honoured ADR-020. The combination is the worst of
+    # both: the gate only RUNS when a manifest changed, and then judges code
+    # the PR never touched. One pre-existing violation in pipelinq therefore
+    # blocked EVERY manifest-touching PR in that repo, permanently, with a
+    # finding naming a file outside the diff — and there is no action the
+    # PR's author can take that is about their own change.
+    #
+    # Inherited debt in an untouched file is not this PR's to answer for
+    # (ADR-020). It is still real; it surfaces on a full-tree run and on the
+    # first PR that touches the file.
     lib = root / "lib"
     if lib.is_dir():
         for php in lib.rglob("*.php"):
             if php.name in {"GenericStoreService.php", "GenericStoreControllerBase.php"}:
+                continue
+            if changed is not None and str(php.relative_to(root)) not in changed:
                 continue
             try:
                 text = php.read_text(encoding="utf-8", errors="ignore")
@@ -272,7 +288,7 @@ def main() -> int:
 
     findings: list[str] = []
     if args.gate == "store":
-        check_store(root, manifests, findings)
+        check_store(root, manifests, findings, changed)
     else:
         check_settings(root, manifests, findings)
 

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -404,13 +404,13 @@ class CoveredRefTest(unittest.TestCase):
 
     def test_long_form_annotation(self):
         _write(self.root, "tests/e2e/foo.spec.ts",
-               "// @e2e openspec/specs/my-spec/spec.md#foo-does-bar\ntest('x', () => {})\n")
+               "// @e2e openspec/specs/my-spec/spec.md#foo-does-bar\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         refs = cec.collect_covered_refs(self.root)
         self.assertIn("my-spec::foo-does-bar", refs)
 
     def test_short_form_annotation(self):
         _write(self.root, "tests/e2e/foo.spec.ts",
-               "// @e2e my-spec::foo-does-bar\ntest('x', () => {})\n")
+               "// @e2e my-spec::foo-does-bar\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         refs = cec.collect_covered_refs(self.root)
         self.assertIn("my-spec::foo-does-bar", refs)
 
@@ -454,7 +454,7 @@ class ReportModeTest(unittest.TestCase):
         _write(self.root, "openspec/specs/my-spec/spec.md", BASIC_SPEC)
         # Cover the first scenario
         _write(self.root, "tests/e2e/foo.spec.ts",
-               "// @e2e my-spec::foo-does-bar\ntest('x', () => {})\n")
+               "// @e2e my-spec::foo-does-bar\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
 
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -472,7 +472,7 @@ class ReportModeTest(unittest.TestCase):
     def test_report_with_exclusion(self):
         _write(self.root, "openspec/specs/my-spec/spec.md", SPEC_WITH_EXCLUSION)
         _write(self.root, "tests/e2e/foo.spec.ts",
-               "// @e2e my-spec::another-covered\ntest('x', () => {})\n")
+               "// @e2e my-spec::another-covered\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
 
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -563,7 +563,7 @@ class GateModeTest(unittest.TestCase):
         base = self._commit("base")
         _write(self.root, "openspec/specs/my-spec/spec.md", BASIC_SPEC)
         _write(self.root, "tests/e2e/my.spec.ts",
-               "// @e2e my-spec::foo-does-bar\n// @e2e my-spec::foo-handles-error\ntest('x', ()=>{})\n")
+               "// @e2e my-spec::foo-does-bar\n// @e2e my-spec::foo-handles-error\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         self._commit("add spec + tests")
 
         os.environ["HYDRA_GATE_BASE_REF"] = base
@@ -601,7 +601,7 @@ class GateModeTest(unittest.TestCase):
         _write(self.root, "openspec/specs/my-spec/spec.md", SPEC_WITH_EXCLUSION)
         # Only the non-excluded scenario needs coverage
         _write(self.root, "tests/e2e/my.spec.ts",
-               "// @e2e my-spec::another-covered\ntest('x', ()=>{})\n")
+               "// @e2e my-spec::another-covered\ntest('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         self._commit("add spec + test for visible scenario")
 
         os.environ["HYDRA_GATE_BASE_REF"] = base
@@ -654,6 +654,131 @@ class GateModeTest(unittest.TestCase):
         # old-spec is not in the diff → should not be flagged
         self.assertEqual(rc, 0)
         self.assertNotIn("old-spec", buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# A PERMANENTLY-SKIPPED TEST IS NOT COVERAGE
+#
+# decidesk carried four tests with EMPTY BODIES and a hardcoded
+# `test.skip(true, ...)`, each tagged `@e2e`, each counted as traceability,
+# together asserting nothing. A gate that accepts a switched-off test as proof
+# is a dead gate by construction.
+#
+# The discriminator is the ARGUMENT, not the call: `test.skip(true)` is a test
+# someone turned off; `test.skip(browserName === 'firefox')` is a real test
+# with a runtime guard, and it runs everywhere else. Both ways, in one class.
+# ---------------------------------------------------------------------------
+class SkippedTestIsNotCoverageTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _refs(self, body: str) -> set:
+        _write(self.root, "tests/e2e/foo.spec.ts", body)
+        return cec.collect_covered_refs(self.root)
+
+    # --- dead: must NOT count -------------------------------------------
+    def test_hardcoded_skip_true_with_empty_body_does_not_count(self):
+        # The decidesk shape, verbatim.
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('minutes are published', async ({ page }) => {\n"
+            "  test.skip(true, 'pending backend work')\n"
+            "})\n"), set())
+
+    def test_skip_modifier_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test.skip('minutes are published', async ({ page }) => {\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"), set())
+
+    def test_xit_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "xit('minutes are published', async () => { await go() })\n"), set())
+
+    def test_fixme_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test.fixme('broken', async () => { await go() })\n"), set())
+
+    def test_empty_body_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('minutes are published', async ({ page }) => {})\n"), set())
+
+    def test_a_body_of_only_comments_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('later', async () => {\n"
+            "  // TODO: write this once the endpoint lands\n"
+            "  /* nothing here yet */\n"
+            "})\n"), set())
+
+    def test_argumentless_skip_does_not_count(self):
+        self.assertEqual(self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('off', async ({ page }) => {\n"
+            "  test.skip()\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"), set())
+
+    # --- live: must STILL count -----------------------------------------
+    def test_a_real_test_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('minutes are published', async ({ page }) => {\n"
+            "  await expect(page.getByRole('heading')).toBeVisible()\n"
+            "})\n"))
+
+    def test_a_runtime_conditional_skip_still_counts(self):
+        # THE anti-blindness pair. This test RUNS on every browser but one.
+        # Refusing it would swap the gate's old blindness for a new one.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('minutes are published', async ({ page, browserName }) => {\n"
+            "  test.skip(browserName === 'firefox', 'flaky on gecko')\n"
+            "  await expect(page.getByRole('heading')).toBeVisible()\n"
+            "})\n"))
+
+    def test_an_env_conditional_skip_still_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('needs a fixture', async ({ page }) => {\n"
+            "  test.skip(!process.env.CI, 'needs a CI fixture')\n"
+            "  await page.goto('/')\n"
+            "})\n"))
+
+    def test_one_live_reference_rescues_a_skipped_sibling(self):
+        # A scenario proven by a real test is covered even if some other
+        # skipped test also names it. The gate reports UNCOVERED, not
+        # "you have a skipped test".
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "test.skip('old version', async () => { await go() })\n"
+            "// @e2e my-spec::foo-does-bar\n"
+            "test('new version', async ({ page }) => {\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"))
+
+    def test_a_file_level_tag_with_no_enclosing_test_still_counts(self):
+        # This gate is fixing tests that were switched OFF. It must not
+        # invent a structural requirement it never had.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "import { test, expect } from '@playwright/test'\n"))
+
+    def test_dead_refs_are_reported_with_a_reason(self):
+        _write(self.root, "tests/e2e/foo.spec.ts",
+               "// @e2e my-spec::foo-does-bar\n"
+               "test('x', async () => { test.skip(true, 'later') })\n")
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertEqual(live, set())
+        self.assertIn("my-spec::foo-does-bar", dead)
+        self.assertIn("never runs", dead["my-spec::foo-does-bar"])
 
 
 if __name__ == "__main__":

--- a/hydra-gates/scripts/lib/test_check_security_cochange.py
+++ b/hydra-gates/scripts/lib/test_check_security_cochange.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_security_cochange (gate-47). Run with:
+
+    python3 scripts/lib/test_check_security_cochange.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+gate-47 classified a changed file by grepping the WHOLE file, so a PR whose
+hunks were CSS tokens and a chevron column was told to add a CSRF test, and a
+provably comment-only PR was told to co-change tests. Neither author used the
+opt-out — which is the tell. People do not reach for an opt-out when they
+believe the finding is wrong.
+
+Every relaxation below is paired, in the same class, with the real security
+change it must not swallow. The two false-positive fixtures are the reported
+shapes: a `.vue` file whose diff is CSS custom properties while the file
+elsewhere uses `IUserSession`, and a `lib/*.php` whose 30 changed lines are
+all docblock prose.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_security_cochange as csc  # noqa: E402
+
+
+class _Repo:
+    def __init__(self):
+        self.root = Path(tempfile.mkdtemp())
+        self._git("init", "-q")
+        self._git("config", "user.email", "t@example.invalid")
+        self._git("config", "user.name", "test")
+
+    def _git(self, *args: str) -> None:
+        subprocess.run(["git", "-C", str(self.root), *args],
+                       check=False, capture_output=True)
+
+    def write(self, rel: str, body: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    def commit(self, msg: str) -> str:
+        self._git("add", "-A")
+        self._git("commit", "-qm", msg)
+        return subprocess.run(["git", "-C", str(self.root), "rev-parse", "HEAD"],
+                              capture_output=True, text=True).stdout.strip()
+
+    def scan(self, base: str):
+        return csc.scan(base, str(self.root))
+
+    def close(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+# A component that DOES use IUserSession — somewhere else in the file.
+VUE_BEFORE = """<template>
+  <div class="panel">
+    <span>{{ user.displayName }}</span>
+  </div>
+</template>
+<script>
+import { getCurrentUser } from '@nextcloud/auth'
+// resolves through IUserSession on the server side
+export default { name: 'Panel' }
+</script>
+<style>
+.panel { --panel-gap: 8px; }
+</style>
+"""
+
+VUE_AFTER_CSS_ONLY = VUE_BEFORE.replace(
+    ".panel { --panel-gap: 8px; }",
+    ".panel { --panel-gap: 12px; --panel-pad: 4px; }\n.panel__chevron { width: 24px; }",
+)
+
+PHP_BEFORE = """<?php
+namespace OCA\\Thing\\Controller;
+
+class ThingController extends Controller
+{
+    /**
+     * List things.
+     */
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        $uid = $this->userSession->getUser()->getUID();
+        return new JSONResponse($this->service->listFor($uid));
+    }
+}
+"""
+
+# 30-ish changed lines, every one of them docblock prose.
+PHP_AFTER_DOCBLOCK_ONLY = PHP_BEFORE.replace(
+    """    /**
+     * List things.
+     */""",
+    """    /**
+     * List things.
+     *
+     * Returns every thing visible to the caller. Visibility is resolved by
+     * the service, which narrows on the caller's organisation; the controller
+     * itself performs no filtering and holds no policy.
+     *
+     * The IUserSession lookup below is the only place the caller identity
+     * enters this method. It is not re-read anywhere else, and callers must
+     * not pass a user id in the request.
+     *
+     * @return JSONResponse the visible things, newest first
+     */""",
+)
+
+
+class WholeFileClassificationFalsePositives(unittest.TestCase):
+    def setUp(self):
+        self.repo = _Repo()
+
+    def tearDown(self):
+        self.repo.close()
+
+    def test_fp_a_css_only_diff_in_a_session_using_component(self):
+        self.repo.write("src/Panel.vue", VUE_BEFORE)
+        base = self.repo.commit("base")
+        self.repo.write("src/Panel.vue", VUE_AFTER_CSS_ONLY)
+        self.repo.commit("css tokens and a chevron column")
+        security, has_test = self.repo.scan(base)
+        self.assertEqual(security, [])
+        self.assertFalse(has_test)
+
+    def test_fp_a_docblock_only_diff_in_an_annotated_controller(self):
+        self.repo.write("lib/Controller/ThingController.php", PHP_BEFORE)
+        base = self.repo.commit("base")
+        self.repo.write("lib/Controller/ThingController.php", PHP_AFTER_DOCBLOCK_ONLY)
+        self.repo.commit("document the visibility rule")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, [])
+
+    def test_tp_editing_the_annotation_itself_still_fires(self):
+        # The pairing for the docblock case. Same file, same PR shape — the
+        # only difference is that the changed line IS the declaration.
+        self.repo.write("lib/Controller/ThingController.php", PHP_BEFORE)
+        base = self.repo.commit("base")
+        self.repo.write("lib/Controller/ThingController.php",
+                        PHP_BEFORE.replace("#[NoAdminRequired]", "#[PublicPage]"))
+        self.repo.commit("make it public")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["lib/Controller/ThingController.php"])
+
+    def test_tp_a_docblock_annotation_counts_because_it_IS_the_declaration(self):
+        # `@NoAdminRequired` in a docblock is Nextcloud's legacy auth
+        # declaration, not prose. Excluding all comment lines would miss it —
+        # which is why the discriminator is the TOKEN, not the line shape.
+        self.repo.write("lib/Controller/Other.php",
+                        "<?php\nclass Other {\n    /**\n     * Do it.\n     */\n"
+                        "    public function go() {}\n}\n")
+        base = self.repo.commit("base")
+        self.repo.write("lib/Controller/Other.php",
+                        "<?php\nclass Other {\n    /**\n     * Do it.\n     * @NoAdminRequired\n     */\n"
+                        "    public function go() {}\n}\n")
+        self.repo.commit("relax auth via docblock")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["lib/Controller/Other.php"])
+
+    def test_tp_adding_a_session_lookup_in_code_still_fires(self):
+        self.repo.write("src/Panel.vue", VUE_BEFORE)
+        base = self.repo.commit("base")
+        self.repo.write("src/Panel.vue", VUE_BEFORE.replace(
+            "export default { name: 'Panel' }",
+            "export default { name: 'Panel', computed: { uid() { return IUserSession.get() } } }"))
+        self.repo.commit("read the session in the component")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["src/Panel.vue"])
+
+
+class PathBasedClassificationUnchanged(unittest.TestCase):
+    def setUp(self):
+        self.repo = _Repo()
+
+    def tearDown(self):
+        self.repo.close()
+
+    def test_any_change_under_an_auth_path_qualifies(self):
+        # There is no incidental edit to lib/Service/Auth/*. Even a comment.
+        self.repo.write("lib/Service/Auth/TokenVerifier.php", "<?php\nclass T {}\n")
+        base = self.repo.commit("base")
+        self.repo.write("lib/Service/Auth/TokenVerifier.php",
+                        "<?php\n// a note\nclass T {}\n")
+        self.repo.commit("comment")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["lib/Service/Auth/TokenVerifier.php"])
+
+    def test_a_csrf_named_file_qualifies(self):
+        self.repo.write("lib/CsrfGuard.php", "<?php\nclass C {}\n")
+        base = self.repo.commit("base")
+        self.repo.write("lib/CsrfGuard.php", "<?php\nclass C { public $x = 1; }\n")
+        self.repo.commit("edit")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["lib/CsrfGuard.php"])
+
+
+class TestCoChangeDetection(unittest.TestCase):
+    def setUp(self):
+        self.repo = _Repo()
+
+    def tearDown(self):
+        self.repo.close()
+
+    def test_a_test_in_the_same_diff_is_seen(self):
+        self.repo.write("lib/Service/Auth/T.php", "<?php\nclass T {}\n")
+        base = self.repo.commit("base")
+        self.repo.write("lib/Service/Auth/T.php", "<?php\nclass T { public $y = 2; }\n")
+        self.repo.write("tests/Unit/TTest.php", "<?php\nclass TTest {}\n")
+        self.repo.commit("change + test")
+        security, has_test = self.repo.scan(base)
+        self.assertEqual(security, ["lib/Service/Auth/T.php"])
+        self.assertTrue(has_test)
+
+
+class LineClassifierDirectly(unittest.TestCase):
+    """The unit the whole fix turns on."""
+
+    def test_annotations_count_in_any_line_shape(self):
+        for line in ("    #[NoAdminRequired]",
+                     "     * @NoCSRFRequired",
+                     "// @PublicPage",
+                     "    #[AuthorizedAdminSetting(Application::APP_ID)]"):
+            with self.subTest(line=line):
+                self.assertTrue(csc.line_is_security_relevant(line))
+
+    def test_code_tokens_count_in_code(self):
+        for line in ("        $u = $this->userSession;  // IUserSession",
+                     "        if (hash_equals($a, $b)) {",
+                     "        $p = parse_url($url);"):
+            with self.subTest(line=line):
+                self.assertTrue(csc.line_is_security_relevant(line))
+
+    def test_code_tokens_do_not_count_in_prose(self):
+        for line in ("     * The IUserSession lookup below is the only place",
+                     "     * we call parse_url on the redirect target.",
+                     "// requesttoken is set by the shell, not here",
+                     "  /* hash_equals is used for the comparison */"):
+            with self.subTest(line=line):
+                self.assertFalse(csc.line_is_security_relevant(line))
+
+    def test_a_php_attribute_is_not_a_hash_comment(self):
+        # `#[...]` starts with `#`. Reading it as a shell comment would drop
+        # every modern Nextcloud auth attribute on the floor.
+        self.assertTrue(csc.line_is_security_relevant("#[NoAdminRequired]"))
+
+
+class GateIsNotBlind(unittest.TestCase):
+    """A floor: every token in the vocabulary must still classify."""
+
+    def test_every_security_token_is_detected_as_code(self):
+        for tok in ("#[NoAdminRequired]", "#[PublicPage]", "#[NoCSRFRequired]",
+                    "@NoAdminRequired", "@NoCSRFRequired", "@PublicPage",
+                    "parse_url($u)", "hash_equals($a,$b)", "password_verify($p,$h)",
+                    "IUserSession", "getSecureRandom()", "requesttoken"):
+            with self.subTest(tok=tok):
+                self.assertTrue(csc.line_is_security_relevant(f"        {tok};"))
+
+    def test_ordinary_code_is_not_security_relevant(self):
+        for line in ("        $total = $a + $b;",
+                     "  .panel { --panel-gap: 12px; }",
+                     "        return new JSONResponse($rows);"):
+            with self.subTest(line=line):
+                self.assertFalse(csc.line_is_security_relevant(line))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_store_and_settings_surface (gates 62 / 63). Run with:
+
+    python3 scripts/lib/test_check_store_and_settings_surface.py
+
+WHY THIS SUITE EXISTS
+---------------------
+Gate-62 had no tests, and half of it ignored diff scoping. Its manifest checks
+honoured ADR-020; its `lib/**.php` store-discovery scan walked the whole tree
+unconditionally. The combination is the worst of both: the gate only RUNS when
+a manifest changed, and then judges code the PR never touched.
+
+Measured on pipelinq: one pre-existing violation blocked EVERY
+manifest-touching PR in that repo, permanently, with a finding naming a file
+outside the diff. There was no action the author could take that was about
+their own change — the definition of an unclosable gate.
+
+Both ways, in the same class: an untouched violation must not block a
+manifest-only PR, and the same violation must still fire the moment the PR
+touches that file, and on any full-tree run.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_store_and_settings_surface as css  # noqa: E402
+
+# Verbatim shape of the pipelinq violation: an app-local re-implementation of
+# OpenRegister store discovery (ADR-080 D2/D3).
+LEGACY_STORE_PHP = """<?php
+namespace OCA\\Pipelinq\\Service;
+
+class LegacyStoreService
+{
+    public function fetch(IClientService $client)
+    {
+        $url = '/apps/openregister/api/objects/' . $this->register;
+        return $client->newClient()->get($url);
+    }
+}
+"""
+
+CLEAN_MANIFEST = {
+    "id": "app",
+    "menu": [{"label": "Store", "icon": "StoreOutline", "route": "store"}],
+    "pages": [{"id": "store", "config": {"cardComponent": "StoreCard"}}],
+}
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args],
+                   check=False, capture_output=True)
+
+
+class LibScanIsDiffScoped(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        (self.root / "src").mkdir(parents=True)
+        (self.root / "lib" / "Service").mkdir(parents=True)
+        (self.root / "src" / "manifest.json").write_text(
+            json.dumps(CLEAN_MANIFEST), encoding="utf-8")
+        (self.root / "lib" / "Service" / "LegacyStoreService.php").write_text(
+            LEGACY_STORE_PHP, encoding="utf-8")
+        _git(self.root, "init", "-q")
+        _git(self.root, "config", "user.email", "t@example.invalid")
+        _git(self.root, "config", "user.name", "test")
+        _git(self.root, "add", "-A")
+        _git(self.root, "commit", "-qm", "base: the violation is already here")
+        self.base = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            capture_output=True, text=True).stdout.strip()
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _run(self, base: str | None) -> tuple[int, str]:
+        argv = [str(self.root), "--gate", "store"]
+        if base:
+            argv += ["--base", base]
+        buf = io.StringIO()
+        old = sys.argv
+        sys.argv = ["check_store_and_settings_surface.py", *argv]
+        try:
+            with redirect_stdout(buf):
+                rc = css.main()
+        finally:
+            sys.argv = old
+        return rc, buf.getvalue()
+
+    def _touch_manifest_only(self):
+        m = json.loads((self.root / "src" / "manifest.json").read_text())
+        m["menu"][0]["label"] = "Store"
+        m["pages"][0]["config"]["cardComponent"] = "StoreCardV2"
+        (self.root / "src" / "manifest.json").write_text(json.dumps(m), encoding="utf-8")
+        _git(self.root, "add", "-A")
+        _git(self.root, "commit", "-qm", "manifest-only change")
+
+    def test_an_untouched_violation_does_not_block_a_manifest_only_pr(self):
+        self._touch_manifest_only()
+        rc, out = self._run(self.base)
+        self.assertNotIn("LegacyStoreService", out)
+        self.assertEqual(rc, 0)
+
+    def test_the_same_violation_fires_when_the_pr_touches_that_file(self):
+        # The pairing. Identical repository, identical violation — only the
+        # diff differs, which is the whole property ADR-020 scoping asserts.
+        self._touch_manifest_only()
+        php = self.root / "lib" / "Service" / "LegacyStoreService.php"
+        php.write_text(php.read_text() + "\n// touched by this PR\n", encoding="utf-8")
+        _git(self.root, "add", "-A")
+        _git(self.root, "commit", "-qm", "touch the service too")
+        rc, out = self._run(self.base)
+        self.assertIn("LegacyStoreService", out)
+        self.assertEqual(rc, 1)
+
+    def test_an_unscoped_full_tree_run_still_reports_inherited_debt(self):
+        # Scoping hides the finding from a PR that did not cause it. It must
+        # not delete it: a full-tree run is where inherited debt is counted.
+        rc, out = self._run(None)
+        self.assertIn("LegacyStoreService", out)
+        self.assertEqual(rc, 1)
+
+    def test_manifest_findings_are_unaffected_by_the_scoping_change(self):
+        m = json.loads((self.root / "src" / "manifest.json").read_text())
+        m["menu"][0]["icon"] = "ShoppingOutline"   # wrong glyph for STORE
+        (self.root / "src" / "manifest.json").write_text(json.dumps(m), encoding="utf-8")
+        _git(self.root, "add", "-A")
+        _git(self.root, "commit", "-qm", "wrong store icon")
+        rc, out = self._run(self.base)
+        self.assertIn("ShoppingOutline", out)
+        self.assertEqual(rc, 1)
+
+
+class GateIsNotBlind(unittest.TestCase):
+    """If `check_store` ever stops producing findings entirely, the scoping
+    assertions above still pass. This asserts the floor directly."""
+
+    def test_check_store_reports_a_bad_icon(self):
+        root = Path(tempfile.mkdtemp())
+        try:
+            findings: list[str] = []
+            bad = dict(CLEAN_MANIFEST)
+            bad["menu"] = [{"label": "Store", "icon": "ShoppingOutline", "route": "store"}]
+            css.check_store(root, [(root / "src" / "manifest.json", bad)], findings)
+            self.assertTrue(any("ShoppingOutline" in f for f in findings))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -268,7 +268,24 @@ if [ "${SCOPE_TO_DIFF}" = "1" ]; then
         exit 99
     fi
     _cf_count=$(printf '%s' "${CHANGED_FILES}" | grep -c . 2>/dev/null || true)
-    if [ "${_cf_count:-0}" = "0" ]; then
+    _cf_count="${_cf_count:-0}"
+    # THE MACHINE-READABLE SCOPE SIZE. One line, one number, emitted exactly
+    # once, and it is the ONLY thing downstream may derive "was the scope
+    # empty?" from.
+    #
+    # `bin/hydra-gates` used to answer that question with
+    # `grep -q "0 changed file(s)"` over this output — a SUBSTRING match, so
+    # `10 changed file(s)` contains it, and so does 20, 30, 100. A run whose
+    # header said `10 changed file(s)` and whose every gate ran therefore also
+    # printed the "SCOPE WAS EMPTY" epilogue, and that epilogue was being used
+    # fleet-wide as the tell for a vacuous run. The report contradicted its own
+    # header and the contradiction pointed the wrong way: it manufactured
+    # doubt about runs that were fine.
+    #
+    # Deriving both statements from this one integer is what makes the
+    # contradiction impossible, rather than merely unlikely.
+    echo "[hydra-gates] SCOPE-FILE-COUNT: ${_cf_count}"
+    if [ "${_cf_count}" = "0" ]; then
         # Genuinely zero changed files is a legitimate outcome, but it must be
         # stated as such rather than looking like a scoped run that found nothing.
         echo "[hydra-gates] Scope: diff vs ${BASE_REF} — 0 changed file(s). Base resolves, histories join, git succeeded; this PR changes nothing."
@@ -3344,26 +3361,36 @@ fi
 # ---------------------------------------------------------------------------
 _scht_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-security-change-has-tests.log
 : > "${_scht_log}"
+_scht_ran=1
+_scht_helper="${SCRIPT_DIR}/lib/check_security_cochange.py"
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
-    _scht_changed=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)
-    _scht_sec=""
-    _scht_has_test=""
-    while IFS= read -r f; do
-        [ -z "$f" ] && continue
-        case "$f" in
-            tests/*|*/tests/*|*.spec.js|*.spec.ts|*.spec.vue) _scht_has_test="1" ;;
-        esac
-        case "$f" in
-            lib/*Auth*|lib/*Csrf*|lib/*Session*|lib/*/Auth/*|lib/*/Session/*|lib/*/Csrf/*|lib/*/Rbac/*|lib/*/Permission/*|lib/*/Authorization/*)
-                _scht_sec="${_scht_sec}${f}\n" ;;
-            lib/*.php|src/*.vue|src/*.js|src/*.ts)
-                # content-based classification
-                if [ -f "$f" ] && grep -qE "(#\[NoAdminRequired\]|#\[AuthorizedAdminSetting\(|@NoAdminRequired|@NoCSRFRequired|#\[PublicPage\]|parse_url|hash_equals|password_verify|IUserSession|getSecureRandom|requesttoken)" "$f" 2>/dev/null; then
-                    _scht_sec="${_scht_sec}${f}\n"
-                fi
-                ;;
-        esac
-    done <<< "${_scht_changed}"
+    if [ ! -f "${_scht_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _scht_ran=0
+        _skip 47 "security-change-has-tests" wiring "check_security_cochange.py not found at ${_scht_helper} — the diff was NOT classified; a security change shipping without a test co-change is UNVERIFIED by this run."
+        _scht_sec=""
+        _scht_has_test="1"
+    else
+        # CLASSIFY ON THE HUNKS, NOT THE FILE.
+        #
+        # This was `grep -qE "<tokens>" "$f"` over the WHOLE FILE, so a file
+        # counted as a security change if a token appeared anywhere in it —
+        # in a method the PR never went near, in an import, in prose. Two
+        # agents hit it the same day: a PR whose hunks were CSS custom
+        # properties and a chevron column was told to add a CSRF test, and a
+        # provably comment-only PR (all 30 changed lib/ lines inside
+        # docblocks) was told to co-change tests. Neither used the opt-out,
+        # which is the tell — people do not reach for an opt-out when they
+        # believe the finding is wrong.
+        _scht_sec=$(python3 "${_scht_helper}" "${BASE_REF}" "$(pwd)" 2>/dev/null || true)
+        _scht_has_test=""
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+                tests/*|*/tests/*|*.spec.js|*.spec.ts|*.spec.vue|*Test.php) _scht_has_test="1" ;;
+            esac
+        done <<< "$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)"
+    fi
     if [ -n "${_scht_sec}" ] && [ -z "${_scht_has_test}" ]; then
         # Check for opt-out in PR body or head commit message
         _scht_optout_re='\[hydra-gate-security-change-has-tests exclude\][[:space:]]+.{20,}'
@@ -3371,18 +3398,18 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
         [ -n "${HYDRA_GATE_PR_BODY:-}" ] && echo "${HYDRA_GATE_PR_BODY:-}" | grep -qE "${_scht_optout_re}" && _scht_optout="1"
         [ -z "${_scht_optout}" ] && git log -1 --pretty=%B 2>/dev/null | grep -qE "${_scht_optout_re}" && _scht_optout="1"
         if [ -z "${_scht_optout}" ]; then
-            printf "%b" "${_scht_sec}" >> "${_scht_log}"
+            printf "%s\n" "${_scht_sec}" >> "${_scht_log}"
         fi
     fi
 fi
-set +e
 _scht_fail=$(wc -l < "${_scht_log}" 2>/dev/null | tr -d ' ')
-set -e
 [ -z "${_scht_fail}" ] && _scht_fail=0
-if [ "${_scht_fail}" -eq 0 ]; then
-    _pass 47 "security-change-has-tests"
-else
-    _fail 47 "security-change-has-tests" "${_scht_fail} security-touching change(s) without a test co-change — see ${_scht_log}"
+if [ "${_scht_ran}" -eq 1 ]; then
+    if [ "${_scht_fail}" -eq 0 ]; then
+        _pass 47 "security-change-has-tests"
+    else
+        _fail 47 "security-change-has-tests" "${_scht_fail} security-touching change(s) without a test co-change — see ${_scht_log}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -133,6 +133,43 @@ else
     _bad "expected exit 0 on an empty diff, got ${RC}"
 fi
 
+# The epilogue must not contradict the header.
+#
+# `bin` decided "was the scope empty?" with `grep -q "0 changed file(s)"` — a
+# SUBSTRING match satisfied by `10 changed file(s)`. A run with ten changed
+# files, every gate running, also printed "SCOPE WAS EMPTY", and that string
+# was in fleet-wide use as the tell for a vacuous run. Ten is the smallest
+# count that reproduces it, so ten is what this fixture builds.
+echo "[test] a NON-empty scope must not claim to be empty"
+mkdir -p "${FIX}/src"
+for _i in 1 2 3 4 5 6 7 8 9 10; do
+    printf 'export const x%s = 1\n' "${_i}" > "${FIX}/src/scope_probe_${_i}.js"
+done
+git -C "${FIX}" add -A >/dev/null 2>&1
+git -C "${FIX}" commit -qm "ten changed files" >/dev/null 2>&1
+OUT_TEN="$("${BIN}" --app-dir "${FIX}" --base "${BASE_SHA}" 2>&1)"
+if printf '%s' "${OUT_TEN}" | grep -q '^\[hydra-gates\] SCOPE-FILE-COUNT: 10$'; then
+    _ok "the machine-readable scope size is emitted, once, as a bare integer"
+else
+    _bad "expected a 'SCOPE-FILE-COUNT: 10' line; the epilogue has nothing exact to derive from"
+fi
+if printf '%s' "${OUT_TEN}" | grep -q "SCOPE WAS EMPTY"; then
+    _bad "a 10-file scope claimed SCOPE WAS EMPTY — the epilogue contradicts the header"
+else
+    _ok "a 10-file scope does not claim to be empty"
+fi
+# ...and the pairing: the epilogue must still fire when the scope really is
+# empty, or this fix has just deleted the warning it was meant to repair.
+git -C "${FIX}" commit -q --allow-empty -m "empty again" >/dev/null 2>&1
+_TEN_SHA="$(git -C "${FIX}" rev-parse HEAD~1)"
+OUT_ZERO="$("${BIN}" --app-dir "${FIX}" --base "${_TEN_SHA}" 2>&1)"
+if printf '%s' "${OUT_ZERO}" | grep -q '^\[hydra-gates\] SCOPE-FILE-COUNT: 0$' \
+   && printf '%s' "${OUT_ZERO}" | grep -q "SCOPE WAS EMPTY"; then
+    _ok "a genuinely empty scope still says SCOPE WAS EMPTY"
+else
+    _bad "a genuinely empty scope no longer warns — the fix has muted the warning"
+fi
+
 echo "[test] a base that IS HEAD is refused, not reported green"
 _HEAD_SHA="$(git -C "${FIX}" rev-parse HEAD)"
 OUT_SELF="$("${BIN}" --app-dir "${FIX}" --base "${_HEAD_SHA}" 2>&1)"; RC_SELF=$?


### PR DESCRIPTION
Follow-up to #175. Four gates that produced findings **a developer could not answer truthfully** — the shape that gets a suite ignored.

Every relaxation ships with the true-positive case it must not swallow, and each was mutation-checked in **both** directions.

---

## 1. The epilogue contradicted its own header

`bin/hydra-gates` decided *"was the scope empty?"* with:

```sh
grep -q "0 changed file(s)"
```

That is a **substring** match. `10 changed file(s)` contains it — and so do 20, 30, 100. A run whose header said ten files changed, with every gate running, **also printed the `SCOPE WAS EMPTY` epilogue**. That string had been adopted fleet-wide as the tell for a vacuous run, so the bug manufactured doubt about runs that were fine while saying nothing new about runs that were not.

Reproduced, then fixed:

```
BEFORE:  [hydra-gates] Scope: diff vs … — 10 changed file(s)
         [hydra-gates] SCOPE WAS EMPTY: 0 files differ from …     ← contradicts the line above

AFTER:   [hydra-gates] SCOPE-FILE-COUNT: 10
         [hydra-gates] Scope: diff vs … — 10 changed file(s)      ← no epilogue
```

The runner now emits `SCOPE-FILE-COUNT: <n>` **once, as a bare integer**, and both statements derive from that one number. Deriving them from one integer is what makes the contradiction *impossible* rather than merely unlikely — and it is the unambiguous line to match on.

⚠️ Worth knowing: the epilogue's own prose (`SCOPE WAS EMPTY`) appears in **comments** in both files, so grepping the *source* for it finds explanations rather than emissions. Grep `SCOPE-FILE-COUNT: 0`.

**Paired:** a genuinely empty scope must still warn, or this fix has muted the warning it was meant to repair. Ten is the smallest count that reproduces the bug, so the test builds ten.

## 2. gate-19 accepted a permanently-skipped test as coverage

decidesk carries four tests with **empty bodies** and a hardcoded `test.skip(true, …)`. Each is tagged `@e2e`, each was counted as traceability, and together they assert nothing.

| now dead | still live |
|---|---|
| `test.skip('name', …)`, `it.skip`, `xit`, `xtest`, `test.fixme` | `test.skip(browserName === 'firefox', …)` |
| `describe.skip(…)` | `test.skip(!process.env.CI, …)` |
| `test.skip(true)` / `test.skip()` at the top of a body | a test with one real assertion |
| a body of only whitespace and comments | a live reference alongside a skipped sibling |

**The discriminator is the ARGUMENT, not the call.** A literal `true` is a test someone turned off; a runtime condition is a real test with a guard that runs everywhere else. Refusing the second would swap this gate's blindness for a different one.

The finding text changed too — *"missing @e2e"* would send someone to add a tag that is already there. It now names the file and says the test does not run.

## 3. gate-47 classified on the whole file, not the hunks

```sh
grep -qE "(…|IUserSession|parse_url|…)" "$f"     # the WHOLE file
```

A file counted as a security change if a token appeared **anywhere** in it. Two agents hit this independently on the same day — a PR whose hunks were CSS custom properties and one chevron column, and a provably comment-only PR (all 30 changed `lib/` lines inside docblocks). **Neither used the opt-out**, which is the tell: people do not reach for an opt-out when they believe the finding is wrong.

Classification now reads `git diff -U0` and judges only added/removed lines. A comment line counts **only for an annotation** — `@NoAdminRequired` and friends *are* Nextcloud's auth declaration in docblock form — while prose mentioning `IUserSession` is a sentence. The discriminator is the token, not the line shape: excluding all comment lines drops the legacy annotation form on the floor, and that mutation fails 13 assertions.

Path-based classification (`lib/**/Auth/**`, `lib/*Csrf*`, …) is unchanged.

## 4. gate-62's `lib/` scan ignored diff scoping

Its manifest checks honour ADR-020; its `lib/**.php` store-discovery scan walked the whole tree unconditionally. **The combination is the worst of both**: the gate only *runs* when a manifest changed, and then judges code the PR never touched.

One pre-existing violation in pipelinq blocked **every** manifest-touching PR in that repo, permanently, naming a file outside the diff.

Paired three ways: the same violation still fires when the PR touches that file, it still fires on any full-tree run, and the manifest findings are unaffected. gate-62 had **no tests at all** before this.

---

## Verification

```
helper suites:                 25 passed, 0 failed   (was 23)
hydra-gates entry-point tests: 39 passed, 0 failed   (was 36)
```

Mutation-checked, per gate:

| mutation | result |
|---|---|
| gate-19 `_ref_is_live` → always True (the old blindness) | **8** failures |
| gate-47 whole-file classification (the original defect) | **2** failures |
| gate-47 drop ALL comment lines (the over-correction) | **13** failures |

End-to-end against the real runner: the docblock-only PR goes **FAIL → PASS** on gate-47, and flipping `#[NoAdminRequired]` to `#[PublicPage]` in that same file still **FAILs**.

Two new suites (gate-47, gates 62/63).
