### PR TITLE
fix(gate-53): two registration dialects check (f) could not see (#238 follow-up)

### DIFF
--- a/hydra-gates/scripts/lib/check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/check_manifest_crossref.js
@@ -252,13 +252,13 @@ function stripJsComments(src) {
 
 // Top-level keys of the `export default { … }` object, with their `kind`.
 // Brace-depth tracking keeps nested object keys (`component:`, `props:`) out.
-function parseRegistry(appDir) {
-	const file = path.join(appDir, 'src', 'registry.js')
+function parseRegistry(appDir, rel) {
+	const file = path.join(appDir, 'src', rel || 'registry.js')
 	let raw
 	try {
 		raw = fs.readFileSync(file, 'utf8')
 	} catch (e) {
-		return null // no registry — check (f) is not applicable
+		return null // absent — nothing to add from this source
 	}
 	const src = stripJsComments(raw)
 	const start = src.search(/export\s+default\s*\{/)
@@ -280,8 +280,16 @@ function parseRegistry(appDir) {
 	const body = src.slice(bodyStart, i)
 
 	// Walk the body, recording `Name:` / `'Name':` / `"Name":` at depth 0 only.
+	//
+	// A QUOTED key may contain characters a bare identifier cannot — hermiq
+	// registers `'agent-form'`, `'agent-skills'`, `'agent-run-history'`. The
+	// first version of this matcher shared one character class with the bare
+	// form, so it captured `agent` and stopped at the hyphen: every hyphenated
+	// registration was invisible and every manifest reference to one was
+	// reported unresolved. 25 false FAILs on hermiq alone. Quoted and bare keys
+	// are therefore matched by SEPARATE alternatives with different classes.
 	depth = 0
-	const KEY = /(?:^|[,{\s])(?:['"]?)([A-Za-z_$][\w$]*)(?:['"]?)\s*:/g
+	const KEY = /(?:^|[,{\s])(?:'([^']+)'|"([^"]+)"|([A-Za-z_$][\w$]*))\s*:/g
 	// Depth map: for each index, how deep we are. Cheap enough for these files.
 	const depthAt = new Array(body.length).fill(0)
 	for (let j = 0; j < body.length; j++) {
@@ -292,9 +300,9 @@ function parseRegistry(appDir) {
 	}
 	let m
 	while ((m = KEY.exec(body)) !== null) {
-		const at = m.index + m[0].indexOf(m[1])
+		const name = m[1] || m[2] || m[3]
+		const at = m.index + m[0].indexOf(name)
 		if (depthAt[at] !== 0) continue
-		const name = m[1]
 		// `kind: 'section'` inside this entry's own braces.
 		const tail = body.slice(m.index, m.index + 400)
 		const km = /\bkind\s*:\s*['"]([a-z-]+)['"]/.exec(tail)
@@ -551,18 +559,29 @@ function main() {
 
 	// (f) component-registry cross-reference — larpingapp#286, both directions.
 	const registry = parseRegistry(APP_DIR)
+	// THE SECOND REGISTRATION SOURCE.
+	//
+	// The runtime resolution order is documented in every app's own
+	// customComponents.js, and the console error this gate quotes says it out
+	// loud: "not found in registry OR customComponents". The first version of
+	// this check read only registry.js and therefore reported 9 false FAILs on
+	// softwarecatalog and 1 on hermiq for components that are registered — just
+	// in the other file. A component resolvable by EITHER route resolves.
+	const legacy = parseRegistry(APP_DIR, 'customComponents.js')
 	if (registry && registry.parsed) {
 		const refs = []
 		collectComponentRefs({ pages: manifest.pages }, '', refs)
 		const named = new Set(refs.map((r) => r.name))
+		const registered = new Set(registry.entries.keys())
+		if (legacy && legacy.parsed) for (const k of legacy.entries.keys()) registered.add(k)
 
 		// Direction 2 — a manifest position naming a component nobody registers.
 		// Renders nothing at runtime, so this FAILS.
 		for (const { ptr, name } of refs) {
 			if (LIB_COMPONENT.test(name)) continue
-			if (registry.entries.has(name)) continue
+			if (registered.has(name)) continue
 			fail('registry-crossref', ptr,
-				`component '${name}' is named by the manifest but is not exported by src/registry.js — resolveTabComponent() falls through and renders NOTHING`)
+				`component '${name}' is named by the manifest but is registered in neither src/registry.js nor src/customComponents.js — resolution falls through and renders NOTHING`)
 		}
 
 		// Direction 1 — a registered component no manifest position names.

--- a/hydra-gates/scripts/lib/test_check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/test_check_manifest_crossref.js
@@ -67,6 +67,9 @@ const VALIDATOR = path.join(LIB, 'check_manifest.js')
 		'registry-orphan/src/registry.js',
 		'registry-missing/src/manifest.json',
 		'registry-missing/src/registry.js',
+		'registry-dialects/src/manifest.json',
+		'registry-dialects/src/registry.js',
+		'registry-dialects/src/customComponents.js',
 	]
 	const missing = required.filter((rel) => !fs.existsSync(path.join(FIX, rel)))
 	if (missing.length > 0) {
@@ -282,6 +285,29 @@ function parseReport(stdout) {
 			&& errs.some((e) => e.message.includes("'SkillTree'")),
 		`commented-out registrations do NOT count as registrations (expected 2 errors, got ${errs.length})`)
 		fs.rmSync(tmp, { recursive: true, force: true })
+	}
+
+	// THE TWO REGISTRATION DIALECTS. Both of these produced FALSE FAILs on
+	// live repos after the first version of check (f) landed, because the
+	// blast radius was measured on five repos and none of them used either
+	// dialect. 34 false FAILs across hermiq and softwarecatalog.
+	{
+		const check = run([CHECKER, '--app-dir', REG('registry-dialects')])
+		const rep = parseReport(check.stdout)
+		const rx = rep.findings.filter((f) => f.check === 'registry-crossref')
+		const errs = rx.filter((f) => f.severity === 'error')
+		const msgs = rx.map((f) => f.message).join(' | ')
+
+		assert(!msgs.includes("'agent-form'"),
+			"a QUOTED HYPHENATED registry key resolves — 'agent-form' (hermiq's dialect, 25 false FAILs)")
+		assert(!msgs.includes("'agent-skills'"),
+			"a double-quoted hyphenated key resolves too — \"agent-skills\"")
+		assert(!msgs.includes("'LegacyOnlyPanel'"),
+			'a component registered ONLY in src/customComponents.js resolves — the second source (9 false FAILs on softwarecatalog)')
+		assert(errs.length === 1 && errs[0].message.includes("'NotAnywherePanel'"),
+			`THE CONTROL: a component in NEITHER file still FAILS (got ${errs.length} error(s))`)
+		assert(check.status === 1,
+			'registry-dialects: the one genuine miss still sets the exit code')
 	}
 
 	// No src/registry.js at all → check (f) is simply not applicable. The

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/customComponents.js
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/customComponents.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture: the legacy consumer-injected registry. Real apps document the
+// runtime resolution order here:
+//
+//   1. Built-in page types          (CnIndexPage, CnDetailPage, …)
+//   2. Built-in widget types        (version-info, register-mapping, …)
+//   3. customComponents (this file) ← consumer-injected components
+//
+// `LegacyOnlyPanel` is registered HERE and nowhere else. A manifest naming it
+// resolves at runtime, so check (f) must not report it. `NotAnywherePanel`,
+// by contrast, is in neither file — that one must still FAIL, which is the
+// control that keeps this exemption from becoming a blanket amnesty.
+import LegacyOnlyPanel from './views/LegacyOnlyPanel.vue'
+
+export default {
+	LegacyOnlyPanel,
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/manifest.json
@@ -1,0 +1,54 @@
+{
+	"schemaVersion": "2.0",
+	"app": { "id": "dialects", "name": "Registry Dialects" },
+	"menu": [
+		{ "id": "af", "label": "Agent form", "icon": "Robot", "route": "AgentForm" },
+		{ "id": "lop", "label": "Legacy", "icon": "History", "route": "LegacyPage" },
+		{ "id": "nap", "label": "Broken", "icon": "Alert", "route": "BrokenPage" }
+	],
+	"pages": [
+		{
+			"id": "AgentForm",
+			"route": "AgentForm",
+			"type": "custom",
+			"title": "Agent form",
+			"component": "agent-form",
+			"_note": "Hyphenated registry key — hermiq's dialect.",
+			"config": {}
+		},
+		{
+			"id": "AgentDetail",
+			"route": "AgentDetail",
+			"type": "detail",
+			"title": "Agent",
+			"config": {
+				"register": "hermiq",
+				"schema": "agent",
+				"sidebar": {
+					"show": true,
+					"tabs": [
+						{ "id": "skills", "label": "Skills", "icon": "Star", "component": "agent-skills" }
+					]
+				}
+			}
+		},
+		{
+			"id": "LegacyPage",
+			"route": "LegacyPage",
+			"type": "custom",
+			"title": "Legacy",
+			"component": "LegacyOnlyPanel",
+			"_note": "Registered only in customComponents.js — the second source.",
+			"config": {}
+		},
+		{
+			"id": "BrokenPage",
+			"route": "BrokenPage",
+			"type": "custom",
+			"title": "Broken",
+			"component": "NotAnywherePanel",
+			"_note": "Registered in NEITHER file — must still FAIL.",
+			"config": {}
+		}
+	]
+}

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/registry.js
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/registry.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Fixture: the two registration dialects the first version of check (f) could
+// not see. Both produced FALSE FAILs on live repos.
+//
+// 1. QUOTED, HYPHENATED KEYS — hermiq's dialect. The original matcher shared
+//    one character class between quoted and bare keys, so `'agent-form'`
+//    captured `agent` and stopped at the hyphen. Every hyphenated registration
+//    was invisible and every manifest reference to one was reported
+//    unresolved: 25 false FAILs on hermiq alone.
+//
+// 2. src/customComponents.js — the SECOND registration source (see the sibling
+//    file in this fixture). The runtime resolution order is documented in
+//    every app's own customComponents.js, and the console error this gate
+//    quotes says it out loud: "not found in registry OR customComponents".
+//    Reading only this file produced 9 false FAILs on softwarecatalog.
+import AgentForm from './views/AgentForm.vue'
+import AgentSkills from './views/AgentSkills.vue'
+import PlainSection from './views/PlainSection.vue'
+
+export default {
+	'agent-form': { kind: 'page', component: AgentForm },
+	"agent-skills": { kind: 'section', component: AgentSkills },
+	PlainSection: { kind: 'section', component: PlainSection },
+}


### PR DESCRIPTION
Urgent follow-up to #250. **34 false FAILs are live on `main` right now** and this removes them.

## What I got wrong

I measured the blast radius of #250 on **five** repos (portaliq, doriath, openconnector, larpingapp, procest), found no new blocking findings, and shipped. Five repos was not the fleet. Sweeping all 20 afterwards found **38 new ERROR findings across five OTHER repos, and 34 of them were false**.

None of my five sample repos used either registration dialect below. That is the whole lesson: a blast-radius sample only tells you about the dialects it happens to contain, and this gate's entire job is reading a file whose dialect varies by app.

## Two causes

### 1. Quoted, hyphenated keys — 25 false FAILs on hermiq

The matcher shared one character class between quoted and bare keys:

```js
/(?:^|[,{\s])(?:['"]?)([A-Za-z_$][\w$]*)(?:['"]?)\s*:/g
```

`[\w$]*` excludes `-`, so `'agent-form'` captured `agent` and stopped at the hyphen. Every hyphenated registration was invisible, and every manifest reference to one — `agent-skills`, `agent-run-history`, `agent-tool-governance` — was reported as naming a component nobody registers. Quoted and bare keys are now **separate alternatives with different character classes**.

### 2. `src/customComponents.js` — 9 false FAILs on softwarecatalog, 1 on hermiq

It is the **second registration source**, and the tell was in the finding message I wrote myself. The runtime error the gate quotes says *"not found in registry **or customComponents**"*, and every app's `customComponents.js` documents the resolution order in its own header:

```
//   3. customComponents (this file) ← consumer-injected components
```

I quoted the fallback and did not implement it. A component resolvable by **either** route now resolves.

## Measured — all 20 repos at `origin/development`

| repo | before | after |
|---|---|---|
| hermiq | 25 ERROR | **0** |
| softwarecatalog | 9 ERROR | **0** |
| decidesk | 1 ERROR | 1 |
| scholiq | 1 ERROR | 1 |
| shillinq | 2 ERROR | 2 |
| all 15 others | 0 | 0 |

## The 4 survivors are true positives

Each verified by hand against the app's own wiring. decidesk and scholiq pass **only** `:registry` in `App.vue`, so a component absent from it renders nothing:

| repo | component | evidence |
|---|---|---|
| decidesk | `MotionIntegrations` | `MotionIntegrations.vue` exists, registered nowhere, named by `pages[].component` |
| scholiq | `OrderPaymentPanel` | same shape |
| shillinq | `ImportWizard` | **no `.vue` file anywhere in `src/`**, named by a `manifest.d` fragment |
| shillinq | `StockLedgerTrace` | same |

These are exactly the direction-2 defect gate-53 was extended to catch: a manifest position that renders nothing.

## Tests

New fixture `registry-dialects` covering both dialects, plus **the control that keeps the exemption from becoming an amnesty**: `NotAnywherePanel` is in neither file and still FAILS.

5 new assertions. Mutations, each asserting it actually applied before writing (a mutation that silently fails to apply is indistinguishable from a surviving mutant):

| mutation | assertions that fail |
|---|---|
| regex reverted (hyphenated keys invisible) | 3 |
| `customComponents.js` source removed | 2 |
| direction 2 disabled entirely | 6 |

`run-helper-suites.sh` → 31 passed, 0 failed, 2 pre-existing quarantines.