### PR TITLE
fix(gate-57): the #[McpTool] attribute-scanner seam is a real registration (#200)

### DIFF
--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -11,8 +11,20 @@ non-test production caller, OR be invoked through a recognised INDIRECT
 seam: an OpenRegister ``handler``/``guard``/``requires``/``save``/
 ``fallbackGuard``/``preconditions`` entry in a register.d fragment, an
 event listener registered in ``lib/AppInfo/Application.php``, a
-background job registered in ``appinfo/info.xml``, or a documented
+background job registered in ``appinfo/info.xml``, an ``#[McpTool]``
+method on a class OpenRegister's ``AttributeToolScanner`` reflects
+(ADR-063 — see ``_build_mcp_attribute_seam``), or a documented
 ``Log*Adapter`` intentional log-only seam.
+
+TWO REMEDIES, NOT ONE. A zero-caller write capability can be dead OR
+redundant, and the finding text only suggests wiring. Before adding a
+route, establish whether the capability is ALREADY LIVE under a different
+method or class — measured on softwarecatalog, where
+``FederationService::publishEntryForFederation()`` had zero callers while
+``PublicationService::publish()`` served the same capability through a
+live route. Wiring the orphan would have duplicated a live endpoint and
+widened the auth surface (it had no per-object guard); deleting it was
+correct (softwarecatalog#447).
 
 Observed 2026-07-13 on shillinq (orphan-capability-sweep, 13 filed
 issues): ``DisposalJournalEmitter::emit()``, ``IntercompanyJournalService``,
@@ -115,6 +127,36 @@ _INTERFACE_RE = re.compile(
     re.MULTILINE,
 )
 _LOG_ADAPTER_RE = re.compile(r"Log\w*Adapter", re.IGNORECASE)
+
+# --- attribute-scanner seam (#200) -----------------------------------------
+# The interface OpenRegister's AttributeToolScanner enumerates (ADR-063).
+_MCP_SCANNABLE_INTERFACE = "IMcpScannableServices"
+# `registerServiceAlias('OCA\OpenRegister\Mcp\IMcpScannableServices::<app>', Impl::class)`
+# On disk the namespace separators are double-backslashed inside the PHP
+# string literal, so the pattern must accept either spelling.
+_MCP_ALIAS_RE = re.compile(
+    r"registerServiceAlias\s*\(\s*"
+    r"(['\"])[^'\"]*" + _MCP_SCANNABLE_INTERFACE + r"::[A-Za-z0-9_-]+\1"
+    r"\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*"
+    r"([A-Za-z_][A-Za-z0-9_]*)\s*::\s*class",
+    re.DOTALL,
+)
+# `Foo::class` inside a scannable-services implementation.
+_CLASS_CONST_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*::\s*class")
+# `#[McpTool(...)]` — optionally namespace-qualified. NOT a comment: `#` opens
+# a line comment in PHP but `#[` opens an attribute, which is exactly why the
+# comment blanker below has to know the difference.
+_MCP_TOOL_ATTR_RE = re.compile(
+    r"#\[\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*McpTool\b"
+)
+# Lines that cannot belong to the attribute block of the method below them.
+# ONLY the statement/block terminators. A word-based boundary (`\bclass\b`)
+# was tried first and is wrong: `#[McpTool(handler: Foo::class)]` contains the
+# word `class` inside its own arguments, so the walk-up would stop before
+# reading the attribute it exists to find. Everything that can legally sit
+# directly above a method's attribute block — the previous method's `}`, a
+# property or `use` `;`, the class's opening `{` — ends in one of these.
+_ATTR_BOUNDARY_RE = re.compile(r"[{};]\s*$")
 _EXCLUDE_RE = re.compile(
     r"@orphaned-write-capability\s+exclude\s+(?P<reason>.{10,})"
 )
@@ -239,6 +281,158 @@ def _build_register_handler_seam(app_root: str) -> set[tuple[str, str]]:
     return seam
 
 
+def _blank_php_comments(text: str) -> str:
+    """Replace PHP comment CONTENT with spaces, preserving length and newlines.
+
+    WHY THIS IS NOT OPTIONAL HERE
+    -----------------------------
+    Every seam this gate recognises is evidence that a method is REACHABLE, so
+    a seam matched inside a comment EXEMPTS live-looking code that nothing
+    actually calls — a false GREEN — and, for the attribute seam specifically,
+    prose is exactly where the phrase turns up. ``LeadService.php`` opens with
+
+        * Both public entry points are annotated `#[McpTool]` (OpenRegister…
+
+    on line 7, seven lines above anything executable. A raw-text search for
+    ``#[McpTool`` matches that sentence. This is the shape gate-64's
+    ``has_prelude()`` had — a checker that greps text misses every constant
+    AND matches every comment, failing in both directions at once.
+
+    Offsets and line numbers are preserved so the result can be used
+    line-for-line against the original.
+
+    ``#`` opens a line comment in PHP, but ``#[`` opens an ATTRIBUTE. Blanking
+    attributes would delete the very thing being looked for, so the two are
+    distinguished.
+    """
+    out = list(text)
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            for k in range(i, j):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+        if (ch == "/" and i + 1 < n and text[i + 1] == "/") or (
+            ch == "#" and not (i + 1 < n and text[i + 1] == "[")
+        ):
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _build_mcp_attribute_seam(app_root: str) -> set[str]:
+    """Short class names OpenRegister's ``AttributeToolScanner`` may reflect.
+
+    THE SEAM (#200, ADR-063). A method reached only by attribute reflection
+    has no ``->method(`` call site anywhere, so the caller index cannot see it
+    and the gate reported it dead. Measured on pipelinq:
+    ``LeadService::createLead`` — a curated, spec'd MCP write tool — was
+    flagged, and acting on that verdict would have deleted it. Same shape as
+    hydra#106, which this module's docstring already records as the failure
+    mode that matters.
+
+    THREE-PART EVIDENCE, all of which must hold, mirroring what the
+    register.d-handler and event-listener seams already demand:
+
+      1. ``lib/AppInfo/Application.php`` binds an implementation under the
+         ``…IMcpScannableServices::<app>`` DI alias, and
+      2. that implementation lists class constants (``Foo::class``), and
+      3. (checked per method in :func:`scan_file`) the method itself carries
+         an ``#[McpTool(...)]`` attribute.
+
+    So a bare ``#[McpTool]`` on a class nobody registers stays RED, a
+    registered class's write methods that carry NO attribute stay RED, and a
+    scannable-services implementation that is never aliased buys nothing.
+    """
+    bound_impls: set[str] = set()
+    lib_dir = os.path.join(app_root, "lib")
+    for dirpath, _dirnames, filenames in os.walk(lib_dir):
+        for fn in filenames:
+            if fn != "Application.php":
+                continue
+            try:
+                with open(os.path.join(dirpath, fn), encoding="utf-8", errors="replace") as fh:
+                    text = _blank_php_comments(fh.read())
+            except OSError:
+                continue
+            for m in _MCP_ALIAS_RE.finditer(text):
+                bound_impls.add(m.group(2))
+    if not bound_impls:
+        return set()
+
+    scannable: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(lib_dir):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        for fn in filenames:
+            if not fn.endswith(".php"):
+                continue
+            fp = os.path.join(dirpath, fn)
+            try:
+                with open(fp, encoding="utf-8", errors="replace") as fh:
+                    raw = fh.read()
+            except OSError:
+                continue
+            text = _blank_php_comments(raw)
+            short = _class_short_name(text)
+            if short is None or short not in bound_impls:
+                continue
+            if _MCP_SCANNABLE_INTERFACE not in text:
+                # The alias named this class, but the class does not implement
+                # the scanner's interface — OpenRegister would never reflect
+                # it, so it grants nothing.
+                continue
+            for m in _CLASS_CONST_RE.finditer(text):
+                scannable.add(m.group(1))
+    scannable.discard("self")
+    scannable.discard("static")
+    scannable -= bound_impls
+    return scannable
+
+
+def _method_has_mcp_attribute(blanked_lines: list[str], method_line_idx: int) -> bool:
+    """Does an ``#[McpTool(...)]`` attribute apply to the method at *idx*?
+
+    Walks up over the attribute block only. *blanked_lines* must come from
+    :func:`_blank_php_comments`, so a docblock that merely MENTIONS
+    ``#[McpTool]`` in prose is already whitespace by the time it is read.
+    """
+    region: list[str] = []
+    j = method_line_idx - 1
+    while j >= 0:
+        stripped = blanked_lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if _ATTR_BOUNDARY_RE.search(stripped):
+            break
+        region.append(stripped)
+        j -= 1
+    return _MCP_TOOL_ATTR_RE.search("\n".join(region)) is not None
+
+
 def _build_listener_class_seam(app_root: str) -> set[str]:
     """Short class names registered via registerEventListener(...) in any
     AppInfo/Application.php — invoked by the event dispatcher, not by an
@@ -251,7 +445,16 @@ def _build_listener_class_seam(app_root: str) -> set[str]:
             fp = os.path.join(dirpath, fn)
             try:
                 with open(fp, encoding="utf-8", errors="replace") as fh:
-                    text = fh.read()
+                    # A COMMENTED-OUT REGISTRATION IS NOT A REGISTRATION.
+                    # This seam EXEMPTS a whole class, so matching one inside a
+                    # comment is a false GREEN: the listener is not wired, its
+                    # write methods are dead, and the gate says nothing.
+                    # Latent rather than observed — a sweep of the 8 repos
+                    # currently under gate found zero comment-only matches, so
+                    # this changes no verdict today — but it is the same shape
+                    # as gate-64's has_prelude(), where a commented-out prelude
+                    # counted as compliance.
+                    text = _blank_php_comments(fh.read())
             except OSError:
                 continue
             for m in re.finditer(
@@ -279,7 +482,10 @@ def _build_job_class_seam(app_root: str) -> set[str]:
         return seam
     try:
         with open(info_xml, encoding="utf-8", errors="replace") as fh:
-            text = fh.read()
+            # `<!-- <job>…</job> -->` is a job that is NOT scheduled. Same
+            # false-GREEN shape as the listener seam above: this exempts the
+            # whole class. XML comments, not PHP ones, so a separate strip.
+            text = re.sub(r"<!--.*?-->", " ", fh.read(), flags=re.DOTALL)
     except OSError:
         return seam
     for m in re.finditer(r"<job>\s*([A-Za-z0-9_\\]+)\s*</job>", text):
@@ -396,13 +602,14 @@ def _build_caller_index(app_root: str, extra_roots: list[str] | None = None) -> 
 
 
 def scan_file(file_path: str, app_root: str, seams, caller_counts, findings: list[str]):
-    register_seam, listener_seam, job_seam = seams
+    register_seam, listener_seam, job_seam, mcp_seam = seams
     try:
         with open(file_path, encoding="utf-8", errors="replace") as fh:
             text = fh.read()
     except OSError:
         return
     lines = text.split("\n")
+    blanked_lines = _blank_php_comments(text).split("\n")
     if _is_interface_or_trait(text):
         # Interface/trait method declarations have no body — there is
         # nothing to be dead. Only the concrete implementation's deadness
@@ -433,6 +640,18 @@ def scan_file(file_path: str, app_root: str, seams, caller_counts, findings: lis
         if _preceding_docblock_has_exclude(lines, idx):
             continue
         if class_short and (class_short, name) in register_seam:
+            continue
+        if (
+            class_short
+            and class_short in mcp_seam
+            and _method_has_mcp_attribute(blanked_lines, idx)
+        ):
+            # Attribute-scanner seam (#200): OpenRegister's AttributeToolScanner
+            # reflects this class and invokes this method. There is no
+            # `->method(` call site anywhere and there never will be, so the
+            # caller index cannot see it. PER METHOD, not per class — a write
+            # method on a scannable class that carries no `#[McpTool]` is still
+            # an orphan and still reported.
             continue
         if caller_counts.get(name, 0) > 0:
             continue
@@ -493,6 +712,7 @@ def _scan_app(app_root: str, files: list[str], findings: list[str]) -> None:
     register_seam = _build_register_handler_seam(app_root)
     listener_seam = _build_listener_class_seam(app_root)
     job_seam = _build_job_class_seam(app_root)
+    mcp_seam = _build_mcp_attribute_seam(app_root)
 
     # --- Cross-app caller awareness (hydra#106, FP class 1) --------------
     # A leaf app's services are consumed only by that app (ADR-022: apps
@@ -520,7 +740,13 @@ def _scan_app(app_root: str, files: list[str], findings: list[str]) -> None:
     caller_counts = _build_caller_index(app_root, extra_roots)
 
     for fp in files:
-        scan_file(fp, app_root, (register_seam, listener_seam, job_seam), caller_counts, findings)
+        scan_file(
+            fp,
+            app_root,
+            (register_seam, listener_seam, job_seam, mcp_seam),
+            caller_counts,
+            findings,
+        )
 
 
 def main(argv):

--- a/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
@@ -610,5 +610,358 @@ def _write(root, rel_path, content):
     return full
 
 
+# ---------------------------------------------------------------------------
+# THE ATTRIBUTE-SCANNER SEAM (#200)
+#
+# gate-57 reported `pipelinq LeadService::createLead` — a curated, spec'd MCP
+# write tool — as an orphan. It is reached by attribute reflection: an
+# `#[McpTool]` attribute, a class listed by an `IMcpScannableServices`
+# implementation, and a `registerServiceAlias` binding that implementation
+# under `…IMcpScannableServices::<app>`. There is no `->createLead(` call site
+# anywhere and there never will be, so the caller index cannot see it. Acting
+# on the verdict would have DELETED a live tool — the failure mode this
+# module's docstring already records from hydra#106.
+#
+# Widening a checker until nothing trips it is the opposite failure. EVERY
+# exemption below is paired with a control that must still be REPORTED: the
+# attribute without the registration, the registration without the attribute,
+# an alias naming a class that does not implement the interface, an
+# implementation nobody aliases, the registration commented out, and the
+# attribute merely MENTIONED in a docblock.
+# ---------------------------------------------------------------------------
+
+_MCP_INFO_XML = "<?xml version='1.0'?>\n<info><id>demoapp</id></info>\n"
+
+_MCP_APPLICATION_TMPL = """<?php
+namespace OCA\\DemoApp\\AppInfo;
+
+use OCA\\DemoApp\\Mcp\\DemoScannableServices;
+
+class Application {
+    public function register($context): void {
+%s
+    }
+}
+"""
+
+_MCP_ALIAS_CALL = """        $context->registerServiceAlias(
+            'OCA\\\\OpenRegister\\\\Mcp\\\\IMcpScannableServices::demoapp',
+            DemoScannableServices::class
+        );"""
+
+_MCP_SCANNABLE_TMPL = """<?php
+namespace OCA\\DemoApp\\Mcp;
+
+use OCA\\OpenRegister\\Mcp\\IMcpScannableServices;
+use OCA\\DemoApp\\Service\\LeadService;
+
+class DemoScannableServices implements IMcpScannableServices
+{
+    public function getScannableServiceClasses(): array
+    {
+        return [
+            LeadService::class,
+        ];
+    }
+}
+"""
+
+# `createLead` is attributed; `createInvoice` is not. Both are write-verb
+# methods with zero `->method(` call sites anywhere in the fixture. The file
+# header deliberately MENTIONS `#[McpTool]` in prose, exactly as pipelinq's
+# real LeadService.php does on line 7.
+_MCP_LEAD_SERVICE_TMPL = """<?php
+/**
+ * Lead service.
+ *
+ * Both public entry points are annotated `#[McpTool]` (OpenRegister ADR-063).
+ * That sentence is PROSE and must not register anything.
+ */
+namespace OCA\\DemoApp\\Service;
+
+use OCA\\OpenRegister\\Mcp\\Attribute\\McpTool;
+
+class LeadService
+{
+%s
+    public function createLead(array $data): array
+    {
+        return $data;
+    }
+
+    /**
+     * No attribute on this one.
+     */
+    public function createInvoice(array $data): array
+    {
+        return $data;
+    }
+}
+"""
+
+_MCP_ATTRIBUTE = """    #[McpTool(
+        name: 'createLead',
+        description: 'Create a lead',
+        readOnlyHint: false,
+        scope: 'create'
+    )]"""
+
+
+class _McpFixture:
+    """A throwaway Nextcloud app tree wired for the attribute seam."""
+
+    def __init__(self, root: str, *, alias: str, attribute: str, scannable: bool = True):
+        self.root = root
+        _write(root, "appinfo/info.xml", _MCP_INFO_XML)
+        _write(root, "lib/AppInfo/Application.php", _MCP_APPLICATION_TMPL % alias)
+        if scannable:
+            _write(root, "lib/Mcp/DemoScannableServices.php", _MCP_SCANNABLE_TMPL)
+        self.service = _write(
+            root, "lib/Service/LeadService.php", _MCP_LEAD_SERVICE_TMPL % attribute
+        )
+
+    def methods(self) -> set:
+        out: list[str] = []
+        owc._scan_app(self.root, [self.service], out)
+        names = set()
+        for line in out:
+            for part in line.split():
+                if part.startswith("method="):
+                    names.add(part[len("method="):])
+        return names
+
+
+class McpAttributeSeamTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "demoapp")
+        os.makedirs(self.root)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    # --- the fix: a genuinely wired tool is no longer named dead ---------
+    def test_registered_and_attributed_method_is_not_flagged(self):
+        f = _McpFixture(self.root, alias=_MCP_ALIAS_CALL, attribute=_MCP_ATTRIBUTE)
+        self.assertNotIn("createLead", f.methods())
+
+    # --- THE CONTROLS. Each must still be REPORTED. ----------------------
+    def test_an_unattributed_write_method_on_a_scannable_class_is_still_flagged(self):
+        # The seam is per METHOD, not per class. Exempting the whole class
+        # would hand every write method on LeadService a free pass.
+        f = _McpFixture(self.root, alias=_MCP_ALIAS_CALL, attribute=_MCP_ATTRIBUTE)
+        self.assertIn("createInvoice", f.methods())
+
+    def test_the_attribute_without_the_DI_alias_is_still_flagged(self):
+        # A bare `#[McpTool]` on a class nobody registers is not a seam —
+        # OpenRegister never reflects it, so the tool does not exist.
+        f = _McpFixture(self.root, alias="        // nothing registered", attribute=_MCP_ATTRIBUTE)
+        self.assertIn("createLead", f.methods())
+
+    def test_the_alias_without_the_attribute_is_still_flagged(self):
+        f = _McpFixture(self.root, alias=_MCP_ALIAS_CALL, attribute="")
+        self.assertIn("createLead", f.methods())
+
+    def test_a_scannable_implementation_that_does_not_exist_is_still_flagged(self):
+        f = _McpFixture(
+            self.root, alias=_MCP_ALIAS_CALL, attribute=_MCP_ATTRIBUTE, scannable=False
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_a_class_not_listed_by_the_implementation_is_still_flagged(self):
+        f = _McpFixture(self.root, alias=_MCP_ALIAS_CALL, attribute=_MCP_ATTRIBUTE)
+        _write(
+            self.root,
+            "lib/Mcp/DemoScannableServices.php",
+            _MCP_SCANNABLE_TMPL.replace("LeadService::class", "TicketService::class"),
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_an_aliased_class_that_does_not_implement_the_interface_grants_nothing(self):
+        # The alias names it, but OpenRegister's scanner only ever calls
+        # getScannableServiceClasses() on an IMcpScannableServices. A class
+        # that does not implement it is never reflected.
+        f = _McpFixture(self.root, alias=_MCP_ALIAS_CALL, attribute=_MCP_ATTRIBUTE)
+        _write(
+            self.root,
+            "lib/Mcp/DemoScannableServices.php",
+            _MCP_SCANNABLE_TMPL
+            .replace("use OCA\\OpenRegister\\Mcp\\IMcpScannableServices;\n", "")
+            .replace(" implements IMcpScannableServices", ""),
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_an_UNALIASED_implementation_grants_nothing_even_when_another_is_aliased(self):
+        # THE CONTROL FOR THE ALIAS REQUIREMENT. A registration exists — so the
+        # seam builder does not bail out early — but it names a DIFFERENT
+        # class. Any class in lib/ that happens to list `LeadService::class`
+        # must not become a seam on that basis.
+        alias = _MCP_ALIAS_CALL.replace(
+            "DemoScannableServices::class", "OtherScannableServices::class"
+        )
+        f = _McpFixture(self.root, alias=alias, attribute=_MCP_ATTRIBUTE)
+        _write(
+            self.root,
+            "lib/Mcp/OtherScannableServices.php",
+            _MCP_SCANNABLE_TMPL
+            .replace("class DemoScannableServices", "class OtherScannableServices")
+            .replace("LeadService::class,", ""),
+        )
+        self.assertIn("createLead", f.methods())
+
+    # --- the gate-64 shape: a comment is not a registration -------------
+    def test_a_COMMENTED_OUT_alias_grants_nothing(self):
+        # gate-64's `has_prelude()` matched inside comments, so a
+        # commented-out prelude counted as compliance. A seam matched in a
+        # comment exempts code that nothing calls.
+        commented = "\n".join(
+            "        // " + ln.strip() for ln in _MCP_ALIAS_CALL.split("\n")
+        )
+        f = _McpFixture(self.root, alias=commented, attribute=_MCP_ATTRIBUTE)
+        self.assertIn("createLead", f.methods())
+
+    def test_a_BLOCK_COMMENTED_alias_grants_nothing(self):
+        f = _McpFixture(
+            self.root,
+            alias="        /*\n" + _MCP_ALIAS_CALL + "\n        */",
+            attribute=_MCP_ATTRIBUTE,
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_a_docblock_that_merely_MENTIONS_the_attribute_is_not_an_attribute(self):
+        f = _McpFixture(
+            self.root,
+            alias=_MCP_ALIAS_CALL,
+            attribute="    /** Annotated with #[McpTool] elsewhere. */",
+        )
+        self.assertIn("createLead", f.methods())
+
+    # --- the SAME shape in the pre-existing seams -----------------------
+    def test_a_commented_out_event_listener_does_not_exempt_the_class(self):
+        # The listener seam exempts a WHOLE class, so a match inside a comment
+        # is a false GREEN. Latent rather than observed — a sweep of the eight
+        # repos under this gate found zero comment-only matches — but it is
+        # the same shape and it is now closed.
+        f = _McpFixture(self.root, alias="        // nothing", attribute="")
+        _write(
+            self.root,
+            "lib/AppInfo/Application.php",
+            _MCP_APPLICATION_TMPL
+            % "        // $context->registerEventListener(SomeEvent::class, LeadService::class);",
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_a_LIVE_event_listener_registration_still_exempts_the_class(self):
+        # THE CONTROL. Blanking comments must not have broken the seam itself.
+        f = _McpFixture(self.root, alias="        // nothing", attribute="")
+        _write(
+            self.root,
+            "lib/AppInfo/Application.php",
+            _MCP_APPLICATION_TMPL
+            % "        $context->registerEventListener(SomeEvent::class, LeadService::class);",
+        )
+        self.assertEqual(f.methods(), set())
+
+    def test_a_commented_out_background_job_does_not_exempt_the_class(self):
+        f = _McpFixture(self.root, alias="        // nothing", attribute="")
+        _write(
+            self.root,
+            "appinfo/info.xml",
+            "<?xml version='1.0'?>\n<info><id>demoapp</id><background-jobs>\n"
+            "<!-- <job>OCA\\DemoApp\\Service\\LeadService</job> -->\n"
+            "</background-jobs></info>\n",
+        )
+        self.assertIn("createLead", f.methods())
+
+    def test_a_LIVE_background_job_registration_still_exempts_the_class(self):
+        f = _McpFixture(self.root, alias="        // nothing", attribute="")
+        _write(
+            self.root,
+            "appinfo/info.xml",
+            "<?xml version='1.0'?>\n<info><id>demoapp</id><background-jobs>\n"
+            "<job>OCA\\DemoApp\\Service\\LeadService</job>\n"
+            "</background-jobs></info>\n",
+        )
+        self.assertEqual(f.methods(), set())
+
+
+class PhpCommentBlankerTest(unittest.TestCase):
+    """The blanker underpins every seam above, so it is tested directly."""
+
+    def test_preserves_line_numbers_and_length(self):
+        src = "<?php\n// gone\n$a = 1; /* gone\nstill gone */ $b = 2;\n# gone\n"
+        out = owc._blank_php_comments(src)
+        self.assertEqual(len(out), len(src))
+        self.assertEqual(out.count("\n"), src.count("\n"))
+        self.assertNotIn("gone", out)
+        self.assertIn("$a = 1;", out)
+        self.assertIn("$b = 2;", out)
+
+    def test_keeps_attributes_because_hash_bracket_is_not_a_comment(self):
+        # `#` opens a line comment in PHP; `#[` opens an ATTRIBUTE. Blanking
+        # attributes would delete the very thing the seam looks for.
+        src = "#[McpTool(name: 'x')]\npublic function createLead() {}\n"
+        self.assertIn("#[McpTool", owc._blank_php_comments(src))
+
+    def test_does_not_eat_a_hash_inside_a_string(self):
+        src = "<?php\n$u = 'http://x/#frag';\n$v = 2;\n"
+        out = owc._blank_php_comments(src)
+        self.assertIn("#frag", out)
+        self.assertIn("$v = 2;", out)
+
+    def test_does_not_treat_a_slash_slash_inside_a_string_as_a_comment(self):
+        src = "<?php\n$u = 'http://example.test';\n$v = 3;\n"
+        self.assertIn("$v = 3;", owc._blank_php_comments(src))
+
+
+class AttributeWalkUpTest(unittest.TestCase):
+    def test_an_attribute_argument_containing_the_word_class_is_still_read(self):
+        # `#[McpTool(handler: Foo::class)]` contains the word `class`. A
+        # word-based boundary stopped the walk-up before reaching it.
+        src = (
+            "<?php\nclass X\n{\n"
+            "    #[McpTool(handler: Foo::class)]\n"
+            "    public function createThing() {}\n}\n"
+        )
+        lines = owc._blank_php_comments(src).split("\n")
+        idx = next(i for i, ln in enumerate(lines) if "function createThing" in ln)
+        self.assertTrue(owc._method_has_mcp_attribute(lines, idx))
+
+    def test_a_previous_methods_attribute_does_not_leak_downward(self):
+        src = (
+            "<?php\nclass X\n{\n"
+            "    #[McpTool(name: 'a')]\n"
+            "    public function createA() { return 1; }\n"
+            "    public function createB() { return 2; }\n}\n"
+        )
+        lines = owc._blank_php_comments(src).split("\n")
+        idx = next(i for i, ln in enumerate(lines) if "function createB" in ln)
+        self.assertFalse(owc._method_has_mcp_attribute(lines, idx))
+
+
+class ExitContractTest(unittest.TestCase):
+    """gate-19 once returned its finding COUNT as an exit status — a byte — so
+    266 findings reported as 10 and exactly 256 would have reported PASS
+    (#209). This helper must not do that: it prints one line per finding and
+    always exits 0, and the bash gate counts the lines."""
+
+    def test_main_exits_zero_even_with_findings(self):
+        with _AppFixture() as root:
+            svc = _write(
+                root,
+                "lib/Service/OrphanService.php",
+                "<?php\nnamespace OCA\\Fixture\\Service;\nclass OrphanService {\n"
+                "    public function postJournalEntry(array $d): void {}\n"
+                "}\n",
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = owc.main(["check_orphaned_write_capability.py", svc])
+            self.assertEqual(rc, 0, "the count must never be returned as an exit status")
+            self.assertGreater(
+                len([ln for ln in buf.getvalue().splitlines() if ln.strip()]), 0
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
gate-57 reported `pipelinq LeadService::createLead` — a curated, spec'd MCP write tool — as an orphaned write capability. Acting on that verdict would have **deleted live code**, which is the failure mode this module's own docstring already records from hydra#106 and the reason it says false positives are the primary risk of this gate.

## The seam

`createLead` has no syntactic `->createLead(` call site and never will. It is reached by attribute reflection (ADR-063):

1. `lib/Service/LeadService.php:117` carries `#[McpTool(name: 'createLead', …)]`
2. `lib/Mcp/PipelinqScannableServices.php` lists `LeadService::class`
3. `lib/AppInfo/Application.php:246` binds it under `'OCA\OpenRegister\Mcp\IMcpScannableServices::pipelinq'`
4. OpenRegister's `AttributeToolScanner` reflects the class and invokes the method

The caller index cannot see any of that.

**All three pieces are required**, mirroring what the register.d-handler and event-listener seams already demand, and the exemption is applied **per method**:

| control | verdict |
|---|---|
| `#[McpTool]` on a class nobody registers | **still RED** |
| a registered class's write method with no attribute | **still RED** |
| alias naming a class that does not implement the interface | **still RED** |
| an implementation nobody aliases | **still RED** |
| attribute merely *mentioned* in a docblock | **still RED** |

`LeadService::createInvoice` in the fixture is exactly that control: same class, same scannable registration, no attribute, still reported.

## The gate-64 shape — checked as asked, and present

gate-64's `has_prelude()` grepped a quoted string literal, so it missed every constant *and* matched inside comments — failing in both directions at once. The attribute seam would have inherited the comment half for free. pipelinq's real `LeadService.php` opens with

```
 * Both public entry points are annotated `#[McpTool]` (OpenRegister ADR-063
```

on **line 7**, seven lines above anything executable. A raw-text search matches that sentence.

So the seam reads a comment-blanked copy. `_blank_php_comments()` preserves length and line numbers, is string-aware, and knows that `#` opens a line comment in PHP while **`#[` opens an attribute** — blanking those would delete the very thing being looked for.

**The two pre-existing seams had the same latent shape.** A commented-out `registerEventListener(...)`, or a `<!-- <job>…</job> -->`, exempts a *whole class* — a false GREEN. Both now strip comments first.

⚠️ **Measured before changing:** a sweep of the eight repos under this gate found **zero** comment-only matches, so this changes **no verdict today**. It closes the hole rather than reacting to it. Both directions are tested — a commented registration must not exempt, a live one must still exempt.

## The count-as-exit-status bug (#209) is not present here

This helper prints one line per finding and always returns `0`; the bash gate counts the printed lines. There is no count anywhere near the exit status. It is now **asserted explicitly** so it cannot drift into one.

## Measured, old vs new

`lib/Service/**` in the eight repos at `origin/development`:

| repo | before | after | | repo | before | after |
|---|---:|---:|---|---|---:|---:|
| openconnector | 1 | 1 | | scholiq | 0 | 0 |
| pipelinq | **5** | **4** | | nldesign | 0 | 0 |
| shillinq | 19 | 19 | | softwarecatalog | 0 | 0 |
| launchpad | 2 | 2 | | portaliq | 0 | 0 |

**Exactly one finding removed** — `lib/Service/LeadService.php:125 method=createLead` — and every other line byte-identical. The gate did not go quiet.

## Tests

22 new tests alongside the suite's existing 21 — **43 total, all green**. Ten mutations of the changed predicates, each **killed**:

| mutation | verdict |
|---|---|
| seam exempts the whole class (per-method check dropped) | killed |
| seam removed entirely (pre-#200) | killed |
| comment blanking disabled | killed |
| implements-interface requirement dropped | killed |
| attribute boundary reverted to word-based | killed |
| DI-alias requirement dropped | killed |
| attribute searched file-wide | killed |
| interface name blanked (any alias counts) | killed |
| XML comment strip removed | killed |
| `#[` treated as a comment | killed |

The word-based boundary mutation is worth naming: `#[McpTool(handler: Foo::class)]` contains the word `class`, so a `\bclass\b` boundary stops the walk-up before reading the attribute it exists to find. That was my first attempt and the test caught it.

## The issue's second point

The module docstring now records it: a zero-caller write capability has **two** remedies, and the finding text only suggests one. softwarecatalog's `publishEntryForFederation()` had zero callers while `PublicationService::publish()` served the same capability through a live route — wiring the orphan would have duplicated a live endpoint and widened the auth surface (it had no per-object guard). Deletion was correct (softwarecatalog#447).

The reader-facing copy of this guidance lives in `hydra/.claude/skills/hydra-gate-orphaned-write-capability/SKILL.md`, a **different repository**, and is not touched here.

## Not done

No waiver, no `@orphaned-write-capability exclude`, no threshold change. Nothing in any consumer repo was edited — the 19 genuine findings stand.

Closes #200
