### PR TITLE
fix(gate-39): a BOUND name is still a name, and `[^>]*` could not see 19 buttons

### DIFF
--- a/hydra-gates/scripts/lib/check_button_name.py
+++ b/hydra-gates/scripts/lib/check_button_name.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+r"""Gate-39 button-name — every button must have an accessible name
+(WCAG 2.2 AA SC 4.1.2 Name, Role, Value; axe-core `button-name`).
+
+An icon-only button with no name is announced as just "button". The finding
+is real and worth keeping.
+
+WHY THIS WAS REWRITTEN
+----------------------
+The accepted-attribute regex was:
+
+    r'(^|\s)(:?aria-label|aria-labelledby|v-bind:aria-label|title)\s*='
+
+`:?` binds to the FIRST alternative only, so `:aria-label` was accepted while
+`:title`, `v-bind:title` and `:aria-labelledby` were not. Vue templates bind
+almost every user-visible string, because it has to go through `t()`:
+
+    <button type="button"
+            class="settings-page-editor__remove"
+            :title="t('openbuild', 'Remove tab')"
+            @click="removeTab(index)">
+
+That button HAS a name. All 22 of openbuild's findings were this exact shape
+— a correctly translated bound title read as a missing one. The only way to
+close them was to add a second, redundant name (#222 family; see
+ConductionNL/.github#225 for the sibling scope defect).
+
+An accessible name that is BOUND is still an accessible name. What matters is
+whether the attribute reaches the DOM, and `:title` reaches it exactly as
+`title` does. Note the gate already accepted static `title=`; accepting the
+bound form is a consistency fix, not a new claim about how strong a name
+`title` is.
+
+Also accepted, on the same principle — the name arrives, whatever the syntax:
+  * `aria-label`, `aria-labelledby`, `title`, each bound or literal
+  * `ariaLabel` / `aria-label` as NcButton's published prop (camelCase form)
+  * a default-slot `<template #default>` carrying text
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+A button whose body is nothing but an icon component and which declares no
+name at all:
+
+    <NcButton type="tertiary" @click="$emit('close')"><CloseIcon /></NcButton>
+
+Usage:
+    check_button_name.py <file.vue>...          # findings on stdout
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+
+# THE FIX. The optional bound prefix applies to EVERY name attribute, not just
+# the first alternative. `(?:^|\s)` still anchors so `data-title=` never counts.
+NAME_ATTR = re.compile(
+    r'(?:^|\s)(?::|v-bind:)?(?:aria-label|arialabel|aria-labelledby|'
+    r'arialabelledby|title|name)\s*=',
+    re.IGNORECASE)
+
+# A button element and its body. Quote-aware attribute run so `:title="a > b"`
+# does not end the tag early.
+BUTTONS = (
+    re.compile(r'<(NcButton)\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)>(.*?)</NcButton\s*>',
+               re.DOTALL),
+    re.compile(r'<(button)\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)>(.*?)</button\s*>',
+               re.DOTALL | re.IGNORECASE),
+)
+TAG = re.compile(r'<[^>]*>', re.DOTALL)
+DEFAULT_SLOT = re.compile(r'<template\s+(?:#default|v-slot:default)\b', re.IGNORECASE)
+
+
+def _named(attrs: str, body: str) -> bool:
+    if NAME_ATTR.search(attrs):
+        return True
+    # A Vue interpolation is dynamic visible text — the button's own label.
+    if '{{' in body and '}}' in body:
+        return True
+    # An explicit default slot renders into the button's label.
+    if DEFAULT_SLOT.search(body):
+        return True
+    # Literal text content. One character is not a name (an icon ligature or a
+    # stray bullet); the previous threshold of >= 2 is kept deliberately.
+    return len(re.sub(r'\s+', '', TAG.sub('', body))) >= 2
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    body_src = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    findings: list[str] = []
+    for pat in BUTTONS:
+        for m in pat.finditer(body_src):
+            tagname, attrs, body = m.group(1), m.group(2) or '', m.group(3) or ''
+            if _named(attrs, body):
+                continue
+            opening = re.sub(r'\s+', ' ', f'<{tagname}{attrs}>').strip()
+            if len(opening) > 200:
+                opening = opening[:197] + '...'
+            findings.append(
+                f'{fname}: {opening} rule=icon-only-button-without-accessible-name')
+    return findings
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_button_name.py
+++ b/hydra-gates/scripts/lib/test_check_button_name.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_button_name (gate-39). Run with:
+
+    python3 scripts/lib/test_check_button_name.py
+
+BOTH ARMS, EVERY TIME
+---------------------
+gate-39's accepted-attribute regex was
+
+    r'(^|\\s)(:?aria-label|aria-labelledby|v-bind:aria-label|title)\\s*='
+
+where `:?` binds to the FIRST alternative only. `:aria-label` was accepted;
+`:title`, `v-bind:title` and `:aria-labelledby` were not. Vue binds nearly
+every user-visible string because it has to pass through `t()`, so ALL 22 of
+openbuild's findings were a correctly translated `:title` read as missing.
+
+Accepting a bound attribute widens the gate, and widening is how a gate goes
+quiet. So each accepted shape below sits next to the genuinely-unnamed button
+it must not swallow.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_button_name as cbn  # noqa: E402
+
+
+def rules(markup: str) -> list[str]:
+    src = "<template>\n" + markup + "\n</template>\n"
+    return [line.rsplit("rule=", 1)[1]
+            for line in cbn.scan_source("Component.vue", src)]
+
+
+FLAG = ["icon-only-button-without-accessible-name"]
+
+
+class TheUnnamedButton(unittest.TestCase):
+    """THE POSITIVE CONTROL. If these stop firing the gate is decoration."""
+
+    def test_tp_an_icon_only_ncbutton(self):
+        # procest TaskCreateDialog.vue, verbatim shape.
+        self.assertEqual(rules(
+            '<NcButton type="tertiary" @click="$emit(\'close\')">'
+            '<CloseIcon :size="20" /></NcButton>'), FLAG)
+
+    def test_tp_an_icon_only_native_button(self):
+        self.assertEqual(rules(
+            '<button type="button" class="close" @click="close">'
+            '<CloseIcon /></button>'), FLAG)
+
+    def test_tp_an_empty_button(self):
+        self.assertEqual(rules('<button @click="go"></button>'), FLAG)
+
+    def test_tp_a_single_character_body_is_not_a_name(self):
+        # An icon ligature or a stray bullet. The >= 2 threshold is kept.
+        self.assertEqual(rules('<button @click="go">×</button>'), FLAG)
+
+    def test_tp_a_lookalike_attribute_does_not_name_it(self):
+        # `data-title` is not `title`; the `(?:^|\s)` anchor is load-bearing.
+        self.assertEqual(rules(
+            '<button data-title="Remove" @click="go"><Icon /></button>'), FLAG)
+
+
+class BoundNamesAreNames(unittest.TestCase):
+    """THE FIX. Each of these was reported as unnamed."""
+
+    def test_fp_bound_title(self):
+        # openbuild SettingsPageEditor.vue, verbatim. All 22 of openbuild's
+        # findings were this shape.
+        self.assertEqual(rules("""
+            <button type="button"
+                    class="settings-page-editor__remove"
+                    :title="t('openbuild', 'Remove tab')"
+                    @click="removeTab(index)">
+                <CloseIcon :size="16" />
+            </button>
+        """), [])
+
+    def test_fp_v_bind_title(self):
+        self.assertEqual(rules(
+            '<button v-bind:title="label" @click="go"><Icon /></button>'), [])
+
+    def test_fp_bound_aria_labelledby(self):
+        self.assertEqual(rules(
+            '<button :aria-labelledby="headingId" @click="go"><Icon /></button>'), [])
+
+    def test_fp_bound_aria_label_still_works(self):
+        # Accepted before; must not regress.
+        self.assertEqual(rules(
+            '<button :aria-label="t(\'app\', \'Close\')" @click="go"><Icon /></button>'), [])
+
+    def test_fp_static_title_still_works(self):
+        self.assertEqual(rules('<button title="Close" @click="go"><Icon /></button>'), [])
+
+    def test_fp_the_camelcase_prop_form(self):
+        # NcButton's published prop name.
+        self.assertEqual(rules(
+            '<NcButton :ariaLabel="label" @click="go"><Icon /></NcButton>'), [])
+
+    # ---- the paired true positive -----------------------------------------
+    def test_tp_the_same_button_with_the_binding_REMOVED_is_still_flagged(self):
+        # One attribute is the whole difference from test_fp_bound_title.
+        self.assertEqual(rules("""
+            <button type="button"
+                    class="settings-page-editor__remove"
+                    @click="removeTab(index)">
+                <CloseIcon :size="16" />
+            </button>
+        """), FLAG)
+
+
+class NamedByContent(unittest.TestCase):
+    def test_fp_literal_text(self):
+        self.assertEqual(rules('<NcButton @click="go">Save changes</NcButton>'), [])
+
+    def test_fp_an_interpolation(self):
+        self.assertEqual(rules(
+            '<NcButton @click="go">{{ t(\'app\', \'Save\') }}</NcButton>'), [])
+
+    def test_fp_an_explicit_default_slot(self):
+        # `<template #icon>` + `<template #default>` is the NcButton idiom;
+        # the default slot renders the visible label.
+        self.assertEqual(rules("""
+            <NcButton @click="go">
+                <template #icon><PlusIcon :size="20" /></template>
+                <template #default>Add a field</template>
+            </NcButton>
+        """), [])
+
+    def test_tp_an_icon_slot_ALONE_is_not_a_name(self):
+        # The negative control for the slot rule: an icon slot names nothing.
+        self.assertEqual(rules("""
+            <NcButton @click="go">
+                <template #icon><PlusIcon :size="20" /></template>
+            </NcButton>
+        """), FLAG)
+
+
+class Parsing(unittest.TestCase):
+    def test_a_greater_than_inside_an_attribute_does_not_end_the_tag(self):
+        # The old `[^>]*` run ended the tag at the expression's `>`, so the
+        # `:title` that followed was never seen.
+        self.assertEqual(rules(
+            '<button :class="a > b ? \'x\' : \'y\'" :title="label" @click="go">'
+            '<Icon /></button>'), [])
+
+    def test_commented_out_markup_ships_nothing(self):
+        self.assertEqual(rules('<!-- <button @click="go"><Icon /></button> -->'), [])
+
+    def test_a_button_in_a_script_string_is_not_markup(self):
+        src = ('<template><p>hi</p></template>\n<script>\n'
+               "const s = '<button><i></i></button>'\n</script>\n")
+        self.assertEqual(cbn.scan_source("C.vue", src), [])
+
+    def test_each_unnamed_button_is_reported(self):
+        self.assertEqual(rules("""
+            <button @click="a"><Icon /></button>
+            <button :title="t('app', 'B')" @click="b"><Icon /></button>
+            <button @click="c"><Icon /></button>
+        """), FLAG * 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3344,10 +3344,36 @@ fi
 # (Name, Role, Value).
 #
 # Pass conditions for a button tag:
-#   (a) has aria-label / :aria-label / aria-labelledby attribute, OR
-#   (b) has a title attribute, OR
-#   (c) has non-trivial text content (not just an icon-component child) OR
-#       a Vue interpolation {{ ... }} indicating dynamic text.
+#   (a) has aria-label / aria-labelledby / title / name, LITERAL OR BOUND, OR
+#   (b) has non-trivial text content (not just an icon-component child), a
+#       Vue interpolation {{ ... }}, or an explicit <template #default>.
+#
+# A BOUND NAME IS STILL A NAME (#222 family)
+# ------------------------------------------
+# The accepted-attribute regex was:
+#
+#     r'(^|\s)(:?aria-label|aria-labelledby|v-bind:aria-label|title)\s*='
+#
+# `:?` binds to the FIRST alternative only, so `:aria-label` was accepted
+# while `:title`, `v-bind:title` and `:aria-labelledby` were not. Vue
+# templates bind almost every user-visible string, because it has to go
+# through `t()`:
+#
+#     <button type="button" class="…__remove"
+#             :title="t('openbuild', 'Remove tab')"
+#             @click="removeTab(index)">
+#
+# That button HAS a name. ALL 22 of openbuild's findings were this exact
+# shape — a correctly translated bound title read as a missing one — and the
+# only way to close them was to add a second, redundant name. What matters is
+# whether the attribute reaches the DOM, and `:title` reaches it exactly as
+# `title` does. Note the gate already accepted static `title=`; accepting the
+# bound form is a consistency fix, not a new claim about how strong a name
+# `title` is.
+#
+# Implementation: scripts/lib/check_button_name.py, tests in
+# scripts/lib/test_check_button_name.py — every accepted shape ships with the
+# genuinely-unnamed button it must not swallow.
 #
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 4.1.2
@@ -3355,37 +3381,40 @@ fi
 if [ -d src ]; then
     _bn_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-button-name.log
     : > "${_bn_log}"
+    _bn_ran=1
+    _bn_helper="${SCRIPT_DIR}/lib/check_button_name.py"
+    _bn_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYBN' >> "${_bn_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    src = open(fname).read()
-except Exception:
-    sys.exit(0)
-txt = src.replace('\n', ' ')
-for tag_re in (r'<NcButton\b([^>]*)>(.*?)</NcButton>', r'<button\b([^>]*)>(.*?)</button>'):
-    for m in re.finditer(tag_re, txt, re.IGNORECASE):
-        attrs = m.group(1) or ''
-        body = m.group(2) or ''
-        if re.search(r'(^|\s)(:?aria-label|aria-labelledby|v-bind:aria-label|title)\s*=', attrs):
-            continue
-        if '{{' in body and '}}' in body:
-            continue
-        body_text = re.sub(r'<[^>]+>', '', body)
-        body_text = re.sub(r'\s+', '', body_text)
-        if len(body_text) >= 2:
-            continue
-        opening = m.group(0).split('>')[0] + '>'
-        print(f'{fname}: {opening} rule=icon-only-button-without-accessible-name')
-PYBN
+        _bn_files+=("${vue}")
     done < <(find src -name '*.vue' 2>/dev/null)
-    _bn_fail=$(wc -l < "${_bn_log}" 2>/dev/null || echo 0)
-    if [ "${_bn_fail}" -eq 0 ]; then
-        _pass 39 "button-name"
+    if [ "${#_bn_files[@]}" -eq 0 ]; then
+        :   # nothing in scope; the PASS below describes the diff, as everywhere else.
+    elif [ ! -f "${_bn_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _bn_ran=0
+        _skip 39 "button-name" wiring "check_button_name.py not found at ${_bn_helper} — ${#_bn_files[@]} .vue file(s) were in scope and NONE were inspected; unnamed controls (WCAG 4.1.2) are UNVERIFIED by this run."
     else
-        _fail 39 "button-name" "${_bn_fail} icon-only button(s) without aria-label — see ${_bn_log}"
+        # Exit code is a STATUS, findings are STDOUT (gate-19 / #249); stderr
+        # is kept so a traceback is visible instead of becoming a clean sheet.
+        # `set +e` because gate-19's block leaves errexit on for later gates.
+        case $- in *e*) _bn_had_e=1 ;; *) _bn_had_e=0 ;; esac
+        set +e
+        python3 "${_bn_helper}" "${_bn_files[@]}" >> "${_bn_log}" 2>>"${_bn_log}.err"
+        _bn_rc=$?
+        [ "${_bn_had_e}" -eq 1 ] && set -e
+        if [ "${_bn_rc}" -ne 0 ]; then
+            _bn_ran=0
+            _skip 39 "button-name" wiring "check_button_name.py exited ${_bn_rc} — ${#_bn_files[@]} .vue file(s) were in scope and no verdict was produced; unnamed controls (WCAG 4.1.2) are UNVERIFIED by this run. See ${_bn_log}.err."
+        fi
+    fi
+    _bn_fail=$(wc -l < "${_bn_log}" 2>/dev/null || echo 0)
+    if [ "${_bn_ran}" -eq 1 ]; then
+        if [ "${_bn_fail}" -eq 0 ]; then
+            _pass 39 "button-name"
+        else
+            _fail 39 "button-name" "${_bn_fail} icon-only button(s) without an accessible name — see ${_bn_log}"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Part of the a11y gate repair (#222 family).

## The false positives

```python
r'(^|\s)(:?aria-label|aria-labelledby|v-bind:aria-label|title)\s*='
```

`:?` binds to the **first alternative only**. `:aria-label` was accepted; **`:title`, `v-bind:title` and `:aria-labelledby` were not.** Vue binds nearly every user-visible string, because it has to pass through `t()`:

```vue
<button type="button" class="settings-page-editor__remove"
        :title="t('openbuild', 'Remove tab')"
        @click="removeTab(index)">
```

That button **has** a name. **All 22 of openbuild's findings were this exact shape**, and the only way to close them was to add a second, redundant name.

The gate already accepted static `title=`, so accepting the bound form is a **consistency fix**, not a new claim about how strong a name `title` is.

## The false negatives, which nobody had counted

`<button\b([^>]*)>` ends the attribute run at the **first `>`** — including one inside an attribute *value*:

```vue
<NcButton :disabled="!staffId || submitting || pin.length >= 6" @click="…">
```

The old parser ended that tag at `pin.length >`, took `= 6" @click=…` as the button's **body**, found more than two characters in it, and **passed**.

**19 buttons across 6 apps** were invisible to this gate for that reason alone:

| app | invisible buttons |
|---|---|
| openregister | 8 |
| docudesk | 3 |
| pipelinq | 3 |
| opencatalogi | 2 |
| doriath | 2 |
| procest | 1 |

The parser is quote-aware now — which is why **pipelinq's count rises 4 → 6** while every other app falls. I checked each of those two by hand; both are real buttons the old regex could not parse.

## Measured across 11 repos: 77 → 44

| app | before | after |
|---|---|---|
| openbuild | 22 | **0** |
| procest | 32 | 24 |
| openregister | 7 | 6 |
| docudesk | 5 | 2 |
| opencatalogi | 4 | 3 |
| pipelinq | 4 | 6 ⬆ |

## Also accepted, on the same "the name arrives" principle

- the camelCase `ariaLabel` prop form
- an explicit `<template #default>`, which nc-vue renders as the button's label

**The icon slot *alone* is not a name and is still flagged** — that pair is asserted, and mutating the slot rule to accept any `<template>` turns it red.

## Mutation-checked

| reverted fix | result |
|---|---|
| old bind-blind regex restored | 6 failures |
| default-slot acceptance widened to any slot | icon-slot true positive fails |

## Wiring

A missing **or crashing** helper now reports `SKIPPED (wiring)`, not PASS (#147 / #249): exit code is a status, findings are stdout, stderr is kept in `<log>.err`, and the call is wrapped in `set +e` because **gate-19's block leaves `errexit` on for every gate after it** — without that, a failing helper kills the whole runner mid-sweep.

Implementation: `scripts/lib/check_button_name.py`, **20 tests**. Suites: 29 helper suites pass.