### PR TITLE
fix(gate-12): the element ended at the arrow of `:reduce="(o) => o.id"` — 18 of 18 findings false on scholiq

### DIFF
--- a/hydra-gates/scripts/lib/check_nc_select_labels.py
+++ b/hydra-gates/scripts/lib/check_nc_select_labels.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-12 nc-input-labels — every `<NcSelect>` must name itself.
+
+A manual `<label>` next to an `NcSelect` does not associate with the
+component's internal combobox input, so the accessible name has to come
+from the component's own API: `input-label` (rendered as the visible
+label) or `aria-label-combobox`. WCAG 2.2 AA SC 1.3.1 / 4.1.2, ADR-004
+hard rule. Observed 2026-04-30 on doriath.
+
+WHY THIS MOVED OUT OF THE BASH GATE
+-----------------------------------
+The gate used to flatten the file's newlines and run::
+
+    grep -oE '<NcSelect[^>]*>'
+
+`[^>]*` ends the element at the FIRST `>` character in the source. In an
+`NcSelect` that is almost never the end of the tag, because the idiomatic
+vue-select usage puts an arrow function in an attribute value::
+
+    <NcSelect
+        v-model="selectedRoundId"
+        :options="roundOptions"
+        :reduce="(o) => o.id"
+        :input-label="t('scholiq', 'Round')"
+        :aria-label-combobox="t('scholiq', 'Round')" />
+                  ^
+                  the `>` of `=>` — extraction stops here
+
+Everything after `:reduce` is invisible to the gate, so the very props it
+is looking for are cut off and the element is reported as unnamed.
+Measured on scholiq 2026-08-08: **18 findings, 18 of them false** — every
+flagged `NcSelect` already carried `:input-label` AND
+`:aria-label-combobox`, in every case written after the `:reduce` prop.
+
+`:reduce` is not exotic. It is how vue-select maps an option object to the
+stored value, so a project that uses object options at all hits this on
+most of its selects. The gate was anti-correlated with its own subject in
+those files: adding the label prop could not clear it, and deleting
+`:reduce` could.
+
+The fix is to end the tag at a `>` that is not inside a quoted attribute
+value. That is the same tag pattern ``check_form_labels.py`` already uses,
+so the two a11y gates now agree on where an element stops.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+An `NcSelect` carrying none of `input-label` / `inputLabel` /
+`aria-label-combobox` / `ariaLabelCombobox` is still reported, including
+when it sits next to a hand-written `<label for=…>` — that is the whole
+point of the rule. The accepted prop set is unchanged from the bash gate
+on purpose, so the before/after numbers stay comparable: this change fixes
+where an element ENDS, not what counts as a name.
+
+Markup inside an HTML comment is not scanned. A commented-out `NcSelect`
+renders nothing and can carry no accessible name.
+
+Usage::
+
+    check_nc_select_labels.py <vue-file> [<vue-file> ...]
+
+Prints one `path: <tag…>` line per violation, the same shape the bash gate
+emitted, so the runner counts lines unchanged. Exits 0 always.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# Quote-aware element match: a `>` inside a double- or single-quoted
+# attribute value never terminates the tag, so `:reduce="(o) => o.id"` is
+# consumed as one attribute instead of ending the element mid-way.
+TAG = re.compile(
+    r'<(/?)([A-Za-z][A-Za-z0-9._:-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/?)>',
+    re.DOTALL,
+)
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+
+# The name-bearing props NcSelect publishes. Both the kebab and camel
+# spellings, bare or bound (`:input-label`, `v-bind:inputLabel`).
+LABEL_PROP = re.compile(
+    r'(^|\s)(:|v-bind:)?'
+    r'(input-label|inputLabel|aria-label-combobox|ariaLabelCombobox)\s*='
+)
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    """Return one finding line per unnamed `<NcSelect>` in *src*."""
+    body = COMMENT.sub(' ', src)
+    out: list[str] = []
+    for m in TAG.finditer(body):
+        closing, name, attrs = m.group(1), m.group(2), m.group(3)
+        if closing or name != 'NcSelect':
+            continue
+        if LABEL_PROP.search(attrs):
+            continue
+        # Report the element as one line, the way the bash gate did, so an
+        # existing consumer of the log still reads it.
+        flat = re.sub(r'\s+', ' ', m.group(0)).strip()
+        out.append(f'{fname}: {flat}')
+    return out
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_nc_select_labels.py
+++ b/hydra-gates/scripts/lib/test_check_nc_select_labels.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_nc_select_labels (gate-12). Run with:
+
+    python3 scripts/lib/test_check_nc_select_labels.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+The bug this helper replaces made the gate ANTI-CORRELATED with its own
+subject: an `NcSelect` that named itself after a `:reduce` prop was
+reported, and deleting the label prop changed nothing while deleting
+`:reduce` cleared it. So the arrow-function fixtures below are paired,
+element for element, with the same markup minus the label prop — which
+must still be reported. A relaxation that cannot be shown to still fire is
+indistinguishable from switching the gate off.
+
+Fixtures are the real fleet markup: scholiq's ConferenceScheduleBoard
+(`:reduce` then `id`+`:input-label`), its LessonComposer (`:reduce` then
+both label props), and a genuinely unnamed select next to a hand-written
+`<label for=…>`, which is the shape the rule exists for.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_nc_select_labels as c  # noqa: E402
+
+
+def scan(src: str) -> list[str]:
+    return c.scan_source('x.vue', src)
+
+
+class ArrowFunctionAttributes(unittest.TestCase):
+    """A `>` inside a quoted attribute value must not end the element."""
+
+    REDUCE_THEN_LABEL = '''
+    <template>
+      <NcSelect id="csb-round"
+        v-model="selectedRoundId"
+        :options="roundOptions"
+        :reduce="(o) => o.id"
+        :input-label="t('scholiq', 'Round')" />
+    </template>
+    '''
+
+    def test_label_after_reduce_is_seen(self):
+        self.assertEqual(scan(self.REDUCE_THEN_LABEL), [])
+
+    def test_same_element_without_the_label_still_fires(self):
+        src = self.REDUCE_THEN_LABEL.replace(
+            ":input-label=\"t('scholiq', 'Round')\"", '')
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('NcSelect', found[0])
+
+    def test_both_label_props_after_reduce(self):
+        src = '''
+        <template>
+          <NcSelect
+            v-model="block.materialId"
+            :options="materialOptions"
+            :reduce="(opt) => opt.id"
+            :input-label="t('scholiq', 'Material')"
+            :aria-label-combobox="t('scholiq', 'Material')" />
+        </template>
+        '''
+        self.assertEqual(scan(src), [])
+
+    def test_aria_label_combobox_alone_after_reduce(self):
+        src = '''
+        <template>
+          <NcSelect :reduce="(o) => o.id"
+                    :aria-label-combobox="t('a', 'Teacher')" />
+        </template>
+        '''
+        self.assertEqual(scan(src), [])
+
+    def test_two_selects_one_named_one_not(self):
+        """The greedy-match trap: a fix that runs past the first element
+        would swallow the second and report neither."""
+        src = '''
+        <template>
+          <NcSelect :reduce="(o) => o.id" :input-label="t('a', 'One')" />
+          <NcSelect :reduce="(o) => o.id" :options="two" />
+        </template>
+        '''
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn(':options="two"', found[0])
+
+
+class StillFails(unittest.TestCase):
+    """Everything the rule exists for is still reported."""
+
+    def test_bare_select(self):
+        self.assertEqual(len(scan('<template><NcSelect /></template>')), 1)
+
+    def test_manual_label_element_does_not_count(self):
+        src = '''
+        <template>
+          <label for="cohort">Cohort</label>
+          <NcSelect id="cohort" :options="opts" />
+        </template>
+        '''
+        self.assertEqual(len(scan(src)), 1)
+
+    def test_aria_label_is_not_an_accepted_name(self):
+        """Unchanged remit: the bash gate accepted only the four props, and
+        widening it here would make the before/after numbers incomparable."""
+        src = '<template><NcSelect aria-label="Cohort" /></template>'
+        self.assertEqual(len(scan(src)), 1)
+
+    def test_unclosed_angle_bracket_does_not_swallow_the_file(self):
+        src = '<template><NcSelect :options="a"><div>x</div></template>'
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertNotIn('div', found[0])
+
+
+class Spellings(unittest.TestCase):
+    def test_camel_case(self):
+        self.assertEqual(scan('<template><NcSelect :inputLabel="x" /></template>'), [])
+
+    def test_v_bind_prefix(self):
+        self.assertEqual(
+            scan('<template><NcSelect v-bind:input-label="x" /></template>'), [])
+
+    def test_unbound_literal(self):
+        self.assertEqual(scan('<template><NcSelect input-label="Cohort" /></template>'), [])
+
+    def test_a_prop_that_merely_ends_in_label_is_not_enough(self):
+        """`my-input-label` must not satisfy the rule by substring."""
+        self.assertEqual(
+            len(scan('<template><NcSelect :my-input-label="x" /></template>')), 1)
+
+
+class Comments(unittest.TestCase):
+    def test_commented_out_select_is_not_a_finding(self):
+        src = '<template><!-- <NcSelect :options="a" /> --></template>'
+        self.assertEqual(scan(src), [])
+
+    def test_a_real_select_after_a_comment_is_still_found(self):
+        src = '<template><!-- old --><NcSelect :options="a" /></template>'
+        self.assertEqual(len(scan(src)), 1)
+
+
+class OtherComponents(unittest.TestCase):
+    def test_ncselectableitem_is_not_ncselect(self):
+        self.assertEqual(scan('<template><NcSelectableItem /></template>'), [])
+
+    def test_closing_tag_is_not_an_element(self):
+        src = '<template><NcSelect :input-label="x">slot</NcSelect></template>'
+        self.assertEqual(scan(src), [])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1382,27 +1382,51 @@ fi
 # inputLabel (or ariaLabelCombobox). Manual <label> elements break the
 # component's internal a11y wiring (WCAG 1.3.1 / 4.1.2). ADR-004 hard
 # rule. Observed 2026-04-30 on doriath.
+#
+# THE ELEMENT ENDS AT A `>` THAT IS NOT INSIDE AN ATTRIBUTE VALUE.
+#
+# This gate used to extract elements with `grep -oE '<NcSelect[^>]*>'`.
+# `[^>]*` stops at the FIRST `>` in the source, and in an NcSelect that is
+# usually the arrow of `:reduce="(o) => o.id"` — so every prop written
+# after `:reduce` was cut off, including the two this gate looks for.
+# Measured on scholiq 2026-08-08: 18 findings, 18 of them false. Each
+# flagged element already carried `:input-label` AND
+# `:aria-label-combobox`, both after `:reduce`. The gate was
+# anti-correlated with its subject there: adding the label could not clear
+# it, removing `:reduce` could. Extraction now lives in a tested helper
+# using the same quote-aware tag pattern as gate-40's.
+#
+# The accepted prop set is UNCHANGED, deliberately — this fixes where an
+# element ends, not what counts as a name, so the numbers stay comparable.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
     _il_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-nc-input-labels.log
     : > "${_il_log}"
+    _il_ran=1
+    _il_helper="${SCRIPT_DIR}/lib/check_nc_select_labels.py"
+    _il_files=()
     while IFS= read -r vue; do
+        [ -f "${vue}" ] || continue
         _in_scope "${vue}" || continue
-        _flat=$(tr '\n' ' ' < "${vue}")
-        echo "${_flat}" \
-            | grep -oE '<NcSelect[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                if ! echo "${tag}" | grep -qE "(input-label|inputLabel|aria-label-combobox|ariaLabelCombobox)"; then
-                    echo "${vue}: ${tag}" >> "${_il_log}"
-                fi
-            done
+        _il_files+=("${vue}")
     done < <(find src -name '*.vue' 2>/dev/null)
-    _il_fail=$(wc -l < "${_il_log}" 2>/dev/null || echo 0)
-    if [ "${_il_fail}" -eq 0 ]; then
-        _pass 12 "nc-input-labels"
+    if [ "${#_il_files[@]}" -eq 0 ]; then
+        : # nothing in scope — ordinary diff scoping.
+    elif [ ! -f "${_il_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _il_ran=0
+        _skip 12 "nc-input-labels" wiring "check_nc_select_labels.py not found at ${_il_helper} — ${#_il_files[@]} component(s) were in scope and NONE had their NcSelect elements inspected; unnamed comboboxes are UNVERIFIED by this run."
     else
-        _fail 12 "nc-input-labels" "${_il_fail} NcSelect without inputLabel/ariaLabelCombobox — see ${_il_log}"
+        python3 "${_il_helper}" "${_il_files[@]}" >> "${_il_log}" 2>/dev/null || true
+    fi
+    _il_fail=$(wc -l < "${_il_log}" 2>/dev/null || echo 0)
+    [ -z "${_il_fail}" ] && _il_fail=0
+    if [ "${_il_ran}" -eq 1 ]; then
+        if [ "${_il_fail}" -eq 0 ]; then
+            _pass 12 "nc-input-labels"
+        else
+            _fail 12 "nc-input-labels" "${_il_fail} NcSelect without inputLabel/ariaLabelCombobox — see ${_il_log}"
+        fi
     fi
 fi
 


### PR DESCRIPTION
fix(gate-12): the element ended at the arrow of `:reduce="(o) => o.id"`

Gate-12 extracted `<NcSelect>` elements with

    grep -oE '<NcSelect[^>]*>'

`[^>]*` stops at the FIRST `>` character in the flattened source. In an
NcSelect that is almost never the end of the tag, because the idiomatic
vue-select usage puts an arrow function in an attribute value:

    <NcSelect
        v-model="selectedRoundId"
        :options="roundOptions"
        :reduce="(o) => o.id"
        :input-label="t('scholiq', 'Round')"
        :aria-label-combobox="t('scholiq', 'Round')" />
                  ^ extraction ends here

Everything after `:reduce` is invisible, so the two props the gate looks
for are cut off and the element is reported as unnamed.

MEASURED, scholiq 2026-08-08 full-tree: **18 findings, 18 of them false.**
Every flagged element already carried `:input-label` AND
`:aria-label-combobox`, in every case written after `:reduce`. A
quote-aware re-scan of the same nine files found 18 NcSelect elements and
18 with a label prop.

The gate was anti-correlated with its own subject in those files: adding
the label prop could not clear it, and deleting `:reduce` could. Same
shape as gate-9's `[^)]*` bug (#198) — a character class used as a
delimiter over content that legitimately contains the delimiter.

FIX
---
Extraction moves to `scripts/lib/check_nc_select_labels.py`, using the same
quote-aware tag pattern `check_form_labels.py` (gate-40) already uses, so
the two a11y gates now agree on where an element stops. Wired with the
missing-helper `_skip` pattern from #147: an absent helper reports
SKIPPED (wiring) naming how many components went uninspected, never PASS.

The accepted prop set is UNCHANGED — `input-label` / `inputLabel` /
`aria-label-combobox` / `ariaLabelCombobox`, bare or bound. This changes
where an element ENDS, not what counts as a name, so before/after numbers
stay comparable. `aria-label` is still not accepted; a manual `<label
for=…>` next to an NcSelect is still a finding.

Markup inside an HTML comment is no longer scanned — a commented-out
NcSelect renders nothing and can carry no accessible name.

EVIDENCE
--------
- 17 new unit tests in `test_check_nc_select_labels.py`, discovered
  automatically by `tests/run-helper-suites.sh`. Every relaxation is
  paired with the true positive it must not swallow:
  `:reduce` + label -> clean, the same element with the label deleted ->
  1 finding; two selects where only one is named -> exactly 1 finding
  (the greedy-match trap a naive fix falls into); an unclosed `<NcSelect`
  followed by a `<div>` -> 1 finding that does not name the div.
- Whole package suite: 28 passed, 0 failed, 2 pre-existing quarantines.
- Against scholiq's tree, unchanged app code: gate-12 goes 18 -> PASS.
- Can-fail on the wiring: renaming the helper away makes the run print
  `SKIPPED (wiring) — … 72 component(s) were in scope and NONE had their
  NcSelect elements inspected`, not PASS.