### PR TITLE
fix(gate-19): rx.test(...) is JavaScript's RegExp, not Playwright's test()

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -457,8 +457,22 @@ _E2E_SHORT_RE = re.compile(
 # guard; a literal `true` is a test someone turned off. Conflating them would
 # swap this gate's blindness for a different one — refusing legitimate
 # conditional skips — so the discriminator is the argument, not the call.
+# `\b` is not enough of a boundary: it matches the `test` in `rx.test(text)`,
+# and JavaScript's RegExp.prototype.test is not Playwright's test(). On
+# openconnector, `dead-letter-replay.spec.ts` has
+#
+#     IGNORED_CONSOLE_PATTERNS.some((rx) => rx.test(text))
+#
+# in a helper ABOVE its tests, and the forward search from the file-level
+# `@e2e` tags landed on it. `_ref_is_live` then read that call's "body" —
+# there is none — and reported all 11 refs as "referenced only by a test that
+# never runs", about a file whose tests run fine.
+#
+# `(?<![.\w$])` rejects a member call (`rx.test`, `foo.it`) and an identifier
+# that merely ends in one (`latest(`, `submit(`), while leaving a bare
+# `test(` / `it(` / `describe(` at a statement boundary matching.
 _TEST_DECL_RE = re.compile(
-    r"\b(?P<fn>test|it|describe)"
+    r"(?<![.\w$])(?P<fn>test|it|describe)"
     r"(?P<mod>\s*\.\s*(?:skip|fixme|failing))?"
     r"\s*\(",
 )

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -780,6 +780,50 @@ class SkippedTestIsNotCoverageTest(unittest.TestCase):
         self.assertIn("my-spec::foo-does-bar", dead)
         self.assertIn("never runs", dead["my-spec::foo-does-bar"])
 
+    # --- a member call named `test` is not a test -----------------------
+    def test_a_regexp_test_call_is_not_mistaken_for_the_enclosing_test(self):
+        # openconnector dead-letter-replay.spec.ts, verbatim in shape: a
+        # console-filter helper sits between the file-level @e2e tags and the
+        # real tests, and it calls RegExp.prototype.test. The forward search
+        # landed on `rx.test(text)`, found no body, and reported all 11 refs
+        # as "referenced only by a test that never runs" — about a file whose
+        # tests run fine.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "const IGNORED = [/Deprecation/i]\n"
+            "function spy(page) {\n"
+            "  page.on('console', (msg) => {\n"
+            "    if (IGNORED.some((rx) => rx.test(msg.text()))) return\n"
+            "  })\n"
+            "}\n"
+            "test('the view mounts', async ({ page }) => {\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"))
+
+    def test_an_identifier_merely_ending_in_test_is_not_a_test(self):
+        # `latest(` / `submit(` end in `it`/`test` and must not open a block.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n"
+            "const v = latest(versions)\n"
+            "test('the view mounts', async ({ page }) => {\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"))
+
+    def test_a_member_call_does_not_rescue_a_genuinely_skipped_test(self):
+        # THE CONTROL. Ignoring `rx.test(...)` must not make the gate skip
+        # forward past a real skipped test and find a live one instead — the
+        # skipped test still owns this tag, and it must still be dead.
+        _write(self.root, "tests/e2e/foo.spec.ts",
+               "// @e2e my-spec::foo-does-bar\n"
+               "const ok = /x/.test('x')\n"
+               "test('x', async () => { test.skip(true, 'later') })\n"
+               "test('unrelated', async ({ page }) => {\n"
+               "  await expect(page).toHaveTitle(/x/)\n"
+               "})\n")
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertEqual(live, set())
+        self.assertIn("my-spec::foo-does-bar", dead)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`_TEST_DECL_RE` anchored on `\b`, which matches the `test` in `rx.test(text)`.

openconnector's `dead-letter-replay.spec.ts` has a console-filter helper sitting between its file-level `@e2e` tags and its real tests:

```js
IGNORED_CONSOLE_PATTERNS.some((rx) => rx.test(text))
```

The forward search from each tag landed there. `_ref_is_live` found no body on a member call and the gate reported **all 11 refs** as *"referenced only by a test that never runs"* — about a file whose tests run fine.

That is the worst shape this gate can produce: it tells an author their coverage is dead, and the remedy it offers (*unskip it, give it a body*) has nothing to act on.

## The fix

`(?<![.\w$])` rejects a member call (`rx.test`, `foo.it`) and an identifier that merely ends in one (`latest(`, `submit(`), while a bare `test(` / `it(` / `describe(` at a statement boundary still matches.

## Tests

Three assertions, **one of them the control**: a `/x/.test(...)` sitting in front of a genuinely skipped test must NOT let the search run past it to a live test further down. The skipped test still owns that tag, and it is still dead.

Suite: 48 passed (was 45). Full helper-suite run: 27 passed, 2 quarantined as documented, 0 failed.