### PR TITLE
fix(gates): make the opt-outs reachable, stop rejecting \Throwable, end the icon deadlock

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3546,6 +3546,26 @@ jobs:
         id: gates
         env:
           HYDRA_GATE_BASE_REF: ${{ steps.base.outputs.base }}
+          # Several gates document a reason-bearing opt-out —
+          # `[hydra-gate-<name> exclude] <reason>` — and read it from THIS
+          # variable, falling back to `git log -1`. Neither reached anything:
+          #
+          #   - this variable was never set, so the first path was always empty
+          #   - on a pull_request, actions/checkout checks out the synthetic
+          #     MERGE commit, whose message is `Merge <sha> into <sha>`, so the
+          #     fallback inspected a message no author wrote
+          #
+          # So every reason-bearing opt-out in the suite was unreachable on a
+          # PR — the one place they are needed. Measured on hermiq#162: the tag
+          # was placed in the PR body AND in an explicit head commit, and the
+          # finding count did not move either time.
+          #
+          # `github.event.pull_request.body` is null on a push, which is
+          # correct: the fallback then reads the real pushed commit.
+          HYDRA_GATE_PR_BODY: ${{ github.event.pull_request.body }}
+          # The author's own head commit, so the fallback stops reading the
+          # merge commit. Empty on a push, where `git log -1` is already right.
+          HYDRA_GATE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -u
           ARGS="--app-dir ${GITHUB_WORKSPACE}/app"

--- a/hydra-gates/scripts/lib/check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/check_icon_vocabulary.py
@@ -178,7 +178,7 @@ def _menu_entries(path: str):
     except (OSError, ValueError):
         return
 
-    def walk(node, label_ctx):
+    def walk(node, label_ctx, in_widget=False):
         if isinstance(node, dict):
             if node.get('type') == 'caption':
                 return
@@ -186,13 +186,16 @@ def _menu_entries(path: str):
                      or node.get('id') or label_ctx)
             icon = node.get('icon')
             if isinstance(icon, str) and icon:
-                yield (str(label or ''), icon, str(node.get('id') or ''))
+                yield (str(label or ''), icon, str(node.get('id') or ''), in_widget)
             for key, value in node.items():
                 if key != 'icon':
-                    yield from walk(value, label)
+                    # Once inside a `widgets` array, everything below it is a
+                    # widget icon and stays flagged as one. See the Tier A
+                    # concept check for why that distinction matters.
+                    yield from walk(value, label, in_widget or key == 'widgets')
         elif isinstance(node, list):
             for item in node:
-                yield from walk(item, label_ctx)
+                yield from walk(item, label_ctx, in_widget)
 
     yield from walk(data, '')
 
@@ -255,7 +258,7 @@ def main() -> int:
 
     for path in paths:
         rel = os.path.relpath(path, repo)
-        for label, icon, entry_id in _menu_entries(path):
+        for label, icon, entry_id, in_widget in _menu_entries(path):
             where = f'{rel}: {label or entry_id or "?"}'
             if not icon:
                 continue
@@ -307,7 +310,37 @@ def main() -> int:
 
             used_mdi.add(icon)
 
+            # WIDGET icons are exempt from the concept MUST, and only from that.
+            #
+            # A widget icon renders through CnWidgetGrid's own `widgetIcons.js`
+            # registry, which is a strict SUBSET of the CnIcon vocabulary this
+            # gate governs. Where the two disagree the concept rule becomes
+            # unsatisfiable: ADR-077 Tier A requires "CogOutline" for the
+            # `settings` concept, `widgetIcons.js` ships "Cog" and NOT
+            # "CogOutline", and gate-55 fails any widget icon outside that
+            # registry. Verified against the installed library, not inferred:
+            #
+            #   grep -c CogOutline widgetIcons.js -> 0
+            #   grep -c '\bCog\b'   widgetIcons.js -> 2
+            #
+            # So obeying this rule on a widget renders the "?" fallback, and
+            # obeying gate-55 fails this one. Hit on hermiq#162, blocking a PR
+            # on a contradiction it could not resolve.
+            #
+            # Everything ABOVE still applies to widgets — a nonexistent icon or
+            # an unbridged `icon-*` is still a failure wherever it appears. Only
+            # the "this concept must use exactly that glyph" rule steps aside,
+            # because gate-55 already governs widget icons against the registry
+            # that actually draws them.
+            #
+            # The better end state is reconciling the two registries (add the
+            # Tier A glyphs to widgetIcons.js), after which this exemption can
+            # go. Until then it is the difference between a gate that is strict
+            # and one that is impossible.
             concept = CONCEPT_LABELS.get(label.strip().lower())
+            if concept and in_widget is True:
+                concept = None
+
             if concept:
                 expected = all_concepts.get(concept)
                 if expected and icon != expected:

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -647,6 +647,43 @@ _fail() {
 }
 _pass() { echo "[gate-$1] $2: PASS"; _EMITTED_GATES="${_EMITTED_GATES}$1 "; }
 
+# _optout_text — every place a reason-bearing `[hydra-gate-<name> exclude]` tag
+# may legitimately be written, as one stream to grep.
+#
+# WHY THIS EXISTS
+# ---------------
+# Each opt-out used to inline two lookups, and on a pull_request BOTH read
+# nothing:
+#
+#   - `${HYDRA_GATE_PR_BODY}` was never exported by the caller workflow, so the
+#     first was always an empty string
+#   - `git log -1` reads the checked-out commit, and for a pull_request that is
+#     GitHub's synthetic MERGE commit (`Merge <sha> into <sha>`) — never a
+#     message any author wrote
+#
+# So every reason-bearing opt-out in this file was unreachable on a PR, which is
+# the only place they matter. Measured on hermiq#162: the tag was placed in the
+# PR body AND in an explicit head commit, and the finding count did not move
+# either time.
+#
+# Centralised so the three call sites cannot drift apart again, and so a fourth
+# gate adding an opt-out inherits the fixed behaviour rather than copying the
+# broken pair of lines.
+_optout_text() {
+    [ -n "${HYDRA_GATE_PR_BODY:-}" ] && printf '%s\n' "${HYDRA_GATE_PR_BODY}"
+
+    # The author's own head commit, when the caller told us which it is. Guarded
+    # on rev-parse because a shallow checkout may not contain it — falling back
+    # is better than emitting nothing.
+    if [ -n "${HYDRA_GATE_HEAD_SHA:-}" ] \
+        && git rev-parse --quiet --verify "${HYDRA_GATE_HEAD_SHA}^{commit}" >/dev/null 2>&1; then
+        git log -1 --pretty=%B "${HYDRA_GATE_HEAD_SHA}" 2>/dev/null
+        return 0
+    fi
+
+    git log -1 --pretty=%B 2>/dev/null
+}
+
 # _skip <n> <name> <category> <reason> — the gate did NOT run. Distinct from
 # PASS on purpose: the gate inspected NOTHING.
 #
@@ -3597,8 +3634,7 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
         # Check for opt-out in PR body or head commit message
         _scht_optout_re='\[hydra-gate-security-change-has-tests exclude\][[:space:]]+.{20,}'
         _scht_optout=""
-        [ -n "${HYDRA_GATE_PR_BODY:-}" ] && echo "${HYDRA_GATE_PR_BODY:-}" | grep -qE "${_scht_optout_re}" && _scht_optout="1"
-        [ -z "${_scht_optout}" ] && git log -1 --pretty=%B 2>/dev/null | grep -qE "${_scht_optout_re}" && _scht_optout="1"
+        _optout_text | grep -qE "${_scht_optout_re}" && _scht_optout="1"
         if [ -z "${_scht_optout}" ]; then
             printf "%s\n" "${_scht_sec}" >> "${_scht_log}"
         fi
@@ -3647,8 +3683,7 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
             # Check for opt-out
             _csrf_optout_re='\[hydra-gate-csrf-cochange exclude\][[:space:]]+.{20,}'
             _csrf_optout=""
-            [ -n "${HYDRA_GATE_PR_BODY:-}" ] && echo "${HYDRA_GATE_PR_BODY:-}" | grep -qE "${_csrf_optout_re}" && _csrf_optout="1"
-            [ -z "${_csrf_optout}" ] && git log -1 --pretty=%B 2>/dev/null | grep -qE "${_csrf_optout_re}" && _csrf_optout="1"
+            _optout_text | grep -qE "${_csrf_optout_re}" && _csrf_optout="1"
             if [ -z "${_csrf_optout}" ]; then
                 echo "@NoCSRFRequired removed but no frontend CSRF-signal added in diff:" >> "${_csrf_log}"
                 echo "${_csrf_removed}" >> "${_csrf_log}"
@@ -3747,8 +3782,28 @@ for fp in files:
             continue
         # Heuristic: if the method body ALREADY has try/catch of one of the tracked exceptions,
         # or its docblock declares @throws for one of them, accept it as intentionally handled.
-        try_ok = re.search(r'catch\s*\(\s*[\\\w]*(' + '|'.join(TRACKED) + r')\b', body)
-        throws_ok = any(x in (m['docblock'] or '') for x in TRACKED)
+        #
+        # `\Throwable` and `\Exception` count too. They are SUPERSETS of every
+        # name in TRACKED, so a method catching one of them handles all nine and
+        # more. Rejecting them reported the broadest possible translation as no
+        # translation at all — measured on hermiq#162, where three controller
+        # methods each caught \Throwable, returned a translated JSON error and
+        # logged the cause, and were still reported as unhandled.
+        #
+        # The cost of that false positive is not the red check. It is that the
+        # finding pushes the author toward the NARROWER handler: catch the one
+        # named exception, leave everything else to become a framework 500 with
+        # a stack trace — which for a #[NoAdminRequired] method reaches a
+        # non-admin. A gate that rejects the stronger guarantee teaches people
+        # to write the weaker one.
+        _CATCH_ALL = ['Throwable', 'Exception']
+        try_ok = re.search(
+            r'catch\s*\(\s*[\\\w]*(' + '|'.join(TRACKED + _CATCH_ALL) + r')\b',
+            body,
+        )
+        # Same reasoning on the docblock side: `@throws \Throwable` declares a
+        # superset of the tracked names, so it is at least as informative.
+        throws_ok = any(x in (m['docblock'] or '') for x in TRACKED + _CATCH_ALL)
         if try_ok or throws_ok:
             continue
         # Otherwise: if any SERVICE CALL invokes a known-throwy shape, log the
@@ -3787,8 +3842,7 @@ fi
 if [ -s "${_cxt_log}" ]; then
     _cxt_optout_re='\[hydra-gate-controller-exception-translation exclude\][[:space:]]+.{20,}'
     _cxt_optout=""
-    [ -n "${HYDRA_GATE_PR_BODY:-}" ] && echo "${HYDRA_GATE_PR_BODY:-}" | grep -qE "${_cxt_optout_re}" && _cxt_optout="1"
-    [ -z "${_cxt_optout}" ] && git log -1 --pretty=%B 2>/dev/null | grep -qE "${_cxt_optout_re}" && _cxt_optout="1"
+    _optout_text | grep -qE "${_cxt_optout_re}" && _cxt_optout="1"
     [ -n "${_cxt_optout}" ] && : > "${_cxt_log}"
 fi
 set +e


### PR DESCRIPTION
Closes #203, #204, #205 — three defects found while landing ConductionNL/hermiq#162, where the gates blocked a PR on findings its author could neither fix nor waive.

Each fix ships with a **control proving the gate can still fail**. A gate that cannot fail is worth as little as one that always does.

## 1. Every reason-bearing opt-out was unreachable on a PR (#205)

The opt-outs read `${HYDRA_GATE_PR_BODY}`, falling back to `git log -1`. On a `pull_request`, **both read nothing**:

- the variable was never exported by `quality.yml`, so the first path was always empty
- `actions/checkout` checks out the synthetic **merge** commit (`Merge <sha> into <sha>`) — never a message an author wrote

Measured on hermiq#162: the tag was placed in the PR body **and** in an explicit head commit; the finding count did not move either time.

`quality.yml` now exports `HYDRA_GATE_PR_BODY` and `HYDRA_GATE_HEAD_SHA`, and the three call sites go through one `_optout_text` helper — so they cannot drift apart, and a fourth gate adding an opt-out inherits the fixed behaviour instead of copying the broken pair of lines.

**Control** — a real author commit behind a merge commit:

```
git log -1        -> tag NOT found   (the bug)
_optout_text      -> tag found       (fixed)
PR body only      -> tag found
```

## 2. gate-49 rejected `catch (\Throwable)`, which is strictly broader (#204)

It matched nine named domain exceptions. `\Throwable` and `\Exception` are **supersets of all nine**, so the broadest possible translation was reported as no translation at all.

The cost is not the red check — it is that the finding pushes the author toward the **narrower** handler: catch the one named exception, leave everything else to become a framework 500 with a stack trace. For a `#[NoAdminRequired]` method that trace reaches a non-admin. A gate that rejects the stronger guarantee teaches people to write the weaker one.

**Control** — `\Throwable`, `\Exception`, `DoesNotExistException` now match; no-catch and an unrelated class still do not.

## 3. gate-55 and gate-60 demanded different icons for the same field (#203)

ADR-077 Tier A requires `CogOutline` for the `settings` concept. The widget renderer's own registry — `CnWidgetGrid/widgetIcons.js`, which gate-55 enforces — ships `Cog` and **not** `CogOutline`. Verified against the installed library rather than inferred:

```
grep -c CogOutline widgetIcons.js  -> 0
grep -c bCogb   widgetIcons.js  -> 2
```

So obeying gate-60 on a widget renders the `?` fallback, and obeying gate-55 fails gate-60. Unsatisfiable — and gate-60 has **no opt-out at all**.

Widget icons are now exempt from the concept MUST **and from nothing else**: a nonexistent icon or an unbridged `icon-*` still fails wherever it appears, and menus keep the full Tier A vocabulary.

**Control** — a MENU labelled "Settings" carrying `Cog` still **FAILS**; the same value on a widget passes. The previously-deadlocked hermiq manifest goes 1 failure → 0.

The better end state is reconciling the two registries (add the Tier A glyphs to `widgetIcons.js`), after which this exemption can go. Until then it is the difference between a gate that is strict and one that is impossible.

## Rollout note

Fix 1 touches `quality.yml`, which every caller consumes `@main` — it takes effect fleet-wide on merge. It is purely additive (two new env vars), so an older pinned gates package simply ignores them.

Fixes 2 and 3 are inside the pinned `hydra-gates` package, so they reach a repo only when its `hydra-gates-ref` moves to a tag containing them. Worth a tag and a consumer sweep, as with v1.5.0.