### PR TITLE
fix(release): keep .hydra out of the package

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -214,6 +214,7 @@ jobs:
             --exclude='/.git' \
             --exclude='/.github' \
             --exclude='/.claude' \
+            --exclude='/.hydra' \
             --exclude='/.cursor' \
             --exclude='/.vscode' \
             --exclude='/.nextcloud' \

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -185,6 +185,7 @@ jobs:
             --exclude='/.git' \
             --exclude='/.github' \
             --exclude='/.claude' \
+            --exclude='/.hydra' \
             --exclude='/.cursor' \
             --exclude='/.vscode' \
             --exclude='/.nextcloud' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
             --exclude='/.git' \
             --exclude='/.github' \
             --exclude='/.claude' \
+            --exclude='/.hydra' \
             --exclude='/.cursor' \
             --exclude='/.vscode' \
             --exclude='/.nextcloud' \


### PR DESCRIPTION
openregister ships a **symlink to an absolute path on one developer's machine** in every release:

```
openregister/.hydra -> /home/rubenlinde/nextcloud-docker-dev/workspace/server/apps-extra/hydra
```

It was committed before `.gitignore` covered it, so ignoring it now doesn't untrack it, and rsync copies it into the tarball.

Any extractor guarding against path traversal refuses **the whole archive**. Nextcloud's does — installing openregister through App Versions fails with `Out-of-path file extraction` and nothing installs. The archive is otherwise valid, which is why `tar tzf` and GNU tar are perfectly happy and the problem only shows at install time.

`.hydra` is developer tooling with no business in a release, so it joins `.claude`, `.cursor` and `.vscode` in the excludes across all three release workflows.

openregister still needs the tracked symlink removed (separate PR); this stops any app shipping one by accident.