### PR TITLE
fix(gate-19): the finding count was returned as an exit status, and a byte only holds 255

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -767,7 +767,14 @@ def run_gate(app_dir: Path) -> int:
         print(
             f"[gate-{GATE_NUM}] e2e-coverage: FAIL — {count} scenario(s) without a running e2e test"
         )
-    return count
+    # An exit code is one byte. Returning the raw count means 266 leaves as
+    # 10, and — the case that matters — a count of exactly 256 leaves as 0,
+    # which the caller reads as PASS on 256 uncovered scenarios.
+    #
+    # The printed summary above carries the true number and is what the bash
+    # gate now reports; this is only the pass/fail signal, so it is clamped
+    # into the byte and never allowed to wrap to zero while findings exist.
+    return min(count, 255)
 
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -536,6 +536,50 @@ class GateModeTest(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("PASS", buf.getvalue())
 
+    def test_the_status_never_wraps_to_zero_while_findings_exist(self):
+        # An exit status is one byte. Returning the raw count meant 266
+        # findings left as 10 — and 256 findings left as 0, which the bash
+        # gate reads as PASS. Any multiple of 256 was a silent green.
+        _write(self.root, "README.md", "# app\n")
+        base = self._commit("base")
+        spec = ["# S\n\n## Requirements\n\n### Requirement: R\n"]
+        for i in range(256):
+            spec.append(f"\n#### Scenario: scenario number {i}\n\n- **WHEN** x happens\n")
+        _write(self.root, "openspec/specs/s/spec.md", "".join(spec))
+        self._commit("add spec")
+
+        os.environ["HYDRA_GATE_BASE_REF"] = base
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cec.run_gate(self.root)
+        finally:
+            del os.environ["HYDRA_GATE_BASE_REF"]
+
+        self.assertNotEqual(rc, 0, "256 findings must not exit 0")
+        self.assertLessEqual(rc, 255, "an exit status is one byte")
+        # The TRUE number still has to reach the reader, which is why the
+        # bash gate reports the printed summary rather than the status.
+        self.assertIn("256 scenario(s) without a running e2e test", buf.getvalue())
+
+    def test_the_clamp_does_not_turn_a_clean_spec_into_a_failure(self):
+        # THE CONTROL for the clamp.
+        _write(self.root, "README.md", "# app\n")
+        base = self._commit("base")
+        _write(self.root, "openspec/specs/s/spec.md",
+               "# S\n\n## Requirements\n\n### Requirement: R\n\n"
+               "#### Scenario: only one\n\n- **WHEN** x happens\n"
+               "- @e2e exclude backend only — covered by PHPUnit\n")
+        self._commit("add spec")
+
+        os.environ["HYDRA_GATE_BASE_REF"] = base
+        try:
+            with redirect_stdout(io.StringIO()):
+                rc = cec.run_gate(self.root)
+        finally:
+            del os.environ["HYDRA_GATE_BASE_REF"]
+        self.assertEqual(rc, 0)
+
     def test_fail_uncovered_scenario_in_diff(self):
         # Baseline: nothing
         _write(self.root, "README.md", "# app\n")

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1863,10 +1863,17 @@ if [ -d openspec/specs ] || [ -d tests/e2e ]; then
         _skip 19 "e2e-coverage" wiring "check_e2e_coverage.py not found at ${_e2e_lib_dir} — no spec scenario was inspected; @e2e traceability (ADR-020) is UNVERIFIED by this run."
     fi
     if [ "${_e2e_ran}" -eq 1 ]; then
+        # Prefer the count the helper PRINTED over its exit status. An exit
+        # code is one byte: 266 findings left as 10, and 256 findings would
+        # have left as 0 — reported as PASS. The helper clamps its status now,
+        # but the honest number is the one in its summary line.
+        _e2e_count=$(grep -oE 'FAIL — [0-9]+ scenario' "${_e2e_log}" 2>/dev/null \
+            | tail -1 | grep -oE '[0-9]+' || true)
+        [ -z "${_e2e_count}" ] && _e2e_count="${_e2e_fail}"
         if [ "${_e2e_fail}" -eq 0 ]; then
             _pass 19 "e2e-coverage"
         else
-            _fail 19 "e2e-coverage" "${_e2e_fail} scenario(s) missing @e2e — see ${_e2e_log}"
+            _fail 19 "e2e-coverage" "${_e2e_count} scenario(s) missing @e2e — see ${_e2e_log}"
         fi
     fi
 fi
@@ -3744,10 +3751,31 @@ for fp in files:
         throws_ok = any(x in (m['docblock'] or '') for x in TRACKED)
         if try_ok or throws_ok:
             continue
-        # Otherwise: if any service call inside the body invokes a known-throwy shape,
-        # log the method. Restricted to OR-specific suffixed names to keep false
-        # positives low; full symbol resolution is out of scope for this gate.
-        risky = re.search(r'\b(deleteObject|findObject|saveObject|updateObject|loadObject|get(One|Object|Register|Schema))\b', body)
+        # Otherwise: if any SERVICE CALL invokes a known-throwy shape, log the
+        # method. Matched against `service_calls` — the `$this->prop->name(`
+        # receivers collected above — and NOT against free text in the body.
+        #
+        # The free-text form asked two unrelated questions and ANDed them:
+        # "does this method call any service at all?" and "does one of these
+        # words appear anywhere?". `getObject` is on the list because
+        # OpenRegister's ObjectService HAS a getObject() — but ObjectEntity has
+        # one too, and that one is a plain array accessor that throws nothing.
+        # So `$entity->getObject()`, which is how every controller reads an
+        # object it already holds, counted as a risky service call. On
+        # openconnector that was 9 of 12 findings, each pointing at a line
+        # doing nothing riskier than reading a property off an entity in hand.
+        #
+        # `find` joins the list at the same time: ObjectService::find()
+        # documents `@throws Exception If the object is not found`, and reading
+        # one object by id is the commonest way a controller meets that throw.
+        # `findAll` deliberately does NOT join it — that one documents no
+        # throws, and adding it would flag every list endpoint in the fleet,
+        # trading one set of false positives for another.
+        RISKY = re.compile(
+            r'^(deleteObject|findObject|find|saveObject|updateObject'
+            r'|loadObject|get(One|Object|Register|Schema))$'
+        )
+        risky = any(RISKY.match(name) for name in service_calls)
         if risky:
             with open(log_path, 'a', encoding='utf-8') as g:
                 g.write(f"{fp}:{m['start_line']}: {m['name']}() calls a service method that may throw a tracked exception, "


### PR DESCRIPTION
`run_gate` returned `count`, and the bash gate reported `$?`. An exit status is one byte:

| findings | exits as | gate reported |
|---|---|---|
| 266 | 10 | "10 scenario(s) missing @e2e" |
| **256** | **0** | **PASS** |

Measured on openconnector: the helper printed *"266 scenario(s) without a running e2e test"* on the same run the gate summarised as **10**.

Every count above 255 was under-reported by a factor nobody could see, and **any multiple of 256 was a silent green** — the failure mode this whole package exists to prevent.

## Two halves

- the helper clamps its status into the byte and never lets it wrap to zero while findings exist
- the bash gate reports the number the helper **printed**, falling back to the status only when the summary line is missing

## Tests

Two assertions, **one of them the control**:

- 256 findings must exit non-zero **and** still say `256` in the summary
- a clean spec must still exit 0, so the clamp cannot invent a failure

Suite: 50 passed. Full helper-suite run: 27 passed, 2 quarantined as documented, 0 failed.