### PR TITLE
fix(release): default to Node 22, not the long-dead Node 18

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -36,7 +36,15 @@ on:
         description: "Node.js version for building"
         required: false
         type: string
-        default: "18"
+        # 22, not 18. Node 18 left support in April 2025 and now fails on
+        # packages the fleet already depends on. Two apps could not release
+        # because of it: nldesign's icon build loads an ES module from
+        # @conduction/nextcloud-vue and dies with "Unexpected token 'export'",
+        # since Node 18 treats it as CommonJS, and app_versions builds with
+        # Vite 7, which requires 20.19+. Both build fine locally on 22, which
+        # is the sort of gap that never gets diagnosed because the failure
+        # only exists on the runner.
+        default: "22"
       verify-vendor-deps:
         description: "Enable vendor dependency verification after composer install"
         required: false

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -16,7 +16,10 @@ on:
         description: "Node.js version for building"
         required: false
         type: string
-        default: "18"
+        # 22, matching release-beta.yml. Node 18 is out of support and fails
+        # on packages the fleet already uses; a stable release must not be
+        # built on a toolchain the beta of the same code could not use.
+        default: "22"
       verify-vendor-deps:
         description: "Enable vendor dependency verification after composer install"
         required: false


### PR DESCRIPTION
Node 18 left support in April 2025 and now fails on packages the fleet already depends on. It cost **two apps their releases**:

- **nldesign** — the icon build loads an ES module from `@conduction/nextcloud-vue` and dies with `SyntaxError: Unexpected token 'export'`, because Node 18 treats it as CommonJS. Node 20.19+ can require ESM, so it builds fine locally and only fails on the runner.
- **app_versions** — builds with Vite 7, which requires Node 20.19+.

Both are the failure mode nobody diagnoses: works on every developer's machine, only the runner disagrees.

Callers can still pin their own `node-version`; this only moves the floor for those that don't. `release.yml` already defaulted to 20 and is left alone, since nothing has failed on it.