### PR TITLE
fix(gate-40): an external <label for> pointing at input-id is a real association

### DIFF
--- a/hydra-gates/scripts/lib/check_form_labels.py
+++ b/hydra-gates/scripts/lib/check_form_labels.py
@@ -151,6 +151,23 @@ def scan_source(fname: str, src: str) -> list[str]:
             v = _attr(attrs, 'id')
             if v and _norm_expr(v) in label_for:
                 return True
+        if name in NC_PROP_COMPONENTS:
+            # `input-id` is what an Nc* wrapper puts on the <input> it renders,
+            # and it is the documented way to point an EXTERNAL <label for> at
+            # that input. The association is real HTML — the same one accepted
+            # for a native element two lines up — so it is an accessible name
+            # by the same evidence.
+            #
+            # Without this, a field written the way the shared components
+            # document it was reported as unlabelled, and the only way to
+            # close the finding was to add a redundant aria-label overriding
+            # the visible label, or a second visible one:
+            #
+            #   <label :for="filePathId">File path or glob</label>
+            #   <NcTextField :input-id="filePathId" ... />
+            v = _attr(attrs, 'input-id')
+            if v and _norm_expr(v) in label_for:
+                return True
         return False
 
     def _report(name: str, attrs: str, rule: str) -> None:

--- a/hydra-gates/scripts/lib/test_check_form_labels.py
+++ b/hydra-gates/scripts/lib/test_check_form_labels.py
@@ -160,6 +160,47 @@ class DynamicIdForPairs(unittest.TestCase):
         """), [])
 
 
+class InputIdOnAWrapperComponent(unittest.TestCase):
+    """`input-id` is how an Nc* wrapper exposes the <input> it renders, and
+    the documented way to point an EXTERNAL <label for> at it. That is the
+    same real HTML association already accepted for a native element, so it
+    is an accessible name by the same evidence.
+
+    Before this, a field written the way the shared components document it
+    was reported unlabelled, and the only remedies were a redundant
+    aria-label overriding the visible label, or a second visible one.
+    """
+
+    def test_fp_an_external_label_for_a_bound_input_id_associates(self):
+        # openconnector SyncConfigWidget, verbatim in shape.
+        self.assertEqual(rules("""
+            <label :for="filePathId" class="sync-config__label">
+                {{ t('openconnector', 'File path or glob') }}
+            </label>
+            <NcTextField :input-id="filePathId" :model-value="sourceIdValue" />
+        """), [])
+
+    def test_fp_a_literal_input_id_associates_too(self):
+        self.assertEqual(rules("""
+            <label for="sync-file-path">File path or glob</label>
+            <NcTextField input-id="sync-file-path" :model-value="v" />
+        """), [])
+
+    def test_tp_an_input_id_no_label_points_at_is_still_reported(self):
+        # The control. If the exemption ever degrades into "has an input-id
+        # at all", this goes quiet — and with it every wrapper whose label
+        # was deleted, renamed, or never written.
+        self.assertEqual(rules("""
+            <label :for="someOtherId">File path or glob</label>
+            <NcTextField :input-id="filePathId" :model-value="v" />
+        """), ["nctextfield-without-label-prop"])
+
+    def test_tp_an_input_id_with_no_label_anywhere_is_still_reported(self):
+        self.assertEqual(rules("""
+            <NcTextField :input-id="filePathId" :model-value="v" />
+        """), ["nctextfield-without-label-prop"])
+
+
 # --------------------------------------------------------------------------
 # Mode 4 — markup that does not ship.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The gate already accepts a matching `for` / `id` pair as an accessible name for a **native** element — bound expressions normalised and all — and then declined to accept the same evidence one line later for an Nc\* wrapper.

`input-id` is what those wrappers put on the `<input>` they render, and the documented way to point an external label at it. So a field written the way the shared components document it was reported unlabelled:

```vue
<label :for="filePathId">File path or glob</label>
<NcTextField :input-id="filePathId" ... />
```

The only ways to close that finding were a redundant `aria-label` overriding the visible label, or a second visible one. Observed on openconnector `SyncConfigWidget`.

The fix reuses the existing `label_for` set and `_norm_expr` normalisation, so a bound `input-id` matches a bound `:for` exactly the way `:id` already does.

## Tests

Four new assertions, **two of them controls**:

- an `input-id` that no label points at → still reported
- an `input-id` with no label anywhere → still reported

If the exemption ever degrades into "has an input-id at all", those go red rather than the fleet going quiet. Suite: 31 passed. Full helper-suite run: 27 passed, 2 quarantined as documented, 0 failed.