### PR TITLE
fix(ci): a failing seed exits 0 (#192); a tag inside describe.skip counts as live (#210)

### DIFF
--- a/.github/workflows/quality-resolve-probe.yml
+++ b/.github/workflows/quality-resolve-probe.yml
@@ -76,6 +76,34 @@ jobs:
           fi
           echo "OK — the lint fails when it should. Its clean pass above is a verdict."
 
+  seed-semantics:
+    name: "A failing seed fails the job"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # POSITIVE CONTROL, FIRST — same discipline as the probe below. The
+      # battery is run against the PRE-#192 step, reconstructed verbatim, and
+      # must reject it. A battery that passed the known-bad body would pass
+      # the fixed one for reasons unrelated to the fix, and its verdict on the
+      # real workflow would mean nothing.
+      - name: "Positive control — the known-bad seed step must be rejected"
+        run: python3 scripts/assert-seed-step-fails-loudly.py --positive-control
+
+      # THE MEASUREMENT. Every step named "Seed test data" is EXTRACTED from
+      # the workflow — env block and run body both — and EXECUTED under the
+      # same shell GitHub uses, against seeds that include a failing `&&`
+      # chain, a legitimate multi-stage chain, and the assignment-prefix +
+      # `|| true` shape launchpad actually ships.
+      #
+      # Running the shipped text rather than grepping it is what found the
+      # THIRD instance of the defect: the Newman job has its own "Seed test
+      # data" step reading `newman-seed-command`, and openbuild passes it
+      # `php occ app:disable openbuild && php occ app:enable openbuild`.
+      - name: "Exercise every 'Seed test data' step in quality.yml"
+        run: python3 scripts/assert-seed-step-fails-loudly.py .github/workflows/quality.yml
+
   probe:
     name: "quality.yml resolves (job count > 0)"
     runs-on: ubuntu-latest
@@ -153,19 +181,20 @@ jobs:
   guard:
     name: "Shared-workflow guard"
     runs-on: ubuntu-latest
-    needs: [static-limits, probe]
+    needs: [static-limits, seed-semantics, probe]
     if: ${{ !cancelled() }}
     steps:
       - name: Assert both guards reached a verdict
         env:
           STATIC: ${{ needs.static-limits.result }}
+          SEED: ${{ needs.seed-semantics.result }}
           PROBE: ${{ needs.probe.result }}
         run: |
           set -eu
-          echo "static-limits=${STATIC} probe=${PROBE}"
+          echo "static-limits=${STATIC} seed-semantics=${SEED} probe=${PROBE}"
           # `skipped` is failed here on purpose. A guard that did not run is
           # not a guard that passed.
-          for pair in "static-limits:${STATIC}" "probe:${PROBE}"; do
+          for pair in "static-limits:${STATIC}" "seed-semantics:${SEED}" "probe:${PROBE}"; do
             name="${pair%%:*}"; result="${pair##*:}"
             [ "${result}" = "success" ] || {
               echo "::error::${name} did not succeed (result=${result}). A guard that \

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1900,13 +1900,38 @@ jobs:
           ADMIN_PASSWORD: admin
           NC_ADMIN_USER: admin
           NC_ADMIN_PASS: admin
+          # THE SEED ARRIVES AS DATA — see the long note on the Playwright
+          # job's seed step (#192). The comment that used to sit here said
+          # "Use eval to support complex commands with pipes or &&", and that
+          # was the assurance the defect hid behind: because the interpolation
+          # was UNQUOTED, `a && b` was split by THIS shell before eval saw it,
+          # eval ran only `a`, and bash's `set -e` exemption for `&&` lists
+          # made a failing `a` exit 0.
+          #
+          # This job is not hypothetical. openbuild ships
+          #   `php occ app:disable openbuild && php occ app:enable openbuild`
+          # as its newman-seed-command — a failed disable meant the enable
+          # never ran and Newman tested whatever state was left, green.
+          SEED_COMMAND: ${{ inputs.newman-seed-command }}
         run: |
           cd server
-          echo "Running seed command: ${{ inputs.newman-seed-command }}"
-          # Run the seed command (e.g. maintenance:repair, custom script, etc.)
-          # Use eval to support complex commands with pipes or &&
-          eval ${{ inputs.newman-seed-command }}
-          echo "Seed command completed."
+          printf 'Running seed command: %s\n' "$SEED_COMMAND"
+          # eval is retained on purpose: fleet callers pass assignment
+          # prefixes (`SEED_SCOPE=register bash …`) and `||` lists. The fix is
+          # the QUOTING — the whole seed reaches eval as one unit, so eval's
+          # combined status is the step's.
+          eval "$SEED_COMMAND" && SEED_RC=0 || SEED_RC=$?
+          if [ "$SEED_RC" -ne 0 ]; then
+            # Diagnostics on STDERR — an `::error::` on stdout is swallowed by
+            # any caller that captures the step's output with `$(…)`.
+            {
+              echo "::error::Seed command failed with exit ${SEED_RC}: ${SEED_COMMAND}"
+              echo "Refusing to run Newman against a half-seeded instance — a full"
+              echo "collection tally from an unseeded server looks exactly like a real one."
+            } >&2
+            exit "$SEED_RC"
+          fi
+          echo "Seed command completed (exit 0)."
 
       - name: Setup Node.js and Newman
         uses: actions/setup-node@v4
@@ -2419,11 +2444,50 @@ jobs:
           ADMIN_PASSWORD: admin
           NC_ADMIN_USER: admin
           NC_ADMIN_PASS: admin
+          # THE SEED ARRIVES THROUGH THE ENVIRONMENT, NOT THE SCRIPT BODY.
+          #
+          # `${{ }}` is a TEXTUAL substitution performed before bash ever sees
+          # the script, so interpolating the input into the body made the seed
+          # part of this step's own source. Two things followed (#192):
+          #
+          #   1. `eval ${{ … }}` was UNQUOTED, so a seed of `a && b && c` was
+          #      parsed by THIS shell as `eval a` && `b` && `c`. eval received
+          #      only the first stage. And bash's `set -e` exemption for `&&`
+          #      lists ("except the command following the final &&") means a
+          #      failing first stage aborts nothing and exits 0 — the tail
+          #      never runs, the step goes green, and Playwright then tests a
+          #      half-seeded instance. Measured on pipelinq run 30800304506.
+          #   2. `echo "Running seed command: ${{ … }}"` expanded the seed's
+          #      own `$(…)` in THIS shell, before the seed ran. pipelinq's
+          #      bundle-truncation control printed identical before/after byte
+          #      counts by construction and could not have caught anything.
+          #
+          # Passing it as data fixes both, and also means a seed containing a
+          # quote can no longer reshape the surrounding script.
+          SEED_COMMAND: ${{ inputs.playwright-seed-command }}
         run: |
           cd server
-          echo "Running seed command: ${{ inputs.playwright-seed-command }}"
-          eval ${{ inputs.playwright-seed-command }}
-          echo "Seed command completed."
+          printf 'Running seed command: %s\n' "$SEED_COMMAND"
+          # `eval` IS still required. A survey of the fleet's callers found
+          # launchpad passing `OC_PASS=… php occ user:add … || true` — an
+          # assignment prefix and a `||` list. Running "$SEED_COMMAND" as a
+          # bare command would exec that whole string as one argv word.
+          # What matters is that the expansion is QUOTED, so the entire seed
+          # reaches eval as one unit and eval's combined status is the answer.
+          eval "$SEED_COMMAND" && SEED_RC=0 || SEED_RC=$?
+          if [ "$SEED_RC" -ne 0 ]; then
+            # Diagnostics on STDERR. An `::error::` written to stdout is eaten
+            # whole when a caller wraps the step's output in `$(…)`, leaving a
+            # bare non-zero exit with no stated cause.
+            {
+              echo "::error::Seed command failed with exit ${SEED_RC}: ${SEED_COMMAND}"
+              echo "Refusing to run Playwright against a half-seeded instance — a full,"
+              echo "credible-looking pass/fail tally from an unseeded server is worse than"
+              echo "no tally at all. Fix the seed, or unset playwright-seed-command."
+            } >&2
+            exit "$SEED_RC"
+          fi
+          echo "Seed command completed (exit 0)."
 
       - name: Run Playwright tests
         run: |
@@ -2936,11 +3000,32 @@ jobs:
 
       - name: Seed test data
         if: inputs.playwright-seed-command != ''
+        env:
+          # Same contract as the E2E job's seed step above — see the long note
+          # there. Short version (#192): interpolating the input into the
+          # script body made `eval ${{ … }}` unquoted, so an `a && b` seed was
+          # split by THIS shell, eval got only `a`, and bash's `set -e`
+          # exemption for `&&` lists let a failing first stage exit 0 while
+          # printing "Seed command completed."
+          SEED_COMMAND: ${{ inputs.playwright-seed-command }}
         run: |
           cd server
-          echo "Running seed command: ${{ inputs.playwright-seed-command }}"
-          eval ${{ inputs.playwright-seed-command }}
-          echo "Seed command completed."
+          printf 'Running seed command: %s\n' "$SEED_COMMAND"
+          # Quoted expansion: the whole seed reaches eval as one unit and
+          # eval's combined status is the step's. eval is retained because
+          # fleet callers pass assignment prefixes and `||` lists.
+          eval "$SEED_COMMAND" && SEED_RC=0 || SEED_RC=$?
+          if [ "$SEED_RC" -ne 0 ]; then
+            # Diagnostics on STDERR — an `::error::` on stdout is swallowed by
+            # any caller that captures the step's output with `$(…)`.
+            {
+              echo "::error::Seed command failed with exit ${SEED_RC}: ${SEED_COMMAND}"
+              echo "Refusing to capture documentation screenshots of a half-seeded"
+              echo "instance — the images would be committed and would look real."
+            } >&2
+            exit "$SEED_RC"
+          fi
+          echo "Seed command completed (exit 0)."
 
       - name: Run docs-capture Playwright project
         run: |

--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -471,9 +471,28 @@ _E2E_SHORT_RE = re.compile(
 # `(?<![.\w$])` rejects a member call (`rx.test`, `foo.it`) and an identifier
 # that merely ends in one (`latest(`, `submit(`), while leaving a bare
 # `test(` / `it(` / `describe(` at a statement boundary matching.
+#
+# THAT LOOKBEHIND ALSO REJECTED PLAYWRIGHT'S OWN CANONICAL SPELLING.
+# `test.describe.skip(` is the form every fleet repo actually writes, and the
+# pattern above could not match it anywhere: at `test` the optional `mod`
+# needs `.skip|.fixme|.failing` and finds `.describe`, so the required `\(`
+# fails; at `describe` the lookbehind sees the preceding `.` and refuses. The
+# whole construct was INVISIBLE — not "seen and judged live", never seen.
+# Measured on the reproduction in #210: BOTH the tag above a
+# `test.describe.skip` and the tag inside one came back LIVE, so the issue's
+# own claim that the `above` case was handled correctly was too generous.
+#
+# The fix is an explicit, optional `test.` / `it.` NAMESPACE segment. It is
+# named rather than general (`\w+\.`) on purpose: `rx.test(` and `foo.it(`
+# must still be rejected, and only Playwright's two roots may open a block.
+# The `.serial` / `.parallel` / `.only` segments are Playwright's other
+# describe modifiers and are NOT switched-off markers — a `describe.only` runs
+# (and suppresses everything else), so it stays live.
 _TEST_DECL_RE = re.compile(
-    r"(?<![.\w$])(?P<fn>test|it|describe)"
+    r"(?<![.\w$])(?:(?:test|it)\s*\.\s*)?(?P<fn>test|it|describe)"
+    r"(?:\s*\.\s*(?:serial|parallel))?"
     r"(?P<mod>\s*\.\s*(?:skip|fixme|failing))?"
+    r"(?:\s*\.\s*only)?"
     r"\s*\(",
 )
 _XTEST_RE = re.compile(r"\b(?:xit|xtest|xdescribe)\s*\(")
@@ -492,12 +511,99 @@ def _strip_comments(text: str) -> str:
     return text
 
 
+def _close_paren(text: str, open_paren: int) -> int | None:
+    """Index of the `)` matching the `(` at *open_paren*, or None."""
+    depth = 0
+    i = open_paren
+    while i < len(text):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def _is_switched_off(decl: str) -> bool:
+    """True when *decl* opens a block that never runs.
+
+    Reads the `mod` group of the declaration regex rather than re-deriving it,
+    so `test.describe.skip(` and `describe.skip(` are judged by one rule. The
+    hand-written pattern this replaces required the modifier to follow the
+    ROOT identifier (`(?:test|it|describe)\\s*\\.\\s*(?:skip|…)`) and therefore
+    could not see the namespaced form at all.
+    """
+    if _XTEST_RE.match(decl):
+        return True
+    m = _TEST_DECL_RE.match(decl)
+    return bool(m and m.group("mod"))
+
+
+def _decl_spans(text: str) -> list[tuple[int, int, str]]:
+    """Every test/describe declaration in *text*, as (start, end, decl_text).
+
+    `end` is the index of the declaration's closing paren, so `start..end`
+    spans the whole call including its callback body.
+    """
+    spans: list[tuple[int, int, str]] = []
+    for rex in (_TEST_DECL_RE, _XTEST_RE):
+        for m in rex.finditer(text):
+            close = _close_paren(text, m.end() - 1)
+            if close is None:
+                continue
+            spans.append((m.start(), close, text[m.start():close + 1]))
+    spans.sort()
+    return spans
+
+
+def _switched_off_ancestor(text: str, pos: int) -> str | None:
+    """The innermost switched-off block ENCLOSING *pos*, if any.
+
+    WHY THIS EXISTS (#210)
+    ----------------------
+    `_enclosing_block` only ever searches FORWARD, because the convention this
+    module documents puts the tag in a comment immediately ABOVE the test it
+    annotates. That is right for the test, and blind to everything wrapping it:
+
+        test.describe.skip('outer', () => {
+            // @e2e demo::something
+            test('inner', async ({ page }) => { … })   <-- forward search lands here
+        })
+
+    The forward search finds the inner, un-skipped `test()`, reports it live,
+    and the enclosing `describe.skip` — which is ABOVE the tag and takes every
+    test inside it with it — is never consulted. The tag counted as coverage
+    while nothing ran, and this is the position the convention itself tells
+    people to write the tag in.
+
+    Measured in the fleet at the time of the fix: 16 spec scenarios across
+    openconnector (11) and scholiq (5).
+
+    The rule is the same one the module docstring already states for
+    `describe.skip(...)`; only the ancestor direction was missing. An ancestor
+    that merely carries `.only` / `.serial` / `.parallel` is NOT switched off.
+    """
+    innermost: str | None = None
+    for start, end, decl in _decl_spans(text):
+        if start >= pos:
+            break            # spans are sorted; nothing later can enclose pos
+        if end < pos:
+            continue         # closed before the tag — a sibling, not a parent
+        if _is_switched_off(decl):
+            innermost = decl
+    return innermost
+
+
 def _enclosing_block(text: str, pos: int) -> tuple[str, str] | None:
     """The nearest `test(`/`it(`/`describe(` declaration at or after *pos*, as
     (declaration_text, body_text).
 
     An `@e2e` tag conventionally sits in a comment immediately ABOVE the test
-    it annotates, so the search runs forward from the tag.
+    it annotates, so the search runs forward from the tag. See
+    :func:`_switched_off_ancestor` for the other direction, which this
+    function deliberately does not cover.
     """
     m = _TEST_DECL_RE.search(text, pos)
     xm = _XTEST_RE.search(text, pos)
@@ -508,17 +614,8 @@ def _enclosing_block(text: str, pos: int) -> tuple[str, str] | None:
     else:
         return None
     # Walk to the matching close paren of the declaration.
-    depth = 0
-    i = open_paren
-    while i < len(text):
-        if text[i] == "(":
-            depth += 1
-        elif text[i] == ")":
-            depth -= 1
-            if depth == 0:
-                break
-        i += 1
-    if i >= len(text):
+    i = _close_paren(text, open_paren)
+    if i is None:
         return None
     whole = text[decl_start:i + 1]
     # THE BODY IS THE LAST BRACE-BALANCED GROUP, FOUND FROM THE END.
@@ -547,9 +644,45 @@ def _enclosing_block(text: str, pos: int) -> tuple[str, str] | None:
     return whole, body
 
 
+def _has_own_unconditional_skip(block_body: str) -> bool:
+    """An unconditional `test.skip(true)` belonging to THIS block, not a child.
+
+    WHY THE OWNERSHIP TEST IS NEEDED
+    --------------------------------
+    Once `test.describe(` became visible to the declaration regex, a file-level
+    tag started resolving to the enclosing describe rather than to the first
+    test inside it — which is more accurate, but it also handed this check a
+    body containing OTHER TESTS. A plain `_UNCONDITIONAL_SKIP_RE.search()` over
+    that body then found a `test.skip(true, …)` written inside ONE nested test
+    and condemned the whole group.
+
+    Measured on launchpad `spec-coverage.spec.ts`: the header tag at :15 went
+    from live to dead because a single nested test at :185 guards itself with
+    `test.skip(true, 'allowUserDashboards is false in this environment')`. The
+    other tests in that describe run fine. Killing the ref for that is the
+    gate's blindness with the sign flipped, and it is not an improvement.
+
+    Playwright does allow a group-level `test.skip()` — called directly in a
+    describe body it skips every test in the group — so the check is kept, and
+    only NESTED occurrences are disowned. An occurrence that starts exactly
+    where a declaration span starts IS the skip call itself (`test.skip(true)`
+    is both), so `<` is strict on the left.
+    """
+    nested = [(s, e) for s, e, _d in _decl_spans(block_body)]
+    for m in _UNCONDITIONAL_SKIP_RE.finditer(block_body):
+        if not any(s < m.start() < e for s, e in nested):
+            return True
+    return False
+
+
 def _ref_is_live(text: str, pos: int) -> bool:
     """Does the test enclosing the `@e2e` tag at *pos* actually assert
     anything?"""
+    # OUTWARD FIRST. A switched-off ancestor takes everything inside it with
+    # it, so no amount of body in the inner test can rescue the ref. Asking
+    # the forward search first would find that inner test and answer "live".
+    if _switched_off_ancestor(text, pos) is not None:
+        return False
     block = _enclosing_block(text, pos)
     if block is None:
         # No enclosing test at all — a file-level tag. Treated as live: this
@@ -558,11 +691,10 @@ def _ref_is_live(text: str, pos: int) -> bool:
         return True
     decl, body = block
     head = decl[:decl.find("{") if "{" in decl else len(decl)]
-    if _XTEST_RE.match(decl) or re.match(
-            r"\s*\b(?:test|it|describe)\s*\.\s*(?:skip|fixme|failing)\s*\(", decl):
+    if _is_switched_off(decl):
         return False
     stripped = _strip_comments(body)
-    if _UNCONDITIONAL_SKIP_RE.search(stripped):
+    if _has_own_unconditional_skip(stripped):
         return False
     inner = stripped.strip()
     if inner.startswith("{"):

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -869,5 +869,309 @@ class SkippedTestIsNotCoverageTest(unittest.TestCase):
         self.assertIn("my-spec::foo-does-bar", dead)
 
 
+# ---------------------------------------------------------------------------
+# A SWITCHED-OFF ANCESTOR TAKES THE TAG WITH IT  (#210)
+#
+# `_enclosing_block` searched FORWARD only. A tag written where the convention
+# says to write it — immediately above the `test()` it annotates — resolved to
+# that inner, un-skipped test, and the `test.describe.skip` wrapping both was
+# never consulted. The ref counted as coverage while nothing ran.
+#
+# A second, wider defect was found while writing these: `_TEST_DECL_RE` could
+# not match `test.describe.skip(` AT ALL. At `test` the modifier group finds
+# `.describe` instead of `.skip` so the required `(` fails; at `describe` the
+# `(?<![.\w$])` lookbehind sees the preceding dot and refuses. So the
+# "correctly dead" case in #210's own reproduction — the tag ABOVE the skipped
+# describe — was in fact reported LIVE too. Both are covered below.
+#
+# EVERY dead assertion here is paired with a live one. `describe.only`,
+# `describe.serial`, a live `describe`, and a sibling that merely follows a
+# closed skipped block must all keep counting: refusing them would trade this
+# gate's blindness for the opposite blindness, which is the same defect with
+# the sign flipped.
+# ---------------------------------------------------------------------------
+class SkippedAncestorTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _refs(self, body: str) -> set:
+        _write(self.root, "tests/e2e/foo.spec.ts", body)
+        return cec.collect_covered_refs(self.root)
+
+    # --- dead: an ancestor that never runs ------------------------------
+    def test_tag_INSIDE_a_skipped_describe_does_not_count(self):
+        # THE #210 DEFECT, verbatim. The tag sits where the docstring says to
+        # put it and the forward search lands on the live inner `test()`.
+        self.assertEqual(self._refs(
+            "test.describe.skip('outer B', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner b', async ({ page }) => {\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"), set())
+
+    def test_tag_ABOVE_a_skipped_describe_does_not_count(self):
+        # #210 believed this case already worked. It did not: the namespaced
+        # `test.describe.skip(` was invisible to the declaration regex, so the
+        # forward search stepped straight over it onto the inner test.
+        self.assertEqual(self._refs(
+            "// @e2e demo::above\n"
+            "test.describe.skip('outer A', () => {\n"
+            "  test('inner a', async ({ page }) => {\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"), set())
+
+    def test_bare_describe_skip_ancestor_does_not_count(self):
+        self.assertEqual(self._refs(
+            "describe.skip('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  it('inner', async () => { await go() })\n"
+            "})\n"), set())
+
+    def test_xdescribe_ancestor_does_not_count(self):
+        self.assertEqual(self._refs(
+            "xdescribe('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  it('inner', async () => { await go() })\n"
+            "})\n"), set())
+
+    def test_describe_fixme_ancestor_does_not_count(self):
+        self.assertEqual(self._refs(
+            "test.describe.fixme('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"), set())
+
+    def test_a_live_describe_nested_in_a_skipped_one_does_not_count(self):
+        # The INNERMOST enclosing block runs, and it still never executes.
+        self.assertEqual(self._refs(
+            "test.describe.skip('outer', () => {\n"
+            "  test.describe('inner group', () => {\n"
+            "    // @e2e demo::deep\n"
+            "    test('t', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "  })\n"
+            "})\n"), set())
+
+    def test_the_scholiq_shape_repeated_tags_inside_the_block(self):
+        # scholiq peer-and-self-assessment.spec.ts: the header tags above the
+        # `describe.skip` were dead, and the SAME refs repeated inside the
+        # block resurrected them. Both copies must now be dead.
+        self.assertEqual(self._refs(
+            "// @e2e demo::a\n"
+            "// @e2e demo::b\n"
+            "test.describe.skip('needs an isolated instance', () => {\n"
+            "  // @e2e demo::a\n"
+            "  test('one', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "  // @e2e demo::b\n"
+            "  test('two', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"), set())
+
+    # --- live: must STILL count -----------------------------------------
+    def test_tag_inside_a_LIVE_describe_still_counts(self):
+        # THE CONTROL for every assertion above. If this ever fails, the
+        # ancestor walk has stopped discriminating and is simply killing
+        # everything nested.
+        self.assertIn("demo::inside", self._refs(
+            "test.describe('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner', async ({ page }) => {\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"))
+
+    def test_describe_only_is_not_switched_off(self):
+        # `.only` RUNS — it suppresses everything else, which is the opposite
+        # of being skipped.
+        self.assertIn("demo::inside", self._refs(
+            "test.describe.only('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"))
+
+    def test_describe_serial_is_not_switched_off(self):
+        self.assertIn("demo::inside", self._refs(
+            "test.describe.serial('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"))
+
+    def test_describe_configure_is_not_a_declaration(self):
+        # `test.describe.configure({...})` is a settings call, not a block. It
+        # must neither open a block nor be mistaken for one by the forward
+        # search that follows a file-level tag.
+        self.assertIn("demo::top", self._refs(
+            "// @e2e demo::top\n"
+            "test.describe.configure({ mode: 'parallel' })\n"
+            "test('real', async ({ page }) => { await expect(page).toBeTruthy() })\n"))
+
+    def test_a_sibling_AFTER_a_closed_skipped_describe_still_counts(self):
+        # The span check must be "encloses", not "appears earlier". A skipped
+        # block that has already closed is a sibling and must not poison what
+        # follows it.
+        self.assertIn("demo::after", self._refs(
+            "test.describe.skip('dead group', () => {\n"
+            "  test('x', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"
+            "// @e2e demo::after\n"
+            "test('live one', async ({ page }) => {\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"))
+
+    def test_a_runtime_conditional_skip_inside_a_live_describe_still_counts(self):
+        # The gate's original anti-blindness pair, now with an ancestor in the
+        # picture: this runs on every browser but one.
+        self.assertIn("demo::inside", self._refs(
+            "test.describe('outer', () => {\n"
+            "  // @e2e demo::inside\n"
+            "  test('inner', async ({ page, browserName }) => {\n"
+            "    test.skip(browserName === 'firefox', 'flaky on gecko')\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"))
+
+    def test_a_live_sibling_rescues_a_ref_dead_inside_a_skipped_describe(self):
+        # Same rule the module already applies to skipped tests: one running
+        # reference is coverage. The gate reports UNCOVERED, not "you have a
+        # skipped describe".
+        self.assertIn("demo::both", self._refs(
+            "test.describe.skip('dead group', () => {\n"
+            "  // @e2e demo::both\n"
+            "  test('x', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+            "})\n"
+            "// @e2e demo::both\n"
+            "test('live one', async ({ page }) => {\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"))
+
+    # --- the regex must still reject what it always rejected -------------
+    def test_a_member_call_named_test_is_still_not_a_declaration(self):
+        # The namespace segment added for `test.describe` must not have
+        # widened into "any member call". `rx.test(` is RegExp.prototype.test.
+        self.assertIn("demo::live", self._refs(
+            "// @e2e demo::live\n"
+            "const IGNORED = [/Deprecation/i]\n"
+            "function spy(page) {\n"
+            "  page.on('console', (msg) => {\n"
+            "    if (IGNORED.some((rx) => rx.test(msg.text()))) return\n"
+            "  })\n"
+            "}\n"
+            "test('the view mounts', async ({ page }) => {\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"))
+
+    # --- ownership of an unconditional skip -----------------------------
+    def test_a_nested_tests_own_skip_does_not_kill_the_whole_group(self):
+        # launchpad spec-coverage.spec.ts, in shape: a file-level tag now
+        # resolves to the enclosing `test.describe`, and ONE nested test in
+        # that group guards itself with `test.skip(true, …)`. The other tests
+        # run. Condemning the group is the gate's blindness with the sign
+        # flipped.
+        self.assertIn("demo::header", self._refs(
+            "// @e2e demo::header\n"
+            "test.describe('sidebar', () => {\n"
+            "  test('a', async ({ page }) => {\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "  test('b', async ({ page }) => {\n"
+            "    test.skip(true, 'not available in this environment')\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"))
+
+    def test_a_group_level_unconditional_skip_still_kills_the_group(self):
+        # THE CONTROL. Playwright's `test.skip()` called directly in a describe
+        # body skips every test in the group, and that must still be dead.
+        self.assertEqual(self._refs(
+            "// @e2e demo::header\n"
+            "test.describe('sidebar', () => {\n"
+            "  test.skip()\n"
+            "  test('a', async ({ page }) => {\n"
+            "    await expect(page).toBeTruthy()\n"
+            "  })\n"
+            "})\n"), set())
+
+    def test_a_tests_own_unconditional_skip_still_kills_that_test(self):
+        # The decidesk shape must not be rescued by the ownership rule.
+        self.assertEqual(self._refs(
+            "test.describe('group', () => {\n"
+            "  // @e2e demo::inner\n"
+            "  test('minutes are published', async ({ page }) => {\n"
+            "    test.skip(true, 'pending backend work')\n"
+            "  })\n"
+            "})\n"), set())
+
+    def test_the_four_case_fixture_from_the_issue(self):
+        # #210's minimal reproduction, whole, in one file — the shape the fix
+        # is measured against.
+        _write(self.root, "tests/e2e/a.spec.ts",
+               "import { test, expect } from '@playwright/test'\n"
+               "\n"
+               "// @e2e demo::tag-above-a-skipped-describe\n"
+               "test.describe.skip('outer A', () => {\n"
+               "  test('inner a', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+               "})\n"
+               "\n"
+               "test.describe.skip('outer B', () => {\n"
+               "  // @e2e demo::tag-inside-a-skipped-describe\n"
+               "  test('inner b', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+               "})\n"
+               "\n"
+               "// @e2e demo::plain-skipped-test\n"
+               "test.skip('plain skipped', async ({ page }) => { await expect(page).toBeTruthy() })\n"
+               "\n"
+               "// @e2e demo::genuinely-live\n"
+               "test('live one', async ({ page }) => { await expect(page).toBeTruthy() })\n")
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertEqual(live, {"demo::genuinely-live"})
+        self.assertEqual(set(dead), {
+            "demo::plain-skipped-test",
+            "demo::tag-above-a-skipped-describe",
+            "demo::tag-inside-a-skipped-describe",
+        })
+
+
+# ---------------------------------------------------------------------------
+# The declaration regex, directly. These are the unit-level counterparts of the
+# behaviour above: `test.describe.skip(` matching AT ALL is the precondition
+# for every dead assertion in the class above, and `rx.test(` NOT matching is
+# the precondition for the live ones.
+# ---------------------------------------------------------------------------
+class DeclarationRegexTest(unittest.TestCase):
+    def _mod(self, src: str):
+        m = cec._TEST_DECL_RE.match(src)
+        return None if m is None else (m.group("fn"), m.group("mod"))
+
+    def test_namespaced_describe_skip_matches(self):
+        self.assertEqual(self._mod("test.describe.skip('a', () => {})")[0], "describe")
+        self.assertIsNotNone(self._mod("test.describe.skip('a', () => {})")[1])
+
+    def test_namespaced_describe_matches_and_is_live(self):
+        self.assertEqual(self._mod("test.describe('a', () => {})"), ("describe", None))
+
+    def test_bare_forms_still_match(self):
+        self.assertEqual(self._mod("test('a', () => {})"), ("test", None))
+        self.assertEqual(self._mod("describe('a', () => {})"), ("describe", None))
+        self.assertIsNotNone(self._mod("test.skip('a', () => {})")[1])
+
+    def test_serial_and_only_are_not_modifiers(self):
+        self.assertEqual(self._mod("test.describe.serial('a', () => {})"), ("describe", None))
+        self.assertEqual(self._mod("test.describe.only('a', () => {})"), ("describe", None))
+
+    def test_member_calls_are_still_rejected(self):
+        for src in ("rx.test(msg)", "foo.it(1)", "latest(versions)", "submit(form)"):
+            self.assertIsNone(cec._TEST_DECL_RE.match(src), src)
+
+    def test_hooks_and_config_calls_are_not_declarations(self):
+        for src in ("test.beforeEach(async () => {})",
+                    "test.use({ locale: 'nl' })",
+                    "test.step('x', async () => {})",
+                    "test.describe.configure({ mode: 'parallel' })"):
+            self.assertIsNone(cec._TEST_DECL_RE.match(src), src)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/assert-seed-step-fails-loudly.py
+++ b/scripts/assert-seed-step-fails-loudly.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Execute the real "Seed test data" `run:` bodies and prove a failing seed fails.
+
+WHY
+---
+`playwright-seed-command` was interpolated into the step body unquoted::
+
+    echo "Running seed command: ${{ inputs.playwright-seed-command }}"
+    eval ${{ inputs.playwright-seed-command }}
+    echo "Seed command completed."
+
+`${{ }}` is a TEXTUAL substitution applied before bash sees the script, so a
+seed of ``a && b && c`` became ``eval a && b && c`` — three commands in an
+``&&`` list, with ``eval`` receiving only the first stage. Bash's ``set -e``
+exemption for ``&&`` lists ("except the command following the final ``&&``")
+then meant a failing first stage aborted nothing, the tail never ran, and the
+step exited 0 while printing ``Seed command completed.`` Playwright went on to
+test a half-seeded instance and produced a full, credible-looking tally
+(#192; measured on pipelinq run 30800304506).
+
+WHAT THIS ASSERTS
+-----------------
+This does not lint the YAML for a pattern. It EXTRACTS each ``Seed test data``
+step's ``run:`` body out of the workflow and RUNS it, under the same shell
+GitHub uses (``bash -e <file>``; quality.yml declares no ``shell:``, so the
+platform default applies), with a battery of seeds:
+
+  * a failing ``&&`` chain            -> must exit non-zero, must not run the
+                                         tail, must not claim completion, and
+                                         must name the cause on STDERR
+  * a legitimate multi-stage seed     -> must still exit 0 with every stage run
+  * an assignment prefix + ``|| true``-> must still work (launchpad ships this)
+  * a seed containing ``$(…)``        -> must be announced LITERALLY, not
+                                         expanded by the announcing shell
+  * an explicit ``exit 42``           -> the step's exit status must be 42
+
+Running the shipped text means the assertions cannot drift from the workflow.
+
+POSITIVE CONTROL
+----------------
+``--positive-control`` runs the identical battery against the PRE-FIX body,
+reconstructed verbatim, with ``${{ inputs.playwright-seed-command }}``
+substituted textually exactly as GitHub would. That body MUST fail the battery.
+If it passes, the battery is measuring nothing and this script exits 1 — a
+check that cannot fail is not a check.
+
+Usage::
+
+    assert-seed-step-fails-loudly.py .github/workflows/quality.yml
+    assert-seed-step-fails-loudly.py --positive-control
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+STEP_NAME = "Seed test data"
+
+# The step exactly as it stood before #192 was fixed: no `env:` at all, the
+# input interpolated straight into the script body. Used only by
+# --positive-control, where it must FAIL the battery below.
+PRE_FIX_STEP = (
+    {},
+    "cd server\n"
+    'echo "Running seed command: ${{ inputs.playwright-seed-command }}"\n'
+    "eval ${{ inputs.playwright-seed-command }}\n"
+    'echo "Seed command completed."\n',
+)
+
+# Both seed inputs. The Newman job has a third `Seed test data` step reading
+# `newman-seed-command`; it had the identical defect and openbuild ships an
+# `&&` chain to it, so the battery must cover it too.
+_INTERPOLATION = re.compile(
+    r"\$\{\{\s*inputs\.(?:playwright|newman)-seed-command\s*\}\}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_seed_steps(path: Path) -> list[tuple[int, dict, str]]:
+    """Every ``Seed test data`` step, as ``(line, env_mapping, run_body)``.
+
+    THE ``env:`` BLOCK IS PART OF THE SUBJECT, not scaffolding. The fix moves
+    the seed out of the script body and into ``SEED_COMMAND:`` under ``env:``;
+    a harness that supplied ``SEED_COMMAND`` itself would keep passing if that
+    line were deleted, and would be testing a step the workflow does not
+    contain. So the environment is read from the file too.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+    found: list[tuple[int, dict, str]] = []
+
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^(\s*)-\s+name:\s*(.+?)\s*$", lines[i])
+        if not m or m.group(2).strip("'\"") != STEP_NAME:
+            i += 1
+            continue
+
+        step_indent = len(m.group(1))
+        i += 1
+        env: dict = {}
+        body_text: str | None = None
+        run_line = 0
+        # Walk the step's own keys until the next list item at the same indent
+        # or any dedent below it.
+        while i < len(lines):
+            line = lines[i]
+            if line.strip() == "":
+                i += 1
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent <= step_indent:
+                break
+
+            env_m = re.match(r"^(\s*)env:\s*$", line)
+            if env_m:
+                key_indent = len(env_m.group(1))
+                i += 1
+                while i < len(lines):
+                    ln = lines[i]
+                    if ln.strip() == "":
+                        i += 1
+                        continue
+                    if len(ln) - len(ln.lstrip()) <= key_indent:
+                        break
+                    if ln.lstrip().startswith("#"):
+                        i += 1
+                        continue
+                    kv = re.match(r"^\s*([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$", ln)
+                    if kv:
+                        env[kv.group(1)] = _unquote(kv.group(2))
+                    i += 1
+                continue
+
+            run_m = re.match(r"^(\s*)run:\s*[|>]", line)
+            if run_m:
+                key_indent = len(run_m.group(1))
+                run_line = i + 1
+                i += 1
+                body: list[str] = []
+                while i < len(lines) and (
+                    lines[i].strip() == ""
+                    or len(lines[i]) - len(lines[i].lstrip()) > key_indent
+                ):
+                    body.append(lines[i])
+                    i += 1
+                body_text = _dedent(body)
+                continue
+            i += 1
+
+        if body_text is not None:
+            found.append((run_line, env, body_text))
+
+    return found
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    return value
+
+
+def _dedent(body: list[str]) -> str:
+    """Strip the common leading indentation of a YAML literal block."""
+    widths = [
+        len(ln) - len(ln.lstrip()) for ln in body if ln.strip() != ""
+    ]
+    pad = min(widths) if widths else 0
+    return "\n".join(ln[pad:] if ln.strip() else "" for ln in body) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+class Result:
+    def __init__(self, rc: int, out: str, err: str, sentinels: set[str]):
+        self.rc = rc
+        self.out = out
+        self.err = err
+        # Files the seed created. "Did the tail run?" MUST be answered by a
+        # side effect, not by grepping the log: the fixed step echoes the seed
+        # text back in its `::error::` line, so any marker word chosen for the
+        # tail also appears in the diagnostic. Grepping for it reported "the
+        # tail ran" on a step where it demonstrably had not — a check that can
+        # match the wrong element is not a check.
+        self.sentinels = sentinels
+
+    @property
+    def both(self) -> str:
+        return self.out + self.err
+
+
+def run_step(step: tuple[dict, str], seed: str) -> Result:
+    """Run the step the way GitHub would, with *seed* as the caller's input.
+
+    ``${{ inputs.<x>-seed-command }}`` is substituted TEXTUALLY in BOTH the
+    ``env:`` values and the ``run:`` body, because that is what the expression
+    engine does and the textual substitution into the body is the whole
+    mechanism of the defect. Nothing is injected that the workflow does not
+    itself declare — if the ``SEED_COMMAND:`` env line were removed, the seed
+    would simply not arrive, and the battery must notice.
+    """
+    step_env, body = step
+    script = _INTERPOLATION.sub(lambda _m: seed, body)
+    with tempfile.TemporaryDirectory() as tmp:
+        # The bodies begin with `cd server`.
+        server = Path(tmp) / "server"
+        server.mkdir()
+        script_path = Path(tmp) / "step.sh"
+        script_path.write_text(script, encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("SEED_COMMAND", None)
+        for key, value in step_env.items():
+            env[key] = _INTERPOLATION.sub(lambda _m: seed, value)
+        # quality.yml declares no `shell:` for these steps, so GitHub's default
+        # applies: `bash -e {0}` — a FILE, not `-c`, and without `pipefail`.
+        proc = subprocess.run(
+            ["bash", "-e", str(script_path)],
+            cwd=tmp,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        sentinels = {
+            p.name
+            for p in server.iterdir()
+            if p.name.startswith("sentinel-")
+        }
+    return Result(proc.returncode, proc.stdout, proc.stderr, sentinels)
+
+
+# ---------------------------------------------------------------------------
+# The battery
+# ---------------------------------------------------------------------------
+
+
+def check_step(step: tuple[dict, str], label: str) -> list[str]:
+    """Return a list of failure strings; empty means the step is sound."""
+    bad: list[str] = []
+
+    def fail(case: str, why: str) -> None:
+        bad.append(f"{label}: [{case}] {why}")
+
+    # -- 0. CONTROL FOR CASE 1. The sentinel mechanism must be able to fire,
+    #    otherwise "the tail did not run" is indistinguishable from "the
+    #    sentinel check is broken" and case 1 would pass on a dead instrument.
+    #    This also proves the seed REACHES the step at all: if the
+    #    `SEED_COMMAND:` env line were dropped, nothing would run and every
+    #    "did not happen" assertion below would pass vacuously.
+    r = run_step(step, "true && touch sentinel-tail")
+    if "sentinel-tail" not in r.sentinels:
+        fail(
+            "sentinel-control",
+            "a seed that DOES reach its tail left no sentinel — either the "
+            "seed never reached the step, or the tail-ran detector below is "
+            "dead. Either way its verdict means nothing.",
+        )
+
+    # -- 1. A failing && chain must fail the job, loudly. ------------------
+    r = run_step(step, "false && touch sentinel-tail && echo second")
+    if r.rc == 0:
+        fail(
+            "failing-&&-chain",
+            "exited 0. A seed whose first stage fails MUST fail the step; this "
+            "is the #192 defect — bash's set -e exemption for && lists.",
+        )
+    if "sentinel-tail" in r.sentinels:
+        fail("failing-&&-chain", "the tail ran after a failed first stage.")
+    if "Seed command completed" in r.both:
+        fail(
+            "failing-&&-chain",
+            "printed a completion message for a seed that did not complete.",
+        )
+    if "::error::" not in r.err:
+        fail(
+            "failing-&&-chain",
+            "no `::error::` on STDERR. A caller capturing this step with $(…) "
+            "would see a bare non-zero exit and no stated cause.",
+        )
+    if "::error::" in r.out:
+        fail(
+            "failing-&&-chain",
+            "wrote `::error::` to STDOUT; diagnostics must go to stderr.",
+        )
+
+    # -- 2. A legitimate multi-stage seed must still succeed, SILENTLY. ----
+    #    The "no ::error:: on success" half is not decoration. An always-true
+    #    failure predicate (`if true; then … exit "$SEED_RC"`) still exits 0
+    #    on a good seed and non-zero on a bad one, so every other assertion
+    #    here passes — while the log cries `::error::Seed command failed with
+    #    exit 0` on every green run. A gate that alarms unconditionally is on
+    #    its way to being ignored unconditionally.
+    r = run_step(step, "echo STAGE_ONE && echo STAGE_TWO && echo STAGE_THREE")
+    if r.rc != 0:
+        fail("legit-&&-chain", f"a valid multi-stage seed failed with {r.rc}.")
+    for stage in ("STAGE_ONE", "STAGE_TWO", "STAGE_THREE"):
+        if stage not in r.both:
+            fail("legit-&&-chain", f"{stage} never ran.")
+    if "::error::" in r.both:
+        fail(
+            "legit-&&-chain",
+            "a SUCCESSFUL seed emitted `::error::`. The failure branch is "
+            "firing unconditionally.",
+        )
+
+    # -- 3. Shell syntax the fleet actually ships must keep working. -------
+    #    launchpad: `OC_PASS=… php occ user:add … || true`
+    #    openconnector (newman): `SEED_SCOPE=register bash …/ci-seed.sh`
+    r = run_step(step, "OC_SEED_VAR=works sh -c 'echo prefix-$OC_SEED_VAR' || true")
+    if r.rc != 0:
+        fail("assignment-prefix-and-||", f"exited {r.rc}; eval is still required.")
+    if "prefix-works" not in r.both:
+        fail("assignment-prefix-and-||", "the assignment prefix was lost.")
+
+    # -- 4. A seed containing quotes must not reshape the script. ----------
+    r = run_step(step, "printf '%s\\n' \"quoted seed ok\"")
+    if r.rc != 0:
+        fail("quoted-seed", f"exited {r.rc}.")
+    if "quoted seed ok" not in r.both:
+        fail("quoted-seed", "did not run.")
+
+    # -- 4b. The seed must reach eval BYTE-FOR-BYTE. -----------------------
+    #    This is what the quoting on `eval "$SEED_COMMAND"` buys. Unquoted,
+    #    the expansion is word-split and glob-expanded first, and eval then
+    #    rejoins the words with single spaces — so runs of whitespace inside
+    #    the seed's own quotes are silently collapsed and a `*` in the seed
+    #    is replaced by whatever happens to be in the working directory.
+    r = run_step(step, "printf '[%s]\\n' 'a   b'")
+    if "[a   b]" not in r.both:
+        fail(
+            "seed-arrives-verbatim",
+            "the seed was word-split before eval saw it — internal whitespace "
+            "did not survive. Quote the expansion.",
+        )
+
+    # -- 5. The announcement must not EXPAND the seed. ---------------------
+    #    pipelinq's control printed identical before/after byte counts because
+    #    `echo "… ${{ … }}"` expanded the seed's own $(…) in the ANNOUNCING
+    #    shell, before the seed ran.
+    r = run_step(step, "echo ran-for-real-$(echo 1)")
+    if "$(echo 1)" not in r.both:
+        fail(
+            "announcement-must-not-expand",
+            "the seed was announced with its $(…) already expanded, so a "
+            "readback written into the seed cannot observe its own effect.",
+        )
+
+    # -- 6. The step's exit status must be the seed's. ---------------------
+    r = run_step(step, "exit 42")
+    if r.rc != 42:
+        fail("exit-status-propagates", f"seed exited 42, step exited {r.rc}.")
+
+    return bad
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("workflows", nargs="*")
+    ap.add_argument(
+        "--positive-control",
+        action="store_true",
+        help="run the battery against the KNOWN-BROKEN pre-#192 body; it must fail.",
+    )
+    args = ap.parse_args()
+
+    if args.positive_control:
+        bad = check_step(PRE_FIX_STEP, "pre-fix step")
+        if not bad:
+            print(
+                "::error::the battery reported the PRE-FIX seed step as sound. "
+                "That step is the #192 defect verbatim — if it passes, these "
+                "assertions are not measuring anything and their verdict on the "
+                "real workflow is worthless."
+            )
+            return 1
+        print("OK — the battery fails on the known-bad step. It can fail:")
+        for line in bad:
+            print(f"  would-flag: {line}")
+        return 0
+
+    if not args.workflows:
+        print("::error::no workflow given.")
+        return 1
+
+    total = 0
+    failures: list[str] = []
+    for path_s in args.workflows:
+        path = Path(path_s)
+        steps = extract_seed_steps(path)
+        # ASSERT THE INPUT IS NON-EMPTY. A parser that silently stopped
+        # matching would find zero steps and report a clean pass forever —
+        # the difference between "all sound" and "measured nothing" is not
+        # visible in the exit code unless it is asserted here.
+        if not steps:
+            print(
+                f"::error file={path_s}::found NO step named '{STEP_NAME}'. Either "
+                f"the step was renamed or this extractor stopped matching; either "
+                f"way the seed contract is now unchecked."
+            )
+            return 1
+        for line, env, body in steps:
+            total += 1
+            label = f"{path_s}:{line}"
+            print(f"exercising {label}")
+            failures.extend(check_step((env, body), label))
+
+    if failures:
+        for line in failures:
+            print(f"::error::{line}")
+        return 1
+
+    print(f"OK — {total} 'Seed test data' step(s) fail loudly on a failing seed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two defects that silently destroy test evidence across the fleet. Both measured, both proven in the direction that matters *and* in the direction that would make the gate blind.

## #192 — a failing seed exits 0

`playwright-seed-command` was interpolated into the step body **unquoted**. `${{ }}` is a textual substitution applied before bash sees the script, so a seed of `a && b && c` became `eval a && b && c` — three commands in an `&&` list, with `eval` receiving only the first stage. Bash's `set -e` exemption for `&&` lists then meant a failing first stage aborted nothing, the tail never ran, and the step exited **0** while printing `Seed command completed.`

Measured on pipelinq run `30800304506`: a bundle-truncation positive control that never truncated anything and reported 107 passed / 61 failed.

**The seed now arrives as data** (`SEED_COMMAND:` under `env:`), the expansion is quoted, the status is checked explicitly, and the diagnostic goes to **stderr** — an `::error::` on stdout is swallowed whole by any caller that captures the step with `$(…)`.

### What the fleet actually passes — enumerated before choosing the shape

Every caller's real value, read from `origin/development`, not from the local checkouts:

| shape | repos |
|---|---|
| bare `bash apps/<app>/tests/e2e/ci-seed.sh` | decidesk, doriath, hrmq, openbuild, opencatalogi, openconnector, openregister, petstore, pipelinq, portaliq, procest, scholiq, softwarecatalog, planix, larpingapp, docudesk (16) |
| bare `php occ config:app:set …` | nldesign |
| **assignment prefix + `\|\| true`** | launchpad — `OC_PASS=E2eGranteePw123 php occ user:add --password-from-env e2e-grantee \|\| true` |

And on the Newman input, which the issue did not cover:

| repo | `newman-seed-command` |
|---|---|
| **openbuild** | `php occ app:disable openbuild && php occ app:enable openbuild` ← **an `&&` chain, the defect live today** |
| openconnector | `SEED_SCOPE=register bash apps/openconnector/tests/e2e/ci-seed.sh` (assignment prefix) |
| procest, launchpad, docudesk | bare script invocations |

**No repo currently passes an `&&` chain to `playwright-seed-command`.** One passes an assignment prefix and a `|| true`; one passes an assignment prefix to the Newman input. So **`eval` is retained deliberately** — a bare `"$SEED_COMMAND"` would exec launchpad's whole string as one argv word. The defect was the *quoting*, not the eval.

### Three steps, not two

`scripts/assert-seed-step-fails-loudly.py` extracts every step named `Seed test data` — **env block and run body both** — and *executes* it under the shell GitHub uses (`bash -e <file>`; quality.yml declares no `shell:`).

Running the shipped text rather than grepping for a pattern found a **third** instance nobody had listed: the Newman job's own seed step, whose comment claimed *"Use eval to support complex commands with pipes or &&"*. That was the assurance the defect hid behind, and openbuild ships an `&&` chain to it.

### Proven both ways

`--positive-control` runs the identical battery against the **pre-fix body reconstructed verbatim** and requires it to **fail**. It does, on six assertions. A battery that passed the known-bad body would be measuring nothing.

Eight mutations of the fixed step, each **killed** by the suite:

| mutation | verdict |
|---|---|
| failure predicate → always FALSE | killed |
| failure predicate → always TRUE | killed |
| diagnostics off stderr | killed |
| explicit `exit` dropped | killed |
| expansion unquoted | killed |
| env passthrough dropped | killed |
| rc capture pinned to 0 | killed |
| full revert to the original bug | killed |

Two of these only started failing after the harness was strengthened, and both gaps were real: an always-true predicate still gated correctly while crying `::error::Seed command failed with exit 0` on every green run, and the harness was injecting `SEED_COMMAND` itself, so deleting the env line changed nothing. It now reads the env block from the file and asserts that a *successful* seed is silent.

One assertion of my own was wrong first time round and is worth recording: "did the tail run?" was grepping the log for a marker word that **also appears in the `::error::` line, which echoes the seed back**. It reported "the tail ran" on a step where it demonstrably had not. It now answers with a filesystem side effect, and has its own control proving the sentinel can fire.

## #210 — a tag inside `test.describe.skip` counted as coverage

`_enclosing_block()` searches **forward** from the tag, because the convention this module documents puts the tag immediately above the test it annotates. That is right for the test and blind to everything wrapping it.

**Reproducing it surfaced a wider defect the issue had not seen.** `_TEST_DECL_RE` could not match `test.describe.skip(` **at all**: at `test` the modifier group finds `.describe` instead of `.skip` so the required `(` fails, and at `describe` the `(?<![.\w$])` lookbehind sees the preceding dot and refuses. The construct was *invisible*, not judged. So the issue's own "correctly dead" control — the tag **above** a skipped describe — was in fact reported **LIVE** too:

```
LIVE demo::genuinely-live
LIVE demo::tag-above-a-skipped-describe      <- issue believed this was DEAD
LIVE demo::tag-inside-a-skipped-describe
DEAD demo::plain-skipped-test
```

Both are fixed: an explicit `test.` / `it.` **namespace** segment — named rather than `\w+\.`, so `rx.test(` is still rejected — plus an outward ancestor walk.

### A regression I introduced, caught by measuring

Making `test.describe(` visible handed the empty-body check a body full of **other tests**, and a single nested `test.skip(true, …)` then condemned the whole group. launchpad's `spec-coverage.spec.ts` header tag went live→dead because one guarded test among many opts out on an env condition. `_has_own_unconditional_skip()` disowns nested occurrences while keeping Playwright's real group-level `test.skip()` dead — with both tests.

### Measured against the fleet

Old code vs new, eight repos at `origin/development`:

| repo | live before | live after | live→dead | dead→live |
|---|---:|---:|---:|---:|
| openconnector | 74 | 63 | **11** | 0 |
| scholiq | 25 | 20 | **5** | 0 |
| launchpad | 112 | 112 | 0 | 0 |
| softwarecatalog | 27 | 28 | 0 | 1 |
| nldesign, pipelinq, portaliq, shillinq | — | — | 0 | 0 |

**16 live→dead — openconnector 11, scholiq 5, exactly the issue's count.**

The single dead→live is `softwarecatalog::org-archimate-export::user-triggers-organization-export-with-toggles`, and it is **not a relaxation**. It exposes a *pre-existing* false positive on `main`: the body finder scans back from the closing paren expecting `}`, and a **trailing comma** before `)` makes a real asserting test read as an empty body. Demonstrated in isolation against both versions:

```
OLD: trailing-comma test        live = False
NEW: trailing-comma test        live = False     <- unchanged, still wrong
OLD: no-trailing-comma control  live = True
NEW: no-trailing-comma control  live = True
```

The ref flips only because the tag now resolves outward to the enclosing `test.describe`, whose body computation succeeds. **That bug is untouched here and filed separately** — it is a false RED, unrelated to either issue, and fixing it inside this PR would change verdicts for a third reason.

### Proven both ways

25 new tests. **Every dead assertion is paired with a live control**: `describe.only`, `describe.serial`, `describe.configure`, a live `describe`, a sibling *after* a closed skipped block, a runtime-conditional skip, and `rx.test(`. Eleven mutations, each **killed**:

| mutation | verdict |
|---|---|
| ancestor check → always DEAD / always LIVE | killed / killed |
| `_switched_off_ancestor` finds nothing | killed |
| "encloses" weakened to "appears earlier" | killed |
| `_is_switched_off` → always True / always False | killed |
| pre-fix regex restored | killed |
| namespace widened to any member (`\w+\.`) | killed |
| `.only` folded into the modifier group | killed |
| `.serial` folded into the modifier group | killed |
| `xdescribe` arm dropped | killed |

**Nothing was unskipped in any consumer repo.** That is a separate decision.

## Resolution safety

The new lint is a **file under `scripts/`**, called by `quality-resolve-probe.yml` — not by `quality.yml`, so no consumer below any tag can break on a path that does not exist in its checkout. It runs as its own job behind the same single `Shared-workflow guard` required check, with its positive control first, exactly as the probe does.

`assert-run-steps-resolvable.py` still passes: every `run:` block is under 16384 bytes, and the largest step added here is ~1 KB.

Full package suite: **27 passed, 0 failed, 2 quarantined** (both pre-existing, unchanged).

## What consumers see on the next run

The fleet tracks `@main` unpinned per #177, so a merge here reaches all callers immediately.

- **A repo whose seed currently fails will now go RED instead of green.** That is the point. openbuild's Newman leg is the one known live `&&` chain.
- **launchpad's `|| true` still cannot fail** — its seed swallows its own status. Unchanged by this PR, and worth a decision separately.
- **gate-19 is diff-scoped.** The 16 refs only bite when a PR touches the spec file that owns them. openconnector and scholiq will see them the next time they touch those specs — with a message that says the tag is present but the test does not run, not "missing @e2e".

Closes #192
Closes #210
