### PR TITLE
fix(gate-46): resolve a spec wherever archiving left it, and accept #T<n> (#228)

### DIFF
--- a/hydra-gates/scripts/lib/check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/check_spec_anchors.py
@@ -80,6 +80,22 @@ CHECKBOX_ID = re.compile(r'^\s*-\s*\[.\]\s*(?:\*\*)?([A-Za-z0-9][A-Za-z0-9.\-]*)
 # `(REQ-PAY-001)`, `[REQ-005]`, `(REQ-PAY-001, REQ-PAY-003)`
 DELIMITED = re.compile(r'[(\[]([^)\]]{1,120})[)\]]')
 
+# `#T1`, `#T02`, `#t9` — the shorthand spelling of "Task N".
+#
+# Two repos' annotation tooling emits it and nothing has ever accepted it:
+# portaliq writes `#T3` against `### Task 3: Fail-closed trust re-checks…`
+# and procest writes `#T02` against `## 2. Controller + routes`. The task is
+# right there in the file; only the spelling of the reference is unusual.
+# It is NOT a GitHub anchor — clicking it lands nowhere — but this gate asks
+# whether the tag NAMES SOMETHING REAL, and `Task 3` is real.
+#
+# Deliberately NOT wired into the positional-checkbox rule. `#task-N` means
+# "the Nth checkbox" as well as "the heading numbered N"; giving `#T99` that
+# second reading too would let it resolve against any file with 99 checkboxes,
+# which is evidence about nothing. `T<n>` resolves against HEADINGS only, so
+# `#T99` against a nine-task file still fails — see ``test_check_spec_anchors``.
+TASK_SHORTHAND = re.compile(r'^[Tt](\d+)$')
+
 # An "id-like" token: something that could be a requirement/task identifier
 # rather than a word of prose. It must contain a digit — `REQ-BIE-004-01`,
 # `2.3`, `T01`, `5.2` do; `retry`, `policy`, `Requirement` do not. Requiring a
@@ -263,7 +279,14 @@ def has_anchor(md_path: str, fragment: str) -> bool:
     # which matches neither alias: not the gh one (underscore rewritten) and
     # not the kebab one (`call-log-sessionid`, split at the underscore).
     # Reported as "anchor not found" on a tag whose link works.
-    frags = (frag_slug, frag_alt, fragment.lower())
+    frags = [frag_slug, frag_alt, fragment.lower()]
+    # `#T3` / `#T02` — see TASK_SHORTHAND. Leading zeros are stripped because
+    # the heading is `## 2. Controller + routes`, whose lifted id token is `2`.
+    sh = TASK_SHORTHAND.match(fragment)
+    if sh:
+        n = sh.group(1).lstrip('0') or '0'
+        frags.extend((f'task-{n}', n))
+    frags = tuple(frags)
     pos_m = re.fullmatch(r'(?:task-)?(\d+)', fragment)
     positional = int(pos_m.group(1)) if pos_m else None
     item_count = 0
@@ -313,6 +336,80 @@ def build_archive_index(root: str) -> dict[str, list[str]]:
     return index
 
 
+def build_capability_index(root: str) -> dict[str, list[str]]:
+    """Every home a capability's `spec.md` can occupy, keyed by capability.
+
+    THE ARCHIVING PROBLEM THIS SOLVES
+    ---------------------------------
+    A capability's spec moves house at least twice in its life:
+
+      1. in flight   `openspec/changes/<change>/specs/<cap>/spec.md`
+      2. archived    `openspec/changes/archive/<date>-<change>/specs/<cap>/spec.md`
+      3. canonical   `openspec/specs/<cap>/spec.md`
+
+    ``build_archive_index`` already carries a tag from (1) to (2), keyed on the
+    CHANGE name. That is not enough, and the gap is what made this gate a
+    treadmill:
+
+      * The project rule — and, after this change, the phpcs SpecTagSniff that
+        instructs authors — says point `@spec` at (3). But archiving in these
+        repos does NOT reliably promote the delta spec into `openspec/specs/`.
+        procest carries 18 tags at `openspec/specs/process-mining-bottlenecks/
+        spec.md`, written exactly as instructed, whose spec only ever existed
+        at (2). Following the correct advice produced a dangling reference.
+      * The change name need not equal the capability name. procest's
+        `realtime-updates-ui` capability lives under the change
+        `adopt-live-updates-ui`, so no CHANGE-keyed index can find it — 10
+        more findings.
+
+    Keying on the CAPABILITY instead spans all three homes and is stable across
+    both the archive move and the promotion that follows it, so a tag written
+    once keeps resolving no matter which stage the change has reached. That is
+    what "a rule that survives archiving" has to mean.
+
+    THIS IS NOT A WIDENING OF WHAT COUNTS AS RESOLVED
+    -------------------------------------------------
+    It only supplies additional FILES to look in, and it is consulted only when
+    every literal spelling has already failed (see ``resolve``). The fragment
+    still has to name a heading that EXISTS in one of them. A tag naming a
+    requirement nobody wrote fails exactly as before — doriath's 77 findings
+    are all of that shape and this index rescues none of them, which is the
+    point. ``test_check_spec_anchors.py`` pins that.
+    """
+    index: dict[str, list[str]] = {}
+    patterns = (
+        'openspec/specs/*/spec.md',
+        'openspec/changes/*/specs/*/spec.md',
+        'openspec/changes/archive/*/specs/*/spec.md',
+        'openspec/archive/*/specs/*/spec.md',
+    )
+    for pattern in patterns:
+        for f in glob.glob(os.path.join(root, pattern)):
+            if os.path.isfile(f):
+                index.setdefault(os.path.basename(os.path.dirname(f)), []).append(f)
+    # The flat spelling, `openspec/specs/<cap>.md`, predates the directory form.
+    for f in glob.glob(os.path.join(root, 'openspec/specs/*.md')):
+        if os.path.isfile(f):
+            index.setdefault(os.path.basename(f)[: -len('.md')], []).append(f)
+    return index
+
+
+def capability_of(path: str) -> str | None:
+    """The capability a spec-path addresses, whichever home it names.
+
+    Returns None for anything that is not a capability spec — `tasks.md`,
+    `design.md`, `proposal.md` — because those are per-CHANGE documents with
+    no canonical home to migrate to, and the change-keyed archive index is
+    already the right resolver for them.
+    """
+    m = re.match(r'openspec/(?:specs|changes/[^/]+/specs|changes/archive/[^/]+/specs|'
+                 r'archive/[^/]+/specs)/([^/]+)/spec\.md$', path)
+    if m:
+        return m.group(1)
+    m = re.match(r'openspec/specs/([^/]+)\.md$', path)
+    return m.group(1) if m else None
+
+
 def _path_shapes(path: str) -> list[str]:
     """The equivalent spellings of one spec path.
 
@@ -331,7 +428,12 @@ def _path_shapes(path: str) -> list[str]:
     return shapes
 
 
-def resolve(path: str, root: str, archive_index: dict[str, list[str]]) -> list[str]:
+def resolve(
+    path: str,
+    root: str,
+    archive_index: dict[str, list[str]],
+    capability_index: dict[str, list[str]] | None = None,
+) -> list[str]:
     """Existing candidate files for a tag path: the literal path, its
     flat/directory counterpart, and archived counterparts of both.
 
@@ -356,6 +458,19 @@ def resolve(path: str, root: str, archive_index: dict[str, list[str]]) -> list[s
             cand = os.path.join(d, m.group(2))
             if os.path.exists(cand) and cand not in cands:
                 cands.append(cand)
+    # LAST RESORT ONLY — see build_capability_index.
+    #
+    # Consulted solely when every literal spelling has already failed, so a
+    # tag whose own path resolves is judged against THAT file and nothing
+    # else. Reaching here means the spec is not where the tag says it is;
+    # the capability index says where it went. The anchor check that follows
+    # is unchanged, so this converts "file not found" into a real anchor
+    # verdict rather than into a pass.
+    if not cands and capability_index:
+        cap = capability_of(path)
+        for cand in capability_index.get(cap or '', []):
+            if cand not in cands:
+                cands.append(cand)
     return cands
 
 
@@ -363,6 +478,7 @@ def scan_files(files: list[str], root: str | None = None) -> list[str]:
     """Return one finding line per unresolved `@spec` target."""
     root = root or find_repo_root() or os.getcwd()
     archive_index = build_archive_index(root)
+    capability_index = build_capability_index(root)
     findings: list[str] = []
     for fp in files:
         try:
@@ -376,7 +492,7 @@ def scan_files(files: list[str], root: str | None = None) -> list[str]:
                 path, frag = target.split('#', 1)
             else:
                 path, frag = target, None
-            candidates = resolve(path, root, archive_index)
+            candidates = resolve(path, root, archive_index, capability_index)
             if not candidates:
                 findings.append(f"{fp}: @spec target file not found → {target}")
                 continue

--- a/hydra-gates/scripts/lib/test_check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/test_check_spec_anchors.py
@@ -450,5 +450,197 @@ class GateIsNotBlind(unittest.TestCase):
                 self.assertFalse(_anchor(BI_EXPORT, frag))
 
 
+# --------------------------------------------------------------------------
+# Mode 6 — `#T3` / `#T02`, the shorthand spelling of "Task N". 117 fleet
+# findings (portaliq 76, procest 41). Paired controls below.
+# --------------------------------------------------------------------------
+PORTALIQ_TASKS = """# Tasks: contract-v2
+
+## Implementation Tasks
+
+### Task 1: Trust vocabulary + normalisation at the session edge
+### Task 2: Registry v2 — multi-audience discovery + minTrust manifest filtering
+### Task 3: Fail-closed trust re-checks on read and create paths
+### Task 9: Demo provider v2 vocabulary + seed claims data
+"""
+
+PROCEST_TASKS = """# Tasks: process-mining-bottlenecks
+
+## 1. Aggregation service
+- [x] 1.1 `ProcessMiningService::getReport()`
+
+## 2. Controller + routes
+- [x] 2.1 `ProcessMiningController`
+
+## 3. Frontend
+- [x] 3.1 `ProcessMiningDashboard.vue`
+
+## 4. Verification
+- [x] 4.1 Manual smoke
+"""
+
+
+class TaskShorthandRelaxed(unittest.TestCase):
+    """`#T3` names `### Task 3: …`; `#T02` names `## 2. …`.
+
+    Both spellings are emitted by real annotation tooling and neither has
+    ever resolved. The task is in the file; only the reference spelling is
+    unusual — which is not what this gate is for.
+    """
+
+    def test_fp_portaliq_T_shorthand_resolves_against_a_task_heading(self):
+        for frag in ("T1", "T2", "T3", "T9"):
+            with self.subTest(frag=frag):
+                self.assertTrue(_anchor(PORTALIQ_TASKS, frag))
+
+    def test_fp_procest_zero_padded_shorthand_resolves_against_a_numbered_section(self):
+        # Leading zeros stripped: the heading's lifted id token is `2`.
+        for frag in ("T01", "T02", "T03", "T04"):
+            with self.subTest(frag=frag):
+                self.assertTrue(_anchor(PROCEST_TASKS, frag))
+
+    def test_tp_a_task_number_the_file_does_not_have_still_fails(self):
+        # THE CONTROL, and it is not hypothetical: procest really does carry
+        # `#T05` against a file whose sections stop at 4, and that finding
+        # survives this relaxation. If this ever goes green the rule has
+        # stopped discriminating and the whole relaxation must come out.
+        for frag in ("T05", "T5", "T99", "T0"):
+            with self.subTest(frag=frag):
+                self.assertFalse(_anchor(PROCEST_TASKS, frag))
+        for frag in ("T4", "T10", "T99"):
+            with self.subTest(frag=frag):
+                self.assertFalse(_anchor(PORTALIQ_TASKS, frag))
+
+    def test_tp_the_shorthand_is_not_wired_to_the_positional_checkbox_rule(self):
+        # `#task-N` also means "the Nth checkbox". `T<n>` deliberately does
+        # NOT, or `#T99` would resolve against any file with 99 checkboxes —
+        # evidence about nothing. This file has 4 checkboxes and no `## 4.`
+        # sibling for T-numbers above it, so a shorthand that leaked into the
+        # positional rule would light up here.
+        checkboxes = "# Tasks\n\n" + "".join(f"- [x] item {i}\n" for i in range(1, 5))
+        for frag in ("T1", "T2", "T3", "T4"):
+            with self.subTest(frag=frag):
+                self.assertFalse(_anchor(checkboxes, frag))
+        # …while the established `#task-N` positional spelling still works.
+        self.assertTrue(_anchor(checkboxes, "task-3"))
+
+    def test_tp_a_bare_T_is_not_a_task_reference(self):
+        for frag in ("T", "TX", "Task", "trust"):
+            with self.subTest(frag=frag):
+                self.assertFalse(_anchor(PORTALIQ_TASKS, frag))
+
+
+# --------------------------------------------------------------------------
+# Mode 7 — the capability index: a spec resolves wherever archiving left it.
+# 28 fleet findings (procest 18 + 10). This is the "survives archiving" rule.
+# --------------------------------------------------------------------------
+CAP_SPEC = """# Process Mining Bottlenecks
+
+## ADDED Requirements
+
+### Requirement: Per-status dwell-time statistics
+
+#### Scenario: A closed case's dwell interval ends at the next transition
+"""
+
+TAGGED_PHP = """<?php
+/**
+ * @spec openspec/specs/process-mining-bottlenecks/spec.md#requirement-per-status-dwell-time-statistics
+ */
+class ProcessMiningService {}
+"""
+
+
+class CapabilityResolutionSurvivesArchiving(unittest.TestCase):
+    """A tag written ONCE keeps resolving through the whole change lifecycle.
+
+    This is acceptance criterion 3 for issue #228: after the SpecTagSniff is
+    repointed at `openspec/specs/<cap>/spec.md`, archiving a change must not
+    leave that anchor dangling. Before this rule it did — procest carries 18
+    tags written exactly as the corrected sniff instructs, whose spec only
+    ever existed inside the archived change directory.
+    """
+
+    def _lifecycle(self, spec_rel: str) -> list[str]:
+        return _scan({spec_rel: CAP_SPEC}, "lib/Service/ProcessMiningService.php", TAGGED_PHP)
+
+    def test_stage_1_in_flight_change_resolves(self):
+        self.assertEqual(self._lifecycle(
+            "openspec/changes/process-mining-bottlenecks/specs/"
+            "process-mining-bottlenecks/spec.md"), [])
+
+    def test_stage_2_archived_change_still_resolves(self):
+        # THE ARCHIVING PROOF. Same tag, same anchor, spec moved to archive.
+        self.assertEqual(self._lifecycle(
+            "openspec/changes/archive/2026-07-14-process-mining-bottlenecks/specs/"
+            "process-mining-bottlenecks/spec.md"), [])
+
+    def test_stage_3_promoted_to_canonical_still_resolves(self):
+        self.assertEqual(self._lifecycle(
+            "openspec/specs/process-mining-bottlenecks/spec.md"), [])
+
+    def test_a_capability_under_a_differently_named_change_resolves(self):
+        # procest's `realtime-updates-ui` capability lives under the change
+        # `adopt-live-updates-ui`. No CHANGE-keyed index can find it; a
+        # CAPABILITY-keyed one can. 10 findings.
+        self.assertEqual(self._lifecycle(
+            "openspec/changes/adopt-live-updates-ui/specs/"
+            "process-mining-bottlenecks/spec.md"), [])
+
+    def test_tp_a_requirement_nobody_wrote_still_fails(self):
+        # THE CONTROL THAT MATTERS MOST — doriath's shape, 77 findings.
+        # The capability index finds the spec file in all three homes; the
+        # anchor names a requirement that is in none of them. Widening WHERE
+        # we look must never widen WHAT counts as resolved.
+        bad = TAGGED_PHP.replace(
+            "#requirement-per-status-dwell-time-statistics",
+            "#requirement-listing-and-download")
+        for spec_rel in (
+            "openspec/specs/process-mining-bottlenecks/spec.md",
+            "openspec/changes/archive/2026-07-14-process-mining-bottlenecks/"
+            "specs/process-mining-bottlenecks/spec.md",
+        ):
+            with self.subTest(spec_rel=spec_rel):
+                findings = _scan({spec_rel: CAP_SPEC},
+                                 "lib/Service/ProcessMiningService.php", bad)
+                self.assertEqual(len(findings), 1, findings)
+                self.assertIn("anchor not found", findings[0])
+
+    def test_tp_a_capability_that_exists_nowhere_still_fails(self):
+        # larpingapp's shape: `manifest-v2-vue-scaffold` is in no home at all.
+        findings = _scan({"openspec/specs/something-else/spec.md": CAP_SPEC},
+                         "lib/Service/ProcessMiningService.php", TAGGED_PHP)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("target file not found", findings[0])
+
+    def test_tp_the_index_does_not_redirect_a_tag_whose_own_path_resolves(self):
+        # The capability index is LAST RESORT. When the tag's own path exists,
+        # the anchor is judged against THAT file — otherwise a stale archived
+        # copy could vouch for a requirement the canonical spec has dropped.
+        canonical = "openspec/specs/process-mining-bottlenecks/spec.md"
+        archived = ("openspec/changes/archive/2026-07-14-process-mining-bottlenecks/"
+                    "specs/process-mining-bottlenecks/spec.md")
+        findings = _scan(
+            {canonical: "# Process Mining Bottlenecks\n\n## Requirements\n\n"
+                        "### Requirement: Something completely different\n",
+             archived: CAP_SPEC},
+            "lib/Service/ProcessMiningService.php", TAGGED_PHP)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("anchor not found", findings[0])
+
+    def test_capability_of_declines_per_change_documents(self):
+        # tasks.md / design.md / proposal.md have no canonical home to
+        # migrate to; the change-keyed archive index already resolves them.
+        for p in ("openspec/changes/foo/tasks.md",
+                  "openspec/changes/foo/design.md",
+                  "openspec/changes/archive/2026-01-01-foo/proposal.md"):
+            with self.subTest(p=p):
+                self.assertIsNone(csa.capability_of(p))
+        self.assertEqual(
+            csa.capability_of("openspec/specs/bar/spec.md"), "bar")
+        self.assertEqual(
+            csa.capability_of("openspec/changes/foo/specs/bar/spec.md"), "bar")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3581,7 +3581,19 @@ if [ "${_sae_ran}" -eq 1 ]; then
     if [ "${_sae_fail}" -eq 0 ]; then
         _pass 46 "spec-anchor-existence"
     else
-        _fail 46 "spec-anchor-existence" "${_sae_fail} unresolved @spec target(s) — see ${_sae_log}"
+        # A FINDING COUNT IS NOT A DEFECT COUNT.
+        #
+        # One dangling target annotated on 15 methods emits 15 findings, and
+        # portaliq's "100 findings" were 29 distinct targets. Reporting only
+        # the raw line count made gate-46 look like a mountain of separate
+        # defects and drove people to grind tags one file at a time, when the
+        # actual work is one repoint per TARGET. Both numbers are printed so
+        # the size of the job is legible from the summary line.
+        set +e
+        _sae_targets=$(sed 's/^[^:]*: //' "${_sae_log}" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+        set -e
+        [ -z "${_sae_targets}" ] && _sae_targets="?"
+        _fail 46 "spec-anchor-existence" "${_sae_fail} unresolved @spec finding(s) from ${_sae_targets} distinct target(s) — fix the TARGET, not each tag; see ${_sae_log}"
     fi
 fi
 


### PR DESCRIPTION
Closes the gate half of #228. The sniff half is being fixed in the app repos separately.

## Cause

Gate-46 was a treadmill. The repo's own **blocking** phpcs `SpecTagSniff` instructs `@spec openspec/changes/{name}/tasks.md#task-N`, and a change directory is by definition temporary. 260 of portaliq's 385 tags did as told and dangled the moment their change was archived.

But repointing tags at `openspec/specs/` — the project rule — **was not safe either**, and that is the part that made this a treadmill rather than a one-off cleanup. A capability's `spec.md` occupies three homes over its life:

1. in flight — `openspec/changes/<change>/specs/<cap>/spec.md`
2. archived — `openspec/changes/archive/<date>-<change>/specs/<cap>/spec.md`
3. canonical — `openspec/specs/<cap>/spec.md`

`build_archive_index` already carried a tag from (1) to (2), keyed on the **change** name. Not enough, twice over:

- Archiving does **not** reliably promote the delta spec into `openspec/specs/`. procest carries 18 tags at `openspec/specs/process-mining-bottlenecks/spec.md`, written exactly as the corrected sniff instructs, whose spec only ever existed at (2). Correct advice, dangling reference.
- The change name need not equal the capability name. procest's `realtime-updates-ui` capability lives under the change `adopt-live-updates-ui`, so no change-keyed index can reach it. 10 more findings.

Keying on the **capability** spans all three homes and is stable across both the archive move and the promotion that may follow. That is what "a rule that survives archiving" has to mean.

Separately, `#T3` / `#T02` — the shorthand spelling of "Task N" — had never resolved. portaliq writes `#T3` against `### Task 3: Fail-closed trust re-checks…`; procest writes `#T02` against `## 2. Controller + routes`. 117 findings, latent from the day they were written.

## This widens WHERE the gate looks, never WHAT counts as resolved

The capability index is consulted **only after every literal spelling has failed**, so a tag whose own path exists is still judged against that file — a stale archived copy cannot vouch for a requirement the canonical spec has dropped. The fragment must still name a heading that exists.

`T<n>` is deliberately **not** wired into the positional-checkbox rule: `#task-N` also means "the Nth checkbox", and giving `T<n>` that second reading would let `#T99` resolve against any file with 99 checkboxes.

## Measured — full-tree, repos at `origin/development`

| repo | before | after |
|---|---|---|
| portaliq | 100 | **24** |
| procest | 82 | **15** |
| doriath | 79 | **79** |
| larpingapp | 1 | 1 |
| openconnector | 0 | 0 |
| **total** | **262** | **119** |

**doriath is the control and it did not move.** Its 77 findings are tags naming requirements — `Listing and download`, `Masked presentation`, `Lease management API` — that appear **nowhere in the repo, in any of the three homes**. Those are true positives and this change rescues none of them. doriath does not even ship the sniff; its cause is different and its findings are real.

Every survivor was checked by hand:
- procest `#T05` — against a file whose sections stop at 4. A natural control for the new shorthand rule: `#T02` now resolves, `#T05` still fails.
- procest `#task-2-5` ×10 — against a list that runs 2.1, 2.1b, 2.2, 2.3, 2.3b, 2.4, 2.4b. No 2.5.
- portaliq ×24 — `example-change`, `scaffold-v2`, `template-manifest-v1`, `portal-file-upload`, `portal-schema-endpoint`, `retrofit-2026-05-26-preferences-api`: deleted, not archived, present in no home.
- larpingapp ×1 — `manifest-v2-vue-scaffold`, in no home at all.

## A finding count is not a defect count

portaliq's 100 findings were **29 distinct targets** — one dangling target annotated on 15 methods emits 15 lines. That arithmetic is what drove people to grind tags one file at a time when the actual work is one repoint per target. The summary line now prints both numbers.

## Tests — 37 → 50, all mutation-checked

`TaskShorthandRelaxed` (5) and `CapabilityResolutionSurvivesArchiving` (8). The latter includes the acceptance proof for #228: the same tag resolves at **all three lifecycle stages**, including after archiving.

Mutation results:

| mutation | new tests that fail |
|---|---|
| shorthand disabled | 8 |
| capability index never consulted | 4 |
| index applied always instead of last-resort | 1 (the redirect control) |
| `has_anchor` returns True unconditionally | every true-positive control in the file |

`bash hydra-gates/tests/run-helper-suites.sh` → 27 passed, 0 failed, 2 pre-existing quarantines.