### PR TITLE
fix(gate-37,gate-43): tabindex="-1" is NOT focusable, and one scope= does not green a table (#222)

### DIFF
--- a/hydra-gates/scripts/lib/check_aria_hidden_focusable.py
+++ b/hydra-gates/scripts/lib/check_aria_hidden_focusable.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+r"""Gate-37 aria-hidden-focusable — an element hidden from assistive tech must
+not also be in the tab order (WCAG 2.2 AA SC 4.1.2; axe-core `aria-hidden-focus`).
+
+The failure this catches is real and serious: keyboard focus lands on a
+control that screen readers do not announce, so the user is on "nothing".
+
+WHY THIS WAS REWRITTEN
+----------------------
+The previous implementation treated `tabindex` **with any value** as proof of
+focusability:
+
+    echo "${tag}" | grep -qE '(^|[[:space:]])(:?tabindex|v-bind:tabindex)[[:space:]]*=' && _focusable=1
+
+`tabindex="-1"` is the attribute that **REMOVES** an element from the tab
+order. It is the one value that proves the opposite of what the gate concluded.
+So the gate's own subject — "hidden from AT *and still reachable by keyboard*"
+— was inverted for every element that had already been fixed.
+
+The canonical hidden-file-input pattern trips it exactly:
+
+    <input ref="fileInput" type="file" :aria-hidden="true" tabindex="-1"
+           @change="onFileInputChange">            (nc-vue CnFilesWidget)
+
+That input is correct. It is hidden from AT, removed from the tab order, and
+driven by a visible `<button>` next to it. The gate's advice was to remove
+`aria-hidden` (exposing a control with no name to screen readers) or to remove
+`tabindex="-1"` (putting a control screen readers cannot see BACK in the tab
+order — the very defect this gate exists to catch). Both remediations regress
+accessibility. See ConductionNL/.github#222.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+Everything genuinely reachable:
+
+  * `tabindex="0"` (or any non-negative value) + `aria-hidden="true"`
+  * a native focusable element (`<a href>`, `<button>`, `<input>`, `<select>`,
+    `<textarea>`, `<details>`, `<summary>`, `<iframe>`) with `aria-hidden="true"`
+    and no negative `tabindex` to take it out of the order
+  * an interactive `role=` + `aria-hidden="true"`
+  * a BOUND `:tabindex="expr"` whose value cannot be read here — unknown is not
+    "safe", and the previous behaviour (flag it) is kept.
+
+The negative-`tabindex` exemption is deliberately the ONLY relaxation, and it
+overrides the native-tag signal, because that is what the attribute does in
+every browser: `tabindex="-1"` takes ANY element, native or not, out of
+sequential navigation.
+
+Usage:
+    check_aria_hidden_focusable.py <file.vue>...     # findings on stdout
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# Opening tags, quote-aware so a `>` inside an attribute value does not end
+# the tag early (`:title="a > b"`). The old grep used `[^>]*` and did.
+TAG = re.compile(
+    r'<([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)/?>',
+    re.DOTALL,
+)
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+
+# `aria-hidden` truthy, literal or bound: aria-hidden="true", :aria-hidden="true".
+ARIA_HIDDEN_TRUE = re.compile(
+    r'(?:^|\s)(?::|v-bind:)?aria-hidden\s*=\s*["\']\s*true\s*["\']')
+
+NATIVE_FOCUSABLE = {'a', 'button', 'input', 'select', 'textarea',
+                    'details', 'summary', 'iframe', 'audio', 'video'}
+
+INTERACTIVE_ROLE = re.compile(
+    r'(?:^|\s)role\s*=\s*"(?:button|link|menuitem|tab|checkbox|radio|switch|'
+    r'option|treeitem|gridcell|columnheader|rowheader|slider|spinbutton|'
+    r'searchbox|combobox|textbox)"')
+
+ANY_TABINDEX = re.compile(r'(?:^|\s)(?::|v-bind:)?tabindex\s*=')
+# A tabindex whose value is a readable integer literal, bound or not.
+# `:tabindex="-1"` is as static as `tabindex="-1"`.
+TABINDEX_LITERAL = re.compile(
+    r'(?:^|\s)(?::|v-bind:)?tabindex\s*=\s*["\']\s*(-?\d+)\s*["\']')
+
+HREF = re.compile(r'(?:^|\s)(?::|v-bind:)?href\s*=')
+
+
+def _tabindex_value(attrs: str) -> int | None:
+    """The element's tabindex as an int, or None when absent or unreadable."""
+    m = TABINDEX_LITERAL.search(attrs)
+    return int(m.group(1)) if m else None
+
+
+def is_focusable(name: str, attrs: str) -> bool:
+    """Can a keyboard user reach this element by tabbing to it?"""
+    ti = _tabindex_value(attrs)
+    # THE FIX. A negative tabindex removes the element from sequential
+    # navigation, whatever it is — native control, ARIA widget or div. It is
+    # the correct half of the canonical hidden-input pattern, and treating it
+    # as focusable inverted this gate's own subject.
+    if ti is not None and ti < 0:
+        return False
+    if ti is not None:          # 0 or positive: explicitly IN the tab order.
+        return True
+    # An unreadable bound value (`:tabindex="foo"`) could be anything; unknown
+    # is not safe, so the pre-existing behaviour is kept.
+    if ANY_TABINDEX.search(attrs):
+        return True
+    if name in NATIVE_FOCUSABLE:
+        # `<a>` is focusable only with an href.
+        return name != 'a' or bool(HREF.search(attrs))
+    return bool(INTERACTIVE_ROLE.search(attrs))
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    body = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    findings: list[str] = []
+    for m in TAG.finditer(body):
+        name, attrs = m.group(1), m.group(2) or ''
+        # Vue/NC component shells (<NcAvatar>, <RouterLink>) are component
+        # invocations; their internal a11y wiring is the component's problem,
+        # not the consumer's. Unchanged from the previous implementation.
+        if name[:1].isupper():
+            continue
+        if not ARIA_HIDDEN_TRUE.search(attrs):
+            continue
+        if not is_focusable(name, attrs):
+            continue
+        tag = re.sub(r'\s+', ' ', m.group(0)).strip()
+        if len(tag) > 200:
+            tag = tag[:197] + '...'
+        findings.append(f'{fname}: {tag} rule=aria-hidden-on-focusable-element')
+    return findings
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_table_headers.py
+++ b/hydra-gates/scripts/lib/check_table_headers.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+r"""Gate-43 table-headers — every `<th>` must declare `scope=` so screen
+readers can associate data cells with their headers (WCAG 2.2 AA SC 1.3.1).
+
+WHY THIS WAS REWRITTEN
+----------------------
+The previous implementation counted TABLES, and it counted them
+at-least-one-wise:
+
+    if re.search(r'<th\b[^>]*\bscope\s*=', body, re.IGNORECASE):
+        continue                       # <- whole table accepted
+
+A SINGLE `scope=` attribute anywhere in a table greened the entire table.
+Proven by negative control: removing exactly one `scope=` from a passing
+table still reported PASS. A table with six headers and one `scope=` — the
+common shape when someone fixes the first column and stops — was
+indistinguishable from a correct one, and the row headers screen-reader users
+actually need were never asked for. See ConductionNL/.github#222.
+
+WHAT IS COUNTED
+---------------
+One finding per `<table>`, NOT one per `<th>`, and the line says how many of
+its headers are unscoped (`unscoped=2/6`). Two reasons: the number stays a
+count of DEFECT SITES rather than of attributes, so it is comparable with the
+number this gate reported before the fix; and a table is what a person
+actually sits down and fixes. A finding count is not a defect count, and the
+two should not be silently swapped while a gate is being repaired.
+
+Accepted as a scope declaration: `scope=`, `:scope=`, `v-bind:scope=`. A
+bound scope is a real one — `:scope="isRowHeader ? 'row' : 'col'"` produces
+the attribute the browser reads.
+
+A HEADER WITH NO NAME IS NOT A HEADER
+-------------------------------------
+Tightening the rule to per-header immediately produced 8 findings in
+openconnector, a repo the old rule reported PASS — and ALL EIGHT were the
+same false positive: the empty spacer column that carries a drag handle or a
+row-actions menu.
+
+    <th class="cn-rules-editor__col-handle" aria-hidden="true" />
+    <th />
+
+`scope=` declares which cells a header NAMES. A header with no accessible
+name names nothing, so the attribute associates nothing and adding it is
+remediation theatre — the same trap as gate-40's `aria-label` advice, where
+the only way to close a finding was to ship a change that helped no one. So a
+`<th>` is exempt when it has no accessible name of its own:
+
+  * `aria-hidden="true"`, or `role="presentation"` / `role="none"`
+  * empty content — self-closing, or a body that is whitespace only
+
+A header WITH text and no `scope=` is untouched by this and still fails.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+  * any NAMED `<th>` in the table without a scope declaration -> th-without-scope
+  * a table with `<td>` rows and no `<th>` at all             -> table-without-th
+
+Comments and `<script>`/`<style>` blocks are excluded: markup that does not
+ship is not a table. Wrapper components (`<CnDataTable>`, `<NcTable>`) own
+their own markup and are not in scope, as before.
+
+Usage:
+    check_table_headers.py <file.vue>...        # findings on stdout
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+
+TABLE = re.compile(r'<table\b([^>]*)>(.*?)</table\s*>', re.IGNORECASE | re.DOTALL)
+# Quote-aware attribute run, so `:title="a > b"` inside a <th> does not end
+# the tag early and hide the missing scope behind a parse error.
+#
+# The body is matched SEPARATELY, in _headers(), rather than as an optional
+# group here. A `(?:(.*?)</th>)?` tail looks equivalent and is not: against
+# `<th /><th scope="col">A</th>` the optional group happily reaches past the
+# self-closed tag to the FIRST `</th>` in the file, swallowing the next
+# header whole — two headers were counted as one.
+TH_OPEN = re.compile(
+    r'<th\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/)?>', re.IGNORECASE | re.DOTALL)
+TH_CLOSE = re.compile(r'</th\s*>', re.IGNORECASE)
+TD = re.compile(r'<td\b', re.IGNORECASE)
+SCOPE = re.compile(r'(?:^|\s)(?::|v-bind:)?scope\s*=')
+ARIA_HIDDEN_TRUE = re.compile(
+    r'(?:^|\s)(?::|v-bind:)?aria-hidden\s*=\s*["\']\s*true\s*["\']')
+PRESENTATIONAL_ROLE = re.compile(r'(?:^|\s)role\s*=\s*["\'](?:presentation|none)["\']')
+ANY_TAG = re.compile(r'<[^>]*>', re.DOTALL)
+
+
+def _has_accessible_name(attrs: str, body: str | None, self_closed: bool) -> bool:
+    """Does this `<th>` name anything at all?
+
+    A header with no name associates no cells, so `scope=` on it is inert and
+    demanding it is remediation theatre. Mirrors gate-40's rule that an
+    element named by its slot must not be told to add `aria-label`.
+    """
+    if ARIA_HIDDEN_TRUE.search(attrs) or PRESENTATIONAL_ROLE.search(attrs):
+        return False
+    if self_closed or body is None:
+        return False
+    # Strip nested markup; `{{ t('app', 'Property') }}` counts — it is the
+    # translated visible header text.
+    return bool(ANY_TAG.sub(' ', body).strip())
+
+
+def _headers(inner: str) -> list[tuple[str, str | None, bool]]:
+    """Every `<th>` in a table body as (attrs, body-or-None, self_closed)."""
+    out: list[tuple[str, str | None, bool]] = []
+    for m in TH_OPEN.finditer(inner):
+        attrs, self_closed = m.group(1) or '', m.group(2) == '/'
+        body: str | None = None
+        if not self_closed:
+            close = TH_CLOSE.search(inner, m.end())
+            body = inner[m.end():close.start()] if close else ''
+        out.append((attrs, body, self_closed))
+    return out
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    body = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    findings: list[str] = []
+    for m in TABLE.finditer(body):
+        inner = m.group(2) or ''
+        ths = _headers(inner)
+        named = [a for a, b, sc in ths if _has_accessible_name(a, b, sc)]
+        if named:
+            unscoped = [a for a in named if not SCOPE.search(a)]
+            if unscoped:
+                # THE FIX: any unscoped NAMED header fails the table. The old
+                # rule was "any scoped header passes it".
+                findings.append(
+                    f'{fname}: <table> unscoped={len(unscoped)}/{len(named)} '
+                    f'rule=th-without-scope')
+        elif not ths and TD.search(inner):
+            findings.append(f'{fname}: <table> rule=table-without-th')
+    return findings
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_aria_hidden_focusable.py
+++ b/hydra-gates/scripts/lib/test_check_aria_hidden_focusable.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_aria_hidden_focusable (gate-37). Run with:
+
+    python3 scripts/lib/test_check_aria_hidden_focusable.py
+
+BOTH ARMS, EVERY TIME
+---------------------
+gate-37 counted `tabindex="-1"` as focusable — the one attribute value that
+proves an element is NOT in the tab order. Its remediation advice was
+therefore to either expose an unnamed control to screen readers, or to put a
+control screen readers cannot see back into the tab order: the exact defect
+this gate exists to catch. Both regress accessibility (#222).
+
+The relaxation is narrow — negative tabindex, and nothing else — so every
+test below that asserts "not flagged" is paired with the near-identical case
+that must still be flagged. A gate that stops catching its own subject is
+worse than no gate, because it reports PASS while doing it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_aria_hidden_focusable as ahf  # noqa: E402
+
+
+def rules(markup: str) -> list[str]:
+    src = "<template>\n" + markup + "\n</template>\n"
+    return [line.rsplit("rule=", 1)[1]
+            for line in ahf.scan_source("Component.vue", src)]
+
+
+FLAG = ["aria-hidden-on-focusable-element"]
+
+
+class NegativeTabindexIsNotFocusable(unittest.TestCase):
+    """THE FIX. `tabindex="-1"` removes the element from sequential
+    navigation — for native controls too, which is why it overrides the
+    native-tag signal."""
+
+    def test_fp_the_canonical_hidden_file_input(self):
+        # @conduction/nextcloud-vue CnFilesWidget.vue, verbatim shape. Hidden
+        # from AT, out of the tab order, driven by a visible <button>.
+        self.assertEqual(rules("""
+            <input ref="fileInput"
+                   type="file"
+                   multiple
+                   :aria-hidden="true"
+                   tabindex="-1"
+                   @change="onFileInputChange">
+        """), [])
+
+    def test_fp_a_programmatically_focused_panel(self):
+        # CnContextMenu.vue shape: focused by script on open, never tabbed to.
+        self.assertEqual(rules(
+            '<div class="panel" role="menu" tabindex="-1" aria-hidden="true" />'), [])
+
+    def test_fp_a_drag_handle_taken_out_of_the_order(self):
+        # openconnector MappingRulesEditor.vue: the row itself is tabbable,
+        # the handle inside it deliberately is not.
+        self.assertEqual(rules(
+            '<button type="button" aria-hidden="true" tabindex="-1">x</button>'), [])
+
+    def test_fp_a_bound_negative_literal_reads_the_same(self):
+        self.assertEqual(rules('<div :tabindex="-1" aria-hidden="true" />'), [])
+
+    def test_fp_any_negative_value(self):
+        self.assertEqual(rules('<div tabindex="-2" aria-hidden="true" />'), [])
+
+    # ---- the paired true positives ----------------------------------------
+    def test_tp_tabindex_zero_is_still_flagged(self):
+        # ONE CHARACTER from the fixture above, and it must flip.
+        self.assertEqual(rules('<div tabindex="0" aria-hidden="true" />'), FLAG)
+
+    def test_tp_positive_tabindex_is_still_flagged(self):
+        self.assertEqual(rules('<div tabindex="3" aria-hidden="true" />'), FLAG)
+
+    def test_tp_a_file_input_WITHOUT_the_negative_tabindex_is_still_flagged(self):
+        # The negative control for the canonical pattern: same element, minus
+        # the one attribute that takes it out of the tab order.
+        self.assertEqual(rules("""
+            <input ref="fileInput" type="file" multiple :aria-hidden="true"
+                   @change="onFileInputChange">
+        """), FLAG)
+
+    def test_tp_a_bound_unreadable_tabindex_is_still_flagged(self):
+        # Unknown is not safe. Keeps the previous behaviour deliberately.
+        self.assertEqual(rules('<div :tabindex="idx" aria-hidden="true" />'), FLAG)
+
+
+class NativeFocusable(unittest.TestCase):
+    def test_tp_a_button(self):
+        self.assertEqual(rules('<button aria-hidden="true">x</button>'), FLAG)
+
+    def test_tp_an_anchor_with_href(self):
+        self.assertEqual(rules('<a href="/x" aria-hidden="true">x</a>'), FLAG)
+
+    def test_fp_an_anchor_without_href_is_not_focusable(self):
+        self.assertEqual(rules('<a aria-hidden="true">x</a>'), [])
+
+    def test_tp_an_anchor_with_a_bound_href(self):
+        self.assertEqual(rules('<a :href="url" aria-hidden="true">x</a>'), FLAG)
+
+    def test_tp_a_select(self):
+        self.assertEqual(rules('<select aria-hidden="true"><option>a</option></select>'), FLAG)
+
+
+class InteractiveRoles(unittest.TestCase):
+    def test_tp_role_button(self):
+        self.assertEqual(rules('<div role="button" aria-hidden="true" />'), FLAG)
+
+    def test_fp_a_presentational_div(self):
+        self.assertEqual(rules('<div class="decoration" aria-hidden="true" />'), [])
+
+    def test_fp_role_presentation(self):
+        self.assertEqual(rules('<div role="presentation" aria-hidden="true" />'), [])
+
+    def test_fp_a_decorative_icon_span(self):
+        # By far the most common correct use of aria-hidden. Must stay quiet.
+        self.assertEqual(rules('<span class="icon-star" aria-hidden="true" />'), [])
+
+
+class ScopeAndParsing(unittest.TestCase):
+    def test_pascal_case_components_are_the_components_problem(self):
+        self.assertEqual(rules('<NcAvatar tabindex="0" aria-hidden="true" />'), [])
+
+    def test_commented_out_markup_ships_nothing(self):
+        self.assertEqual(rules('<!-- <div tabindex="0" aria-hidden="true" /> -->'), [])
+
+    def test_script_blocks_are_not_markup(self):
+        src = ('<template><p>hi</p></template>\n<script>\n'
+               'const s = \'<div tabindex="0" aria-hidden="true">\'\n</script>\n')
+        self.assertEqual(
+            [l.rsplit("rule=", 1)[1] for l in ahf.scan_source("C.vue", src)], [])
+
+    def test_a_greater_than_inside_an_attribute_does_not_end_the_tag(self):
+        # The old `[^>]*` grep ended the tag at the `>` in the expression and
+        # could not see the tabindex that followed.
+        self.assertEqual(
+            rules('<div :title="a > b" aria-hidden="true" tabindex="0" />'), FLAG)
+
+    def test_aria_hidden_false_is_not_hidden(self):
+        self.assertEqual(rules('<div tabindex="0" aria-hidden="false" />'), [])
+
+    def test_multiple_findings_in_one_file_are_reported_separately(self):
+        self.assertEqual(rules("""
+            <div tabindex="0" aria-hidden="true" />
+            <button aria-hidden="true">x</button>
+            <input type="file" aria-hidden="true" tabindex="-1">
+        """), FLAG * 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_table_headers.py
+++ b/hydra-gates/scripts/lib/test_check_table_headers.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_table_headers (gate-43). Run with:
+
+    python3 scripts/lib/test_check_table_headers.py
+
+THE NEGATIVE CONTROL THAT NAMED THE DEFECT
+------------------------------------------
+gate-43 accepted a whole table on the strength of ONE `scope=` anywhere in
+it. Removing exactly one `scope=` from a passing table still reported PASS
+(#222). `test_removing_exactly_one_scope_flips_the_verdict` below IS that
+experiment, run as an assertion: it builds a table that passes, deletes a
+single attribute, and requires the verdict to change. If the
+at-least-one-wise rule is ever reintroduced, that test is the one that fails.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_table_headers as cth  # noqa: E402
+
+
+def findings(markup: str) -> list[str]:
+    src = "<template>\n" + markup + "\n</template>\n"
+    return cth.scan_source("Component.vue", src)
+
+
+def rules(markup: str) -> list[str]:
+    return [line.rsplit("rule=", 1)[1] for line in findings(markup)]
+
+
+PASSING_TABLE = """
+<table class="rules">
+    <thead>
+        <tr>
+            <th scope="col">Key</th>
+            <th scope="col">Value</th>
+            <th scope="col">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td>a</td><td>1</td><td>x</td></tr>
+    </tbody>
+</table>
+"""
+
+
+class TheNegativeControl(unittest.TestCase):
+    def test_a_fully_scoped_table_passes(self):
+        self.assertEqual(rules(PASSING_TABLE), [])
+
+    def test_removing_exactly_one_scope_flips_the_verdict(self):
+        # THE EXPERIMENT FROM #222, as an assertion. One attribute, one
+        # occurrence, and the table must stop passing.
+        mutated = PASSING_TABLE.replace('<th scope="col">Value</th>',
+                                        '<th>Value</th>', 1)
+        self.assertNotEqual(mutated, PASSING_TABLE, "the mutation did not apply")
+        self.assertEqual(rules(mutated), ["th-without-scope"])
+
+    def test_the_finding_says_how_many_headers_are_unscoped(self):
+        mutated = PASSING_TABLE.replace('<th scope="col">Value</th>',
+                                        '<th>Value</th>', 1)
+        self.assertIn("unscoped=1/3", findings(mutated)[0])
+
+    def test_a_table_where_only_the_first_column_was_fixed(self):
+        # The shape this defect hid: someone scopes one header and stops.
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">Name</th><th>Size</th><th>Modified</th></tr>
+                <tr><td>a</td><td>1</td><td>x</td></tr>
+            </table>
+        """), ["th-without-scope"])
+        self.assertIn("unscoped=2/3", findings("""
+            <table>
+                <tr><th scope="col">Name</th><th>Size</th><th>Modified</th></tr>
+                <tr><td>a</td><td>1</td><td>x</td></tr>
+            </table>
+        """)[0])
+
+
+class StillCaught(unittest.TestCase):
+    def test_no_scope_anywhere(self):
+        self.assertEqual(rules(
+            '<table><tr><th>A</th><th>B</th></tr>'
+            '<tr><td>1</td><td>2</td></tr></table>'), ["th-without-scope"])
+
+    def test_a_data_table_with_no_headers_at_all(self):
+        self.assertEqual(rules(
+            '<table><tr><td>1</td><td>2</td></tr></table>'), ["table-without-th"])
+
+    def test_row_headers_in_the_body_are_asked_too(self):
+        # The scoped <th> is in the head; the unscoped ones are row headers in
+        # the body — precisely the association a screen-reader user needs.
+        self.assertEqual(rules("""
+            <table>
+                <thead><tr><th scope="col">Metric</th><th scope="col">Value</th></tr></thead>
+                <tbody>
+                    <tr><th>Uptime</th><td>99%</td></tr>
+                    <tr><th>Errors</th><td>3</td></tr>
+                </tbody>
+            </table>
+        """), ["th-without-scope"])
+
+    def test_each_table_is_reported_separately(self):
+        self.assertEqual(rules(
+            '<table><tr><th>A</th></tr><tr><td>1</td></tr></table>'
+            '<table><tr><td>1</td></tr></table>'),
+            ["th-without-scope", "table-without-th"])
+
+
+class NotFindings(unittest.TestCase):
+    def test_a_bound_scope_is_a_real_scope(self):
+        # `:scope="isRow ? 'row' : 'col'"` produces the attribute the browser
+        # reads. Refusing it would demand a literal for no a11y benefit.
+        self.assertEqual(rules("""
+            <table>
+                <tr><th :scope="headerScope">A</th><th scope="col">B</th></tr>
+                <tr><td>1</td><td>2</td></tr>
+            </table>
+        """), [])
+
+    def test_a_layout_table_with_neither_th_nor_td(self):
+        self.assertEqual(rules('<table><caption>x</caption></table>'), [])
+
+    def test_commented_out_markup_ships_nothing(self):
+        self.assertEqual(rules(
+            '<!-- <table><tr><th>A</th></tr><tr><td>1</td></tr></table> -->'), [])
+
+    def test_a_wrapper_component_owns_its_own_markup(self):
+        self.assertEqual(rules('<CnDataTable :rows="rows" />'), [])
+
+    def test_a_greater_than_inside_a_th_attribute_does_not_hide_the_scope(self):
+        # A `[^>]*` attribute run would end the tag at the expression's `>`
+        # and report a correctly-scoped header as unscoped.
+        self.assertEqual(rules("""
+            <table>
+                <tr><th :class="a > b ? 'x' : 'y'" scope="col">A</th></tr>
+                <tr><td>1</td></tr>
+            </table>
+        """), [])
+
+    def test_self_closing_th_with_scope(self):
+        self.assertEqual(rules(
+            '<table><tr><th scope="col" /></tr><tr><td>1</td></tr></table>'), [])
+
+
+class UnnamedHeadersAreNotHeaders(unittest.TestCase):
+    """Tightening to per-header produced 8 findings in openconnector, a repo
+    the old rule passed — and all 8 were this same spacer column. `scope=` on
+    a header with no name associates nothing."""
+
+    def test_fp_an_aria_hidden_spacer_column(self):
+        # openconnector MappingRulesEditor.vue, verbatim: the drag-handle column.
+        self.assertEqual(rules("""
+            <table>
+                <thead><tr>
+                    <th class="col-handle" aria-hidden="true" />
+                    <th scope="col">Target property</th>
+                    <th scope="col">Template</th>
+                </tr></thead>
+                <tbody><tr><td>a</td><td>b</td><td>c</td></tr></tbody>
+            </table>
+        """), [])
+
+    def test_fp_an_empty_self_closed_actions_column(self):
+        # openconnector ApprovalsIndex.vue / SyncDeadLetterPage.vue shape.
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">Name</th><th /></tr>
+                <tr><td>a</td><td><button>x</button></td></tr>
+            </table>
+        """), [])
+
+    def test_fp_an_empty_paired_th(self):
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">Name</th><th></th></tr>
+                <tr><td>a</td><td>b</td></tr>
+            </table>
+        """), [])
+
+    def test_fp_role_presentation(self):
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">Name</th><th role="presentation">x</th></tr>
+                <tr><td>a</td><td>b</td></tr>
+            </table>
+        """), [])
+
+    # ---- the paired true positives ----------------------------------------
+    def test_tp_the_same_column_WITH_a_name_is_still_asked(self):
+        # One word of content is the whole difference.
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">Name</th><th>Actions</th></tr>
+                <tr><td>a</td><td>b</td></tr>
+            </table>
+        """), ["th-without-scope"])
+
+    def test_tp_a_header_named_by_an_interpolation_is_still_asked(self):
+        self.assertEqual(rules("""
+            <table>
+                <tr><th scope="col">A</th><th>{{ t('app', 'Size') }}</th></tr>
+                <tr><td>1</td><td>2</td></tr>
+            </table>
+        """), ["th-without-scope"])
+
+    def test_a_table_of_only_unnamed_headers_is_not_reported_as_headerless(self):
+        # It HAS <th> elements, so `table-without-th` would be a wrong
+        # diagnosis; and none of them can carry a useful scope.
+        self.assertEqual(rules(
+            '<table><tr><th /><th /></tr><tr><td>1</td><td>2</td></tr></table>'), [])
+
+    def test_the_count_only_counts_named_headers(self):
+        mutated = """
+            <table>
+                <tr><th aria-hidden="true" /><th scope="col">A</th><th>B</th></tr>
+                <tr><td>1</td><td>2</td><td>3</td></tr>
+            </table>
+        """
+        self.assertIn("unscoped=1/2", findings(mutated)[0])
+
+
+class ScriptBlocks(unittest.TestCase):
+    def test_a_table_in_a_script_string_is_not_markup(self):
+        src = ('<template><p>hi</p></template>\n<script>\n'
+               "const t = '<table><tr><th>A</th></tr><tr><td>1</td></tr></table>'\n"
+               '</script>\n')
+        self.assertEqual(cth.scan_source("C.vue", src), [])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_a11y_helper_wiring.sh — a broken a11y helper must report SKIPPED,
+# never PASS, and must never take the rest of the run down with it.
+#
+# WHY THIS EXISTS
+# ---------------
+# gates 37 and 43 were moved out of the runner into python helpers. Both call
+# sites started life as:
+#
+#     python3 "${helper}" "${files[@]}" >> "${log}" 2>/dev/null || true
+#
+# which discards the traceback AND the failure. A helper that crashes leaves an
+# empty findings log, and an empty findings log is how these gates spell PASS —
+# a falsely-green gate manufactured by its own plumbing, which is exactly the
+# defect #147 was filed for and gate-19 (#249) was re-plumbed for.
+#
+# The second failure mode is worse and less obvious. gate-19's block turns
+# `set -e` ON and leaves it on for every gate after it, though this script's
+# header sets only `set -u`. With errexit live, a non-zero helper does not
+# reach its own `_skip` — it kills the entire runner mid-sweep. When this was
+# first measured on gate-38, 21 later gates went silently unreported and the
+# run ended on the abort guard. So each case below asserts BOTH that the gate
+# says SKIPPED and that the run still reached its COVERAGE summary.
+#
+# Run: bash scripts/lib/test_gate_a11y_helper_wiring.sh   (exit 0 = green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+
+_fail_n=0
+_pass_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+# A minimal app tree with something for each gate to find, so "no finding" can
+# never be confused with "nothing to look at".
+_APP="$(mktemp -d "${TMPDIR:-/tmp}/hydra-a11y-app.XXXXXXXX")" || exit 1
+mkdir -p "${_APP}/src" "${_APP}/lib" "${_APP}/appinfo"
+cat > "${_APP}/src/Thing.vue" <<'VUE'
+<template>
+	<div>
+		<div tabindex="0" aria-hidden="true">unreachable-but-tabbable</div>
+		<table>
+			<tr><th>Name</th><th>Size</th></tr>
+			<tr><td>a</td><td>1</td></tr>
+		</table>
+	</div>
+</template>
+VUE
+
+_STAGE=""
+_stage() {   # copy the package so a helper can be broken without touching it
+    _STAGE="$(mktemp -d "${TMPDIR:-/tmp}/hydra-a11y-pkg.XXXXXXXX")" || return 1
+    cp -r "${PKG_ROOT}/scripts" "${_STAGE}/scripts" || return 1
+    return 0
+}
+
+_verdict() {  # <gate-n> -> echoes the gate's verdict line
+    local _logdir _out
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-a11y-log.XXXXXXXX")"
+    _out="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${_STAGE}/scripts/run-hydra-gates.sh" "${_APP}" 2>&1 || true)"
+    printf '%s' "${_out}"
+    rm -rf "${_logdir}"
+}
+
+_check() {  # <gate-n> <gate-name> <how-broken> <out>
+    local _n="$1" _name="$2" _how="$3" _out="$4" _line
+    _line="$(printf '%s' "${_out}" | grep -E "^\[gate-${_n}\] " | head -1)"
+    case "${_line}" in
+        *"SKIPPED"*) _ok "gate-${_n} ${_name}: a ${_how} helper reports SKIPPED" ;;
+        *": PASS"*)  _bad "gate-${_n} ${_name}: a ${_how} helper reported PASS having inspected NOTHING — ${_line}" ;;
+        "")          _bad "gate-${_n} ${_name}: a ${_how} helper produced NO verdict line at all (did the run abort?)" ;;
+        *)           _bad "gate-${_n} ${_name}: wanted SKIPPED, got — ${_line}" ;;
+    esac
+    # The run must still finish. An aborted run's PASS lines read exactly like
+    # a clean run's, so "did not abort" is a separate assertion from "SKIPPED".
+    if printf '%s' "${_out}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _ok "gate-${_n} ${_name}: the run still reached its summary — later gates were not lost"
+    else
+        _bad "gate-${_n} ${_name}: the run ABORTED — a ${_how} helper took the whole sweep down"
+    fi
+}
+
+echo "== gate-37 / gate-43 helper wiring =="
+echo
+
+# ---------------------------------------------------------------------------
+# 0. POSITIVE CONTROL. With both helpers intact the fixture app must FAIL both
+#    gates. Every assertion below is only meaningful because these fire.
+# ---------------------------------------------------------------------------
+if _stage; then
+    _out="$(_verdict)"
+    for _g in 37 43; do
+        _line="$(printf '%s' "${_out}" | grep -E "^\[gate-${_g}\] " | head -1)"
+        case "${_line}" in
+            *": FAIL"*) _ok "positive control: gate-${_g} FAILS on the fixture app — ${_line%%—*}" ;;
+            *) _bad "positive control: gate-${_g} did not fail on a fixture built to fail it — ${_line:-<none>}" ;;
+        esac
+    done
+    rm -rf "${_STAGE}"
+else
+    _bad "could not stage the package — nothing below ran"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. MISSING helper (#147).
+# ---------------------------------------------------------------------------
+for _case in "37:aria-hidden-focusable:check_aria_hidden_focusable.py" \
+             "43:table-headers:check_table_headers.py"; do
+    _n="${_case%%:*}"; _rest="${_case#*:}"; _name="${_rest%%:*}"; _file="${_rest#*:}"
+    if _stage; then
+        rm -f "${_STAGE}/scripts/lib/${_file}"
+        _check "${_n}" "${_name}" "MISSING" "$(_verdict)"
+        rm -rf "${_STAGE}"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. CRASHING helper (#249). Present, importable path, dies on invocation.
+#    This is the case `2>/dev/null || true` could not tell from "no findings".
+# ---------------------------------------------------------------------------
+for _case in "37:aria-hidden-focusable:check_aria_hidden_focusable.py" \
+             "43:table-headers:check_table_headers.py"; do
+    _n="${_case%%:*}"; _rest="${_case#*:}"; _name="${_rest%%:*}"; _file="${_rest#*:}"
+    if _stage; then
+        printf 'raise SystemExit("boom")\n' > "${_STAGE}/scripts/lib/${_file}"
+        _check "${_n}" "${_name}" "CRASHING" "$(_verdict)"
+        rm -rf "${_STAGE}"
+    fi
+done
+
+rm -rf "${_APP}"
+
+echo
+echo "== summary =="
+printf '   passed: %d\n   failed: %d\n' "${_pass_n}" "${_fail_n}"
+[ "${_fail_n}" -eq 0 ] || exit 1
+echo
+echo "ALL wiring assertions held."

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3063,59 +3063,51 @@ fi
 #   - openspec/architecture/wcag-coverage.md SC 4.1.2 (Name, Role, Value)
 #   - axe-core rule `aria-hidden-focus` (impact: serious)
 # ---------------------------------------------------------------------------
+#
+# `tabindex="-1"` IS NOT FOCUSABLE (#222)
+# --------------------------------------
+# Until 2026-08-08 this gate treated `tabindex` WITH ANY VALUE as proof of
+# focusability. `tabindex="-1"` is the attribute that REMOVES an element from
+# the tab order — the one value that proves the opposite of what the gate
+# concluded — so the gate's own subject was inverted for every element that
+# had already been fixed. The canonical hidden-file-input pattern
+#
+#     <input type="file" :aria-hidden="true" tabindex="-1" @change="…">
+#
+# is correct, and the gate's advice was to remove `aria-hidden` (exposing an
+# unnamed control to screen readers) or to remove `tabindex="-1"` (putting a
+# control screen readers cannot see BACK in the tab order — the very defect
+# this gate exists to catch). Both remediations regress accessibility.
+#
+# Implementation moved to scripts/lib/check_aria_hidden_focusable.py, with
+# both-arms tests in scripts/lib/test_check_aria_hidden_focusable.py.
+# ---------------------------------------------------------------------------
 if [ -d src ]; then
     _ahf_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-aria-hidden-focusable.log
     : > "${_ahf_log}"
+    _ahf_ran=1
+    _ahf_helper="${SCRIPT_DIR}/lib/check_aria_hidden_focusable.py"
+    _ahf_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        _flat=$(tr '\n' ' ' < "${vue}")
-        # Match every opening HTML tag that contains aria-hidden="true".
-        # We grep with -oE for the full tag including all attributes.
-        echo "${_flat}" \
-            | grep -oE '<[a-zA-Z][a-zA-Z0-9-]*\b[^>]*aria-hidden[[:space:]]*=[[:space:]]*"true"[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                # Extract the element name (between < and the first space-or->).
-                _elem=$(echo "${tag}" | sed -nE 's|^<([a-zA-Z][a-zA-Z0-9-]*)\b.*|\1|p')
-                [ -z "${_elem}" ] && continue
-                # Vue/NC component shells like <NcAvatar> or <RouterLink>
-                # are component invocations; their internal a11y wiring is
-                # the component's problem, not the consumer's. Skip
-                # PascalCase tags (starts with uppercase).
-                case "${_elem}" in
-                    [A-Z]*) continue ;;
-                esac
-                # Focusable signals:
-                #   1. native focusable tag
-                #   2. tabindex= attribute (any value)
-                #   3. interactive role=
-                _focusable=0
-                case "${_elem}" in
-                    a|button|input|select|textarea|details|summary|iframe|audio|video)
-                        # `<a>` is only focusable when href is set.
-                        if [ "${_elem}" = "a" ]; then
-                            echo "${tag}" | grep -qE '\bhref[[:space:]]*=' && _focusable=1
-                        else
-                            _focusable=1
-                        fi
-                        ;;
-                esac
-                if [ "${_focusable}" -eq 0 ]; then
-                    echo "${tag}" | grep -qE '(^|[[:space:]])(:?tabindex|v-bind:tabindex)[[:space:]]*=' && _focusable=1
-                fi
-                if [ "${_focusable}" -eq 0 ]; then
-                    echo "${tag}" | grep -qE 'role[[:space:]]*=[[:space:]]*"(button|link|menuitem|tab|checkbox|radio|switch|option|treeitem|gridcell|columnheader|rowheader|slider|spinbutton|searchbox|combobox|textbox)"' && _focusable=1
-                fi
-                if [ "${_focusable}" -eq 1 ]; then
-                    echo "${vue}: ${tag} rule=aria-hidden-on-focusable-element" >> "${_ahf_log}"
-                fi
-            done
+        _ahf_files+=("${vue}")
     done < <(find src -name '*.vue' 2>/dev/null)
-    _ahf_fail=$(wc -l < "${_ahf_log}" 2>/dev/null || echo 0)
-    if [ "${_ahf_fail}" -eq 0 ]; then
-        _pass 37 "aria-hidden-focusable"
+    if [ "${#_ahf_files[@]}" -eq 0 ]; then
+        :   # nothing in scope; the PASS below describes the diff, as everywhere else.
+    elif [ ! -f "${_ahf_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _ahf_ran=0
+        _skip 37 "aria-hidden-focusable" wiring "check_aria_hidden_focusable.py not found at ${_ahf_helper} — ${#_ahf_files[@]} .vue file(s) were in scope and NONE were inspected; focusable elements hidden from assistive tech (WCAG 4.1.2) are UNVERIFIED by this run."
     else
-        _fail 37 "aria-hidden-focusable" "${_ahf_fail} aria-hidden=true on focusable element(s) — remove aria-hidden OR remove the focusable mechanism — see ${_ahf_log}"
+        python3 "${_ahf_helper}" "${_ahf_files[@]}" >> "${_ahf_log}" 2>/dev/null || true
+    fi
+    _ahf_fail=$(wc -l < "${_ahf_log}" 2>/dev/null || echo 0)
+    if [ "${_ahf_ran}" -eq 1 ]; then
+        if [ "${_ahf_fail}" -eq 0 ]; then
+            _pass 37 "aria-hidden-focusable"
+        else
+            _fail 37 "aria-hidden-focusable" "${_ahf_fail} aria-hidden=true on focusable element(s) — remove aria-hidden OR remove the focusable mechanism — see ${_ahf_log}"
+        fi
     fi
 fi
 
@@ -3409,16 +3401,39 @@ PYLQ
 fi
 
 # ---------------------------------------------------------------------------
-# Gate 43: Table-headers — every `<table>` in `.vue` templates must have at
-# least one `<th>` with a `scope="col"` / `scope="row"` attribute. Without
-# it, screen readers can't associate data cells with their headers. Per
-# WCAG 2.2 AA SC 1.3.1 (Info and Relationships).
+# Gate 43: Table-headers — EVERY `<th>` in a `.vue` template must declare
+# `scope="col"` / `scope="row"`. Without it, screen readers can't associate
+# data cells with their headers. Per WCAG 2.2 AA SC 1.3.1 (Info and
+# Relationships).
+#
+# ONE `scope=` USED TO GREEN THE WHOLE TABLE (#222)
+# ------------------------------------------------
+# Until 2026-08-08 the check was:
+#
+#     if re.search(r'<th\b[^>]*\bscope\s*=', body): continue   # whole table OK
+#
+# A SINGLE `scope=` anywhere in the table accepted every other header in it.
+# Proven by negative control: removing exactly one `scope=` from a passing
+# table still reported PASS. The common shape — someone scopes the first
+# column and stops — was indistinguishable from a correct table, and the row
+# headers screen-reader users actually need were never asked for. The rule is
+# now "any unscoped header fails the table", not "any scoped header passes it".
 #
 # Two failure shapes:
-#   - rule=th-without-scope: <table> has <th> but no scope=
+#   - rule=th-without-scope: one or more <th> in the table lack scope=
+#     (the line reports `unscoped=N/M`)
 #   - rule=table-without-th: <table> with <td> rows but no <th> at all
 #
-# Wrapper components (<CnDataTable>, <NcTable>) are not in scope.
+# COUNTING: one finding per TABLE, not per <th> — the number stays a count of
+# defect sites, comparable with what this gate reported before the fix, and a
+# table is what a person actually sits down and repairs. A finding count is
+# not a defect count, and the two must not be silently swapped mid-repair.
+#
+# Wrapper components (<CnDataTable>, <NcTable>) own their own markup and are
+# not in scope, as before.
+#
+# Implementation: scripts/lib/check_table_headers.py, tests in
+# scripts/lib/test_check_table_headers.py.
 #
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 1.3.1
@@ -3426,31 +3441,29 @@ fi
 if [ -d src ]; then
     _th_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-table-headers.log
     : > "${_th_log}"
+    _th_ran=1
+    _th_helper="${SCRIPT_DIR}/lib/check_table_headers.py"
+    _th_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYTH' >> "${_th_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    src = open(fname).read()
-except Exception:
-    sys.exit(0)
-txt = src.replace('\n', ' ')
-for m in re.finditer(r'<table\b([^>]*)>(.*?)</table>', txt, re.IGNORECASE | re.DOTALL):
-    body = m.group(2) or ''
-    if re.search(r'<th\b[^>]*\bscope\s*=', body, re.IGNORECASE):
-        continue
-    if re.search(r'<th\b', body, re.IGNORECASE):
-        print(f'{fname}: <table> rule=th-without-scope')
-    elif re.search(r'<td\b', body, re.IGNORECASE):
-        print(f'{fname}: <table> rule=table-without-th')
-PYTH
+        _th_files+=("${vue}")
     done < <(find src -name '*.vue' 2>/dev/null)
-    _th_fail=$(wc -l < "${_th_log}" 2>/dev/null || echo 0)
-    if [ "${_th_fail}" -eq 0 ]; then
-        _pass 43 "table-headers"
+    if [ "${#_th_files[@]}" -eq 0 ]; then
+        :   # nothing in scope; the PASS below describes the diff, as everywhere else.
+    elif [ ! -f "${_th_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _th_ran=0
+        _skip 43 "table-headers" wiring "check_table_headers.py not found at ${_th_helper} — ${#_th_files[@]} .vue file(s) were in scope and NONE were inspected; unassociated table headers (WCAG 1.3.1) are UNVERIFIED by this run."
     else
-        _fail 43 "table-headers" "${_th_fail} <table>(s) missing <th scope=> — see ${_th_log}"
+        python3 "${_th_helper}" "${_th_files[@]}" >> "${_th_log}" 2>/dev/null || true
+    fi
+    _th_fail=$(wc -l < "${_th_log}" 2>/dev/null || echo 0)
+    if [ "${_th_ran}" -eq 1 ]; then
+        if [ "${_th_fail}" -eq 0 ]; then
+            _pass 43 "table-headers"
+        else
+            _fail 43 "table-headers" "${_th_fail} <table>(s) with a <th> missing scope= — see ${_th_log}"
+        fi
     fi
 fi
 

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3247,7 +3247,23 @@ if [ -d src ]; then
         _ahf_ran=0
         _skip 37 "aria-hidden-focusable" wiring "check_aria_hidden_focusable.py not found at ${_ahf_helper} — ${#_ahf_files[@]} .vue file(s) were in scope and NONE were inspected; focusable elements hidden from assistive tech (WCAG 4.1.2) are UNVERIFIED by this run."
     else
-        python3 "${_ahf_helper}" "${_ahf_files[@]}" >> "${_ahf_log}" 2>/dev/null || true
+        # THE EXIT CODE IS A STATUS, THE FINDINGS ARE STDOUT (gate-19 / #249).
+        # `2>/dev/null || true` would swallow a traceback AND the failure, so a
+        # crashed helper left an empty log and the gate reported PASS. stderr
+        # is kept; a non-zero exit is a wiring failure, not a clean sheet.
+        #
+        # `set +e` because gate-19's block turns errexit ON and leaves it on
+        # for every gate after it, so a failing helper would kill the whole
+        # runner instead of reaching the _skip below.
+        case $- in *e*) _ahf_had_e=1 ;; *) _ahf_had_e=0 ;; esac
+        set +e
+        python3 "${_ahf_helper}" "${_ahf_files[@]}" >> "${_ahf_log}" 2>>"${_ahf_log}.err"
+        _ahf_rc=$?
+        [ "${_ahf_had_e}" -eq 1 ] && set -e
+        if [ "${_ahf_rc}" -ne 0 ]; then
+            _ahf_ran=0
+            _skip 37 "aria-hidden-focusable" wiring "check_aria_hidden_focusable.py exited ${_ahf_rc} — ${#_ahf_files[@]} .vue file(s) were in scope and no verdict was produced; focusable elements hidden from assistive tech (WCAG 4.1.2) are UNVERIFIED by this run. See ${_ahf_log}.err."
+        fi
     fi
     _ahf_fail=$(wc -l < "${_ahf_log}" 2>/dev/null || echo 0)
     if [ "${_ahf_ran}" -eq 1 ]; then
@@ -3603,7 +3619,18 @@ if [ -d src ]; then
         _th_ran=0
         _skip 43 "table-headers" wiring "check_table_headers.py not found at ${_th_helper} — ${#_th_files[@]} .vue file(s) were in scope and NONE were inspected; unassociated table headers (WCAG 1.3.1) are UNVERIFIED by this run."
     else
-        python3 "${_th_helper}" "${_th_files[@]}" >> "${_th_log}" 2>/dev/null || true
+        # Exit code is a STATUS, findings are STDOUT (gate-19 / #249); stderr
+        # is kept so a traceback is visible instead of becoming a clean sheet.
+        # `set +e` because gate-19's block leaves errexit on for later gates.
+        case $- in *e*) _th_had_e=1 ;; *) _th_had_e=0 ;; esac
+        set +e
+        python3 "${_th_helper}" "${_th_files[@]}" >> "${_th_log}" 2>>"${_th_log}.err"
+        _th_rc=$?
+        [ "${_th_had_e}" -eq 1 ] && set -e
+        if [ "${_th_rc}" -ne 0 ]; then
+            _th_ran=0
+            _skip 43 "table-headers" wiring "check_table_headers.py exited ${_th_rc} — ${#_th_files[@]} .vue file(s) were in scope and no verdict was produced; unassociated table headers (WCAG 1.3.1) are UNVERIFIED by this run. See ${_th_log}.err."
+        fi
     fi
     _th_fail=$(wc -l < "${_th_log}" 2>/dev/null || echo 0)
     if [ "${_th_ran}" -eq 1 ]; then


### PR DESCRIPTION
Closes #222.

Two gates whose remediation advice **regressed the thing they measure**.

## gate-37 — `tabindex="-1"` counted as focusable

The check was `grep -qE '(:?tabindex|v-bind:tabindex)='` — **any value**. But `tabindex="-1"` is the attribute that **removes** an element from the tab order: the one value that proves the *opposite* of what the gate concluded. The gate's own subject ("hidden from AT **and still keyboard-reachable**") was inverted for every element that had already been fixed.

The canonical hidden-file-input pattern trips it exactly:

```vue
<input type="file" :aria-hidden="true" tabindex="-1" @change="…">
```

The advice was to remove `aria-hidden` (exposing an unnamed control to screen readers) **or** to remove `tabindex="-1"` (putting a control screen readers cannot see *back* in the tab order — the very defect this gate exists to catch). **Both remediations regress accessibility.**

**Measured: nextcloud-vue 2 → 0.** Both were `tabindex="-1"` (`CnFilesWidget`'s file input, `CnCalendarEventCreate`'s submit bridge). Both 100% false.

**Still flagged:** `tabindex="0"`/positive, native focusables with no negative tabindex, interactive `role=`, and a **bound** `:tabindex="expr"` whose value cannot be read — unknown is not "safe", so the old behaviour is kept there.

## gate-43 — one `scope=` greened the whole table

```python
if re.search(r'<th\b[^>]*\bscope\s*=', body): continue   # whole table OK
```

A **single** `scope=` anywhere accepted every other header. Negative control: **removing exactly one `scope=` from a passing table still reported PASS.** The rule is now *any unscoped **named** header fails the table*. That experiment is now an assertion — `test_removing_exactly_one_scope_flips_the_verdict`.

### A header with no name is not a header

Tightening to per-header immediately produced **8 findings in openconnector, a repo the old rule passed — and all 8 were the same false positive**: the empty spacer column carrying a drag handle or row-actions menu (`<th aria-hidden="true" />`, `<th />`).

`scope=` declares which cells a header **names**. A header with no name names nothing, so the attribute is inert and demanding it is remediation theatre — the same trap as gate-40's `aria-label` advice. Exempt: `aria-hidden="true"`, `role="presentation"`/`none`, empty content. **A header with text and no `scope=` still fails.** openconnector: back to 0.

### Counting

One finding **per table**, not per `<th>`, with `unscoped=N/M` on the line. The number stays a count of *defect sites* and comparable with what this gate reported before. *A finding count is not a defect count*, and the two must not be silently swapped mid-repair.

## Fleet effect, measured over 10 repos

gate-43 numbers **identical** before and after (opencatalogi 15, docudesk 11, procest 28, openbuild 8, openregister 56, pipelinq 43, doriath 14, openconnector 0). The tightening and the exemption are **not** cancelling each other — the tests prove each arm independently; the fleet simply has no partially-scoped table whose unscoped header is named.

## Mutation-checked

| reverted fix | suite result |
|---|---|
| gate-37 "any tabindex is focusable" | 6 failures |
| gate-43 "at-least-one scope" | 5 failures |
| gate-43 unnamed-header exemption widened to all | 7 failures |

Also caught by mutation rather than by reading: an optional `(?:(.*?)</th>)?` body group let a self-closed `<th />` reach past itself to the **first `</th>` in the file** and swallow the next header whole — two headers counted as one.

## Also

- Both implementations moved out of the runner into tested helpers (`check_aria_hidden_focusable.py` +24 tests, `check_table_headers.py` +23 tests).
- Both are **quote-aware**: the old `[^>]*` attribute runs ended a tag at the `>` inside `:title="a > b"`, hiding attributes that followed.
- Both strip comments and `<script>`/`<style>` — markup that does not ship is not a control.
- A missing helper now reports **SKIP-wiring, not PASS**, for both gates (#147).

Suites: **29 helper suites pass, 59 entry-point tests pass.**