### PR TITLE
fix(gate-14): an AppHost generic the leaf registers itself is not an unreachable route

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_route_auth.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_auth.sh
@@ -117,7 +117,7 @@ _expect_log() {   # <snapshot-var-contents> <regex> <description>
 echo "== gate-5 route-auth / gate-14 reachability control pairs =="
 echo
 
-for _f in unguarded guarded apphost apphost-unguarded orphan-route; do
+for _f in unguarded guarded apphost apphost-unguarded orphan-route di-registered-generic; do
     if [ ! -d "${FIXTURES}/${_f}" ]; then
         _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
     fi
@@ -193,6 +193,34 @@ if _run "${FIXTURES}/orphan-route"; then
         "orphan-route fixture: gate-14 log names controller-class-not-found"
     _expect_log "${_RRLOG}" 'rule=method-not-found-on-target-controller' \
         "orphan-route fixture: gate-14 still names the missing-method shape too"
+fi
+
+# ---------------------------------------------------------------------------
+# 5b. THE OTHER WAY AN APPHOST GENERIC REACHES A ROUTE. openconnector
+#     (2026-08-07) registers OpenRegister's GenericPreferencesController
+#     itself, under the standard controller class name, so the generic gets
+#     this app's `appName` and its `pref_` user values stay scoped here. No
+#     Bootstrap::register() alias, and the route slug is `genericPreferences`
+#     rather than `preferences` — so the five-slug list could not see it and
+#     gate-14 reported a working endpoint unreachable.
+#
+#     The control lives in the SAME fixture: `gadget#run` names a class that
+#     is neither on disk nor registered. If _di_binds_controller() ever
+#     loosens into "this app registers services, so absences are fine", that
+#     assertion goes red here rather than going quiet in the fleet.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/di-registered-generic"; then
+    _expect_gate 14 FAIL "di-registered-generic fixture: an unregistered, absent controller is still raised"
+    _expect_log "${_RRLOG}" "GadgetController.php route='gadget#run' rule=controller-class-not-found" \
+        "di-registered-generic fixture: gate-14 names gadget#run"
+    if printf '%s' "${_RRLOG}" | grep -q 'GenericPreferencesController'; then
+        _bad "di-registered-generic fixture: gate-14 reported the DI-registered generic as unreachable"
+    else
+        _ok "di-registered-generic fixture: the DI-registered generic is NOT reported"
+    fi
+    _expect_gate 5 PASS "di-registered-generic fixture: the absent generic is not an auth finding either"
+    _expect_log "${_UNRES}" 'genericPreferences#getPreference' \
+        "di-registered-generic fixture: gate-5 states the generic was NOT JUDGED rather than dropping it"
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -503,6 +503,68 @@ _apphost_serves() {
 }
 
 # ---------------------------------------------------------------------------
+# _di_binds_controller <controller-file-path> — 0 when lib/AppInfo/Application.php
+# registers a service under EXACTLY the class name that path resolves to.
+#
+# `Bootstrap::register()` is not the only way an AppHost generic reaches a
+# route. A leaf that needs the generic constructed with its OWN collaborators
+# registers it itself, under the standard controller class name, because that
+# is the name NC's `App::main` synthesises from a plain route slug:
+#
+#   openconnector lib/AppInfo/Application.php
+#     $context->registerService(
+#         'OCA\\OpenConnector\\Controller\\GenericPreferencesController',
+#         static fn ($c) => new GenericPreferencesController(appName: 'openconnector', ...)
+#     );
+#
+# The class resolves at request time and has no file here — the same
+# legitimate absence `_apphost_serves` already covers, arrived at a different
+# way. The slug list could not see it: it is keyed on the five slugs
+# Bootstrap aliases (`preferences`), and this route is named
+# `genericPreferences`, so gate-14 called a working endpoint unreachable.
+#
+# Deliberately NOT a wildcard, and deliberately not "the app adopts AppHost,
+# so absences are fine". The evidence required is the exact fully-qualified
+# class name appearing as a literal within a few lines of a registerService
+# call — i.e. this repository can be shown to bind that specific name. A
+# controller that is simply missing still fails, which is the invariant.
+# ---------------------------------------------------------------------------
+_di_binds_controller() {
+    local _p="$1"
+    [ -f lib/AppInfo/Application.php ] || return 1
+
+    # lib/Controller/Sub/FooController.php -> Sub\FooController
+    local _rel="${_p#lib/Controller/}"
+    _rel="${_rel%.php}"
+    local _cls="${_rel//\//\\}"
+
+    # The app's own namespace, from its own file: `namespace OCA\<App>\AppInfo;`
+    local _app_ns
+    _app_ns=$(grep -m1 -oE '^namespace[[:space:]]+OCA\\[A-Za-z0-9_]+' lib/AppInfo/Application.php \
+        | awk '{print $2}')
+    [ -n "${_app_ns}" ] || return 1
+
+    # In PHP source the literal carries escaped backslashes.
+    local _fqcn="${_app_ns}\\Controller\\${_cls}"
+    local _needle="${_fqcn//\\/\\\\}"
+
+    # Through the environment, NOT `awk -v`: -v runs escape processing over the
+    # value, so the `\\` pairs this needle is made of arrive as single
+    # backslashes and never match the PHP literal. Silently — the helper just
+    # answers "no such binding" for every controller, which reads exactly like
+    # a correct verdict.
+    _HYDRA_DI_NEEDLE="${_needle}" awk '
+        BEGIN { needle = ENVIRON["_HYDRA_DI_NEEDLE"] }
+        /registerService(Alias)?[[:space:]]*\(/ { window = 6 }
+        window > 0 {
+            if (index($0, needle) > 0) { found = 1; exit }
+            window--
+        }
+        END { exit(found ? 0 : 1) }
+    ' lib/AppInfo/Application.php
+}
+
+# ---------------------------------------------------------------------------
 # _ctrl_path_from_name <route-slug> — the file a routed `controller#method`
 # name resolves to. Handles the three shapes Nextcloud accepts:
 #
@@ -918,7 +980,7 @@ if [ -f appinfo/routes.php ]; then
             [ -n "${ctrl:-}" ] || continue
             path=$(_ctrl_path_from_name "${ctrl}")
             if [ ! -f "$path" ]; then
-                if _apphost_serves "${ctrl}"; then
+                if _apphost_serves "${ctrl}" || _di_binds_controller "${path}"; then
                     echo "${ctrl}#${method} — served by the OpenRegister AppHost generic controller (ADR-040); its auth attribute lives in the openregister package and is NOT visible from this repository" >> "${_ra_unresolved_log}"
                 else
                     echo "${ctrl}#${method} — ${path} is not present in this repository; controller class UNRESOLVED (see gate-14, which owns route reachability)" >> "${_ra_unresolved_log}"
@@ -1469,10 +1531,13 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
                 # ReflectionException 500 at request time — precisely
                 # invariant 2, one step earlier than a missing method.
                 #
-                # ADR-040 AppHost generics are the ONE legitimate absence:
-                # Bootstrap::register() binds those class names in the DI
-                # container, so the route resolves with no file on disk.
+                # ADR-040 AppHost generics are the legitimate absence: the
+                # class name is bound in the DI container, so the route
+                # resolves with no file on disk. Two ways in — Bootstrap
+                # aliasing one of its five generics, or the leaf registering
+                # the generic itself under the standard controller name.
                 _apphost_serves "${_ctrl}" && continue
+                _di_binds_controller "${_path}" && continue
                 echo "${_path} route='${_ctrl}#${_method}' rule=controller-class-not-found" >> "${_rr_log}"
                 continue
             fi

--- a/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/appinfo/routes.php
@@ -1,0 +1,32 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture mirroring openconnector (2026-08-07): an AppHost generic reaching a
+// route WITHOUT Bootstrap::register() aliasing it.
+//
+// This app needs OpenRegister's GenericPreferencesController constructed with
+// its OWN appName, so that the `pref_` user-value namespace stays scoped here
+// rather than to OpenRegister. It therefore registers the generic itself, in
+// lib/AppInfo/Application.php, under the standard controller class name — the
+// name NC's App::main synthesises from a plain route slug. The file does not
+// exist in this repository, by design, exactly as with a Bootstrap alias.
+//
+// The slug is `genericPreferences`, NOT `preferences`, because the service key
+// must be the class name the router builds. That is why the five-slug
+// _apphost_serves() list cannot recognise it, and why gate-14 called a working
+// endpoint unreachable.
+//
+// `gadget#run` is the control half, kept in this same fixture so it cannot
+// drift away from the case it guards: a class that is neither on disk nor
+// registered anywhere is still a reachability defect. If
+// _di_binds_controller() ever loosens into "this app registers services, so
+// absences are fine", this route goes quiet and the suite goes red.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'gadget#run',  'url' => '/api/gadgets/run',  'verb' => 'POST'],
+
+        ['name' => 'genericPreferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        ['name' => 'genericPreferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/lib/AppInfo/Application.php
@@ -1,0 +1,47 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Controller\GenericPreferencesController;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+
+/**
+ * NOTE: no `Bootstrap::register()` call. This app adopts ONE AppHost generic
+ * and wires it by hand, because it needs `appName` injected so the `pref_`
+ * user-value namespace stays scoped to this app rather than to OpenRegister.
+ *
+ * The service key MUST be the standard `OCA\Fixture\Controller\…` namespace:
+ * that is the class name NC's App::main synthesises from the plain
+ * `genericPreferences#…` route slug. A key in any other namespace is never
+ * looked up by the router and every request 503s.
+ */
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'fixture';
+
+    public function register(IRegistrationContext $context): void
+    {
+        $context->registerService(
+            'OCA\\Fixture\\Controller\\GenericPreferencesController',
+            static function (ContainerInterface $c) {
+                return new GenericPreferencesController(
+                    appName: self::APP_ID,
+                    request: $c->get(IRequest::class),
+                    config: $c->get(IConfig::class),
+                    userSession: $c->get(IUserSession::class)
+                );
+            }
+        );
+    }
+
+    public function boot(\OCP\AppFramework\Bootstrap\IBootContext $context): void
+    {
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/di-registered-generic/lib/Controller/WidgetController.php
@@ -1,0 +1,21 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * An ordinary, guarded controller. Present so this fixture's gate-5 verdict
+ * is about the generic and the orphan route, not about a stray IDOR shape.
+ */
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}


### PR DESCRIPTION
`Bootstrap::register()` is not the only way an ADR-040 AppHost generic reaches a route.

A leaf that needs the generic constructed with its **own** collaborators registers it by hand, under the standard controller class name — the name NC's `App::main` synthesises from a plain route slug:

```php
// openconnector lib/AppInfo/Application.php
$context->registerService(
    'OCA\OpenConnector\Controller\GenericPreferencesController',
    static fn ($c) => new GenericPreferencesController(appName: self::APP_ID, ...)
);
```

`appName` is the point: it keeps the `pref_` user-value namespace scoped to openconnector rather than to OpenRegister. The class resolves at request time and has no file in the leaf repo — the same legitimate absence `_apphost_serves` already covers, arrived at a different way.

## Why the slug list could not see it

`_HYDRA_APPHOST_SLUGS` is keyed on the five slugs Bootstrap aliases (`preferences`). This route has to be named `genericPreferences`, because that is the slug from which `App::main` builds the class name the service is registered under. So gate-14 reported `genericPreferences#getPreference` and `#setPreference` as `controller-class-not-found` — **two findings on a working endpoint, on every openconnector run**.

## The fix asks for evidence, not for a category

`_di_binds_controller` requires the exact fully-qualified class name to appear as a literal within a few lines of a `registerService` call in the app's own `Application.php`.

Not a wildcard, and deliberately not *"this app adopts AppHost, so absences are fine"* — a controller that is simply missing still fails, which is the invariant the gate exists for.

## One thing worth calling out

The needle goes through the environment, **not** `awk -v`. `-v` runs escape processing over the value, so the `\\` pairs a PHP class literal is made of arrive as single backslashes and match nothing. That failure is silent: the helper answers "no such binding" for every controller, which reads exactly like a correct verdict. Caught by exercising the helper directly before wiring it in.

## Tests

New fixture `di-registered-generic`, carrying its own control in the same directory so the two cannot drift apart:

- the DI-registered generic must **not** be reported
- `gadget#run` — a class neither on disk nor registered — must **still** be reported
- gate-5 must state the generic was NOT JUDGED, naming AppHost as the reason, rather than dropping it

Verified by renaming the registration away and watching the generic come back as a finding, so the exemption is doing work rather than blanket-passing.

`test_gate_route_auth.sh`: 30 assertions, 0 failures. Full helper-suite run: 26 passed, 2 quarantined as documented, 0 failed.
