### PR TITLE
fix(gate-38): a mount point is not a page root, and the remedy it demanded regressed a11y (#214, #216, #227)

### DIFF
--- a/hydra-gates/scripts/lib/php_template_scope.py
+++ b/hydra-gates/scripts/lib/php_template_scope.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Does a Nextcloud PHP template OWN THE DOCUMENT, or is it a fragment?
+
+WHY THIS EXISTS
+---------------
+Nextcloud's `OCP\\Template` renderer SUBSTITUTES an app template into core's
+own page. A template that emits no `<html>` / `<body>` is a fragment inside a
+document core already built — core emitted that page's landmarks, its `lang`
+attribute and its skip link long before the template's first byte.
+
+gate-38 was asking every `templates/settings/*.php` in the fleet for a skip
+link. Measured: NOT ONE of the 30 app templates in this fleet owns a document
+— the typical body is literally `<div id="procest-settings"></div>`, a Vue
+mount point — so the finding was universal and its only remedy was to inject
+a SECOND "skip to content" anchor ahead of core's real one. A WCAG 2.4.1
+regression demanded by a WCAG 2.4.1 gate (#214, #216, #227).
+
+WHY A HELPER AND NOT A GREP
+---------------------------
+The first cut of this check was `grep -iE '<(html|body)\\b'`, and the very
+first fixture it ran against defeated it: the fixture's own explanatory
+comment contained the words `<html>`, so a bare mount point was classified as
+a page root. That is the gate-64 defect verbatim — a checker that greps a
+string literal misses every constant and matches every comment, failing both
+ways at once — so the classification is done on EMITTED MARKUP only:
+
+  * `<?php … ?>` regions are removed. Anything inside them is code, a
+    docblock or a `//` comment; none of it is markup the browser receives.
+  * `<!-- … -->` HTML comments are removed. Commented-out markup ships
+    nothing.
+
+Usage:
+    php_template_scope.py --owns-document <file>   # exit 0 = owns, 1 = fragment
+    php_template_scope.py --classify <file>...     # "<path>: page-root|fragment"
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# `<?php … ?>` and the short echo form `<?= … ?>`. An unterminated opener runs
+# to end of file, which is the language's own rule and the common shape of a
+# template whose PHP header is followed by nothing but more PHP.
+PHP_BLOCK = re.compile(r'<\?(?:php\b|=)?.*?(?:\?>|\Z)', re.DOTALL | re.IGNORECASE)
+HTML_COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+
+DOCUMENT_TAG = re.compile(r'<(?:html|body)\b', re.IGNORECASE)
+
+
+def emitted_markup(src: str) -> str:
+    """The template's output shape: PHP regions and HTML comments removed.
+
+    Order matters. Comments are stripped AFTER php blocks, because a `?>`
+    inside an HTML comment really does close the block in PHP, and pretending
+    otherwise would swallow markup that does ship.
+    """
+    return HTML_COMMENT.sub(' ', PHP_BLOCK.sub(' ', src))
+
+
+def owns_document(src: str) -> bool:
+    """True when the template emits `<html>` or `<body>` itself.
+
+    Only such a template is rendered outside core's shell, and only such a
+    template can carry a bypass mechanism (SC 2.4.1) or a `lang` attribute
+    (SC 3.1.1) of its own.
+    """
+    return bool(DOCUMENT_TAG.search(emitted_markup(src)))
+
+
+def _read(path: str) -> str:
+    with open(path, encoding='utf-8', errors='replace') as f:
+        return f.read()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 3 and argv[1] == '--owns-document':
+        try:
+            return 0 if owns_document(_read(argv[2])) else 1
+        except OSError:
+            # Unreadable is NOT "fragment". Refuse rather than answer.
+            print(f'php_template_scope: cannot read {argv[2]}', file=sys.stderr)
+            return 2
+    if len(argv) >= 3 and argv[1] == '--classify':
+        for path in argv[2:]:
+            try:
+                kind = 'page-root' if owns_document(_read(path)) else 'fragment'
+            except OSError:
+                kind = 'unreadable'
+            print(f'{path}: {kind}')
+        return 0
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
+++ b/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
@@ -113,6 +113,11 @@ if _run "${FIXTURES}/accidental"; then
     _expect_gate 38 FAIL "accidental: a bespoke shell with no skip link is still reported"
     _expect_log "${_SLLOG}" 'App\.vue: no <NcContent> shell' \
         "accidental: gate-38 names the root component"
+    # #214/#216 — the PHP half must keep a true positive. `standalone.php`
+    # emits <html> and <body>: it owns the document, so SC 2.4.1 is its to
+    # satisfy, and it does not.
+    _expect_log "${_SLLOG}" 'templates/standalone\.php: no <NcContent> shell' \
+        "accidental: a PHP template that OWNS the document and has no bypass link is still reported"
 fi
 
 # ---------------------------------------------------------------------------
@@ -128,6 +133,34 @@ if _run "${FIXTURES}/stated"; then
     _expect_gate 38 PASS "stated: a CnAppRoot shell counts as having NC's skip link"
     _expect_not_log "${_SLLOG}" 'App\.vue' \
         "stated: gate-38 log is empty"
+    _expect_not_log "${_SLLOG}" 'standalone\.php' \
+        "stated: a document-owning template WITH a bypass anchor is not a finding"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. MOUNT POINT vs PAGE ROOT (#214 / #216 / #227).
+#
+#    These three assertions run against `accidental/` — the fixture where
+#    EVERYTHING ELSE fails. That is deliberate: asserting "not reported" in a
+#    tree where the gate reports nothing proves nothing at all. Here the gate
+#    is demonstrably firing (section 1 named App.vue and standalone.php in
+#    this same run), so an absence is a decision rather than an empty scope.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/accidental"; then
+    _expect_log "${_SLLOG}" 'App\.vue|standalone\.php' \
+        "mount-point control: gate-38 IS firing in this tree (positive control for the three below)"
+    _expect_not_log "${_SLLOG}" 'settings/admin\.php' \
+        "#214/#216: a fragment template (<div id=...> mount point) is not a page root"
+    _expect_not_log "${_SLLOG}" 'AdminRoot\.vue' \
+        "#227: an admin-settings surface cannot own a page shell, so it is not asked for one"
+    # And the narrowing must not have swallowed the whole PHP arm: exactly one
+    # template is named, and it is the document-owning one.
+    if [ "$(printf '%s\n' "${_SLLOG}" | grep -c '\.php:')" = "1" ]; then
+        _ok "#214/#216: exactly ONE of the two PHP templates is in scope — the one that owns the document"
+    else
+        _bad "#214/#216: expected exactly 1 .php finding, got $(printf '%s\n' "${_SLLOG}" | grep -c '\.php:')"
+        printf '%s\n' "${_SLLOG}" | sed 's/^/       /'
+    fi
 fi
 
 echo

--- a/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
+++ b/hydra-gates/scripts/lib/test_gate_monitoring_and_skiplink.sh
@@ -163,6 +163,50 @@ if _run "${FIXTURES}/accidental"; then
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# 4. A BROKEN CLASSIFIER MUST NOT REPORT PASS (#147 / #249).
+#
+#    gate-38's PHP arm is driven entirely by php_template_scope.py. If that
+#    helper crashes and the runner reads its exit byte as an answer, every
+#    template classifies as "fragment", the whole arm evaporates, and the gate
+#    reports PASS having inspected nothing — a falsely-green gate manufactured
+#    by its own plumbing. Both wiring failures are asserted here.
+# ---------------------------------------------------------------------------
+_broken="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-broken.XXXXXXXX")"
+cp -r "${PKG_ROOT}" "${_broken}/pkg" 2>/dev/null
+_BROKEN_RUNNER="${_broken}/pkg/scripts/run-hydra-gates.sh"
+
+_expect_skip() {  # <runner> <description>
+    local _out _logdir
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-test.XXXXXXXX")"
+    _out="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "$1" "${FIXTURES}/stated" 2>&1 || true)"
+    local _line
+    _line="$(printf '%s' "${_out}" | grep -E '^\[gate-38\] ' | head -1)"
+    case "${_line}" in
+        *"SKIPPED"*) _ok "$2 — ${_line%%—*}" ;;
+        *": PASS"*)  _bad "$2 — reported PASS having classified NOTHING: ${_line}" ;;
+        *)           _bad "$2 — wanted SKIPPED, got: ${_line:-<no gate-38 line at all>}" ;;
+    esac
+}
+
+if [ -f "${_BROKEN_RUNNER}" ]; then
+    # 4a. helper absent
+    mv "${_broken}/pkg/scripts/lib/php_template_scope.py" \
+       "${_broken}/pkg/scripts/lib/php_template_scope.py.hidden"
+    _expect_skip "${_BROKEN_RUNNER}" "a MISSING classifier reports SKIPPED, not PASS (#147)"
+    mv "${_broken}/pkg/scripts/lib/php_template_scope.py.hidden" \
+       "${_broken}/pkg/scripts/lib/php_template_scope.py"
+    # 4b. helper present but crashing. This is the case an exit-byte boolean
+    #     could not tell from "fragment": a crash exits 1, and so does a
+    #     fragment. The answer must come from stdout.
+    printf 'import sys\nraise SystemExit("boom")\n' \
+        > "${_broken}/pkg/scripts/lib/php_template_scope.py"
+    _expect_skip "${_BROKEN_RUNNER}" "a CRASHING classifier reports SKIPPED, not PASS (#249)"
+else
+    _bad "could not stage a broken-helper copy of the package — wiring assertions did not run"
+fi
+rm -rf "${_broken}"
+
 echo
 echo "== summary =="
 printf '   passed: %d\n   failed: %d\n' "${_pass_n}" "${_fail_n}"

--- a/hydra-gates/scripts/lib/test_php_template_scope.py
+++ b/hydra-gates/scripts/lib/test_php_template_scope.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for php_template_scope (gate-38's page-root / fragment classifier).
+
+    python3 scripts/lib/test_php_template_scope.py
+
+WHY EACH CASE IS HERE
+---------------------
+gate-38's PHP arm reported 8 templates across 6 apps, and every one was a
+fragment whose page — and whose skip link — belongs to Nextcloud core. The
+narrowing that removes those findings is the single question "does this file
+emit a document?", so this suite is where that question is held honest.
+
+The comment cases are not hypothetical padding. The FIRST implementation was
+`grep -iE '<(html|body)\\b'`, and the first fixture it met defeated it: the
+fixture's own explanatory comment said `<html>`, so a bare mount point
+classified as a page root and the whole fix silently did nothing. Both
+comment shapes are pinned below.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import php_template_scope as pts  # noqa: E402
+
+
+class Fragments(unittest.TestCase):
+    """Everything here is rendered INTO a page core already built."""
+
+    def test_the_fleet_mount_point(self):
+        # procest/templates/settings/admin.php, verbatim shape. This is the
+        # single most common template in the fleet.
+        self.assertFalse(pts.owns_document(
+            "<?php\nscript('procest', 'admin');\n?>\n"
+            '<div id="procest-settings"></div>\n'))
+
+    def test_a_long_fragment_with_real_markup_is_still_a_fragment(self):
+        # nldesign/templates/settings/admin.php is 502 lines of real controls
+        # and still owns no document.
+        self.assertFalse(pts.owns_document(
+            '<div id="nldesign-settings" class="section">\n'
+            '  <h2>NL Design System Theme</h2>\n'
+            '  <label for="ts">Design token set</label>\n'
+            '  <select id="ts"><option>a</option></select>\n'
+            '</div>\n'))
+
+    def test_a_php_comment_naming_html_does_not_make_it_a_page_root(self):
+        # THE REGRESSION THAT MOTIVATED THIS HELPER. A `//` comment inside a
+        # PHP block explaining that core emitted the <html> element must not
+        # be read as this file emitting one.
+        self.assertFalse(pts.owns_document(
+            "<?php\n"
+            "// Core emitted this page's <html> and <body> long before this\n"
+            "// file's first byte; this template is only a mount point.\n"
+            "?>\n"
+            '<div id="fixture-settings"></div>\n'))
+
+    def test_a_docblock_naming_body_does_not_make_it_a_page_root(self):
+        self.assertFalse(pts.owns_document(
+            "<?php\n/**\n * Substituted into core's <body>.\n */\n?>\n"
+            '<div id="x"></div>\n'))
+
+    def test_commented_out_markup_ships_nothing(self):
+        self.assertFalse(pts.owns_document(
+            '<!-- <html><body>an older, abandoned standalone page</body></html> -->\n'
+            '<div id="x"></div>\n'))
+
+    def test_an_all_php_file_owns_no_document(self):
+        self.assertFalse(pts.owns_document("<?php\nreturn ['a' => 1];\n"))
+
+    def test_empty_file(self):
+        self.assertFalse(pts.owns_document(''))
+
+
+class PageRoots(unittest.TestCase):
+    """A template that emits the document is in scope and must stay in scope.
+
+    If these ever go false the gate has stopped asking anyone the question,
+    and gate-38's PHP arm is decoration.
+    """
+
+    def test_a_standalone_document(self):
+        self.assertTrue(pts.owns_document(
+            '<!DOCTYPE html>\n<html lang="en">\n<head><title>x</title></head>\n'
+            '<body><div id="app"></div></body>\n</html>\n'))
+
+    def test_body_alone_is_enough(self):
+        # Some standalone templates are included after a partial header.
+        self.assertTrue(pts.owns_document('<body class="public">\n<p>hi</p>\n'))
+
+    def test_markup_after_a_closed_php_block_is_still_seen(self):
+        # The PHP-stripper must not eat the rest of the file. A `?>` closes
+        # exactly one block.
+        self.assertTrue(pts.owns_document(
+            "<?php\n$title = 'x';\n?>\n<html lang=\"en\"><body>hi</body></html>\n"))
+
+    def test_html_between_two_php_blocks(self):
+        self.assertTrue(pts.owns_document(
+            "<?php $a = 1; ?>\n<html lang=\"en\">\n<?php echo $a; ?>\n"
+            "<body>hi</body></html>\n"))
+
+    def test_uppercase_tags(self):
+        self.assertTrue(pts.owns_document('<HTML LANG="en"><BODY>hi</BODY></HTML>'))
+
+    def test_a_real_comment_next_to_a_real_document(self):
+        # Stripping comments must not strip the document with them.
+        self.assertTrue(pts.owns_document(
+            '<!-- a standalone public page; core does not wrap this -->\n'
+            '<html lang="nl"><body><p>hi</p></body></html>\n'))
+
+
+class UnterminatedPhp(unittest.TestCase):
+    def test_an_unclosed_php_opener_swallows_the_rest(self):
+        # PHP's own rule, and the common shape of a pure-logic template.
+        self.assertFalse(pts.owns_document("<?php\n// <html> mentioned here\n$x = 1;\n"))
+
+
+class Cli(unittest.TestCase):
+    """The bash caller keys on the EXIT STATUS, so the status is a contract.
+
+    Gate-19 returned a finding COUNT as an exit status and lost 256 findings
+    to a byte; an exit status this gate reads must be tested as an interface,
+    not assumed.
+    """
+
+    def _write(self, tmp, name, content):
+        p = os.path.join(tmp, name)
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return p
+
+    def test_exit_codes(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._write(tmp, 'root.php', '<html lang="en"><body>hi</body></html>')
+            frag = self._write(tmp, 'frag.php', '<div id="x"></div>')
+            self.assertEqual(pts.main(['x', '--owns-document', root]), 0)
+            self.assertEqual(pts.main(['x', '--owns-document', frag]), 1)
+            # A file that cannot be read is NOT silently "fragment" — that
+            # would drop it from scope and read as a pass.
+            self.assertEqual(
+                pts.main(['x', '--owns-document', os.path.join(tmp, 'nope.php')]), 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3350,9 +3350,14 @@ if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]; then
     # checker that greps a string literal misses every constant and matches
     # every comment, failing both ways at once. scripts/lib/php_template_scope.py
     # classifies EMITTED MARKUP, with PHP regions and HTML comments removed.
-    _sl_php_owns_document() {
-        python3 "${SCRIPT_DIR}/lib/php_template_scope.py" --owns-document "$1" 2>/dev/null
-    }
+    #
+    # THE ANSWER COMES FROM STDOUT, THE EXIT CODE IS A STATUS (gate-19 / #249).
+    # An earlier draft used the exit byte as the boolean — 0 owns, 1 fragment —
+    # and a helper that CRASHES also exits 1. Every template would have read as
+    # a fragment, the whole PHP arm would have evaporated, and the gate would
+    # have reported PASS on nothing. One `--classify` call for the whole set
+    # prints `<path>: page-root|fragment`, and a non-zero exit is a wiring
+    # failure rather than an answer.
     _sl_check() {
         local _f="$1"
         _in_scope "$_f" || return 0
@@ -3412,10 +3417,32 @@ if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]; then
             _sl_ran=0
             _skip 38 "skip-link" wiring "php_template_scope.py not found at ${_sl_helper} — ${#_sl_php[@]} PHP template(s) were in scope and NONE were classified; a document-owning template with no bypass mechanism (WCAG 2.4.1) is UNVERIFIED by this run."
         else
-            for _f in "${_sl_php[@]}"; do
-                _sl_php_owns_document "$_f" || continue
-                _sl_check "$_f"
-            done
+            _sl_cls_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-skip-link.classify.err"
+            # gate-19's block (line ~1901) turns `set -e` ON and leaves it on
+            # for every gate after it, even though this script's own header
+            # sets only `set -u`. A helper that exits non-zero would therefore
+            # kill the whole runner mid-sweep — every LATER gate silently
+            # unreported — instead of reaching the _skip below. Measured: the
+            # crashing-classifier assertion aborted the run right here, 21
+            # later gates lost. Disable errexit around the call and restore
+            # the caller's flag.
+            case $- in *e*) _sl_had_e=1 ;; *) _sl_had_e=0 ;; esac
+            set +e
+            _sl_cls=$(python3 "${_sl_helper}" --classify "${_sl_php[@]}" 2>"${_sl_cls_err}")
+            _sl_rc=$?
+            [ "${_sl_had_e}" -eq 1 ] && set -e
+            if [ "${_sl_rc}" -ne 0 ]; then
+                # The classifier fell over. It answered nothing, so there is no
+                # verdict to give — stderr is KEPT, not discarded (#249).
+                _sl_ran=0
+                _skip 38 "skip-link" wiring "php_template_scope.py exited ${_sl_rc} — ${#_sl_php[@]} PHP template(s) were in scope and NONE were classified; a document-owning template with no bypass mechanism (WCAG 2.4.1) is UNVERIFIED by this run. See ${_sl_cls_err}."
+            else
+                while IFS= read -r _line; do
+                    case "${_line}" in
+                        *": page-root") _sl_check "${_line%: page-root}" ;;
+                    esac
+                done <<< "${_sl_cls}"
+            fi
         fi
     fi
     _sl_fail=$(wc -l < "${_sl_log}" 2>/dev/null || echo 0)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3597,10 +3597,17 @@ if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]; then
     if [ -d templates ] || [ -d appinfo/templates ]; then
         _sl_helper="${SCRIPT_DIR}/lib/php_template_scope.py"
         _sl_php=()
+        # ONE SCOPE DEFINITION FOR THE FAMILY (#225 / #261). This arm used its
+        # own `find templates appinfo/templates -name '*.php'`, which is
+        # `_a11y_markup_files` minus the exclusions — so a generated
+        # phpmetrics/ or vendor/ template would have been audited here and
+        # nowhere else. Filtering the shared enumeration keeps the two from
+        # drifting, and there is deliberately no third definition.
         while IFS= read -r _f; do
             [ -z "$_f" ] && continue
+            case "$_f" in *.php) ;; *) continue ;; esac
             _in_scope "$_f" && _sl_php+=("$_f")
-        done < <(find templates appinfo/templates -name '*.php' 2>/dev/null)
+        done < <(_a11y_markup_files)
         if [ "${#_sl_php[@]}" -eq 0 ]; then
             :   # nothing in scope; the verdict below describes the diff, as everywhere else.
         elif [ ! -f "${_sl_helper}" ]; then
@@ -3611,19 +3618,15 @@ if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]; then
             _skip 38 "skip-link" wiring "php_template_scope.py not found at ${_sl_helper} — ${#_sl_php[@]} PHP template(s) were in scope and NONE were classified; a document-owning template with no bypass mechanism (WCAG 2.4.1) is UNVERIFIED by this run."
         else
             _sl_cls_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-skip-link.classify.err"
-            # gate-19's block (line ~1901) turns `set -e` ON and leaves it on
-            # for every gate after it, even though this script's own header
-            # sets only `set -u`. A helper that exits non-zero would therefore
-            # kill the whole runner mid-sweep — every LATER gate silently
-            # unreported — instead of reaching the _skip below. Measured: the
-            # crashing-classifier assertion aborted the run right here, 21
-            # later gates lost. Disable errexit around the call and restore
-            # the caller's flag.
-            case $- in *e*) _sl_had_e=1 ;; *) _sl_had_e=0 ;; esac
+            # `set +e` only, never `set -e` after. Errexit is OFF for this
+            # whole script and nothing may turn it on (#243, and the invariant
+            # at the top of this file). Before that landed, a non-zero helper
+            # here killed the entire runner mid-sweep instead of reaching the
+            # _skip below — measured at 21 later gates silently lost, the run
+            # ending on the abort banner.
             set +e
             _sl_cls=$(python3 "${_sl_helper}" --classify "${_sl_php[@]}" 2>"${_sl_cls_err}")
             _sl_rc=$?
-            [ "${_sl_had_e}" -eq 1 ] && set -e
             if [ "${_sl_rc}" -ne 0 ]; then
                 # The classifier fell over. It answered nothing, so there is no
                 # verdict to give — stderr is KEPT, not discarded (#249).

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3121,24 +3121,90 @@ fi
 
 
 # ---------------------------------------------------------------------------
-# Gate 38: Skip-link — every app entry-point Vue (App.vue / *Root.vue) or
-# admin/settings PHP template must include a skip-to-content affordance,
-# either via NC's shell (typically inherited by mounting under <NcContent>)
-# or via an explicit `<a href="#main">` / `<a href="#content">` link as
-# the first focusable element. Per WCAG 2.2 AA SC 2.4.1 (Bypass Blocks).
+# Gate 38: Skip-link — every app PAGE ROOT must include a skip-to-content
+# affordance, either via NC's shell (typically inherited by mounting under
+# <NcContent>) or via an explicit `<a href="#main">` / `<a href="#content">`
+# link as the first focusable element. Per WCAG 2.2 AA SC 2.4.1 (Bypass
+# Blocks).
 #
-# Heuristic: a file is in scope if it's a top-level Vue mount root (App.vue
-# / **/AdminRoot.vue / **/Root.vue) OR a settings admin template
-# (templates/settings/*.php). We pass if the file either renders
-# `<NcContent>` / `<NcAppContent>` (which inherits NC's skip-link) OR
-# contains a literal `skip-` link / `skip-to-content` reference.
+# A PAGE ROOT IS NOT A MOUNT POINT (#214 / #216 / #227)
+# ----------------------------------------------------
+# SC 2.4.1 is a property of a DOCUMENT: "a mechanism is available to bypass
+# blocks of content repeated on multiple WEB PAGES". Only the thing that owns
+# the document can satisfy it. Two shapes in this fleet own no document, and
+# this gate was reporting all of them:
+#
+#   templates/**/*.php   Nextcloud's `Template` renderer SUBSTITUTES an app
+#                        template into core's own page. Every one of the 30
+#                        PHP templates in this fleet is a fragment — measured:
+#                        NOT ONE emits <html>, <head> or <body>. The typical
+#                        body is literally `<div id="procest-settings"></div>`,
+#                        a Vue mount point. The skip link for that page is
+#                        emitted by NC core, above this file's first byte.
+#                        8 templates across 6 apps failed this way.
+#
+#   Admin / personal     `AdminRoot.vue` is rendered INTO core's Settings
+#   settings roots       page, inside the section core already built. It is a
+#                        <CnAdminSettingsShell> — a stack of
+#                        <NcSettingsSection>s — not an app shell. #227: these
+#                        surfaces cannot own a page shell, so they cannot own
+#                        a skip link either.
+#
+# In both cases the gate's implied remedy was to ADD a skip link to an element
+# that is not the page root: a second "skip to content" anchor pointing into
+# the middle of a page that already has one, announced to every screen-reader
+# user ahead of core's real one. A WCAG 2.4.1 REGRESSION demanded by a WCAG
+# 2.4.1 gate, which is why the finding could not be closed honestly.
+#
+# WHAT REMAINS IN SCOPE, AND STILL FAILS
+# --------------------------------------
+#   - src/App.vue, src/views/App.vue        — the app's own shell
+#   - **/*Root.vue that is NOT a settings surface
+#   - a PHP template that DOES own the document, i.e. emits <html>/<body>
+#     (a standalone / PublicPage template rendered outside core's shell). No
+#     fleet app has one today; the gate is ready for the first that does, and
+#     the fixture pair in scripts/test-fixtures/monitoring-skiplink proves it
+#     still fires. Note this WIDENS the PHP arm: it used to look only at
+#     templates/settings/, and now asks every app template the question.
 #
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 2.4.1
+#   - ConductionNL/.github#214, #216, #227
 # ---------------------------------------------------------------------------
-if [ -d src ] || [ -d templates ]; then
+if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]; then
     _sl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-skip-link.log
     : > "${_sl_log}"
+    # A Vue root that is a SETTINGS SURFACE, not a page root. Two independent
+    # signals, because neither alone covers the fleet:
+    #   name  — all 8 settings roots measured across the fleet are called
+    #           AdminRoot.vue / PersonalRoot.vue / AdminSettings.vue, and 3 of
+    #           them (petstore, portaliq, openregister) are NOT under a
+    #           settings/ path, so a path rule alone would miss them.
+    #   shell — a root rendering <CnAdminSettingsShell> / <NcSettingsSection> /
+    #           <CnSettingsSection> is a stack of settings sections mounted
+    #           into core's Settings page, whatever it happens to be called.
+    _sl_is_settings_surface() {
+        local _f="$1"
+        case "${_f##*/}" in
+            AdminRoot.vue|PersonalRoot.vue|AdminSettings.vue|PersonalSettings.vue) return 0 ;;
+        esac
+        case "${_f}" in
+            */views/settings/*|*/views/admin/*|*/components/userSettings/*) return 0 ;;
+        esac
+        grep -qE '<CnAdminSettingsShell\b|<NcSettingsSection\b|<CnSettingsSection\b' "$_f" 2>/dev/null
+    }
+    # A PHP template owns the document only if it EMITS one.
+    #
+    # This is deliberately NOT a grep. The first cut of it was, and the very
+    # first fixture defeated it: that fixture's own explanatory COMMENT
+    # contained the word `<html>`, so a bare `<div id="x"></div>` mount point
+    # classified as a page root. That is the gate-64 defect verbatim — a
+    # checker that greps a string literal misses every constant and matches
+    # every comment, failing both ways at once. scripts/lib/php_template_scope.py
+    # classifies EMITTED MARKUP, with PHP regions and HTML comments removed.
+    _sl_php_owns_document() {
+        python3 "${SCRIPT_DIR}/lib/php_template_scope.py" --owns-document "$1" 2>/dev/null
+    }
     _sl_check() {
         local _f="$1"
         _in_scope "$_f" || return 0
@@ -3172,19 +3238,45 @@ if [ -d src ] || [ -d templates ]; then
     done
     while IFS= read -r _f; do
         [ -z "$_f" ] && continue
+        # #227: a settings surface is not a page root and cannot own a skip
+        # link. Skipping it is the only honest verdict — the alternative
+        # remedy regresses the page that already has one.
+        _sl_is_settings_surface "$_f" && continue
         _sl_check "$_f"
     done < <(_enum_tracked 'Root\.vue$' src)
-    if [ -d templates/settings ]; then
+    # #214 / #216: a PHP template is checked only when it owns the document.
+    # `templates/settings/` is no longer the scope — the question asked of
+    # EVERY app template is whether it emits <html>/<body>.
+    _sl_ran=1
+    if [ -d templates ] || [ -d appinfo/templates ]; then
+        _sl_helper="${SCRIPT_DIR}/lib/php_template_scope.py"
+        _sl_php=()
         while IFS= read -r _f; do
             [ -z "$_f" ] && continue
-            _sl_check "$_f"
-        done < <(find templates/settings -name '*.php' 2>/dev/null)
+            _in_scope "$_f" && _sl_php+=("$_f")
+        done < <(find templates appinfo/templates -name '*.php' 2>/dev/null)
+        if [ "${#_sl_php[@]}" -eq 0 ]; then
+            :   # nothing in scope; the verdict below describes the diff, as everywhere else.
+        elif [ ! -f "${_sl_helper}" ]; then
+            # A MISSING HELPER MUST NOT REPORT PASS (#147). Without the
+            # classifier every template silently reads as a fragment, the
+            # whole PHP arm evaporates, and the gate goes green on nothing.
+            _sl_ran=0
+            _skip 38 "skip-link" wiring "php_template_scope.py not found at ${_sl_helper} — ${#_sl_php[@]} PHP template(s) were in scope and NONE were classified; a document-owning template with no bypass mechanism (WCAG 2.4.1) is UNVERIFIED by this run."
+        else
+            for _f in "${_sl_php[@]}"; do
+                _sl_php_owns_document "$_f" || continue
+                _sl_check "$_f"
+            done
+        fi
     fi
     _sl_fail=$(wc -l < "${_sl_log}" 2>/dev/null || echo 0)
-    if [ "${_sl_fail}" -eq 0 ]; then
-        _pass 38 "skip-link"
-    else
-        _fail 38 "skip-link" "${_sl_fail} root component(s) without skip-link / <NcContent> — see ${_sl_log}"
+    if [ "${_sl_ran}" -eq 1 ]; then
+        if [ "${_sl_fail}" -eq 0 ]; then
+            _pass 38 "skip-link"
+        else
+            _fail 38 "skip-link" "${_sl_fail} page root(s) without skip-link / <NcContent> — see ${_sl_log}"
+        fi
     fi
 fi
 

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/src/views/settings/AdminRoot.vue
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/src/views/settings/AdminRoot.vue
@@ -1,0 +1,38 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<template>
+	<!--
+	  #227: an ADMIN SETTINGS SURFACE. This component is rendered into core's
+	  Settings page, inside the section core already built for it. It is a
+	  stack of settings sections, not an app shell: it has no Nextcloud
+	  content wrapper, no shared app root, and no jump-to-content affordance,
+	  and it must NOT be reported for any of those, because it owns no
+	  document.
+
+	  NOTHING in this comment may name the markup the gate greps for. The
+	  first draft of this file spelled out the wrapper element it does not
+	  have, and the gate matched the COMMENT and accepted the file — so the
+	  "#227 is fixed" assertion passed identically with the fix reverted. A
+	  fixture that quotes the pattern it is meant to defeat defeats itself
+	  instead (the gate-56 lesson, relearned here the hard way).
+
+	  Deliberately placed in `accidental/`, next to an App.vue that DOES still
+	  fail: the two files agree on every signal gate-38 used to look at and
+	  differ only in being a settings surface. The suite asserts App.vue and
+	  standalone.php are still named in the SAME run, so "not reported" here
+	  can never be an empty scope reading as a pass.
+	-->
+	<CnAdminSettingsShell app-id="fixture" app-name="Fixture">
+		<CnSettingsSection name="Things">
+			<p>Configure things.</p>
+		</CnSettingsSection>
+	</CnAdminSettingsShell>
+</template>
+
+<script>
+import { CnAdminSettingsShell, CnSettingsSection } from '@conduction/nextcloud-vue'
+
+export default {
+	name: 'AdminRoot',
+	components: { CnAdminSettingsShell, CnSettingsSection },
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/templates/settings/admin.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/templates/settings/admin.php
@@ -1,0 +1,17 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// A MOUNT POINT, verbatim in the shape measured across the fleet
+// (procest/templates/settings/admin.php is literally this). Nextcloud's
+// Template renderer substitutes this into core's Settings page; core emitted
+// that page's <html>, its landmarks and its bypass mechanism long before this
+// file's first byte.
+//
+// It owns no document, so it cannot own a skip link, and adding one here
+// would announce a second "skip to content" ahead of core's real one.
+// gate-38 must NOT report it. Its sibling `standalone.php` differs by owning
+// the document, and must still be reported.
+script('fixture', 'admin');
+style('fixture', 'admin');
+?>
+<div id="fixture-settings"></div>

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/templates/standalone.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/accidental/templates/standalone.php
@@ -1,0 +1,28 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// THE POSITIVE CONTROL for the PHP half of gate-38.
+//
+// This template OWNS THE DOCUMENT: it emits <html> and <body> itself, so it
+// is rendered outside Nextcloud's shell and nothing above it emitted a
+// bypass mechanism. It has no jump-to-content affordance. It is a genuine
+// WCAG 2.4.1 failure and MUST be reported.
+//
+// Its sibling `settings/admin.php` differs by exactly the one thing the
+// #214/#216 narrowing accepts — it is a fragment — and must NOT be reported.
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Fixture standalone page</title>
+</head>
+<body>
+	<nav class="fixture-nav">
+		<a href="/apps/fixture/things">Things</a>
+	</nav>
+	<div class="fixture-page">
+		<?php print_unescaped($_['body'] ?? ''); ?>
+	</div>
+</body>
+</html>

--- a/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/templates/standalone.php
+++ b/hydra-gates/scripts/test-fixtures/monitoring-skiplink/stated/templates/standalone.php
@@ -1,0 +1,24 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// A template that OWNS THE DOCUMENT and therefore IS in scope — and answers
+// the gate properly, with a real bypass anchor as the first focusable
+// element. The pair with `accidental/templates/standalone.php` is the whole
+// point: same shape, same scope, one has the affordance and one does not.
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Fixture standalone page</title>
+</head>
+<body>
+	<a href="#main-content" class="skip-link">Skip to main content</a>
+	<nav class="fixture-nav">
+		<a href="/apps/fixture/things">Things</a>
+	</nav>
+	<main id="main-content">
+		<?php print_unescaped($_['body'] ?? ''); ?>
+	</main>
+</body>
+</html>


### PR DESCRIPTION
Closes #214. Closes #216. Closes #227.

## The defect

WCAG 2.4.1 (Bypass Blocks) is a property of a **document**. gate-38 was asking it of two shapes that own no document:

| shape | why it owns no document |
|---|---|
| `templates/**/*.php` | NC's `Template` renderer **substitutes** the template into core's page. **Measured: all 30 app templates in the fleet are fragments — not one emits `<html>`, `<head>` or `<body>`.** The typical body is literally `<div id="procest-settings"></div>`. |
| `AdminRoot.vue` | rendered *into* core's Settings page, inside the section core already built. A `<CnAdminSettingsShell>` is a stack of `<NcSettingsSection>`s, not an app shell (#227). |

**8 templates across 6 apps** failed this way (nldesign, opencatalogi, docudesk, larpingapp, procest ×2, openbuild), plus 2 `AdminRoot.vue`.

### The remedy was an a11y regression

The only way to close the finding was to add a **second "skip to content" anchor** pointing into the middle of a page that already has one — announced to every screen-reader user ahead of core's real one. A WCAG 2.4.1 regression demanded by a WCAG 2.4.1 gate. That is why these findings could never be closed honestly.

## What still fails

- `src/App.vue` / `src/views/App.vue` with a bespoke shell
- `**/*Root.vue` that is **not** a settings surface
- a PHP template that **does** own the document and has no bypass mechanism

⚠️ This **widens** the PHP arm: it used to look only at `templates/settings/`, and now asks *every* app template the question. A standalone/PublicPage template is covered where before it was not.

## The classifier is not a grep, and that is load-bearing

The first cut **was** `grep -iE '<(html|body)\b'`, and the first fixture it met defeated it: **the fixture's own explanatory comment contained `<html>`**, so a bare mount point classified as a page root and the fix silently did nothing. Same defect as gate-64 — *a checker that greps a string literal misses every constant and matches every comment, failing both ways at once.*

`scripts/lib/php_template_scope.py` classifies **emitted markup**, with PHP regions and HTML comments removed. Both comment shapes are pinned in tests.

## The same trap bit the fixture, twice

The `AdminRoot.vue` fixture's comment spelled out the wrapper element it does not have. The gate matched the **comment**, accepted the file, and **the "#227 is fixed" assertion passed identically with the fix reverted.** Caught by mutation-checking, not by reading.

## Mutation check — all three go red

| mutation | assertion that fails |
|---|---|
| classifier forced to "owns document" (old behaviour) | fragment assertions |
| settings-surface exclusion removed | #227 assertion |
| PHP arm removed | `standalone.php` true positive is lost |

## Tests

- 4 new fixtures: a document-owning template **with** and **without** a bypass anchor, a mount point, a settings surface
- 4 new assertions in `test_gate_monitoring_and_skiplink.sh` — **16/16 green**
- new `test_php_template_scope.py` — **15 cases**
- full helper suite: **28 passed, 0 failed** (2 pre-existing quarantines)

Every "not reported" assertion runs in the `accidental/` tree, **where the gate is demonstrably firing in the same run**, so an absence is a decision and never an empty scope.

A missing helper now reports **SKIP-wiring, not PASS** (#147).