### PR TITLE
fix(gate-30,gate-38): both gates reported correct code, and both remedies were security or noise

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
+++ b/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_monitoring_and_skiplink.sh — control pairs for gate-30
+# (public-monitoring) and gate-38 (skip-link).
+#
+# WHY THIS EXISTS
+# ---------------
+# Both gates were reporting correct code, and both remedies were worse than
+# the finding.
+#
+#   gate-30  demanded #[PublicPage] on every monitoring-shaped route,
+#            including /api/metrics. ADR-006 makes metrics admin-only ON
+#            PURPOSE — openregister's engine-owned GenericMetricsController
+#            carries only #[NoCSRFRequired] and says "admin-only, ADR-006",
+#            while its GenericHealthController IS #[PublicPage]. The only way
+#            to close the finding was to publish the fleet's metrics to
+#            anonymous callers.
+#
+#   gate-38  looked for <NcContent> in the root component. All 18 fleet apps
+#            root on <CnAppRoot>, which RENDERS an NcContent one component
+#            deeper — so the gate reported every app in the fleet as shipping
+#            no skip link. The only way to close it was to bolt a second,
+#            redundant skip link on top of the one already there.
+#
+# Both fixes widen what counts as an answer, and widening is exactly how a
+# gate goes quiet. So each fixture here has a sibling that differs by the ONE
+# thing the widening accepts, and must still fail:
+#
+#   stated/      metrics documents its admin-only posture   -> gate-30 PASS
+#                health is #[PublicPage]
+#                App.vue is a CnAppRoot                     -> gate-38 PASS
+#
+#   accidental/  metrics says NOTHING about its posture     -> gate-30 FAIL
+#                health is admin-only, however documented   -> gate-30 FAIL
+#                App.vue is a bespoke shell whose only      -> gate-38 FAIL
+#                mention of NcContent/skip-link is a comment
+#
+# Run: bash scripts/lib/test_gate_monitoring_and_skiplink.sh  (exit 0 = green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+FIXTURES="${PKG_ROOT}/scripts/test-fixtures/monitoring-skiplink"
+
+_fail_n=0
+_pass_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+_OUT=""
+_PMLOG=""
+_SLLOG=""
+_run() {
+    local _dir="$1"; shift
+    local _logdir
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-test.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    _PMLOG="$(cat "${_logdir}/hydra-gate-public-monitoring.log" 2>/dev/null || true)"
+    _SLLOG="$(cat "${_logdir}/hydra-gate-skip-link.log" 2>/dev/null || true)"
+    # A run that aborts before its summary leaves the per-gate PASS lines on
+    # stdout and reads exactly like a clean run.
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "run in ${_dir} ABORTED before the summary — verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_expect_gate() {  # <n> <PASS|FAIL> <description>
+    local _n="$1" _want="$2" _desc="$3" _line
+    _line="$(printf '%s' "${_OUT}" | grep -E "^\[gate-${_n}\] " | head -1)"
+    if [ -z "${_line}" ]; then
+        _bad "${_desc} — gate-${_n} emitted NO verdict line at all"
+        return
+    fi
+    case "${_line}" in
+        *": ${_want}"*) _ok "${_desc} — ${_line}" ;;
+        *) _bad "${_desc} — wanted ${_want}, got: ${_line}" ;;
+    esac
+}
+
+_expect_log() {   # <log-contents> <regex> <description>
+    if printf '%s' "$1" | grep -qE "$2"; then _ok "$3"; else
+        _bad "$3 — no log line matching /$2/"
+    fi
+}
+_expect_not_log() {
+    if printf '%s' "$1" | grep -qE "$2"; then
+        _bad "$3 — unexpected: $(printf '%s' "$1" | grep -E "$2" | head -1)"
+    else _ok "$3"; fi
+}
+
+echo "== gate-30 public-monitoring / gate-38 skip-link control pairs =="
+echo
+
+for _f in stated accidental; do
+    [ -d "${FIXTURES}/${_f}" ] || _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
+done
+
+# ---------------------------------------------------------------------------
+# 1. THE POSITIVE CONTROL, first. Everything in section 2 is only meaningful
+#    because these fire.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/accidental"; then
+    _expect_gate 30 FAIL "accidental: an undeclared monitoring posture is still reported"
+    _expect_log "${_PMLOG}" 'MetricsController.php:[0-9]+ method=index' \
+        "accidental: metrics with no stated posture at all is named"
+    _expect_log "${_PMLOG}" 'HealthController.php:[0-9]+ method=index' \
+        "accidental: an admin-only HEALTH endpoint is named — the carve-out is metrics-only"
+
+    _expect_gate 38 FAIL "accidental: a bespoke shell with no skip link is still reported"
+    _expect_log "${_SLLOG}" 'App\.vue: no <NcContent> shell' \
+        "accidental: gate-38 names the root component"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The shapes that were being reported wrongly.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/stated"; then
+    _expect_gate 30 PASS "stated: a documented admin-only metrics endpoint is not a finding"
+    _expect_not_log "${_PMLOG}" 'MetricsController' \
+        "stated: metrics is absent from the log entirely"
+    _expect_not_log "${_PMLOG}" 'HealthController' \
+        "stated: a #[PublicPage] health endpoint is absent from the log"
+
+    _expect_gate 38 PASS "stated: a CnAppRoot shell counts as having NC's skip link"
+    _expect_not_log "${_SLLOG}" 'App\.vue' \
+        "stated: gate-38 log is empty"
+fi
+
+echo
+echo "== summary =="
+printf '   passed: %d\n   failed: %d\n' "${_pass_n}" "${_fail_n}"
+[ "${_fail_n}" -eq 0 ] || exit 1
+echo
+echo "ALL control pairs held."

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2616,7 +2616,43 @@ if [ -f appinfo/routes.php ] && [ -d lib/Controller ]; then
             # Inspect annotations above the method declaration (up to 20 lines back)
             _ann_start=$((_method_line > 20 ? _method_line - 20 : 1))
             _annotations=$(sed -n "${_ann_start},${_method_line}p" "${_ctrl_path}")
-            if ! echo "${_annotations}" | grep -qE '#\[PublicPage\]|@PublicPage\b'; then
+            # An explicitly declared ADMIN posture is an answer too. What this
+            # gate is really preventing is an ACCIDENTAL posture: in Nextcloud
+            # the absence of `#[NoAdminRequired]` IS the admin gate, so a
+            # deliberate admin-only endpoint and a forgotten attribute look
+            # identical in the source. `#[AuthorizedAdminSetting(...)]` is the
+            # one positive, code-level way to say "admin required" and settles
+            # it either way.
+            # Anchored to ATTRIBUTE position (`#[` at the start of a line) or
+            # PHPDoc-TAG position (`* @`), never as a loose substring. The
+            # 20-line window is a blind slice, so it routinely contains a class
+            # docblock, and prose about an attribute is not an attribute: a
+            # sentence reading "no #[PublicPage] here on purpose" was closing
+            # this gate. Same anchoring gate-9 already applies for the same
+            # reason (openregister#1419, 8 of 10 findings were prose).
+            _pm_ok='^[[:space:]]*#\[PublicPage\]|^[[:space:]]*\*[[:space:]]*@PublicPage\b|^[[:space:]]*#\[AuthorizedAdminSetting\('
+            case "${_ctrl}" in
+                *metrics*)
+                    # ADR-006 makes /api/metrics admin-only ON PURPOSE, and the
+                    # engine that owns the decision says so in prose rather than
+                    # in an attribute: openregister's GenericMetricsController
+                    # carries only #[NoCSRFRequired] and documents "admin-only,
+                    # ADR-006" — while its GenericHealthController IS
+                    # #[PublicPage]. Demanding #[PublicPage] on metrics asks the
+                    # fleet to publish its metrics to anonymous callers to
+                    # satisfy a gate, which is the gate overriding the
+                    # architecture it exists to encode.
+                    #
+                    # A stated admin-only posture therefore counts here, and
+                    # ONLY here. It is weaker evidence than an attribute — prose
+                    # can lie — but the alternative is a finding whose only
+                    # remedy is a security regression. health / liveness /
+                    # readiness / probe keep the strict requirement; the engine
+                    # agrees with the gate on those.
+                    _pm_ok="${_pm_ok}"'|^[[:space:]]*\*.*[Aa]dmin-only'
+                    ;;
+            esac
+            if ! echo "${_annotations}" | grep -qE "${_pm_ok}"; then
                 echo "${_ctrl_path}:${_method_line} method=${_method} rule=monitoring-endpoint-missing-public-page" >> "${_pm_log}"
             fi
         done
@@ -3063,6 +3099,21 @@ if [ -d src ] || [ -d templates ]; then
         local _f="$1"
         _in_scope "$_f" || return 0
         if grep -qE '<NcContent\b|<NcAppContent\b|<NcAppContentList\b' "$_f" 2>/dev/null; then return 0; fi
+        # The shared app shell. `<CnAppRoot>` (@conduction/nextcloud-vue) IS an
+        # <NcContent> — it renders one as its own root element and puts the
+        # router-view inside an <NcAppContent> — so an app whose App.vue is a
+        # CnAppRoot has NC's skip-link, one component deeper than this grep can
+        # see.
+        #
+        # All 18 fleet apps root on CnAppRoot, so this gate reported every one
+        # of them as shipping no skip link. Same principle already written down
+        # for the AppHost generics in gate-5/gate-14: "I cannot see it" is not
+        # "it is absent", and only the first of those is true here.
+        #
+        # This does not weaken the gate for an app that writes its own shell —
+        # a root component that is neither an NcContent nor a CnAppRoot still
+        # has to carry a skip-link affordance of its own.
+        if grep -qE '<CnAppRoot\b' "$_f" 2>/dev/null; then return 0; fi
         # The skip-link affordance must be an actual anchor or marked
         # element — not just a stray mention of the words. Accept:
         #   - <a ... class="skip-link" ...> or class containing skip-link / skip-nav

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/appinfo/routes.php
@@ -1,0 +1,8 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+return [
+    'routes' => [
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+        ['name' => 'health#index',  'url' => '/api/health',  'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/lib/Controller/HealthController.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/lib/Controller/HealthController.php
@@ -1,0 +1,35 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * THE CONTROL for the strict half.
+ *
+ * Health keeps the hard requirement — the engine agrees with the gate there —
+ * so a session-gated health endpoint is a defect however it is written up.
+ * This one states its restricted posture in the same words the metrics
+ * carve-out accepts, and must STILL be reported: that carve-out is for
+ * metrics and for nothing else.
+ *
+ * Restricted to administrators, deliberately.
+ */
+class HealthController extends Controller
+{
+    /**
+     * GET /api/health.
+     *
+     * Admin-only, deliberately — see the class docblock.
+     *
+     * @return JSONResponse `{status, app, version, checks}`.
+     */
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse($this->engine->checks());
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/lib/Controller/MetricsController.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/lib/Controller/MetricsController.php
@@ -1,0 +1,33 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\TextPlainResponse;
+
+/**
+ * THE CONTROL for the metrics carve-out.
+ *
+ * The `stated` fixture's shape with its posture sentence taken out. Nothing
+ * here declares what the endpoint requires, which is precisely what a
+ * forgotten attribute looks like, so it must still be reported.
+ *
+ * Nothing in this file names an attribute, in prose or otherwise — a fixture
+ * that quotes the pattern it is meant to defeat defeats itself instead (the
+ * gate-56 lesson).
+ */
+class MetricsController extends Controller
+{
+    /**
+     * GET /api/metrics — declarative Prometheus metrics.
+     *
+     * @return TextPlainResponse Prometheus text exposition 0.0.4.
+     */
+    #[NoCSRFRequired]
+    public function index(): TextPlainResponse
+    {
+        return new TextPlainResponse($this->engine->render());
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/src/App.vue
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/src/App.vue
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<template>
+	<!--
+	  THE CONTROL for the shared-shell exemption. A bespoke shell: the root is
+	  a plain <div>, not the shared app root and not a Nextcloud content
+	  wrapper, and there is no jump-to-content affordance anywhere in it.
+
+	  The words this gate looks for appear nowhere in this file, including
+	  here — a fixture that quotes the pattern it is meant to defeat defeats
+	  itself instead (the gate-56 lesson).
+	-->
+	<div class="fixture-app">
+		<nav class="fixture-app__nav">
+			<a href="/apps/fixture/things">Things</a>
+		</nav>
+		<main class="fixture-app__main">
+			<router-view />
+		</main>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'App',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/appinfo/routes.php
@@ -1,0 +1,8 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+return [
+    'routes' => [
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+        ['name' => 'health#index',  'url' => '/api/health',  'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/lib/Controller/HealthController.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/lib/Controller/HealthController.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\JSONResponse;
+
+class HealthController extends Controller
+{
+    /**
+     * GET /api/health — scraped by kubelet and by external uptime monitors,
+     * neither of which has a Nextcloud session.
+     *
+     * @return JSONResponse `{status, app, version, checks}`.
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse($this->engine->checks());
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/lib/Controller/MetricsController.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/lib/Controller/MetricsController.php
@@ -1,0 +1,28 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\TextPlainResponse;
+
+/**
+ * Copied in structure from openregister's engine-owned
+ * GenericMetricsController, which is where ADR-006 puts the decision.
+ */
+class MetricsController extends Controller
+{
+    /**
+     * GET /api/metrics — declarative Prometheus metrics (admin-only, ADR-006).
+     *
+     * Admin-only by the deliberate absence of `#[NoAdminRequired]`.
+     *
+     * @return TextPlainResponse Prometheus text exposition 0.0.4.
+     */
+    #[NoCSRFRequired]
+    public function index(): TextPlainResponse
+    {
+        return new TextPlainResponse($this->engine->render());
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/src/App.vue
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/src/App.vue
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<template>
+	<CnAppRoot
+		app-id="fixture"
+		:manifest="manifest"
+		:registry="registry" />
+</template>
+
+<script>
+import { CnAppRoot } from '@conduction/nextcloud-vue'
+
+export default {
+	name: 'App',
+	components: { CnAppRoot },
+}
+</script>


### PR DESCRIPTION
Two gates were reporting correct code, and in both cases the only way to close the finding made things worse.

## gate-38 — the shared app shell

The gate greps the root component for `<NcContent>`. **All 18 fleet apps root on `<CnAppRoot>`** (`@conduction/nextcloud-vue`), which renders an `NcContent` as its own root element and puts the router-view inside an `NcAppContent`. So every app in the fleet has NC's skip link — one component deeper than a grep of `App.vue` can reach — and every app in the fleet was reported as shipping none.

The remedy on offer was to bolt a second, redundant skip link on top of the one already there.

Same principle already written down for the AppHost generics in gate-5/gate-14: *"I cannot see it" is not "it is absent"*. An app that writes its own shell is unaffected — it still has to carry its own affordance.

## gate-30 — metrics is admin-only on purpose

The gate demanded `#[PublicPage]` on every monitoring-shaped route, metrics included. ADR-006 says otherwise, and the engine that owns the decision is explicit about it:

| controller | attributes | posture |
|---|---|---|
| openregister `GenericMetricsController::index` | `#[NoCSRFRequired]` | *"admin-only, ADR-006"* |
| openregister `GenericHealthController::index` | `#[PublicPage]` `#[NoCSRFRequired]` | public |

The only way to close the finding was to publish the fleet's metrics to anonymous callers — the gate overriding the architecture it exists to encode.

**Now accepted for any monitoring route:** `#[PublicPage]`, or `#[AuthorizedAdminSetting(...)]`. The second matters because in Nextcloud the *absence* of `#[NoAdminRequired]` is what does the gating, so a deliberate admin-only endpoint and a forgotten attribute are identical in the source; `AuthorizedAdminSetting` is the one positive, code-level way to say "admin required".

**For metrics-shaped names only**, a stated admin-only posture also counts, because the engine records the decision in prose and ships no attribute. That is weaker evidence and is labelled as such in the code — but the alternative is a finding whose only remedy is a security regression. `health` / `liveness` / `readiness` / `probe` keep the hard requirement; the engine agrees with the gate on those.

## A hole found while writing the tests

gate-30 matched its attributes as loose substrings over a blind 20-line window. That window routinely contains a class docblock, and **prose about an attribute is not an attribute** — a sentence reading *"no `#[PublicPage]` here on purpose"* was closing the gate. Now anchored to attribute position (`#[` at line start) or PHPDoc-tag position (`* @`), the same way gate-9 anchors for the same reason (openregister#1419, 8 of 10 findings were prose).

I found this because **my first control fixture passed** — its own explanatory comment quoted the pattern it was meant to defeat. That is the gate-56 lesson happening live. The fixtures now name no attribute at all.

## Tests

New `test_gate_monitoring_and_skiplink.sh`, picked up automatically by the discovery runner. 10 assertions across a `stated` / `accidental` fixture pair that differ only by the one thing each widening accepts:

- metrics with **no** stated posture → still FAILS
- an admin-only **health** endpoint → still FAILS, however it is documented
- a bespoke shell with no skip link → still FAILS

Full helper-suite run: 27 passed, 2 quarantined as documented, 0 failed.
