### PR TITLE
fix(gate-64): a named constant is the prelude, spelled better — not a missing one

### DIFF
--- a/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
@@ -93,6 +93,34 @@ import sys
 PRELUDE = re.compile(r"registerAutoloading\s*\(([^)]*)\)", re.S)
 OPENREGISTER_LITERAL = re.compile(r"""['"]openregister['"]""")
 
+# A name BOUND to the literal 'openregister' in the same blob. Three spellings:
+#   const OPENREGISTER_APP_ID = 'openregister';
+#   define('OPENREGISTER_APP_ID', 'openregister');
+#   $openRegisterAppId = 'openregister';
+# The binding must be to the EXACT literal — this resolves names, it does not
+# guess at them, and a name bound to anything else is not a match.
+CONST_BINDING = re.compile(
+    r"""(?:
+          const\s+(?P<name1>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]openregister['"]
+        | define\s*\(\s*['"](?P<name2>[A-Za-z_][A-Za-z0-9_]*)['"]\s*,\s*['"]openregister['"]
+        | \$(?P<name3>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]openregister['"]
+    )""",
+    re.X,
+)
+
+
+def _binding_name(match: "re.Match[str]") -> str:
+    return match.group("name1") or match.group("name2") or match.group("name3")
+
+
+# A name USED as a call argument: `self::NAME`, `static::NAME`, `Cls::NAME`,
+# a bare `NAME`, or `$var`. Matched against the bound names above, never
+# accepted on its own.
+ARG_NAME = re.compile(
+    r"""(?:(?:self|static|parent|[A-Za-z_][A-Za-z0-9_\\]*)\s*::\s*)?"""
+    r"""\$?(?P<name>[A-Za-z_][A-Za-z0-9_]*)""",
+)
+
 # loadApp('openregister') is a WRONG fix, not a prelude — it boots OpenRegister
 # before its own register() has run. Named so the reader is told why.
 LOAD_APP = re.compile(r"""loadApp\s*\(\s*['"]openregister['"]\s*\)""")
@@ -135,11 +163,45 @@ def _sources(app_dir: str) -> dict[str, str]:
     return out
 
 
+def openregister_aliases(text: str) -> set[str]:
+    """Names bound to the literal 'openregister' somewhere in this text.
+
+    WHY THIS EXISTS. The prelude used to be recognised only as a QUOTED literal
+    inside the call parentheses:
+
+        \\OC_App::registerAutoloading('openregister', $path);        accepted
+        \\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $path);  REJECTED
+
+    The second form is the same call with the app id given a name, which is the
+    better of the two — and doriath, which does exactly that, was reported as
+    having NO prelude while its prelude sat four lines above the call. A gate
+    that fails the tidier spelling of the thing it is asking for teaches people
+    to write the untidy one, and its finding is not about the defect at all.
+
+    Resolution is deliberately SHALLOW and LITERAL: a name counts only when
+    this same source blob binds it to the exact string 'openregister'. We do
+    not follow imports, and we do not accept a name we cannot see bound. An
+    unresolvable name is still a finding — see test_unknown_constant_still_FAILS
+    and test_constant_bound_to_another_app_still_FAILS, which are what stop this
+    from becoming "any argument at all satisfies the gate".
+    """
+    return {_binding_name(m) for m in CONST_BINDING.finditer(text)} - {""}
+
+
 def has_prelude(text: str) -> bool:
-    """True when text contains registerAutoloading(... 'openregister' ...)."""
+    """True when text calls registerAutoloading() for the openregister app.
+
+    Accepts the app id as a quoted literal, or as any name this same blob binds
+    to that literal (a class constant, a define(), or a plain variable).
+    """
+    aliases = openregister_aliases(text)
     for m in PRELUDE.finditer(text):
-        if OPENREGISTER_LITERAL.search(m.group(1)):
+        args = m.group(1)
+        if OPENREGISTER_LITERAL.search(args):
             return True
+        for ref in ARG_NAME.finditer(args):
+            if ref.group("name") in aliases:
+                return True
     return False
 
 

--- a/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
@@ -124,6 +124,93 @@ class RedThenGreenTest(GateCase):
         self.assertIn("apphost-autoload-prelude: OK", out)
 
 
+class NamedConstantPreludeTest(GateCase):
+    """The app id may be given a NAME, and that must not be a finding.
+
+    doriath writes the prelude as
+
+        \\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $path);
+
+    with `private const OPENREGISTER_APP_ID = 'openregister';` four lines
+    above. That is the same call as the documented one, spelled better — and
+    the gate reported it as having NO prelude, because the matcher required a
+    QUOTED literal inside the parentheses.
+
+    Measured on doriath#163: gate-64 FAIL, "2 AppHost adoption(s) with no
+    OpenRegister autoload prelude", with the prelude present and correct.
+
+    The three tests below are one unit. The first is the fix; the second and
+    third are what stop the fix from being "accept any argument", which would
+    make the gate blind to the defect it exists to catch.
+    """
+
+    CONST_FORM = """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    private const %s = '%s';
+    public function register($context): void {
+        $path = \\OCP\\Server::get(\\OCP\\App\\IAppManager::class)->getAppPath('openregister');
+        \\OC_App::registerAutoloading(self::%s, $path);
+        Bootstrap::register($context, 'leaf', []);
+    }
+}
+"""
+
+    def test_named_constant_bound_to_openregister_is_GREEN(self):
+        self.app("Application.php", self.CONST_FORM % (
+            "OPENREGISTER_APP_ID", "openregister", "OPENREGISTER_APP_ID"))
+        rc, out = _run(self.dir)
+        self.assertEqual(
+            rc, 0,
+            "a const bound to 'openregister' IS the prelude — this is doriath's shape")
+        self.assertIn("apphost-autoload-prelude: OK", out)
+
+    def test_constant_bound_to_another_app_still_FAILS(self):
+        """The discriminator. Same syntax, different binding."""
+        self.app("Application.php", self.CONST_FORM % (
+            "SOME_OTHER_APP_ID", "opencatalogi", "SOME_OTHER_APP_ID"))
+        rc, out = _run(self.dir)
+        self.assertEqual(
+            rc, 1,
+            "registerAutoloading() for a DIFFERENT app is not an OpenRegister prelude")
+        self.assertIn("FAIL", out)
+
+    def test_unknown_constant_still_FAILS(self):
+        """A name the blob never binds must not be taken on trust."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    public function register($context): void {
+        \\OC_App::registerAutoloading(self::NEVER_DEFINED_ANYWHERE, $path);
+        Bootstrap::register($context, 'leaf', []);
+    }
+}
+""")
+        rc, out = _run(self.dir)
+        self.assertEqual(
+            rc, 1,
+            "an unresolvable name must not satisfy the gate — that is how it goes blind")
+        self.assertIn("FAIL", out)
+
+    def test_variable_and_define_spellings_are_accepted(self):
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    public function register($context): void {
+        $openRegisterAppId = 'openregister';
+        $path = \\OCP\\Server::get(\\OCP\\App\\IAppManager::class)->getAppPath($openRegisterAppId);
+        \\OC_App::registerAutoloading($openRegisterAppId, $path);
+        Bootstrap::register($context, 'leaf', []);
+    }
+}
+""")
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0, "a variable bound to the literal is the same prelude")
+
+
 class DetectionShapesTest(GateCase):
     def test_class_exists_probe_without_prelude_is_RED(self):
         self.app("Application.php", """<?php


### PR DESCRIPTION
## The finding that had nothing behind it

gate-64 recognised the ADR-040 autoload prelude only as a **quoted literal inside the call parentheses**:

```php
\OC_App::registerAutoloading('openregister', $path);              // accepted
\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $path);   // REJECTED
```

The second is the same call with the app id given a name, four lines below `private const OPENREGISTER_APP_ID = 'openregister';`. doriath writes it that way — and gate-64 reported it as an AppHost adoption with **no** prelude, with the prelude present, correct, and unit-tested.

Measured on doriath#163: `FAIL — 2 AppHost adoption(s) with no OpenRegister autoload prelude`.

A gate that fails the tidier spelling of the thing it is asking for is not reporting a defect. It teaches people to write the untidy spelling, and it spends the reader's attention on nothing.

## The fix, and why it does not go blind

Resolution is deliberately **shallow and literal**: a name counts only when the same source blob binds it to the exact string `'openregister'` — via `const`, `define()`, or a plain variable. Imports are not followed, and **a name that cannot be seen bound is not accepted**.

That last property is the whole design. "Accept any argument" would clear doriath and blind the gate in the same stroke, so two of the four new tests exist to fail in exactly that direction.

| test | direction |
|---|---|
| `test_named_constant_bound_to_openregister_is_GREEN` | doriath's shape passes |
| `test_variable_and_define_spellings_are_accepted` | the other two bindings |
| `test_constant_bound_to_another_app_still_FAILS` | `registerAutoloading()` for a **different** app is not a prelude |
| `test_unknown_constant_still_FAILS` | an unresolvable name is not taken on trust |

### Mutants — disjoint sets, both directions

| mutant | tests turned red |
|---|---|
| accept any argument name | the 2 discriminators |
| resolve nothing (regression to the bug) | the 2 acceptance tests |

## Measured against the real trees

This is what settles it — the gate must lose the false positive **and keep both true positives**.

| repo | gate-64 @ `main` | with this fix | |
|---|---|---|---|
| doriath | `rc=1` FAIL | `rc=0` PASS | false positive cleared |
| scholiq | `rc=1` FAIL | `rc=1` FAIL | real defect, still caught |
| openbuild | `rc=1` FAIL | `rc=1` FAIL | real defect, still caught |

scholiq and openbuild genuinely have no prelude, and openbuild is the acute one: its `class_exists(Bootstrap::class)` guard answers **false** on a perfectly healthy instance, because `openbuild` sorts before `openregister` and `Coordinator::registerApps()` registers autoloading one app at a time. So `Bootstrap::register()` has apparently never run there, and its generic controllers, install repair steps and deep-link listener are silently absent. Those are fixed in their own repos, not here.

⚠️ Note on my own method: my first before/after table was **wrong in the safe-looking direction** — I copied the "baseline" helper *after* patching it, so both columns ran the fixed matcher and doriath appeared to pass on `main`. The table above is re-measured against `git show origin/main:` and the md5sums were checked. A baseline captured after the edit is not a baseline.

18 gate-64 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)