### PR TITLE
fix(gate-14): stop flattening namespaced route names; understand a DI-bound fully-qualified controller

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_fq_route_names.sh
+++ b/hydra-gates/scripts/lib/test_gate_fq_route_names.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_fq_route_names.sh — control-pair suite for the FULLY-QUALIFIED
+# route-name shape in gate-14 (route-reachability) and gate-5 (route-auth).
+#
+# WHY THIS EXISTS
+# ---------------
+# Measured 2026-08-08 on opencatalogi origin/development (9e63d9f3): gate-14
+# reported six findings, all of them false.
+#
+#   lib/Controller/OCAOpenCatalogiAppHostControllerGenericDashboardController.php
+#     route='OCAOpenCatalogiAppHostControllerGenericDashboard#catchAll'
+#     rule=controller-class-not-found
+#
+# Two defects, stacked, and the outer one hid the inner:
+#
+#   1. `while IFS='#' read ctrl method` — WITHOUT `-r`. `read` performs
+#      backslash removal, so the route name
+#      `OCA\OpenCatalogi\AppHost\Controller\GenericDashboard` arrived FLATTENED
+#      as `OCAOpenCatalogiAppHostControllerGenericDashboard`. Every namespaced
+#      route name in the fleet was affected: openregister's 55 `Settings\…`
+#      routes flattened to `SettingsLlmSettings` and friends, which is why
+#      _ctrl_path_from_name's `Settings\Foo -> lib/Controller/Settings/
+#      FooController.php` branch — documented since the day it was written —
+#      had never once been reached from either gate.
+#
+#   2. Once un-flattened, the name is a fully-qualified class under the app's
+#      own namespace, and neither exemption helper understood that shape.
+#      `_apphost_serves` is keyed on the five short slugs Bootstrap aliases;
+#      `_di_binds_controller` rebuilds `<app_ns>\Controller\…` from a file
+#      path. The route is bound in lib/AppInfo/Application.php under the name
+#      verbatim + `Controller`, which is the only name NC will ever look up
+#      for it: App::main() does `$container->get($controllerName)` first, and
+#      for a name containing `\Controller\` the QueryException branch throws
+#      rather than rewriting.
+#
+# The fix that can go wrong quietly is "backslashes are unverifiable, skip
+# them" — that would retire the reachability invariant for every namespaced
+# route in the fleet, silently. So both arms are asserted here:
+#
+#   fq-bound    -> gate-14 PASS  (bound fully-qualified routes are NOT findings)
+#   fq-unbound  -> gate-14 FAIL  (an UNBOUND fully-qualified route still is)
+#
+# Run: bash scripts/lib/test_gate_fq_route_names.sh   (exit 0 = all green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+FIXTURES="${PKG_ROOT}/scripts/test-fixtures/fq-route-names"
+
+_fail_n=0
+_pass_n=0
+
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# _run <app-dir> — capture the whole run into _OUT, the two route logs into
+# _RRLOG / _UNRES. Same contract as test_gate_route_auth.sh: an abort before
+# the summary leaves per-gate PASS lines on stdout and looks exactly like a
+# clean run, so a run without the COVERAGE line is rejected outright. Each
+# invocation gets its own log directory — a concurrent run truncating a shared
+# /tmp path is a real, measured contamination (see that suite's note).
+# ---------------------------------------------------------------------------
+_OUT=""
+_RRLOG=""
+_UNRES=""
+_run() {
+    local _dir="$1"; shift
+    local _logdir
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-fqroute.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    _RRLOG="$(cat "${_logdir}/hydra-gate-route-reachability.log" 2>/dev/null || true)"
+    _UNRES="$(cat "${_logdir}/hydra-gate-route-auth-unresolved.log" 2>/dev/null || true)"
+    rm -rf "${_logdir}"
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "run in ${_dir} ABORTED before the summary — verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_gate_line() { printf '%s' "${_OUT}" | grep -E "^\[gate-$1\] " | head -1; }
+
+# _expect_gate <n> <PASS|FAIL> <description>
+_expect_gate() {
+    local _n="$1" _want="$2" _desc="$3" _line
+    _line="$(_gate_line "${_n}")"
+    if [ -z "${_line}" ]; then
+        _bad "${_desc} — gate-${_n} emitted NO verdict line at all"
+        return
+    fi
+    case "${_line}" in
+        *": ${_want}"*) _ok "${_desc} — ${_line}" ;;
+        *) _bad "${_desc} — wanted ${_want}, got: ${_line}" ;;
+    esac
+}
+
+_expect_log() {   # <log-contents> <fixed-string> <description>
+    if printf '%s' "$1" | grep -qF "$2"; then _ok "$3"; else
+        _bad "$3 — no log line containing '$2'; log was: $(printf '%s' "$1" | tr '\n' '|')"
+    fi
+}
+_expect_not_log() { # <log-contents> <fixed-string> <description>
+    if printf '%s' "$1" | grep -qF "$2"; then
+        _bad "$3 — unexpected log line: $(printf '%s' "$1" | grep -F "$2" | head -1)"
+    else _ok "$3"; fi
+}
+
+echo "== gate-14 / gate-5 fully-qualified route-name control pairs =="
+echo
+
+for _f in fq-bound fq-unbound; do
+    if [ ! -d "${FIXTURES}/${_f}" ]; then
+        _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 1. THE DEFECT. Three fully-qualified routes, each bound in Application.php
+#    under the name verbatim + `Controller`. No Bootstrap::register() call in
+#    this fixture, deliberately: `_apphost_serves` is switched off, so the
+#    binding evidence is the ONLY thing that can exempt them. If it stops
+#    working, this goes red rather than being carried by the slug list.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/fq-bound"; then
+    _expect_gate 14 PASS "fq-bound: DI-bound fully-qualified routes are not reachability findings"
+    _expect_gate 5 PASS  "fq-bound: nor are they auth findings"
+
+    # The flattening is the root cause; assert it is gone by name. A resolver
+    # that starts stripping backslashes again produces this token and nothing
+    # else in this suite would necessarily notice.
+    if printf '%s' "${_OUT}${_RRLOG}${_UNRES}" | grep -qF 'OCAFixture'; then
+        _bad "fq-bound: a FLATTENED route name (OCAFixture…) reappeared — read -r regressed"
+    else
+        _ok "fq-bound: no flattened route name anywhere in the run"
+    fi
+
+    # The `Settings\Foo` branch of _ctrl_path_from_name is reachable at last:
+    # the class is opened and judged rather than reported missing.
+    _expect_not_log "${_RRLOG}" 'SettingsWidgetController.php' \
+        "fq-bound: Settings\\Widget resolves to lib/Controller/Settings/, not the flattened path"
+    _expect_not_log "${_UNRES}" 'Settings\Widget#show' \
+        "fq-bound: Settings\\Widget#show is judged, not filed as unresolvable"
+
+    # Not judged is STATED, never silently dropped — same contract as the
+    # AppHost generics in test_gate_route_auth.sh.
+    _expect_log "${_UNRES}" 'OCA\Fixture\AppHost\Controller\GenericDashboard#page' \
+        "fq-bound: gate-5 states the DI-bound generic was NOT JUDGED rather than dropping it"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. THE ANTI-DEAD-GATE CONTROL. Same app, same three bindings, plus a
+#    fully-qualified route that is bound NOWHERE. It must still fail — that is
+#    the invariant the fix above is required to preserve.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/fq-unbound"; then
+    _expect_gate 14 FAIL "fq-unbound: an UNBOUND fully-qualified route is still raised"
+
+    _expect_log "${_RRLOG}" \
+        "lib/AppHost/Controller/GenericGadgetController.php route='OCA\Fixture\AppHost\Controller\GenericGadget#run' rule=controller-class-not-found" \
+        "fq-unbound: gate-14 names the unbound class at its PSR-4 path, with the route name intact"
+
+    # The three bound siblings sit in the SAME file. If the exemption were
+    # keyed on anything coarser than the individual binding — "the app binds
+    # services", "the name is fully qualified" — they would be reported here
+    # too, or the gadget would not be.
+    for _bound in GenericDashboardController GenericHealthController; do
+        _expect_not_log "${_RRLOG}" "${_bound}" \
+            "fq-unbound: the DI-bound ${_bound} is NOT reported alongside the unbound one"
+    done
+
+    # The other newly-reachable shape: class on disk, method absent. Before
+    # the resolver stopped flattening, this was misreported as a missing CLASS.
+    _expect_log "${_RRLOG}" \
+        "lib/Controller/Settings/WidgetController.php route='Settings\Widget#absentMethod' rule=method-not-found-on-target-controller" \
+        "fq-unbound: a Settings\\ route whose method is absent is reported as method-not-found, not class-not-found"
+
+    # Exactly two findings — no more, no fewer. A count assertion is what
+    # catches an exemption that has quietly become a blanket one.
+    _rr_n="$(printf '%s' "${_RRLOG}" | grep -c . || true)"
+    if [ "${_rr_n}" = "2" ]; then
+        _ok "fq-unbound: exactly 2 findings (the unbound class + the absent method)"
+    else
+        _bad "fq-unbound: expected 2 findings, got ${_rr_n}: $(printf '%s' "${_RRLOG}" | tr '\n' '|')"
+    fi
+
+    # gate-5 must not turn red on any of this: an unresolvable class is a
+    # reachability defect, not an auth finding (ConductionNL/.github#153).
+    _expect_gate 5 PASS "fq-unbound: the unresolvable class is not an auth finding either"
+fi
+
+echo
+echo "== summary =="
+echo "   passed: ${_pass_n}"
+echo "   failed: ${_fail_n}"
+if [ "${_pass_n}" -eq 0 ]; then
+    echo "FAIL — zero assertions ran; an empty suite is not a green suite"
+    exit 1
+fi
+[ "${_fail_n}" -eq 0 ] || exit 1
+echo "ALL fully-qualified route-name control pairs PASSED"
+exit 0

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -705,7 +705,14 @@ _ctrl_path_from_name() {
             # masked by `local`.
             local _last_cap
             _last_cap="$(printf '%s' "${_last}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-            echo "lib/Controller/${_ns}/${_last_cap}Controller.php"
+            # EVERY remaining separator becomes a directory separator, not just
+            # the last one. `${_ns}` used to be interpolated raw, so a two-level
+            # name produced a path with a literal backslash inside it —
+            # `lib/Controller/AppHost\Controller/GenericHealthController.php` —
+            # which cannot exist on disk and so always resolved to "missing".
+            # Invisible until 2026-08-08 because plain `read` had been deleting
+            # the backslashes before this branch could ever see two of them.
+            echo "lib/Controller/${_ns//\\//}/${_last_cap}Controller.php"
             ;;
         *_*)
             local _camel

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -492,6 +492,15 @@ fi
 # a wildcard would let ANY missing controller hide behind AppHost adoption.
 _HYDRA_APPHOST_SLUGS="dashboard preferences settings health metrics"
 
+# The app's own top namespace, read from its own file:
+# `namespace OCA\<App>\AppInfo;`. Empty when there is no Application.php, which
+# every consumer below treats as "cannot decide" -> no exemption.
+_HYDRA_APP_NS=""
+if [ -f lib/AppInfo/Application.php ]; then
+    _HYDRA_APP_NS=$(grep -m1 -oE '^namespace[[:space:]]+OCA\\[A-Za-z0-9_]+' lib/AppInfo/Application.php \
+        | awk '{print $2}')
+fi
+
 # _apphost_serves <route-slug> — 0 when this app adopts AppHost AND the slug is
 # one of the generics AppHost provides, i.e. the missing file is expected.
 _apphost_serves() {
@@ -500,6 +509,38 @@ _apphost_serves() {
         *" $1 "*) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+# ---------------------------------------------------------------------------
+# _app_php_binds_class <fully-qualified-class-name> — 0 when
+# lib/AppInfo/Application.php registers a service under EXACTLY that name.
+#
+# The SINGLE place the needle is built and matched. Both binding helpers below
+# derive a class name in their own way and then hand it here, so a change to
+# the matching rule can never apply to one shape and silently not the other.
+# ---------------------------------------------------------------------------
+_app_php_binds_class() {
+    local _fqcn="$1"
+    [ -f lib/AppInfo/Application.php ] || return 1
+    [ -n "${_fqcn}" ] || return 1
+
+    # In PHP source the literal carries escaped backslashes.
+    local _needle="${_fqcn//\\/\\\\}"
+
+    # Through the environment, NOT `awk -v`: -v runs escape processing over the
+    # value, so the `\\` pairs this needle is made of arrive as single
+    # backslashes and never match the PHP literal. Silently — the helper just
+    # answers "no such binding" for every controller, which reads exactly like
+    # a correct verdict.
+    _HYDRA_DI_NEEDLE="${_needle}" awk '
+        BEGIN { needle = ENVIRON["_HYDRA_DI_NEEDLE"] }
+        /registerService(Alias)?[[:space:]]*\(/ { window = 6 }
+        window > 0 {
+            if (index($0, needle) > 0) { found = 1; exit }
+            window--
+        }
+        END { exit(found ? 0 : 1) }
+    ' lib/AppInfo/Application.php
 }
 
 # ---------------------------------------------------------------------------
@@ -538,39 +579,94 @@ _di_binds_controller() {
     _rel="${_rel%.php}"
     local _cls="${_rel//\//\\}"
 
-    # The app's own namespace, from its own file: `namespace OCA\<App>\AppInfo;`
-    local _app_ns
-    _app_ns=$(grep -m1 -oE '^namespace[[:space:]]+OCA\\[A-Za-z0-9_]+' lib/AppInfo/Application.php \
-        | awk '{print $2}')
-    [ -n "${_app_ns}" ] || return 1
+    [ -n "${_HYDRA_APP_NS}" ] || return 1
+    _app_php_binds_class "${_HYDRA_APP_NS}\\Controller\\${_cls}"
+}
 
-    # In PHP source the literal carries escaped backslashes.
-    local _fqcn="${_app_ns}\\Controller\\${_cls}"
-    local _needle="${_fqcn//\\/\\\\}"
-
-    # Through the environment, NOT `awk -v`: -v runs escape processing over the
-    # value, so the `\\` pairs this needle is made of arrive as single
-    # backslashes and never match the PHP literal. Silently — the helper just
-    # answers "no such binding" for every controller, which reads exactly like
-    # a correct verdict.
-    _HYDRA_DI_NEEDLE="${_needle}" awk '
-        BEGIN { needle = ENVIRON["_HYDRA_DI_NEEDLE"] }
-        /registerService(Alias)?[[:space:]]*\(/ { window = 6 }
-        window > 0 {
-            if (index($0, needle) > 0) { found = 1; exit }
-            window--
-        }
-        END { exit(found ? 0 : 1) }
-    ' lib/AppInfo/Application.php
+# ---------------------------------------------------------------------------
+# _di_binds_fq_controller <route-controller-name> — 0 when the route names a
+# class that is ALREADY fully qualified under this app's own top namespace AND
+# lib/AppInfo/Application.php binds exactly that name + `Controller`.
+#
+# THIRD SHAPE, measured 2026-08-08 on opencatalogi origin/development
+# (9e63d9f3): gate-14 reported 6 findings, all of them wrong.
+#
+#   appinfo/routes.php
+#     ['name' => 'OCA\OpenCatalogi\AppHost\Controller\GenericDashboard#page', …]
+#   lib/AppInfo/Application.php
+#     $context->registerService(
+#         'OCA\\OpenCatalogi\\AppHost\\Controller\\GenericDashboardController',
+#         static fn ($c) => new GenericDashboardController(appName: self::APP_ID, …)
+#     );
+#
+# This resolves at runtime, and it is the ONLY thing that can. NC's
+# \OC\AppFramework\App::main() does `$container->get($controllerName)` FIRST,
+# with the literal name RouteParser::buildControllerName() produced — that
+# builder only does `underScoreToCamelCase(ucfirst($controller)) . 'Controller'`,
+# so the backslashes survive untouched. And the `catch (QueryException)`
+# fallback to `OCA\<App>\Controller\<name>` is not even reachable for this
+# shape: its first statement is
+#     if (str_contains($controllerName, '\\Controller\\')) { throw new
+#         HintException('App ' . strtolower($app) . ' is not enabled'); }
+# so a fully-qualified name that is not bound 500s rather than falling back.
+# (Read from /var/www/html/lib/private/AppFramework/App.php in a live NC 33.)
+#
+# Neither existing helper could see it, and each declined for its own correct
+# reason — which is why this needed a third, and not a loosening of either:
+#   * _apphost_serves     is keyed on the five short slugs Bootstrap aliases
+#                         (`dashboard`). The route name is the whole class.
+#   * _di_binds_controller takes a FILE PATH and rebuilds
+#                         `<app_ns>\Controller\<…>` from it. Fed this route it
+#                         reconstructed
+#                         `OCA\OpenCatalogi\Controller\OCAOpenCatalogiAppHostControllerGenericDashboardController`,
+#                         which matches nothing — the name had already been
+#                         flattened (see the `read -r` note in gate-5/gate-14).
+#
+# The narrower alternative — "add the six opencatalogi names to a list" — was
+# rejected: it is the `_HYDRA_APPHOST_SLUGS` failure mode a second time, and
+# 2026-08-07 already showed that list going stale against openconnector.
+# The BLIND alternative — "a route name containing backslashes is unverifiable,
+# skip it" — was rejected harder: it would retire the invariant for every
+# namespaced route in the fleet. The evidence demanded here is the same
+# evidence _di_binds_controller demands, no weaker: this repository must be
+# shown to bind that exact literal near a registerService call. An unbound
+# fully-qualified route still FAILS, which is the point.
+#
+# Scoped to the app's OWN namespace on purpose. `OCA\SomeOtherApp\…` is a class
+# this repository does not own and cannot vouch for, so it is left to fail.
+# ---------------------------------------------------------------------------
+_di_binds_fq_controller() {
+    local _name="$1"
+    [ -n "${_HYDRA_APP_NS}" ] || return 1
+    # Must be fully qualified UNDER THIS APP: `OCA\<App>\` + at least one more
+    # segment. The trailing `\` in the prefix is what stops `OCA\Foo` matching
+    # a sibling app whose name merely starts the same way (`OCA\FooBar\…`).
+    case "${_name}" in
+        "${_HYDRA_APP_NS}"\\*) ;;
+        *) return 1 ;;
+    esac
+    # The router appends `Controller` to whatever it was given; the DI key must
+    # therefore be the route name verbatim plus that suffix.
+    _app_php_binds_class "${_name}Controller"
 }
 
 # ---------------------------------------------------------------------------
 # _ctrl_path_from_name <route-slug> — the file a routed `controller#method`
-# name resolves to. Handles the three shapes Nextcloud accepts:
+# name resolves to. Handles the four shapes Nextcloud accepts:
 #
+#   OCA\App\AppHost\Controller\GenericDashboard
+#                    -> lib/AppHost/Controller/GenericDashboardController.php
 #   Settings\Foo  -> lib/Controller/Settings/FooController.php
 #   my_thing      -> lib/Controller/MyThingController.php   (snake_case)
 #   credentialVerify -> lib/Controller/CredentialVerifyController.php
+#
+# The first shape is PSR-4, not the `lib/Controller/` convention: a name that
+# is already fully qualified under the app's own top namespace is anchored at
+# `OCA\<App>\` -> `lib/`, so appending it to `lib/Controller/` would name a
+# file that could never exist. Added 2026-08-08 with the opencatalogi fix; see
+# _di_binds_fq_controller above for the measurement. A leaf that genuinely
+# SHIPS such a class (rather than binding a foreign one) is therefore opened
+# and judged normally by both gates, instead of being unresolvable.
 #
 # SHARED by gate-5 (route-auth) and gate-14 (route-reachability). It used to be
 # defined INSIDE gate-14 only, and gate-5 carried its own narrower copy —
@@ -587,6 +683,21 @@ _di_binds_controller() {
 _ctrl_path_from_name() {
     local _name="$1"
     case "${_name}" in
+        "${_HYDRA_APP_NS:-__no_app_ns__}"\\*)
+            # PSR-4: `OCA\<App>\` maps to `lib/`. Strip the app prefix, turn
+            # the remaining namespace separators into directory separators.
+            local _sub="${_name#"${_HYDRA_APP_NS}"\\}"
+            local _sub_last="${_sub##*\\}"
+            local _sub_ns="${_sub%\\*}"
+            local _sub_last_cap
+            _sub_last_cap="$(printf '%s' "${_sub_last}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
+            if [ "${_sub_ns}" = "${_sub}" ]; then
+                # `OCA\<App>\Foo` — no intermediate namespace.
+                echo "lib/${_sub_last_cap}Controller.php"
+            else
+                echo "lib/${_sub_ns//\\//}/${_sub_last_cap}Controller.php"
+            fi
+            ;;
         *\\*)
             local _last="${_name##*\\}"
             local _ns="${_name%\\*}"
@@ -1013,11 +1124,22 @@ if [ -f appinfo/routes.php ]; then
     _in_scope "appinfo/routes.php" && _ra_routes_touched=1
     # Process substitution, not a pipeline: the loop must run in THIS shell so
     # the log appends and the scope flags are read from one consistent state.
-    while IFS='#' read ctrl method; do
+    #
+    # `read -r`, not `read`. Without -r, `read` performs backslash removal on
+    # the value, so every NAMESPACED route name arrived here FLATTENED:
+    # `OCA\OpenCatalogi\AppHost\Controller\GenericDashboard` became
+    # `OCAOpenCatalogiAppHostControllerGenericDashboard`, and `Settings\Foo`
+    # became `SettingsFoo`. Measured 2026-08-08 on opencatalogi (6 routes) and
+    # openregister (55). The flattened name resolves to a path that cannot
+    # exist, which is why _ctrl_path_from_name's `Settings\Foo ->
+    # lib/Controller/Settings/FooController.php` branch — documented since it
+    # was written — had never once been reached from either gate.
+    while IFS='#' read -r ctrl method; do
             [ -n "${ctrl:-}" ] || continue
             path=$(_ctrl_path_from_name "${ctrl}")
             if [ ! -f "$path" ]; then
-                if _apphost_serves "${ctrl}" || _di_binds_controller "${path}"; then
+                if _apphost_serves "${ctrl}" || _di_binds_controller "${path}" \
+                    || _di_binds_fq_controller "${ctrl}"; then
                     echo "${ctrl}#${method} — served by the OpenRegister AppHost generic controller (ADR-040); its auth attribute lives in the openregister package and is NOT visible from this repository" >> "${_ra_unresolved_log}"
                 else
                     echo "${ctrl}#${method} — ${path} is not present in this repository; controller class UNRESOLVED (see gate-14, which owns route reachability)" >> "${_ra_unresolved_log}"
@@ -1545,7 +1667,10 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     # ---- Invariant 2: every routed entry resolves to a method that exists.
     grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
         | grep -oE "${_ROUTE_PAIR_RX}" | sort -u \
-        | while IFS='#' read _ctrl _method; do
+        | while IFS='#' read -r _ctrl _method; do
+            # `read -r` for the reason spelled out in gate-5's loop: plain
+            # `read` strips the backslashes out of a namespaced route name, and
+            # this gate then reported the resulting nonsense path as a finding.
             # Resolver is shared with gate-5 — see _ctrl_path_from_name above.
             # It lived here, inline, while gate-5 carried a narrower private
             # copy; the divergence is what let 23 of scholiq's 37 routes go
@@ -1572,9 +1697,14 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
                 # class name is bound in the DI container, so the route
                 # resolves with no file on disk. Two ways in — Bootstrap
                 # aliasing one of its five generics, or the leaf registering
-                # the generic itself under the standard controller name.
+                # the generic itself under the standard controller name, or —
+                # opencatalogi, 2026-08-08 — the route naming the leaf's own
+                # fully-qualified class and Application.php binding that exact
+                # literal. Each is a NAMED binding this repo can be shown to
+                # make; an absence with no binding still fails below.
                 _apphost_serves "${_ctrl}" && continue
                 _di_binds_controller "${_path}" && continue
+                _di_binds_fq_controller "${_ctrl}" && continue
                 echo "${_path} route='${_ctrl}#${_method}' rule=controller-class-not-found" >> "${_rr_log}"
                 continue
             fi

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/appinfo/routes.php
@@ -1,0 +1,29 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture mirroring opencatalogi origin/development (9e63d9f3), 2026-08-08.
+//
+// The AppHost generic routes are named with a FULLY-QUALIFIED class name in
+// the controller slot, under this app's OWN top namespace. NC's
+// \OC\AppFramework\App::main() does `$container->get($controllerName)` FIRST,
+// with the literal name RouteParser::buildControllerName() produced (that
+// builder only appends 'Controller', so backslashes survive), and for a name
+// containing `\Controller\` the QueryException fallback does not rewrite the
+// name at all — it throws "App … is not enabled". So the ONLY thing that can
+// make these routes work is the exact DI binding in lib/AppInfo/Application.php,
+// and it is there. Every one of these four routes resolves at runtime.
+//
+// `Settings\Widget#show` is here for a second reason: until 2026-08-08 both
+// route gates read this file through `read` without `-r`, which strips
+// backslashes, so this name reached the resolver as `SettingsWidget` and
+// _ctrl_path_from_name's documented `Settings\Foo` branch was unreachable.
+// The file below is at the path that branch names.
+return [
+    'routes' => [
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericDashboard#page', 'url' => '/', 'verb' => 'GET'],
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericDashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
+
+        ['name' => 'Settings\Widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/lib/AppInfo/Application.php
@@ -1,0 +1,54 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Controller\GenericDashboardController;
+use OCA\OpenRegister\AppHost\Controller\GenericHealthController;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\IRequest;
+use Psr\Container\ContainerInterface;
+
+/**
+ * NOTE: deliberately NO `Bootstrap::register()` call, so `_apphost_serves()`
+ * is switched off for this fixture. The only thing that can exempt the
+ * fully-qualified routes is the binding evidence below — which is exactly what
+ * this suite is here to measure. If the suite passed with Bootstrap adoption
+ * present it would be measuring the five-slug list instead.
+ */
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'fixture';
+
+    public function register(IRegistrationContext $context): void
+    {
+        // The service key MUST be the route name verbatim + `Controller`:
+        // that is the literal App::main looks up, and for a name containing
+        // `\Controller\` there is no fallback to rewrite it.
+        $context->registerService(
+            'OCA\\Fixture\\AppHost\\Controller\\GenericDashboardController',
+            static function (ContainerInterface $c) {
+                return new GenericDashboardController(
+                    appName: self::APP_ID,
+                    request: $c->get(IRequest::class)
+                );
+            }
+        );
+        $context->registerService(
+            'OCA\\Fixture\\AppHost\\Controller\\GenericHealthController',
+            static function (ContainerInterface $c) {
+                return new GenericHealthController(
+                    appName: self::APP_ID,
+                    request: $c->get(IRequest::class)
+                );
+            }
+        );
+    }
+
+    public function boot(IBootContext $context): void
+    {
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/lib/Controller/Settings/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-bound/lib/Controller/Settings/WidgetController.php
@@ -1,0 +1,17 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller\Settings;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(int $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/appinfo/routes.php
@@ -1,0 +1,32 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// THE CONTROL HALF of fq-bound. Same app, same three bound fully-qualified
+// routes, plus two that must still be reported:
+//
+//   OCA\Fixture\AppHost\Controller\GenericGadget#run
+//       fully qualified, under this app's own namespace, and bound NOWHERE.
+//       lib/AppInfo/Application.php does not name it. At runtime this is a
+//       QueryException -> HintException "App fixture is not enabled", i.e. a
+//       500 on every request. If _di_binds_fq_controller() ever loosens into
+//       "a fully-qualified name is unverifiable, skip it", this goes quiet and
+//       the suite goes red.
+//
+//   Settings\Widget#absentMethod
+//       the class IS on disk and IS opened — the method is not on it. Only
+//       reachable at all because the resolver stopped flattening `Settings\…`
+//       names; before 2026-08-08 this route resolved to
+//       lib/Controller/SettingsWidgetController.php and was reported as a
+//       missing CLASS, which is a different (and wrong) defect.
+return [
+    'routes' => [
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericDashboard#page', 'url' => '/', 'verb' => 'GET'],
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericDashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
+
+        ['name' => 'OCA\Fixture\AppHost\Controller\GenericGadget#run', 'url' => '/api/gadgets/run', 'verb' => 'POST'],
+
+        ['name' => 'Settings\Widget#show', 'url' => '/api/widgets/{id}', 'verb' => 'GET'],
+        ['name' => 'Settings\Widget#absentMethod', 'url' => '/api/widgets/absent', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/lib/AppInfo/Application.php
@@ -1,0 +1,54 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Controller\GenericDashboardController;
+use OCA\OpenRegister\AppHost\Controller\GenericHealthController;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\IRequest;
+use Psr\Container\ContainerInterface;
+
+/**
+ * NOTE: deliberately NO `Bootstrap::register()` call, so `_apphost_serves()`
+ * is switched off for this fixture. The only thing that can exempt the
+ * fully-qualified routes is the binding evidence below — which is exactly what
+ * this suite is here to measure. If the suite passed with Bootstrap adoption
+ * present it would be measuring the five-slug list instead.
+ */
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'fixture';
+
+    public function register(IRegistrationContext $context): void
+    {
+        // The service key MUST be the route name verbatim + `Controller`:
+        // that is the literal App::main looks up, and for a name containing
+        // `\Controller\` there is no fallback to rewrite it.
+        $context->registerService(
+            'OCA\\Fixture\\AppHost\\Controller\\GenericDashboardController',
+            static function (ContainerInterface $c) {
+                return new GenericDashboardController(
+                    appName: self::APP_ID,
+                    request: $c->get(IRequest::class)
+                );
+            }
+        );
+        $context->registerService(
+            'OCA\\Fixture\\AppHost\\Controller\\GenericHealthController',
+            static function (ContainerInterface $c) {
+                return new GenericHealthController(
+                    appName: self::APP_ID,
+                    request: $c->get(IRequest::class)
+                );
+            }
+        );
+    }
+
+    public function boot(IBootContext $context): void
+    {
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/lib/Controller/Settings/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/fq-route-names/fq-unbound/lib/Controller/Settings/WidgetController.php
@@ -1,0 +1,17 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller\Settings;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(int $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}


### PR DESCRIPTION
## What this fixes

`gate-14 route-reachability` reported **6 findings on opencatalogi `origin/development` (9e63d9f3), all false**:

```
lib/Controller/OCAOpenCatalogiAppHostControllerGenericDashboardController.php route='OCAOpenCatalogiAppHostControllerGenericDashboard#catchAll' rule=controller-class-not-found
… same for GenericDashboard#page, GenericHealth#index, GenericMetrics#index, GenericPreferences#getPreference, GenericPreferences#setPreference
```

Two defects, stacked. The outer one hid the inner one.

### 1. `read` without `-r` — every namespaced route name was flattened

Both route gates read `appinfo/routes.php` through `while IFS='#' read ctrl method`. `read` **performs backslash removal**, so

| route name in the file | what the resolver actually received |
|---|---|
| `OCA\OpenCatalogi\AppHost\Controller\GenericDashboard` | `OCAOpenCatalogiAppHostControllerGenericDashboard` |
| `Settings\LlmSettings` | `SettingsLlmSettings` |

```
$ printf 'OCA\\Foo\\Bar#page\n' | while IFS='#' read    a b; do echo "[$a]"; done
[OCAFooBar]
$ printf 'OCA\\Foo\\Bar#page\n' | while IFS='#' read -r a b; do echo "[$a]"; done
[OCA\Foo\Bar]
```

Consequence: `_ctrl_path_from_name`'s `Settings\Foo -> lib/Controller/Settings/FooController.php` branch — **documented since the day it was written** — had never once been reached from either gate. openregister's 55 `Settings\…` routes all resolved to non-existent flattened paths.

### 2. A fully-qualified route name was not a shape any helper understood

Un-flattened, opencatalogi's names are FQCNs under the app's own namespace, bound in `lib/AppInfo/Application.php`:

```php
// appinfo/routes.php
['name' => 'OCA\OpenCatalogi\AppHost\Controller\GenericDashboard#page', 'url' => '/', 'verb' => 'GET'],

// lib/AppInfo/Application.php
$context->registerService(
    'OCA\\OpenCatalogi\\AppHost\\Controller\\GenericDashboardController',
    static fn ($c) => new GenericDashboardController(appName: self::APP_ID, request: $c->get('OCP\\IRequest'))
);
```

**That binding is the only thing that can make the route work.** From `/var/www/html/lib/private/AppFramework/App.php` in a live NC 33 container (`docker exec procest-cilocal-nc awk '/public static function main/,/^\t}/' …`):

```php
// first try $controllerName then go for \OCA\AppName\Controller\$controllerName
try {
    $controller = $container->get($controllerName);
} catch (QueryException $e) {
    if (str_contains($controllerName, '\\Controller\\')) {
        // This is from a global registered app route that is not enabled.
        [/*OC(A)*/, $app, /* Controller/Name*/] = explode('\\', $controllerName, 3);
        throw new HintException('App ' . strtolower($app) . ' is not enabled');
    }
    …
    $controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
```

The literal lookup happens **first**, and for a name containing `\Controller\` the fallback does not rewrite anything — it throws. `RouteParser::buildControllerName()` only does `underScoreToCamelCase(ucfirst($controller)) . 'Controller'`, so the backslashes reach the container untouched.

Neither existing helper could see this, each for its own correct reason:
- `_apphost_serves` is keyed on the five short slugs `Bootstrap::register()` aliases (`dashboard`). The route name is the whole class.
- `_di_binds_controller` takes a **file path** and rebuilds `<app_ns>\Controller\…` from it. Fed the flattened name it reconstructed `OCA\OpenCatalogi\Controller\OCAOpenCatalogiAppHostControllerGenericDashboardController`, which matches nothing.

## The change

- `read -r` in gate-5 and gate-14.
- `_ctrl_path_from_name` maps a name fully qualified under the app's own namespace to its **PSR-4** path (`OCA\<App>\` → `lib/`), so a leaf that genuinely *ships* such a class is opened and judged rather than being unresolvable. It also now turns *every* namespace separator into a path separator, not just the last — `AppHost\Controller\GenericHealth` used to produce `lib/Controller/AppHost\Controller/GenericHealthController.php`, a path with a literal backslash that can never exist.
- New `_di_binds_fq_controller`, sharing the needle matcher with `_di_binds_controller` through a new `_app_php_binds_class`. The `_HYDRA_DI_NEEDLE` environment technique is preserved verbatim (`awk -v` runs escape processing and silently destroys the `\\` pairs).

## What still FAILS — the invariant is intact

**Not** a wildcard, and **not** "a route name with backslashes is unverifiable, skip it" — that would retire reachability for every namespaced route in the fleet, silently. The evidence demanded is exactly what `_di_binds_controller` already demands: the exact escaped literal within a few lines of a `registerService`/`registerServiceAlias` call in `lib/AppInfo/Application.php`.

**An unbound fully-qualified route still fails**, and the fixture proves it:

```
lib/AppHost/Controller/GenericGadgetController.php route='OCA\Fixture\AppHost\Controller\GenericGadget#run' rule=controller-class-not-found
```

Also scoped to the app's **own** namespace on purpose: `OCA\SomeOtherApp\…` is a class this repo does not own and cannot vouch for, so it is left to fail.

## Measured before / after — full-tree

**opencatalogi `origin/development` (9e63d9f3)** — 64 gate verdicts captured on both arms and diffed; after normalising the per-run `/tmp/hydra-gates.XXXX` log-dir token, **exactly one line differs**:

```
before: [gate-14] route-reachability: FAIL — 6 unrouted method(s) or wrong-target route(s) — see LOGDIR/hydra-gate-route-reachability.log
after:  [gate-14] route-reachability: PASS
```

`gate-5` stays `PASS` on both arms with the same 6 NOT-JUDGED entries; only their stated reason improves, from `… is not present in this repository; controller class UNRESOLVED` to `served by the OpenRegister AppHost generic controller (ADR-040)`. Runner exit code 12 → 11.

**Fleet, same A/B (`origin/main` worktree vs this branch):**

| repo | gate-14 before | gate-14 after |
|---|---|---|
| opencatalogi | FAIL — 6 | **PASS** |
| hermiq | FAIL — 6 | **PASS** |
| openregister | FAIL — 53 | FAIL — 2 |

openregister's remaining 2 are a **different, still-open false positive** (see below). `gate-5` on openregister goes 11 → 12 findings — both arms already FAIL, and the extra one is a **true** finding the gate was blind to because the name was flattened:

```
lib/Controller/Settings/FileSettingsController.php:323 method=getFileExtractionStats rule=missing-auth-attribute
```

## Can-fail proof

`hydra-gates/scripts/lib/test_gate_fq_route_names.sh` (13 assertions, auto-discovered by `tests/run-helper-suites.sh`) with **both arms**: `fq-bound` → gate-14 PASS, `fq-unbound` → gate-14 FAIL.

Stashing *only* the `run-hydra-gates.sh` change and re-running the new suite — exit code read directly, not through a pipe:

```
$ git stash push -- hydra-gates/scripts/run-hydra-gates.sh
$ bash hydra-gates/scripts/lib/test_gate_fq_route_names.sh; echo "EXIT=$?"
FAIL — fq-bound: DI-bound fully-qualified routes are not reachability findings — wanted PASS, got: [gate-14] route-reachability: FAIL — 4 unrouted method(s) or wrong-target route(s)
FAIL — fq-bound: a FLATTENED route name (OCAFixture…) reappeared — read -r regressed
FAIL — fq-bound: Settings\Widget resolves to lib/Controller/Settings/, not the flattened path — unexpected log line: lib/Controller/SettingsWidgetController.php route='SettingsWidget#show' rule=controller-class-not-found
FAIL — fq-bound: gate-5 states the DI-bound generic was NOT JUDGED rather than dropping it — …
FAIL — fq-unbound: gate-14 names the unbound class at its PSR-4 path, with the route name intact — … log was: lib/Controller/OCAFixtureAppHostControllerGenericDashboardController.php route='OCAFixtureAppHostControllerGenericDashboard#catchAll' rule=controller-class-not-found|…
FAIL — fq-unbound: the DI-bound GenericDashboardController is NOT reported alongside the unbound one
FAIL — fq-unbound: the DI-bound GenericHealthController is NOT reported alongside the unbound one
FAIL — fq-unbound: a Settings\ route whose method is absent is reported as method-not-found, not class-not-found
FAIL — fq-unbound: expected 2 findings, got 6
== summary ==
   passed: 4
   failed: 9
EXIT=1
```

The positive-control arm goes red **for the right reason**: `rule=controller-class-not-found` on the bound fixture, on flattened `OCAFixture…` names — the exact opencatalogi shape. With the change restored it is 13/13 green.

Regression harness, all read directly:
```
bash hydra-gates/tests/run-helper-suites.sh   -> EXIT=0   (28 passed, 2 quarantined, 0 failed)
bash hydra-gates/tests/test-hydra-gates-bin.sh -> EXIT=0
bash hydra-gates/scripts/lib/test_gate_route_auth.sh -> EXIT=0 (30/30, unchanged)
```

## Known remaining false positive — NOT fixed here

openregister names two routes with a **relative** namespace and binds them verbatim:

```php
// appinfo/routes.php
['name' => 'AppHost\Controller\GenericHealth#index',  …]
// lib/AppInfo/Application.php
$context->registerService('AppHost\\Controller\\GenericHealthController', …);
```

`_di_binds_fq_controller` is deliberately scoped to `OCA\<App>\…`, so these two are still reported. They were reported before this PR too (as part of the 53), so this is not a regression — but it is the same class of defect one step over, and it wants a decision rather than a silent widening. Flagging rather than fixing.
