### PR TITLE
fix(gate-51): an ADR-037 overlay fragment does not own the metadata it is overlaying

### DIFF
--- a/hydra-gates/scripts/lib/check_schema_property_meta.py
+++ b/hydra-gates/scripts/lib/check_schema_property_meta.py
@@ -241,6 +241,33 @@ def _check_property(file_path, schema_name, prop_path, prop, line, findings):
     if set(prop.keys()) <= {"$ref"}:
         return
 
+    # An ADR-037 overlay fragment property — same reasoning as the $ref case
+    # above, one step further.
+    #
+    # `lib/Settings/register.d/99-source-secrets-writeonly.json` exists to
+    # deep-merge ONE flag onto a property the base register already declares:
+    #
+    #     "apikey": { "writeOnly": true }
+    #
+    # It declares no type, no shape, no members — the base register owns all
+    # of that, including the title and description. Demanding metadata here
+    # forces every fragment to restate the base's prose, and duplicated prose
+    # drifts: the fragment's copy goes stale the moment the base is edited,
+    # and neither copy is then trustworthy.
+    #
+    # The test is structural, not path-based: a property is an overlay when it
+    # DECLARES nothing (no type/shape/members) and DOCUMENTS nothing. A
+    # property carrying a title but no description still fails — it is trying
+    # to declare, and half its metadata is genuinely missing.
+    _DECLARING = {
+        "type", "properties", "items", "enum", "format",
+        "$ref", "oneOf", "anyOf", "allOf", "const",
+    }
+    if not (_DECLARING & set(prop.keys())) and not (
+        prop.get("title") or prop.get("description")
+    ):
+        return
+
     title = prop.get("title")
     desc = prop.get("description")
     missing = []

--- a/hydra-gates/scripts/lib/test_check_schema_property_meta.py
+++ b/hydra-gates/scripts/lib/test_check_schema_property_meta.py
@@ -79,6 +79,73 @@ class FullScanTest(unittest.TestCase):
             self.assertFalse(any("titledProp" in m for m in msgs))
 
 
+class OverlayFragmentTest(unittest.TestCase):
+    """An ADR-037 fragment deep-merges a flag onto a property the BASE register
+    already declares — and already titles and describes.
+
+    Real shape, from openconnector
+    `lib/Settings/register.d/99-source-secrets-writeonly.json`:
+
+        "apikey": { "writeOnly": true }
+
+    Demanding a title there forces every fragment to restate the base's prose,
+    and duplicated prose drifts: the fragment's copy goes stale the moment the
+    base is edited, and neither copy is then trustworthy.
+
+    The controls are what keep this from becoming "properties may skip their
+    metadata": anything that DECLARES (a type, a shape, members) or that has
+    already started DOCUMENTING (a title, a description) is still checked.
+    """
+
+    def _scan(self, props):
+        with tempfile.TemporaryDirectory() as d:
+            f = os.path.join(d, "fragment.json")
+            doc = {"components": {"schemas": {"source": {"properties": props}}}}
+            Path(f).write_text(json.dumps(doc, indent=2))
+            findings = []
+            g.check_file(f, findings)
+            return [m for _, m in findings]
+
+    def test_a_pure_overlay_property_is_not_flagged(self):
+        self.assertEqual(self._scan({"apikey": {"writeOnly": True}}), [])
+
+    def test_several_overlay_properties_are_not_flagged(self):
+        self.assertEqual(
+            self._scan({
+                "apikey": {"writeOnly": True},
+                "secret": {"writeOnly": True},
+                "password": {"writeOnly": True},
+            }),
+            [],
+        )
+
+    def test_a_property_that_declares_a_type_is_still_flagged(self):
+        # THE CONTROL. Add one declaring key and the exemption must not apply:
+        # this is a declaration site, so it owns its own metadata.
+        msgs = self._scan({"apikey": {"writeOnly": True, "type": "string"}})
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn("missing title + description", msgs[0])
+
+    def test_a_half_documented_overlay_is_still_flagged(self):
+        # THE OTHER CONTROL. A property that has started documenting is not an
+        # overlay — the missing half is genuinely missing.
+        msgs = self._scan({"apikey": {"writeOnly": True, "title": "API key"}})
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn("missing description", msgs[0])
+        self.assertNotIn("title", msgs[0].split("missing", 1)[1])
+
+    def test_an_overlay_with_nested_members_is_still_flagged(self):
+        # A fragment that introduces structure is declaring, not overlaying.
+        msgs = self._scan({
+            "authenticationConfig": {
+                "writeOnly": True,
+                "properties": {"scheme": {"type": "string"}},
+            },
+        })
+        self.assertTrue(any("authenticationConfig" in m for m in msgs), msgs)
+        self.assertTrue(any("scheme" in m for m in msgs), msgs)
+
+
 class DiffScopeTest(unittest.TestCase):
     """Property-level diff-scoping: only properties on changed lines flag."""
 


### PR DESCRIPTION
`lib/Settings/register.d/99-source-secrets-writeonly.json` exists to deep-merge **one flag** onto properties the base register already declares:

```json
"apikey": { "writeOnly": true }
```

It declares no type, no shape, no members — the base register owns all of that, **including the title and the description**. The gate asked for metadata anyway, so on openconnector it reported 10 findings whose only remedy was to restate the base's prose in every fragment.

Duplicated prose drifts. The fragment's copy goes stale the moment the base is edited, and neither copy is then trustworthy — which is worse than the missing title the finding was about.

This is the same reasoning the `$ref` skip directly above it already applies, one step further: a site that points at a declaration elsewhere has no place for a title.

## The test is structural, not path-based

A property is an overlay when it **declares nothing** (no `type`/`properties`/`items`/`enum`/`format`/`$ref`/`oneOf`/`anyOf`/`allOf`/`const`) **and documents nothing** (no title, no description). No filename matching, so a fragment that starts declaring is judged like any other declaration site.

## Tests

Five assertions, **three of them controls**:

- add a `type` → flagged again, both fields
- add a `title` → the missing description is still reported
- add nested `properties` → the property *and* its members are checked

Measured on openconnector: **25 findings → 16**. All 9 removed were pure overlays; all 16 remaining are genuine and are being fixed app-side.

Suite: 10 passed (was 5). Full helper-suite run: 27 passed, 2 quarantined as documented, 0 failed.