### PR TITLE
feat(quality): stop pinning the gates package per repo, and gate main on the failure mode that has no red

### DIFF
--- a/.github/workflows/hydra-gates-package.yml
+++ b/.github/workflows/hydra-gates-package.yml
@@ -18,20 +18,31 @@ name: hydra-gates package
 # location, with no local checkout of the package on the box and no
 # credentials, tests the thing that was actually wrong.
 
+# NO `paths:` FILTER, DELIBERATELY.
+#
+# This used to run only when hydra-gates/**, composer.json or .gitattributes
+# changed. That was defensible while every caller PINNED the package: a repo on
+# v1.3.0 was unaffected by anything landing here, so gating unrelated PRs on a
+# 25-minute container job bought nothing.
+#
+# It stopped being defensible when the fleet unpinned. As of
+# `chore/track-latest-gates` all 23 callers take the package from @main, so the
+# blast radius of a merge here is the whole fleet and the question "did this PR
+# touch the gates?" is the wrong one — the runner resolves at RUN time, not at
+# merge time, so a PR that changes nothing under hydra-gates/ can still be the
+# commit a caller picks up.
+#
+# A required check with a `paths:` filter is also a trap in its own right: on
+# every PR the filter excludes, the check never reports, and the PR sits
+# pending forever unless the ruleset is taught the exception. The two ways out
+# are a hand-maintained filter that decays exactly like the hand-maintained
+# test list this same workflow already learned not to keep (see "discovered,
+# not listed" below), or no filter at all. No filter at all.
 on:
   pull_request:
-    paths:
-      - "hydra-gates/**"
-      - "composer.json"
-      - ".gitattributes"
-      - ".github/workflows/hydra-gates-package.yml"
+    branches: [main]
   push:
     branches: [main]
-    paths:
-      - "hydra-gates/**"
-      - "composer.json"
-      - ".gitattributes"
-      - ".github/workflows/hydra-gates-package.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality-resolve-probe.yml
+++ b/.github/workflows/quality-resolve-probe.yml
@@ -1,0 +1,176 @@
+name: Quality resolve probe
+
+# THE GUARD ON THE SHARED WORKFLOW.
+#
+# Every caller in the fleet consumes .github/workflows/quality.yml at @main and,
+# as of `chore/track-latest-gates`, takes the gates package from @main too. That
+# is what the product owner asked for — nobody should have to bump a pin in 23
+# repositories to receive a fix. The cost of it is that a broken main now
+# reaches all 23 at once, so main has to be gated on the one failure mode that
+# does not announce itself.
+#
+# THE FAILURE MODE
+# ----------------
+# An unresolvable reusable workflow is not a red check. GitHub creates a run
+# with no jobs in it, or creates no run at all. There is nothing to fail, so
+# nothing fails: every caller quietly stops being checked and every dashboard
+# stays green. On 2026-08-04 a single ~22 KB `run:` step did exactly this
+# (#161); it was reverted (#166) and re-landed with the script in a file (#168).
+#
+# The signature is `jobs == 0`. So this probe COUNTS JOBS. It never looks at
+# whether they passed — a conclusion is a different measurement and reading it
+# here would reintroduce the same blind spot one level up.
+#
+# WHY TWO WORKFLOWS
+# -----------------
+# The thing being resolved is `quality-selftest.yml`. It lives in its own file
+# rather than as a job here, and that separation is load-bearing: if the call
+# sat in THIS workflow and quality.yml were unresolvable, this whole workflow
+# would fail to materialise, the required check would never report, and the PR
+# would sit PENDING FOREVER. A permanently-pending gate is one of the three
+# shapes a dead gate takes, and the hardest to notice. Split in two, the probe
+# always runs and always reports, so the outage surfaces as an explicit RED.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: quality-resolve-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-limits:
+    name: "No `run:` step big enough to break resolution"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deterministic, and it names the offending step — which a job count
+      # cannot do. This is the #161 class caught before merge rather than
+      # after.
+      - name: Assert every `run:` block is under the limit
+        run: python3 scripts/assert-run-steps-resolvable.py .github/workflows/*.yml
+
+      # POSITIVE CONTROL for the lint. A limit low enough that today's largest
+      # step must trip it proves the check has a reachable failure branch and
+      # is reading real sizes. Without this, a lint that silently stopped
+      # parsing `run:` blocks would report the same clean pass forever.
+      - name: "Positive control — the lint must fail on a limit it cannot meet"
+        run: |
+          set -eu
+          if python3 scripts/assert-run-steps-resolvable.py --limit 1 \
+               .github/workflows/quality.yml > /dev/null 2>&1; then
+            echo "::error::the run-step lint reported OK at a 1-byte limit. It is \
+          not measuring anything — every workflow in this repo has `run:` blocks \
+          larger than one byte."
+            exit 1
+          fi
+          echo "OK — the lint fails when it should. Its clean pass above is a verdict."
+
+  probe:
+    name: "quality.yml resolves (job count > 0)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # POSITIVE CONTROL, FIRST. Run the counter against a workflow that
+      # cannot possibly have a run at this SHA and require the answer to be 0.
+      #
+      # This is the assertion the whole probe rests on: that a count of zero is
+      # something this instrument can actually produce and report. If the
+      # counter were broken — wrong repo, missing token scope, a jq path that
+      # silently yields nothing — it would return 0 here AND 0 for the real
+      # subject, and the probe would be a gate that only ever fails. Equally, a
+      # counter that had started returning a constant would pass the real check
+      # forever. Measuring the known-zero case first distinguishes the two.
+      - name: "Positive control — a workflow that does not exist must count 0"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          # Short timeout: this one is EXPECTED to find nothing, so there is no
+          # race to wait out.
+          n="$(bash scripts/count-workflow-jobs.sh '__no-such-workflow.yml' "${HEAD_SHA}" 5)"
+          echo "control count = ${n}"
+          [ "${n}" = "0" ] || {
+            echo "::error::the counter returned ${n} jobs for a workflow that does not \
+          exist. It is not counting what it claims to count, so its verdict on \
+          quality.yml means nothing."
+            exit 1
+          }
+          echo "OK — the counter can return 0, and reports it."
+
+      # THE MEASUREMENT. quality-selftest.yml calls ./.github/workflows/quality.yml
+      # on this same commit. If quality.yml resolves, that run materialises its
+      # jobs (18 top-level jobs as of this change, some of which skip — a
+      # skipped job is still a job and still counts, which is the point: the
+      # probe measures RESOLUTION, not execution).
+      - name: "Count the jobs quality-selftest.yml materialised"
+        id: count
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          n="$(bash scripts/count-workflow-jobs.sh 'quality-selftest.yml' "${HEAD_SHA}" 420)"
+          echo "count=${n}" >> "$GITHUB_OUTPUT"
+          echo "quality-selftest.yml materialised ${n} jobs at ${HEAD_SHA}"
+
+      - name: "Assert the shared workflow resolved"
+        env:
+          COUNT: ${{ steps.count.outputs.count }}
+        run: |
+          set -eu
+          if [ "${COUNT}" -eq 0 ]; then
+            echo "::error::quality.yml produced ZERO jobs. This is the #161 outage \
+          signature, not a slow run: an unresolvable reusable workflow yields a run \
+          with no jobs (or no run) and NEVER goes red on its own. Do not merge — \
+          every caller in the fleet consumes this file at @main and would silently \
+          stop being checked. Check for an oversized \`run:\` step, a malformed \
+          \`on: workflow_call\` block, or a YAML error."
+            exit 1
+          fi
+          echo "OK — ${COUNT} jobs. quality.yml is resolvable at this commit."
+
+  # A single check to require in the ruleset, so adding a job above does not
+  # need a branch-protection edit to be enforced. `needs:` implies success(),
+  # which is what we want here — but it also DELETES this job if a dependency
+  # is skipped, so `!cancelled()` is used and each result is asserted by name
+  # rather than inferred from this job having run at all.
+  guard:
+    name: "Shared-workflow guard"
+    runs-on: ubuntu-latest
+    needs: [static-limits, probe]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Assert both guards reached a verdict
+        env:
+          STATIC: ${{ needs.static-limits.result }}
+          PROBE: ${{ needs.probe.result }}
+        run: |
+          set -eu
+          echo "static-limits=${STATIC} probe=${PROBE}"
+          # `skipped` is failed here on purpose. A guard that did not run is
+          # not a guard that passed.
+          for pair in "static-limits:${STATIC}" "probe:${PROBE}"; do
+            name="${pair%%:*}"; result="${pair##*:}"
+            [ "${result}" = "success" ] || {
+              echo "::error::${name} did not succeed (result=${result}). A guard that \
+          was skipped or cancelled has returned no verdict at all."
+              exit 1
+            }
+          done
+          echo "OK — both guards ran and passed."

--- a/.github/workflows/quality-selftest.yml
+++ b/.github/workflows/quality-selftest.yml
@@ -1,0 +1,55 @@
+name: Quality selftest (resolve subject)
+
+# This workflow exists to BE RESOLVED, not to pass.
+#
+# It is the in-repo caller of ./.github/workflows/quality.yml. Its only purpose
+# is to make GitHub attempt the same resolution every fleet caller attempts, on
+# the PR's own version of quality.yml, so that an unresolvable shared workflow
+# is discovered HERE instead of by 23 repositories at once.
+#
+# ITS CONCLUSION IS NOT A VERDICT. Read `quality-resolve-probe.yml` instead:
+# that workflow counts the JOBS this run materialised. An unresolvable reusable
+# workflow does not fail — it produces a run with no jobs, or no run at all, and
+# a green dashboard. `jobs == 0` is the outage signature, so the count is the
+# measurement and this file is only the thing being measured. Do not make this
+# workflow a required check; make the probe one.
+#
+# Everything the shared workflow can switch off is switched off. The .github
+# repository is not a Nextcloud app: it has no composer.json app, no frontend
+# and no PHPUnit suite, so running those legs here would measure nothing and
+# cost ~30 minutes per PR. Resolution happens at run-creation time and is
+# entirely independent of what the jobs then decide to do, so a call with every
+# leg disabled resolves exactly as a full one does.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-selftest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: "Resolve quality.yml"
+    uses: ./.github/workflows/quality.yml
+    with:
+      app-name: github-selftest
+      enable-php: false
+      enable-npm: false
+      enable-frontend: false
+      enable-phpunit: false
+      enable-newman: false
+      enable-playwright: false
+      enable-hydra-gates: false
+      enable-license-check: false
+      enable-journeydoc-capture: false
+      enable-coverage-guard: false
+      enable-sbom: false
+      enable-features-extract: false

--- a/.github/workflows/quality-selftest.yml
+++ b/.github/workflows/quality-selftest.yml
@@ -28,8 +28,24 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# These must be at least as wide as the widest `permissions:` any job in
+# quality.yml declares — currently journeydoc-capture, which asks for
+# `contents: write` and `actions: write`.
+#
+# MEASURED, not copied: this file first shipped with `contents: read`, and run
+# 31073908079 came back `startup_failure` with ZERO jobs. Permissions are
+# validated when the run is CREATED, so `enable-journeydoc-capture: false` does
+# not help — the job's `if:` is never reached.
+#
+# That is worth stating plainly, because it is a second way into the same
+# outage and it applies to every caller in the fleet, not just this one: a
+# caller whose permission grant is narrower than the shared workflow requests
+# produces NO JOBS AND NO RED, exactly like an oversized `run:` step does. The
+# probe caught it on its first execution, which is the only reason it is
+# documented here rather than discovered in production.
 permissions:
-  contents: read
+  contents: write
+  actions: write
 
 concurrency:
   group: quality-selftest-${{ github.ref }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -259,7 +259,59 @@ on:
         type: boolean
         default: false
       hydra-gates-ref:
-        description: "Ref of ConductionNL/.github to take the gate package from. Pin this to a tag to stop a gate change from altering a repo's verdict without a commit in that repo. NOTE: this workflow is consumed at @main while the package is consumed at this pin, so the two move independently and a new default here can reach an old runner. v1.3.0 is the minimum for hydra-gates-require-full-coverage and enable-axe to be honoured (earlier packages count every not-applicable gate as a coverage gap); v1.4.0 is the minimum for enable-axe to run at all (it ships the axe runner). Below those, the affected flag is withheld with a named warning rather than failing the run for something the repo did not do."
+        # DEFAULT `main`, AND CALLERS SHOULD NOT SET THIS AT ALL.
+        #
+        # A pin is a silent expiry date. It has now cost the fleet twice:
+        #
+        #   #159  22 repos sat on v1.0.1, which predated a batch of gate fixes.
+        #         16 gates were DEAD fleet-wide and every one of them reported
+        #         PASS, because a gate whose helper never ran emits a tick
+        #         identical to a real one.
+        #   #173  the coverage flag was flipped to default true HERE, at @main,
+        #         and reached v1.0.1 runners that predate the accounting that
+        #         makes it survivable. decidesk and doriath went red (exit 98)
+        #         on gates 4, 24 and 33 — precisely the not-applicable gates
+        #         that must never fail a run.
+        #
+        # Both are the same defect: this workflow is consumed at @main while the
+        # package was consumed at a pin, so the two moved independently and a
+        # change on one side reached a runner from the other side's past. The
+        # fix is not a better pin. It is no pin — the two sides move together
+        # again, and a fix landed here is a fix everyone has.
+        #
+        # ROLLBACK, because "always latest" is only safe with a way back:
+        #
+        #   fleet-wide, immediate — revert the offending commit on
+        #     ConductionNL/.github main. One commit, no per-repo PRs, and every
+        #     caller picks it up on its next run. This is the normal lever, and
+        #     it is strictly faster than the 23-PR bump that a pin makes
+        #     necessary.
+        #   one repo, immediate — set this input to a tag or SHA in that repo's
+        #     caller. Still supported, still honoured, and the right move when a
+        #     single repo needs to hold still while an upstream problem is
+        #     sorted out. Treat it as a temporary escape hatch and remove it
+        #     when the reason is gone: an explicit pin is exactly the state that
+        #     produced #159 and #173, and nothing here will remind you it is set.
+        #
+        # A moving major tag (`v1`, re-pointed each release) was considered and
+        # rejected. It would give a release boundary, but only while someone
+        # remembers to move it — and a tag nobody re-points is indistinguishable
+        # from the stale pin this change exists to remove. It would reproduce
+        # the failure silently, which is the one property being engineered out.
+        # `main` cannot rot, and main is now gated: see
+        # .github/workflows/quality-resolve-probe.yml, which counts the JOBS a
+        # real in-repo caller materialises, and hydra-gates-package.yml, which
+        # runs the package's own suites on every PR here.
+        #
+        # Version floors, still enforced by the capability probe below rather
+        # than by parsing this string (a pin may be a branch, a SHA or a fork,
+        # and none of those carry a version): v1.3.0 is the minimum for
+        # hydra-gates-require-full-coverage to be honoured — earlier packages
+        # count every not-applicable gate as a coverage gap — and v1.4.0 is the
+        # minimum for enable-axe to run at all, since it ships the axe runner.
+        # Below those the affected flag is WITHHELD with a named warning rather
+        # than failing the run for something the repo did not do.
+        description: "Ref of ConductionNL/.github to take the gate package from. LEAVE UNSET: the default tracks @main so a gate fix reaches every repo without a commit in that repo, and this workflow is itself consumed at @main so the two sides stay in step. Set it only as a temporary escape hatch when one repo must hold still — an explicit pin is a silent expiry date and has twice left gates dead or falsely red fleet-wide (#159, #173). To roll back for everyone, revert on ConductionNL/.github main instead. Older refs are still supported: a capability probe reads the package's own accounting and withholds a flag the pinned runner cannot honour, rather than failing the run."
         required: false
         type: string
         default: "main"

--- a/scripts/assert-run-steps-resolvable.py
+++ b/scripts/assert-run-steps-resolvable.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail when a workflow carries a `run:` block big enough to make it unresolvable.
+
+WHY
+---
+On 2026-08-04 a single `run:` step of ~22 KB in .github/workflows/quality.yml
+made the whole workflow unresolvable (#161). Nothing went red. The fleet's
+callers simply stopped producing a gates job, because an unresolvable reusable
+workflow yields a run with NO JOBS rather than a failure. It was reverted in
+#166 and re-landed in #168 with the script moved into a file.
+
+The dynamic resolve probe catches this class after the fact, by counting jobs.
+This lint catches the same class BEFORE merge, deterministically, and names the
+offending step — which the job count cannot do.
+
+THRESHOLD
+---------
+Measured on this repository:
+
+  known-bad   ~22000 bytes   quality.yml at d68fb72, unresolvable (#161)
+  current max  10533 bytes   quality.yml `run:` at line ~1127, resolves fine
+
+16384 sits above every step the fleet actually ships and below the size that
+is known to have broken it. It is a tripwire, not a style rule: a step
+approaching it should move into a file under scripts/, exactly as #168 did.
+
+Usage:  assert-run-steps-resolvable.py [--limit N] <workflow.yml> [...]
+Exit:   0 all clear, 1 at least one step is over the limit.
+"""
+
+import argparse
+import re
+import sys
+
+RUN_BLOCK = re.compile(r"^(\s*)run:\s*[|>]")
+
+
+def oversized_steps(path, limit):
+    """Yield (line_number, size) for every literal `run:` block over `limit`."""
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    findings = []
+    index = 0
+    while index < len(lines):
+        match = RUN_BLOCK.match(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        indent = len(match.group(1))
+        start = index
+        index += 1
+        body = []
+        # The block runs until a line that is neither blank nor more-indented
+        # than the `run:` key itself. This is the same rule the YAML parser
+        # uses for a literal scalar, and it is why blank lines cannot end it.
+        while index < len(lines) and (
+            lines[index].strip() == ""
+            or len(lines[index]) - len(lines[index].lstrip()) > indent
+        ):
+            body.append(lines[index])
+            index += 1
+
+        size = len("\n".join(body))
+        if size > limit:
+            findings.append((start + 1, size))
+
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=16384)
+    parser.add_argument("workflows", nargs="+")
+    args = parser.parse_args()
+
+    failed = False
+    for path in args.workflows:
+        for line, size in oversized_steps(path, args.limit):
+            failed = True
+            print(
+                f"::error file={path},line={line}::`run:` block is {size} bytes, "
+                f"over the {args.limit}-byte limit. A step this large is what made "
+                f"quality.yml unresolvable in #161 — every caller produced ZERO jobs "
+                f"and nothing went red. Move the script into a file under scripts/ "
+                f"and call it, as #168 did."
+            )
+        print(f"checked {path}")
+
+    if failed:
+        return 1
+    print(f"OK — every `run:` block is under {args.limit} bytes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/count-workflow-jobs.sh
+++ b/scripts/count-workflow-jobs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Count the JOBS a workflow materialised for a given head SHA.
+#
+# WHY THIS COUNTS JOBS AND NOT CONCLUSIONS
+# ----------------------------------------
+# When a reusable workflow cannot be resolved, GitHub does not fail the run.
+# It produces a run with NO JOBS IN IT, or produces no run at all. Neither
+# shape is a red check — there is simply nothing to report — so every caller
+# in the fleet silently stops being checked while every dashboard stays clean.
+# That is what happened on 2026-08-04: a single `run:` step of ~22 KB made
+# .github/workflows/quality.yml unresolvable (#161), the fleet's gates
+# evaporated, and it took a revert (#166) and a re-land (#168) to recover.
+#
+# The outage signature is therefore `jobs == 0`, NOT `conclusion == failure`.
+# This script reports the count and says nothing about whether the jobs passed.
+#
+# Usage:
+#   count-workflow-jobs.sh <workflow-file-name> <head-sha> [timeout-seconds]
+#
+# Prints the job count on stdout. Always exits 0 — the CALLER decides what a
+# count means. A script that both measures and judges cannot be positive-
+# controlled against a case that is expected to measure zero.
+
+set -euo pipefail
+
+WORKFLOW="${1:?usage: count-workflow-jobs.sh <workflow-file-name> <head-sha> [timeout-seconds]}"
+HEAD_SHA="${2:?missing head sha}"
+TIMEOUT="${3:-300}"
+
+: "${GH_TOKEN:?GH_TOKEN must be set (needs actions:read)}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+deadline=$(( $(date +%s) + TIMEOUT ))
+
+# Poll rather than read once. The probe and the workflow it measures are
+# started by the SAME event, so the run under test may not exist yet at the
+# moment this script first looks. Reading once would make a scheduling race
+# indistinguishable from the outage, and the race is far more common — which
+# is the exact way a probe teaches its readers to ignore it.
+while :; do
+    runs_json="$(gh api \
+        "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${HEAD_SHA}&per_page=100" \
+        2>/dev/null || echo '{"workflow_runs":[]}')"
+
+    run_id="$(printf '%s' "${runs_json}" \
+        | jq -r '.workflow_runs | sort_by(.created_at) | reverse | .[0].id // empty')"
+
+    if [ -n "${run_id}" ]; then
+        # A run exists. Its jobs may still be materialising, so keep polling
+        # until at least one appears or the deadline passes: "not yet" and
+        # "never" look identical for the first few seconds.
+        count="$(gh api --paginate \
+            "repos/${REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+            --jq '.jobs[].id' 2>/dev/null | wc -l | tr -d ' ')"
+
+        if [ "${count}" -gt 0 ]; then
+            echo "${count}"
+            exit 0
+        fi
+    fi
+
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        # Either no run was ever created for this workflow at this SHA, or one
+        # was created and never grew a single job. Both are the outage.
+        echo "0"
+        exit 0
+    fi
+
+    sleep 10
+done


### PR DESCRIPTION
## What the PO asked for

> can we stop pinning the packadge per repro causing al repos to alwyas use the newest packadge.

23 repositories pin `hydra-gates-ref` (21 on `v1.3.0`, openregister and softwarecatalog on `v1.4.0`). Every gate fix therefore needs 23 PRs to reach the fleet, and the bump PRs are a treadmill: 11 are open right now for `v1.3.0 -> v1.4.0` alone.

## Ref strategy: `main`, not a moving `v1`

The `hydra-gates-ref` default here was already `main`. This PR makes that the documented contract, removes the pins on the caller side (separate PRs, one per repo), and states the rollback levers.

A moving major tag was considered. It buys a release boundary — but only while someone remembers to re-point it, and **a tag nobody re-points is indistinguishable from the stale pin this change exists to remove**. It would reproduce the failure silently, which is the one property being engineered out. `main` cannot rot.

**Rollback:**
- *fleet-wide, immediate* — revert the offending commit on this repo's `main`. One commit, no per-repo PRs, picked up on the next run. Strictly faster than the 23-PR bump a pin makes necessary.
- *one repo, immediate* — set `hydra-gates-ref:` explicitly in that repo's caller. Still supported and still honoured; a temporary escape hatch, not a resting state.

## Why main now needs a guard

Unpinning means a broken `main` reaches 23 repos at once. The failure mode that matters does not announce itself:

> An unresolvable reusable workflow is not a red check. GitHub produces a run with **no jobs**, or no run at all. Nothing fails, every dashboard stays green, and every caller quietly stops being checked.

That is #161 — a ~22 KB `run:` step — reverted by #166, re-landed by #168. The signature is `jobs == 0`, not `conclusion == failure`.

| file | role |
|---|---|
| `quality-selftest.yml` | in-repo caller of `./.github/workflows/quality.yml`. Exists to **be resolved**, not to pass. Its conclusion is not a verdict — do not make it a required check. |
| `quality-resolve-probe.yml` | **counts the jobs** that caller materialised, and asserts `> 0`. Never reads a conclusion. |
| `scripts/count-workflow-jobs.sh` | the counter. Polls, so a scheduling race is not mistaken for the outage. Always exits 0 — the caller judges, so the instrument can be controlled against an expected-zero case. |
| `scripts/assert-run-steps-resolvable.py` | static lint: no `run:` block over 16 KB. Catches the #161 class *before* merge and **names the offending step**, which a job count cannot. |

**Two workflows, deliberately.** With the `uses:` call inside the probe, an unresolvable `quality.yml` would delete the probe too — the required check would never report and the PR would sit **pending forever**, the hardest of the three dead-gate shapes to notice. Split in two, the probe always runs and the outage surfaces as an explicit red.

## Proof the guards can fail

Both are positive-controlled **on every run**, not once at authoring time:

- the probe first counts a workflow that cannot exist and requires the answer to be `0`. A counter that had started returning a constant, or that had lost its token scope, would otherwise pass the real check forever.
- the lint is re-run at a 1-byte limit it cannot possibly meet.

And the lint reproduces the **real historical outage**. Run against `quality.yml` as it stood at `d68fb72` (the commit that took the fleet down):

```
::error file=q161.yml,line=2338::`run:` block is 26959 bytes, over the 16384-byte limit.
rc=1
```

Against current `main`: `OK — every run: block is under 16384 bytes`, rc=0. Threshold sits above the largest step the fleet ships (10533 bytes) and below the size known to have broken it.

## `hydra-gates-package.yml` loses its `paths:` filter

Defensible while callers pinned — a repo on `v1.3.0` was unaffected by anything landing here. Not defensible once the fleet tracks `@main`: the runner resolves at **run** time, so a PR that touches nothing under `hydra-gates/` can still be the commit a caller picks up. A required check with a `paths:` filter is also its own trap — every excluded PR sits pending. The alternative was a hand-maintained filter, which decays exactly like the hand-maintained test list this same workflow already learned not to keep.

Refs #159, #161, #166, #168, #173