### PR TITLE
fix(hydra-gates): gate-64 read spelling, not code — 2 false REDs and 1 false GREEN

### DIFF
--- a/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
@@ -93,6 +93,20 @@ import sys
 PRELUDE = re.compile(r"registerAutoloading\s*\(([^)]*)\)", re.S)
 OPENREGISTER_LITERAL = re.compile(r"""['"]openregister['"]""")
 
+# A composition root may pass the app id as a CLASS CONSTANT rather than a
+# quoted literal — `const OPENREGISTER_APP_ID = 'openregister';` then
+# `registerAutoloading(self::OPENREGISTER_APP_ID, $path)`. That is the same
+# prelude and must not be read as its absence.
+#
+# MEASURED, not hypothetical: doriath ships exactly this shape
+# (lib/AppInfo/OpenRegisterAutoloader.php) and called it correctly, BEFORE the
+# Bootstrap reference in Application::register(). Matching only the literal
+# reported a compliant composition root as an ADR-040 violation — a gate
+# failing an app for the way it spells a constant.
+APPID_CONST = re.compile(
+    r"""const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]openregister['"]"""
+)
+
 # loadApp('openregister') is a WRONG fix, not a prelude — it boots OpenRegister
 # before its own register() has run. Named so the reader is told why.
 LOAD_APP = re.compile(r"""loadApp\s*\(\s*['"]openregister['"]\s*\)""")
@@ -135,11 +149,87 @@ def _sources(app_dir: str) -> dict[str, str]:
     return out
 
 
+def strip_comments(text: str) -> str:
+    """PHP source with comments removed, string literals preserved.
+
+    EVERY pattern below is evidence about CODE. Scanning raw source made
+    comments count as source, in both directions:
+
+      * `// Deliberately NOT IAppManager::loadApp('openregister')` — a comment
+        explaining why the WRONG fix was avoided — was reported as that wrong
+        fix. Measured on doriath, where both `loadApp` occurrences under
+        lib/AppInfo/ are prose saying the code does not do it.
+      * a commented-OUT `registerAutoloading('openregister', …)` would have
+        counted as a prelude that no longer runs — a false GREEN, the more
+        dangerous direction.
+
+    Newlines are preserved so any line-based reporting stays aligned.
+
+    `#[` opens a PHP 8 attribute, not a comment; treating it as one would
+    swallow the rest of the line, including `#[NoAdminRequired]`.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    state: str | None = None
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if state is None:
+            if c == "'":
+                state, _ = "sq", out.append(c)
+                i += 1
+            elif c == '"':
+                state, _ = "dq", out.append(c)
+                i += 1
+            elif c == "/" and nxt == "/":
+                state, i = "line", i + 2
+            elif c == "#" and nxt != "[":
+                state, i = "line", i + 1
+            elif c == "/" and nxt == "*":
+                state, i = "block", i + 2
+            else:
+                out.append(c)
+                i += 1
+        elif state in ("sq", "dq"):
+            quote = "'" if state == "sq" else '"'
+            if c == "\\" and i + 1 < n:
+                out.append(c)
+                out.append(text[i + 1])
+                i += 2
+                continue
+            out.append(c)
+            if c == quote:
+                state = None
+            i += 1
+        elif state == "line":
+            if c == "\n":
+                out.append(c)
+                state = None
+            i += 1
+        else:  # block
+            if c == "*" and nxt == "/":
+                state, i = None, i + 2
+            else:
+                if c == "\n":
+                    out.append(c)
+                i += 1
+    return "".join(out)
+
+
 def has_prelude(text: str) -> bool:
-    """True when text contains registerAutoloading(... 'openregister' ...)."""
+    """True when text registers OpenRegister's autoloader.
+
+    Accepts the app id as a quoted literal OR as a constant defined in the
+    same composition root to that literal — both are the same prelude.
+    """
+    const_names = set(APPID_CONST.findall(text))
     for m in PRELUDE.finditer(text):
-        if OPENREGISTER_LITERAL.search(m.group(1)):
+        args = m.group(1)
+        if OPENREGISTER_LITERAL.search(args):
             return True
+        for name in const_names:
+            if re.search(r"\b" + re.escape(name) + r"\b", args):
+                return True
     return False
 
 
@@ -162,23 +252,29 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
     if not sources:
         return []
 
+    # Every rule below is evidence about CODE, so it reads comment-stripped
+    # source. The SUPPRESSION is the one exception — it is authored AS a
+    # comment — so it keeps reading the raw text.
+    raw_blob = "\n".join(sources.values())
+    code = {path: strip_comments(text) for path, text in sources.items()}
+
     # OpenRegister owns AppHost — exempt by namespace, not by directory name,
     # so a checkout under any directory name is still recognised.
-    if any(OWN_NAMESPACE.search(text) for text in sources.values()):
+    if any(OWN_NAMESPACE.search(text) for text in code.values()):
         return []
 
-    blob = "\n".join(sources.values())
+    blob = "\n".join(code.values())
 
     # The prelude may legitimately live in a sibling composition-root file that
     # register() calls, so look for it across the whole of lib/AppInfo/.
     if has_prelude(blob):
         return []
 
-    if suppression_reason(blob):
+    if suppression_reason(raw_blob):
         return []
 
     findings: list[tuple[str, str]] = []
-    for path, text in sorted(sources.items()):
+    for path, text in sorted(code.items()):
         if BOOTSTRAP_REF.search(text):
             findings.append(
                 (path, "references OCA\\OpenRegister\\AppHost\\Bootstrap")

--- a/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
@@ -220,5 +220,157 @@ class WrongFixTest(GateCase):
         self.assertIn("bootApp()", out)
 
 
+class ConstantAppIdTest(GateCase):
+    """The app id may be a class constant, not only a quoted literal.
+
+    MEASURED on doriath, which shipped a correct prelude
+    (lib/AppInfo/OpenRegisterAutoloader.php) called BEFORE its Bootstrap
+    reference, and was still reported as an ADR-040 violation — the gate was
+    reading how the id is SPELLED, not what the code does.
+    """
+
+    def test_constant_resolving_to_openregister_is_a_prelude(self):
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    private const OPENREGISTER_APP_ID = 'openregister';
+    public function register($context): void {
+        $p = \\OCP\\Server::get(\\OCP\\App\\IAppManager::class)
+            ->getAppPath(self::OPENREGISTER_APP_ID);
+        \\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $p);
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        self.assertEqual(
+            _run(self.dir)[0], 0,
+            "a constant defined to 'openregister' is the same prelude",
+        )
+
+    def test_prelude_may_live_in_a_sibling_file(self):
+        """doriath's real shape: the prelude is its own class."""
+        self.app("OpenRegisterAutoloader.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+class OpenRegisterAutoloader {
+    private const OPENREGISTER_APP_ID = 'openregister';
+    public static function register(): bool {
+        try {
+            $m = \\OCP\\Server::get(\\OCP\\App\\IAppManager::class);
+            \\OC_App::registerAutoloading(
+                self::OPENREGISTER_APP_ID,
+                $m->getAppPath(self::OPENREGISTER_APP_ID)
+            );
+            return true;
+        } catch (\\Throwable) {
+            return false;
+        }
+    }
+}
+""")
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    public function register($context): void {
+        OpenRegisterAutoloader::register();
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_constant_naming_a_DIFFERENT_app_is_not_a_prelude(self):
+        """The positive control: the constant path must still be able to fail."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    private const OTHER_APP_ID = 'opencatalogi';
+    public function register($context): void {
+        \\OC_App::registerAutoloading(self::OTHER_APP_ID, $p);
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        self.assertEqual(
+            _run(self.dir)[0], 1,
+            "registering SOME OTHER app's autoloader is not the prelude",
+        )
+
+
+class CommentsAreNotCodeTest(GateCase):
+    """Every rule is evidence about code, so comments must not feed it."""
+
+    def test_comment_explaining_that_loadApp_is_avoided_is_not_a_finding(self):
+        """doriath's second false finding, exactly.
+
+        Both `loadApp` occurrences under its lib/AppInfo/ are prose saying the
+        code deliberately does NOT call it.
+        """
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    private const OPENREGISTER_APP_ID = 'openregister';
+    public function register($context): void {
+        // Deliberately NOT IAppManager::loadApp('openregister'): that would
+        // boot OpenRegister before its own register() has run.
+        \\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $p);
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0, "a comment about loadApp is not a call to it")
+        self.assertNotIn("bootApp()", out)
+
+    def test_commented_OUT_prelude_is_NOT_a_prelude(self):
+        """The dangerous direction: stripping comments must not buy a green."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    public function register($context): void {
+        // \\OC_App::registerAutoloading('openregister', $p);
+        /* \\OC_App::registerAutoloading('openregister', $p); */
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        self.assertEqual(
+            _run(self.dir)[0], 1,
+            "a prelude that does not RUN is not a prelude",
+        )
+
+    def test_php8_attribute_is_not_read_as_a_comment(self):
+        """`#[` opens an attribute; treating it as `#` would eat the line."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+class Application {
+    #[SomeAttribute]
+    public function register($context): void {
+        if (class_exists('OCA\\\\OpenRegister\\\\AppHost\\\\Bootstrap') === true) {
+            return;
+        }
+    }
+}
+""")
+        self.assertEqual(
+            _run(self.dir)[0], 1,
+            "the class_exists probe after an attribute must still be seen",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Found while unpinning `hydra-gates-ref` across the 14 caller repos: doriath went red on gate-64 with 2 findings. Neither is real.

## What was wrong

`check_apphost_autoload_prelude.py` judged ADR-040 compliance from **raw text**, which was wrong in both directions.

### False RED 1 — the app id as a class constant
`has_prelude()` required a quoted `'openregister'` *inside* `registerAutoloading(...)`. doriath passes it as `self::OPENREGISTER_APP_ID`:

- `lib/AppInfo/OpenRegisterAutoloader.php:55` — `private const OPENREGISTER_APP_ID = 'openregister';`
- `lib/AppInfo/OpenRegisterAutoloader.php:89` — `\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $path);`
- `lib/AppInfo/Application.php:145` — calls that prelude
- `lib/AppInfo/Application.php:150` — *only then* references `Bootstrap`

That is exactly what ADR-040 asks for. Substituting the literal for the constant flips `has_prelude()` from `False` to `True` with no other change — the gate was reading how the id is **spelled**, not what the code does.

### False RED 2 — comments counted as code
The `loadApp` rule matched doriath's own prose explaining that the code deliberately does **not** use it. Both occurrences under `lib/AppInfo/` are comments (`Application.php:131`, `OpenRegisterAutoloader.php:69`). Documentation of the correct choice was reported as the wrong one.

### False GREEN 3 — a commented-OUT prelude counted as a prelude
The more dangerous direction, found while writing the tests: an app whose prelude had been **commented out** passed gate-64. This is why the fix strips comments generally rather than patching the two observed symptoms.

## The fix

- All rules read comment-stripped source.
- The **suppression** annotation still reads raw text — it is authored as a comment.
- `#[` is preserved as a PHP 8 attribute, not treated as a `#` comment.
- Constants defined to `'openregister'` in the same composition root are resolved.

## Evidence it still bites

Measured across all 14 consumer repos:

| repo | before | after |
|---|---|---|
| doriath | 2 findings | **0** (compliant) |
| procest | 1 | **1** (genuine — no prelude anywhere) |
| openbuild | 1 | **1** (genuine, LIVE-EXPOSED) |
| scholiq | 1 | **1** (genuine) |
| other 10 | 0 | 0 |

6 tests added. **Against the pre-fix checker 4 of them fail**, so they are shown capable of failing rather than merely passing. The existing 14 tests are unchanged and still pass.