### PR TITLE
fix(gates): the runner enabled errexit 27 times and called it a restore (#243)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_errexit_discipline.sh
+++ b/hydra-gates/scripts/lib/test_gate_errexit_discipline.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_errexit_discipline.sh — the runner must never enable errexit, and a
+# crashing checker must not be able to kill the rest of the suite.
+#
+# WHAT THIS GUARDS (.github#243)
+# ------------------------------
+# run-hydra-gates.sh runs under `set -u` only. errexit is deliberately OFF,
+# because a gate returning non-zero is how a gate reports findings.
+#
+# Twenty-six blocks wrapped a helper call in `set +e … set -e` and read the
+# trailing `set -e` as "restore". It is an unconditional ENABLE: errexit was
+# never on. The first offender sat in gate-19, so gates 20–64 ran under an
+# errexit that the code around them does not expect.
+#
+# Measured before the fix, with a `python3` that exits 127: gate-39's unguarded
+# `python3 - "$vue" <<'PYBN'` tripped errexit and the run DIED there —
+# 37 of 64 gates emitted a verdict, 27 never executed.
+#
+# Two arms, because a static check and a behavioural check fail for different
+# reasons and a fix that satisfies only one is not a fix:
+#
+#   ARM 1  no bare `set -e` line exists in run-hydra-gates.sh
+#   ARM 2  a full run with a deliberately non-zero helper still reports EVERY
+#          gate the runner declares, and prints no abort banner
+#
+# ARM 2 is the one that matters, and it is deliberately driven by the same
+# mechanism that produced the original outage rather than by a mock.
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+# Overridable so the fix can be MUTATION-CHECKED against a known-bad copy of the
+# runner without editing the shipped file:
+#
+#   HYDRA_GATES_RUNNER_UNDER_TEST=/path/to/pre-fix/run-hydra-gates.sh \
+#       bash scripts/lib/test_gate_errexit_discipline.sh
+#
+# Against the pre-fix runner both arms must go RED. A single-site mutation is
+# NOT sufficient to red ARM 2 — the remaining `set +e` sites switch errexit back
+# off a few gates later, which is exactly why the leak was survivable often
+# enough to stay unnoticed. The honest mutant is the whole pre-fix file.
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()   { echo "  ok   — $1"; }
+_bad()  { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_errexit_discipline.sh"
+
+# ---------------------------------------------------------------------------
+# ARM 1 — static: nothing re-enables errexit.
+# ---------------------------------------------------------------------------
+_bare=$(grep -n '^[[:space:]]*set -e$' "${_runner}" 2>/dev/null || true)
+if [ -z "${_bare}" ]; then
+    _ok "no bare 'set -e' in run-hydra-gates.sh"
+else
+    _bad "run-hydra-gates.sh re-enables errexit — a restore site must say 'set +e':"
+    printf '%s\n' "${_bare}" | sed 's/^/         /'
+fi
+
+# The backstop must stay in place: every gate ends at one of these three, so
+# re-asserting `set +e` there caps the blast radius of any future leak.
+for _fn in _pass _fail _skip; do
+    if awk -v fn="${_fn}" '
+        $0 ~ "^"fn"\\(\\)" { inside = 1 }
+        inside && /set \+e/ { found = 1 }
+        inside && /^}/      { inside = 0 }
+        END { exit(found ? 0 : 1) }
+    ' "${_runner}"; then
+        _ok "${_fn}() re-asserts 'set +e' (leak backstop)"
+    else
+        _bad "${_fn}() no longer re-asserts 'set +e' — a leaked errexit would survive past a gate verdict"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# ARM 2 — behavioural: a crashing checker must not truncate the suite.
+#
+# A `python3` shim that exits 127 stands in for "the checker had a bad day":
+# not installed, OOM-killed, argv too long, syntax error in a helper. Every one
+# of those reaches the runner as a non-zero exit from a bare command.
+# ---------------------------------------------------------------------------
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-errexit-test.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_app="${_tmp}/app"
+mkdir -p "${_app}/src/views" "${_app}/openspec/specs" "${_app}/appinfo" "${_app}/lib"
+printf '<template>\n  <div><button><span class="icon-x" /></button></div>\n</template>\n' \
+    > "${_app}/src/views/Thing.vue"
+printf '{"name":"fx"}\n' > "${_app}/src/manifest.json"
+printf '<?php\nreturn [];\n' > "${_app}/appinfo/routes.php"
+printf '## Purpose\n\n#### Scenario: a thing happens\n- WHEN x\n- THEN y\n' \
+    > "${_app}/openspec/specs/spec.md"
+(
+    cd "${_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_shim="${_tmp}/shim"
+mkdir -p "${_shim}"
+printf '#!/bin/sh\necho "python3: simulated crash" >&2\nexit 127\n' > "${_shim}/python3"
+chmod +x "${_shim}/python3"
+
+_logs="${_tmp}/logs"
+mkdir -p "${_logs}"
+_out="${_tmp}/run.txt"
+(
+    cd "${_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_logs}" PATH="${_shim}:${PATH}" \
+        bash "${_runner}" . > "${_out}" 2>&1
+)
+
+# The runner declares its own inventory; compare against that rather than a
+# hardcoded 64, so adding a gate cannot quietly shrink this assertion.
+_declared=$(grep -cE '^# Gate [0-9]+' "${_runner}" 2>/dev/null || echo 0)
+_reported=$(grep -cE '^\[gate-[0-9]+\]' "${_out}" 2>/dev/null || echo 0)
+
+if grep -q 'ABORTED before the summary' "${_out}"; then
+    _bad "the run ABORTED — a crashing checker still kills the suite"
+    grep -E '^\[gate-[0-9]+\]' "${_out}" | tail -1 | sed 's/^/         last verdict: /'
+else
+    _ok "no abort banner — the run survived a crashing checker"
+fi
+
+if [ "${_reported}" -ge "${_declared}" ] && [ "${_declared}" -gt 0 ]; then
+    _ok "every declared gate reported (${_reported} verdicts for ${_declared} declared gates)"
+else
+    _bad "only ${_reported} of ${_declared} declared gates reported — the suite was truncated"
+fi
+
+# The summary must actually be reached; its absence is how a truncated run used
+# to read as green.
+if grep -q '^\[hydra-gates\] COVERAGE:' "${_out}"; then
+    _ok "the coverage summary was reached"
+else
+    _bad "the coverage summary never printed"
+fi
+
+echo
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_errexit_discipline.sh: ALL PASS"
+    exit 0
+fi
+echo "test_gate_errexit_discipline.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -66,6 +66,34 @@
 
 set -u
 
+# ---------------------------------------------------------------------------
+# ERREXIT IS OFF FOR THIS ENTIRE SCRIPT, AND NOTHING MAY TURN IT ON.
+#
+# A gate returning non-zero is NORMAL — it is how a gate reports findings. So
+# this runner deliberately runs under `set -u` only.
+#
+# Twenty-seven blocks used to wrap a helper call in `set +e … set -e`, reading
+# the trailing `set -e` as "restore". It is not a restore: it is an
+# unconditional ENABLE, because errexit was never on. The first sits in gate-19,
+# so gates 20-64 — forty-five gates — executed under an errexit the code around
+# them does not expect. Two comments further down (gate-27, gate-53) even
+# document the leak and work around it locally instead of fixing it.
+#
+# The consequence is not theoretical. Measured 2026-08-08 against a fixture with
+# a deliberately crashing `python3`: gate-39's unguarded
+# `python3 - "$vue" <<'PYBN'` returned 127, errexit was live, and the run DIED
+# THERE — 37 of 64 gates emitted a verdict and 27 NEVER EXECUTED. The abort
+# banner does fire, so the run is not silently green; it is simply a whole-suite
+# outage caused by one checker having a bad day.
+#
+# The invariant is therefore: a block MAY disable errexit and MUST NOT enable
+# it. Restore sites say `set +e`, which is the state this script actually runs
+# in. `scripts/lib/test_gate_errexit_discipline.sh` asserts that no bare
+# `set -e` re-enters this file, and `_pass`/`_fail`/`_skip` re-assert `set +e`
+# as a backstop so a future gate that leaks cannot carry the leak past its own
+# verdict line.
+# ---------------------------------------------------------------------------
+
 # Resolve this script's own directory ONCE, as an absolute path, BEFORE any
 # `cd` into the app dir below. Gates that shell out to co-located Python
 # helpers (scripts/lib/*.py) must use ${SCRIPT_DIR} — resolving via
@@ -757,13 +785,14 @@ _NA_GATES=""
 # wrapper — anchors on `^\[gate-`. A verdict that wraps onto a second line is
 # a verdict that silently loses its own reason.
 _fail() {
+    set +e   # backstop — see the errexit invariant at the top of this file
     local _reason
     _reason=$(printf '%s' "${3:-}" | tr '\n' ' ')
     echo "[gate-$1] $2: FAIL${_reason:+ — ${_reason}}"
     _FAILED=$((_FAILED + 1))
     _EMITTED_GATES="${_EMITTED_GATES}$1 "
 }
-_pass() { echo "[gate-$1] $2: PASS"; _EMITTED_GATES="${_EMITTED_GATES}$1 "; }
+_pass() { set +e; echo "[gate-$1] $2: PASS"; _EMITTED_GATES="${_EMITTED_GATES}$1 "; }
 
 # _optout_text — every place a reason-bearing `[hydra-gate-<name> exclude]` tag
 # may legitimately be written, as one stream to grep.
@@ -833,6 +862,7 @@ _optout_text() {
 # making any gate's absence stop counting — which is precisely the accounting
 # hole this whole block exists to close, re-opened from the inside.
 _skip() {
+    set +e   # backstop — see the errexit invariant at the top of this file
     local _cat _reason
     _cat="${3:-}"
     _reason=$(printf '%s' "${4:-}" | tr '\n' ' ')
@@ -2035,7 +2065,7 @@ if [ -d openspec/specs ] || [ -d tests/e2e ]; then
             python3 "${_e2e_lib_dir}/check_e2e_coverage.py" . \
             >> "${_e2e_log}" 2>&1
         _e2e_fail=$?
-        set -e
+        set +e
     else
         _e2e_ran=0
         _skip 19 "e2e-coverage" wiring "check_e2e_coverage.py not found at ${_e2e_lib_dir} — no spec scenario was inspected; @e2e traceability (ADR-020) is UNVERIFIED by this run."
@@ -2232,7 +2262,7 @@ if [ -f src/manifest.json ]; then
         set +e
         node "${_mv_validator}" src/manifest.json >> "${_mv_log}" 2>&1
         _mv_rc=$?
-        set -e
+        set +e
         # Advisory: run the app's own check:manifest when it exists, purely so
         # a divergence between it and the canonical validator is VISIBLE.
         _mv_app_note=""
@@ -2241,7 +2271,7 @@ if [ -f src/manifest.json ]; then
             set +e
             npm run --silent check:manifest >> "${_mv_log}" 2>&1
             _mv_app_rc=$?
-            set -e
+            set +e
             if [ "${_mv_app_rc}" -ne 0 ]; then
                 _mv_app_note=" [advisory: the app's own check:manifest also exits ${_mv_app_rc} — see ${_mv_log}]"
             fi
@@ -2461,7 +2491,7 @@ if [ -f appinfo/routes.php ]; then
             python3 "${_cc_lib_dir}/check_contract_coverage.py" . \
             >> "${_cc_log}" 2>/dev/null
         _cc_fail=$?
-        set -e
+        set +e
     else
         _cc_ran=0
         _skip 25 "contract-coverage" wiring "check_contract_coverage.py not found at ${_cc_lib_dir} — appinfo/routes.php is present but NO endpoint was inspected; wire-contract coverage of newly-exposed endpoints is UNVERIFIED by this run."
@@ -2506,7 +2536,7 @@ if [ -d src ]; then
             python3 "${_vc_lib_dir}/check_visual_coverage.py" . \
             >> "${_vc_log}" 2>/dev/null
         _vc_fail=$?
-        set -e
+        set +e
     else
         _vc_ran=0
         _skip 26 "visual-coverage" wiring "check_visual_coverage.py not found at ${_vc_lib_dir} — src/ is present but NO page component was inspected; visual-regression coverage of new screens is UNVERIFIED by this run."
@@ -2585,7 +2615,7 @@ fi
 # grep -c double-zero bug entirely (always exits 0, prints the line count).
 set +e
 _pcar_fail=$(wc -l < "${_pcar_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_pcar_fail}" ] && _pcar_fail=0
 if [ "${_pcar_ran}" -eq 1 ]; then
     if [ "${_pcar_fail}" -eq 0 ]; then
@@ -3723,7 +3753,7 @@ else
 fi
 set +e
 _sae_fail=$(wc -l < "${_sae_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_sae_fail}" ] && _sae_fail=0
 if [ "${_sae_ran}" -eq 1 ]; then
     if [ "${_sae_fail}" -eq 0 ]; then
@@ -3739,7 +3769,7 @@ if [ "${_sae_ran}" -eq 1 ]; then
         # the size of the job is legible from the summary line.
         set +e
         _sae_targets=$(sed 's/^[^:]*: //' "${_sae_log}" 2>/dev/null | sort -u | wc -l | tr -d ' ')
-        set -e
+        set +e
         [ -z "${_sae_targets}" ] && _sae_targets="?"
         _fail 46 "spec-anchor-existence" "${_sae_fail} unresolved @spec finding(s) from ${_sae_targets} distinct target(s) — fix the TARGET, not each tag; see ${_sae_log}"
     fi
@@ -3853,7 +3883,7 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
 fi
 set +e
 _csrf_fail=$(wc -l < "${_csrf_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_csrf_fail}" ] && _csrf_fail=0
 if [ "${_csrf_fail}" -eq 0 ]; then
     _pass 48 "csrf-cochange"
@@ -4007,7 +4037,7 @@ if [ -s "${_cxt_log}" ]; then
 fi
 set +e
 _cxt_fail=$(wc -l < "${_cxt_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_cxt_fail}" ] && _cxt_fail=0
 if [ "${_cxt_fail}" -eq 0 ]; then
     _pass 49 "controller-exception-translation"
@@ -4083,7 +4113,7 @@ PY
 fi
 set +e
 _scfm_fail=$(wc -l < "${_scfm_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_scfm_fail}" ] && _scfm_fail=0
 if [ "${_scfm_fail}" -eq 0 ]; then
     _pass 50 "security-config-fail-mode"
@@ -4140,7 +4170,7 @@ if [ "${#_spt_files[@]}" -gt 0 ]; then
 fi
 set +e
 _spt_fail=$(wc -l < "${_spt_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_spt_fail}" ] && _spt_fail=0
 if [ "${_spt_ran}" -eq 1 ]; then
     if [ "${_spt_fail}" -eq 0 ]; then
@@ -4204,7 +4234,7 @@ if [ "${#_cwr_files[@]}" -gt 0 ]; then
             python3 "${_cwr_helper}" "${_cwr_files[@]}" >> "${_cwr_log}" 2>&1
         fi
         _cwr_fail=$?
-        set -e
+        set +e
     else
         _cwr_ran=0
         _skip 52 "custom-widget-ratchet" wiring "check_custom_widget_ratchet.py not found at ${_cwr_helper} — ${#_cwr_files[@]} frontend file(s) were in scope and NONE were inspected; custom kind:\"widget\" growth (ADR-049) is UNVERIFIED by this run — no base/head/delta counts were produced."
@@ -4340,7 +4370,7 @@ if [ -f src/manifest.json ]; then
                     echo "ALL" > "${_em_scope_file}"
                     _em_scope_rc=0
                 fi
-                set -e
+                set +e
                 if [ "${_em_scope_rc}" -ne 0 ]; then
                     # Could not compute a scope → do not narrow. Say so.
                     echo "ALL" > "${_em_scope_file}"
@@ -4372,7 +4402,7 @@ if [ -f src/manifest.json ]; then
             set +e
             node "${_em_validator}" "${_em_tmp}" ${_em_scope_flag} ${_em_scope_val} >> "${_em_log}" 2>&1
             _em_val_rc=$?
-            set -e
+            set +e
             if [ "${_em_val_rc}" -eq 3 ]; then
                 _em_reason="SCHEMA VALIDATION DID NOT HAPPEN — the vendored validator degraded to its structural lint (Ajv unresolvable mid-run); see ${_em_log}"
             elif [ "${_em_val_rc}" -ne 0 ]; then
@@ -4385,7 +4415,7 @@ if [ -f src/manifest.json ]; then
                 set +e
                 node "${_em_crossref}" --app-dir . --manifest "${_em_tmp}" ${_em_scope_flag} ${_em_scope_val} >> "${_em_log}" 2>&1
                 _em_cr_rc=$?
-                set -e
+                set +e
                 if [ "${_em_cr_rc}" -ne 0 ]; then
                     _em_n=$(grep -E '^at ' "${_em_log}" 2>/dev/null | grep -cvE ': (WARN|PRE-EXISTING) ' || true)
                     { [ -z "${_em_n}" ] || [ "${_em_n}" -eq 0 ]; } && _em_n=1
@@ -4466,7 +4496,7 @@ fi
 set +e
 _rd_fail=$(grep -cv '^WARN:' "${_rd_log}" 2>/dev/null | tr -d ' ')
 _rd_warn=$(grep -c '^WARN:' "${_rd_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_rd_fail}" ] && _rd_fail=0
 [ -z "${_rd_warn}" ] && _rd_warn=0
 [ "${_rd_warn}" -gt 0 ] && echo "[gate-54] relation-dialect: ${_rd_warn} WARN finding(s) (non-blocking) — see ${_rd_log}"
@@ -4525,7 +4555,7 @@ if [ "${#_dpd_files[@]}" -gt 0 ]; then
 fi
 set +e
 _dpd_fail=$(wc -l < "${_dpd_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_dpd_fail}" ] && _dpd_fail=0
 if [ "${_dpd_ran}" -eq 1 ]; then
     if [ "${_dpd_fail}" -eq 0 ]; then
@@ -4580,7 +4610,7 @@ if [ "${#_rhr_files[@]}" -gt 0 ]; then
 fi
 set +e
 _rhr_fail=$(wc -l < "${_rhr_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_rhr_fail}" ] && _rhr_fail=0
 if [ "${_rhr_ran}" -eq 1 ]; then
     if [ "${_rhr_fail}" -eq 0 ]; then
@@ -4634,7 +4664,7 @@ if [ "${#_owc_files[@]}" -gt 0 ]; then
 fi
 set +e
 _owc_fail=$(wc -l < "${_owc_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_owc_fail}" ] && _owc_fail=0
 if [ "${_owc_ran}" -eq 1 ]; then
     if [ "${_owc_fail}" -eq 0 ]; then
@@ -4685,7 +4715,7 @@ while IFS= read -r f; do
 done < <(find tests/e2e -type f \( -name '*.ts' -o -name '*.js' \) 2>/dev/null)
 set +e
 _nwi_fail=$(wc -l < "${_nwi_log}" 2>/dev/null | tr -d ' ')
-set -e
+set +e
 [ -z "${_nwi_fail}" ] && _nwi_fail=0
 if [ "${_nwi_fail}" -eq 0 ]; then
     _pass 58 "e2e-networkidle"
@@ -4717,7 +4747,7 @@ if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; th
     set +e
     python3 "${SCRIPT_DIR}/lib/check_unclosable_gate.py" . > "${_ucg_log}" 2>&1
     _ucg_rc=$?
-    set -e
+    set +e
     if [ "${_ucg_rc}" -eq 0 ]; then
         _pass 59 "unclosable-gate"
     else
@@ -4774,7 +4804,7 @@ if [ -f src/manifest.json ]; then
         set +e
         python3 "${SCRIPT_DIR}/lib/check_icon_vocabulary.py" . ${_iv_args} > "${_iv_log}" 2>&1
         _iv_rc=$?
-        set -e
+        set +e
         # Surface warnings even on a pass — they are the deprecation pressure.
         grep -E '^(WARN|NOTE)' "${_iv_log}" || true
         if [ "${_iv_rc}" -eq 0 ]; then
@@ -4830,7 +4860,7 @@ if [ -d lib/AppInfo ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_listener_placement.py" . --base "${BASE_REF}" > "${_lwp_log}" 2>&1
     _lwp_rc=$?
-    set -e
+    set +e
     if [ "${_lwp_rc}" -eq 0 ]; then
         _pass 61 "listener-work-placement"
     else
@@ -4850,7 +4880,7 @@ _sp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-store-plane.log
 set +e
 python3 "${SCRIPT_DIR}/lib/check_store_and_settings_surface.py" . --gate store --base "${BASE_REF}" > "${_sp_log}" 2>&1
 _sp_rc=$?
-set -e
+set +e
 if [ "${_sp_rc}" -eq 0 ]; then
     _pass 62 "store-plane"
 else
@@ -4867,7 +4897,7 @@ _ss_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-settings-surface.log
 set +e
 python3 "${SCRIPT_DIR}/lib/check_store_and_settings_surface.py" . --gate settings --base "${BASE_REF}" > "${_ss_log}" 2>&1
 _ss_rc=$?
-set -e
+set +e
 if [ "${_ss_rc}" -eq 0 ]; then
     _pass 63 "settings-surface"
 else
@@ -4919,7 +4949,7 @@ if [ -d lib/AppInfo ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_apphost_autoload_prelude.py" . > "${_aap_log}" 2>&1
     _aap_rc=$?
-    set -e
+    set +e
     if [ "${_aap_rc}" -eq 0 ]; then
         _pass 64 "apphost-autoload-prelude"
     else


### PR DESCRIPTION
Closes #243.

## The defect

`run-hydra-gates.sh` runs under `set -u` only. **errexit is deliberately OFF**, because a gate returning non-zero is how a gate reports findings.

Twenty-seven blocks wrapped a helper call in `set +e … set -e` and read the trailing `set -e` as *"restore"*. It is not a restore — it is an unconditional **ENABLE**, because errexit was never on in the first place. The first offender sits in **gate-19**, so **gates 20–64 — forty-five gates — ran under an errexit the surrounding code does not expect.**

The file already knew. Two comments work *around* the leak instead of fixing it:

- gate-27: `NOTE: gates 25/26 above leave 'set -e' ENABLED, so a 'grep -c .' on an empty log would kill the script here.`
- gate-53: `NOTE: 'set -e' is still enabled at this point in the script (gates 25/26 leave it on) — every command below is guarded.`

## Reproduction

A fixture app plus a `python3` shim that exits 127 — standing in for the checker being uninstalled, OOM-killed, argv-too-long, or syntactically broken. gate-39's **unguarded** `python3 - "$vue" <<'PYBN'` returns non-zero, errexit is live, and the run dies there:

| | before | after |
|---|---|---|
| gates reporting a verdict | **37 of 64** | **64 of 64** |
| gates never executed | **27** | 0 |
| last verdict | `[gate-38] skip-link: PASS` | `[gate-64] …` |
| coverage summary reached | no | yes |

The abort banner does fire, so the run is not silently green. It is a **whole-suite outage triggered by one checker having a bad day.**

## The fix

- every restore site now says `set +e` — the state the script actually runs in
- `_pass` / `_fail` / `_skip` re-assert `set +e` as a **backstop**: every gate ends at one of these three, so a future gate that leaks cannot carry the leak past its own verdict line
- `scripts/lib/test_gate_errexit_discipline.sh` asserts both a static arm (no bare `set -e`) and a behavioural arm (full run, crashing checker, all gates still report)

## Mutation check

The test takes `HYDRA_GATES_RUNNER_UNDER_TEST` so the fix can be checked against a known-bad copy without editing the shipped file. Against pristine `origin/main` **all seven assertions go red**, with the exact measured numbers.

Worth recording: a **single-site** mutation is *not* enough to red the behavioural arm — the remaining `set +e` sites switch errexit back off a few gates later. That is precisely why this leak survived long enough to be documented twice and fixed neither time, and why the honest mutant is the whole pre-fix file.

## Coordination

No overlap with #247 on any errexit line (verified: `git diff origin/main...pr247` touches none of them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)