### PR TITLE
fix(gates): a checker that could not run must not judge the code (#245, #233)

### DIFF
--- a/hydra-gates/scripts/lib/check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/check_icon_vocabulary.py
@@ -69,6 +69,13 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 VOCAB_PATH = os.path.join(HERE, '..', 'schemas', 'semantic-icons.json')
 
+# The rules this gate can enforce without node_modules are not all of them. When
+# vue-material-design-icons is absent the "does this icon name exist upstream?"
+# rule cannot run, and neither a FAIL nor a PASS is honest about that — the gate
+# has shipped both errors in turn (.github#233). This status says the third
+# thing, and the runner maps it to SKIPPED (wiring).
+EXIT_TOOLING_MISSING = 5
+
 # A manifest icon value that is NOT an MDI name: an image URL, a data URI, or a
 # raw SVG path. All three stay legal per ADR-077 rule 1.
 _URLISH = ('/', 'http://', 'https://', 'data:')
@@ -379,6 +386,17 @@ def main() -> int:
         # No silent caps: say what could not be checked.
         print('NOTE: vue-material-design-icons is not installed — could not verify '
               'that icon names exist upstream. Install dependencies for full coverage.')
+        # ...and do not let the caller read that NOTE as a clean bill of health.
+        #
+        # This gate once reported 43 confident FAILs when node_modules was
+        # absent ("Calendar does not exist"), turning an environment failure
+        # into findings. That was fixed by guarding the existence check on
+        # `available is not None` — which swapped it for the OPPOSITE error: the
+        # check silently stops happening and the gate returns 0, so the runner
+        # prints PASS over an invented-icon-name rule that never ran.
+        #
+        # Neither reading is honest. A missing dependency is a THIRD state:
+        # not a finding, and not a pass. (.github#233)
 
     for w in warns:
         print(f'WARN  {w}')
@@ -387,7 +405,15 @@ def main() -> int:
 
     print(f'\nchecked {len(paths)} manifest(s): {len(fails)} failure(s), '
           f'{len(warns)} warning(s)')
-    return 1 if fails else 0
+    if fails:
+        return 1
+    if available is None:
+        # Clean on every rule that COULD run, but the invented-name rule could
+        # not. The runner reports this as SKIPPED (wiring), which is visible to
+        # --require-full-coverage. Returning 0 here would claim the icon names
+        # were verified against the library when the library was not there.
+        return EXIT_TOOLING_MISSING
+    return 0
 
 
 if __name__ == '__main__':

--- a/hydra-gates/scripts/lib/detect-redundant-controllers.py
+++ b/hydra-gates/scripts/lib/detect-redundant-controllers.py
@@ -373,6 +373,16 @@ def main(argv: list[str]) -> int:
         help="Newline-separated list of paths in scope (empty = scan all).",
     )
     parser.add_argument(
+        "--changed-files-file",
+        default="",
+        help=(
+            "Path to a file holding the newline-separated scope list. Prefer "
+            "this over --changed-files: a single argv string is capped at "
+            "MAX_ARG_STRLEN (128 KiB) regardless of ARG_MAX, and openregister's "
+            "root-scoped file list is 404 KB. See .github#245."
+        ),
+    )
+    parser.add_argument(
         "app_dir",
         nargs="?",
         default=".",
@@ -387,11 +397,26 @@ def main(argv: list[str]) -> int:
     )
     flat_paths = [p for group in candidates for p in group]
 
+    # A scope list can arrive as an argv string or as a file. The file form
+    # exists because the argv form has a hard ceiling the caller cannot see:
+    # a SINGLE argument is limited to MAX_ARG_STRLEN (128 KiB on Linux) even
+    # though ARG_MAX is 2 MB. openregister's root-scoped list is 404 KB across
+    # 7,224 files, so `--changed-files=<list>` raised E2BIG, python3 never
+    # started, and the gate reported "FAIL — 0 pass-through method(s)" — a
+    # crashed checker wearing a finding count. (.github#245)
+    _scope_text = args.changed_files
+    if args.changed_files_file:
+        try:
+            _scope_text = Path(args.changed_files_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"# ERROR: could not read --changed-files-file: {exc}", file=sys.stderr)
+            return 2
+
     scope_filter: set[str] | None = None
-    if args.changed_files.strip():
+    if _scope_text.strip():
         scope_filter = {
             line.strip()
-            for line in args.changed_files.splitlines()
+            for line in _scope_text.splitlines()
             if line.strip()
         }
 

--- a/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
+++ b/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_crashed_checker_is_not_a_finding.sh — a checker that could not run
+# must not produce a verdict about the code.
+#
+# WHAT THIS GUARDS (.github#245, #233)
+# ------------------------------------
+# Two gates turned an ENVIRONMENT failure into a statement about the source:
+#
+#   gate-17  passed the scope list as ONE argv string,
+#            `--changed-files=<404 KB>`. A single argument is capped at
+#            MAX_ARG_STRLEN — 128 KiB on Linux — regardless of ARG_MAX being
+#            2 MB. The exec raised E2BIG, python3 never started, and the log
+#            held the shell's "Argument list too long". `grep -c '^lib/'` then
+#            counted zero findings in that error text and the gate reported
+#            `FAIL — 0 pass-through method(s)`: a crashed checker wearing a
+#            finding count, and a count of zero at that.
+#
+#            Measured on openregister: root-scoped CHANGED_FILES is 404,828
+#            bytes across 7,224 files — over 3x the limit — and the pre-fix
+#            baseline reports exactly that FAIL — 0 line.
+#
+#   gate-60   reported 43 confident FAILs ("Calendar does not exist") when
+#            node_modules was absent. That was fixed by guarding the existence
+#            check — which swapped it for the OPPOSITE error: the rule silently
+#            stops running and the gate returns 0, so the runner prints PASS
+#            over a check that never executed.
+#
+# Both directions are the same mistake. "I could not look" is a THIRD state:
+# never PASS, never a finding count that was never measured.
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_crashed_checker_is_not_a_finding.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-crashed.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+# ---------------------------------------------------------------------------
+# THE MECHANISM ITSELF — a single argv string over 128 KiB is unusable.
+#
+# Asserted directly, because this is the fact the gate-17 fix depends on and it
+# is not obvious: ARG_MAX says 2 MB, and the limit that bites is a different,
+# per-argument one.
+# ---------------------------------------------------------------------------
+if python3 - <<'PY'
+import subprocess, sys
+big = "x" * (200 * 1024)
+try:
+    subprocess.run(["/bin/true", "--changed-files=" + big], check=True)
+except OSError:
+    sys.exit(0)   # E2BIG — the limit is real
+sys.exit(1)       # no error: this platform does not have the limit
+PY
+then
+    _ok "a single 200 KiB argv string raises E2BIG (the limit gate-17 tripped over)"
+    _argv_limited=1
+else
+    echo "  note — this platform accepts a 200 KiB single argument; the file-based"
+    echo "         scope path is still asserted below, but E2BIG cannot be provoked here."
+    _argv_limited=0
+fi
+
+# ---------------------------------------------------------------------------
+# gate-17 — a scope list far larger than MAX_ARG_STRLEN must still be inspected,
+# and must NOT come back as "FAIL — 0 pass-through method(s)".
+# ---------------------------------------------------------------------------
+_app="${_tmp}/app"
+mkdir -p "${_app}/lib/Controller" "${_app}/src"
+printf '{"name":"fx","menu":[]}\n' > "${_app}/src/manifest.json"
+cat > "${_app}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController {
+    public function index() { return 1; }
+}
+PHP
+# TWO commits: the diff has to be root..HEAD, and a repo whose root IS its HEAD
+# has an empty diff — the runner refuses that outright (base == HEAD), so no
+# gate would report and this arm would pass for the wrong reason.
+(
+    cd "${_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+# Enough files that the newline-joined path list clears 128 KiB comfortably.
+mkdir -p "${_app}/src/filler"
+_i=0
+while [ "${_i}" -lt 3000 ]; do
+    printf 'export const x%s = 1\n' "${_i}" \
+        > "${_app}/src/filler/a-file-with-a-deliberately-long-name-${_i}.ts"
+    _i=$((_i + 1))
+done
+(
+    cd "${_app}" || exit 1
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm "bulk"
+) >/dev/null 2>&1
+
+_root=$(cd "${_app}" && git rev-list --max-parents=0 HEAD | tail -1)
+_scope_bytes=$(cd "${_app}" && git diff --name-only --diff-filter=ACMR "${_root}...HEAD" | wc -c)
+echo "  (scope list is ${_scope_bytes} bytes; MAX_ARG_STRLEN is 131072)"
+
+_logs="${_tmp}/logs"
+mkdir -p "${_logs}"
+_out="${_tmp}/run.txt"
+(
+    cd "${_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_logs}" bash "${_runner}" \
+        --scope-to-diff --base "${_root}" . > "${_out}" 2>&1
+)
+
+_v17=$(grep -oE '^\[gate-17\] [^:]+: [A-Z]+( \([a-z]+\))?' "${_out}" | head -1 | sed 's/^[^:]*: //')
+if grep -qE '^\[gate-17\][^:]*: FAIL — 0 ' "${_out}"; then
+    _bad "gate-17 reported 'FAIL — 0 pass-through method(s)' — a crash rendered as a finding count"
+elif [ "${_v17}" = "PASS" ] || [ "${_v17}" = "FAIL" ]; then
+    _ok "gate-17 produced a real verdict (${_v17}) over a ${_scope_bytes}-byte scope list"
+elif [ "${_v17}" = "SKIPPED (wiring)" ]; then
+    _ok "gate-17 reported SKIPPED (wiring) — honest, though the scope file should have avoided the crash"
+else
+    _bad "gate-17 verdict is '${_v17:-none emitted}' — expected a real verdict"
+fi
+
+# The mechanism: the scope must travel via a FILE, not argv.
+if [ -s "${_logs}/hydra-gate-17-scope.txt" ]; then
+    _ok "the scope list travelled in a file, not in argv"
+else
+    _bad "no scope file was written — the list is still going through argv and will E2BIG again"
+fi
+
+# ---------------------------------------------------------------------------
+# gate-60 — node_modules absent. Not a pass, and not 43 findings.
+# ---------------------------------------------------------------------------
+_icon_app="${_tmp}/icons"
+mkdir -p "${_icon_app}/src"
+cat > "${_icon_app}/src/manifest.json" <<'JSON'
+{"name":"fx","menu":[{"label":"Calendar","icon":"Calendar","route":"/cal"}]}
+JSON
+(
+    cd "${_icon_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_ilogs="${_tmp}/ilogs"
+mkdir -p "${_ilogs}"
+_iout="${_tmp}/icons.txt"
+(
+    cd "${_icon_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_ilogs}" bash "${_runner}" . > "${_iout}" 2>&1
+)
+
+_v60=$(grep -oE '^\[gate-60\] [^:]+: [A-Z]+( \([a-z]+\))?' "${_iout}" | head -1 | sed 's/^[^:]*: //')
+case "${_v60}" in
+    "SKIPPED (wiring)")
+        _ok "gate-60 reports SKIPPED (wiring) when vue-material-design-icons is absent"
+        ;;
+    PASS)
+        _bad "gate-60 reported PASS while the icon-existence rule never ran — the #233 regression, inverted"
+        ;;
+    FAIL)
+        _bad "gate-60 reported FAIL from a missing dependency — an environment failure rendered as findings (#233)"
+        ;;
+    *)
+        _bad "gate-60 verdict is '${_v60:-none emitted}' — expected SKIPPED (wiring)"
+        ;;
+esac
+
+# It must say WHAT could not be checked, not merely that something was skipped.
+if grep -qE '^\[gate-60\][^:]*: SKIPPED \(wiring\) — .*vue-material-design-icons' "${_iout}"; then
+    _ok "gate-60's skip names the missing dependency and what it left unverified"
+else
+    _bad "gate-60's skip does not name the missing dependency"
+fi
+
+# THE CONTROL: the rules that CAN run without node_modules must still run, so
+# this is not "skip the gate whenever a dependency is missing".
+_bad_icon_app="${_tmp}/icons-bad"
+mkdir -p "${_bad_icon_app}/src"
+cat > "${_bad_icon_app}/src/manifest.json" <<'JSON'
+{"name":"fx","menu":[{"label":"Dashboard","icon":"CarSportOutline","route":"/d"}]}
+JSON
+(
+    cd "${_bad_icon_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+_blogs="${_tmp}/blogs"
+mkdir -p "${_blogs}"
+_bout="${_tmp}/icons-bad.txt"
+(
+    cd "${_bad_icon_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_blogs}" bash "${_runner}" . > "${_bout}" 2>&1
+)
+if grep -qE '^\[gate-60\][^:]*: FAIL' "${_bout}"; then
+    _ok "a Tier-A concept on a non-canonical icon is STILL caught without node_modules"
+else
+    _v=$(grep -oE '^\[gate-60\] [^:]+: [A-Z]+( \([a-z]+\))?' "${_bout}" | head -1 | sed 's/^[^:]*: //')
+    _bad "gate-60 returned '${_v}' for a real violation it can detect offline — the missing dependency is now suppressing rules that DO work"
+fi
+
+echo
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_crashed_checker_is_not_a_finding.sh: ALL PASS"
+    exit 0
+fi
+echo "test_gate_crashed_checker_is_not_a_finding.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1934,13 +1934,36 @@ SCRIPT_DIR_REDUNDANT="${SCRIPT_DIR}"
 # argparse to reject every file after the first as "unrecognized arguments"
 # and the gate to fail spuriously. Observed 2026-05-27 on PR #739 canary.
 _redundant_args=()
+# THE SCOPE LIST GOES IN A FILE, NOT IN ARGV (#245).
+#
+# `--changed-files=${CHANGED_FILES}` is ONE argument, and a single argument is
+# capped at MAX_ARG_STRLEN — 128 KiB on Linux — regardless of ARG_MAX being
+# 2 MB. openregister's root-scoped list is 404,828 bytes across 7,224 files, so
+# the exec raised E2BIG, python3 never started, the log held only the shell's
+# "Argument list too long", and `grep -c '^lib/'` counted zero findings in it.
+# The gate then reported `FAIL — 0 pass-through method(s)`: a crashed checker
+# wearing a finding count, and a count of zero at that. Reproduced verbatim in
+# openregister's root-scoped baseline.
+_redundant_scope_file="${HYDRA_GATE_LOG_DIR}/hydra-gate-17-scope.txt"
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${CHANGED_FILES}" ]; then
-    _redundant_args+=("--changed-files=${CHANGED_FILES}")
+    printf '%s\n' "${CHANGED_FILES}" > "${_redundant_scope_file}" 2>/dev/null \
+        && _redundant_args+=("--changed-files-file=${_redundant_scope_file}")
 fi
 _redundant_args+=("${APP_DIR}")
 if python3 "${SCRIPT_DIR_REDUNDANT}/lib/detect-redundant-controllers.py" \
         "${_redundant_args[@]}" > "${_redundant_log}" 2>&1; then
     _pass 17 "redundant-controller"
+elif ! grep -q '^# count=' "${_redundant_log}" 2>/dev/null; then
+    # THE CHECKER DID NOT FINISH. Its terminal `# count=<n>` marker is absent,
+    # so it never reached its own summary — E2BIG, a traceback, an OOM kill, a
+    # missing interpreter. It has no verdict to give, and the old code turned
+    # that into `FAIL — 0 pass-through method(s)` by counting matches in a log
+    # that contains an error message rather than findings.
+    #
+    # A crash is a distinct state: never PASS, and never a finding count that
+    # was never measured. --require-full-coverage counts this against coverage.
+    _redundant_why=$(head -3 "${_redundant_log}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+    _skip 17 "redundant-controller" wiring "detect-redundant-controllers.py did not complete — it never printed its terminal '# count=' marker, so NO controller or service method was inspected and ADR-022 pass-through wrappers are UNVERIFIED by this run. Checker output: ${_redundant_why:-<empty>}. See ${_redundant_log}."
 elif grep -q '^# count=0$' "${_redundant_log}" 2>/dev/null; then
     # The python script ran cleanly and printed its terminal `# count=0`
     # line — it found zero pass-through controllers. The non-zero exit
@@ -4907,6 +4930,13 @@ if [ -f src/manifest.json ]; then
         grep -E '^(WARN|NOTE)' "${_iv_log}" || true
         if [ "${_iv_rc}" -eq 0 ]; then
             _pass 60 "icon-vocabulary"
+        elif [ "${_iv_rc}" -eq 5 ]; then
+            # vue-material-design-icons is not installed, so the "does this
+            # icon name exist upstream?" rule could not run. This gate has
+            # already shipped both dishonest answers to that: 43 confident
+            # FAILs when node_modules was absent, then — once those were
+            # guarded — a silent PASS over a rule that never executed (#233).
+            _skip 60 "icon-vocabulary" wiring "vue-material-design-icons is not installed, so icon names could NOT be verified to exist upstream — an invented MDI name would render blank and this run would not have caught it (ADR-077 rule 1). Every other icon rule passed. Run npm ci to restore full coverage. See ${_iv_log}."
         else
             _iv_n=$(_count '^FAIL' "${_iv_log}")
             [ "${_iv_n}" -eq 0 ] && _iv_n=1
@@ -4914,7 +4944,7 @@ if [ -f src/manifest.json ]; then
         fi
     fi
 else
-    _pass 60 "icon-vocabulary"
+    _skip 60 "icon-vocabulary" na "no src/manifest.json — this app declares no menu icon for the ADR-077 vocabulary to constrain."
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #245. Closes #233.

Two gates turned an **environment failure** into a statement about the source code — in opposite directions.

## gate-17 (#245) — a crash wearing a finding count

The scope list was passed as **one argv string**, `--changed-files=<404 KB>`. A *single argument* is capped at `MAX_ARG_STRLEN` — **128 KiB on Linux** — regardless of `ARG_MAX` being 2 MB. The exec raised `E2BIG`, `python3` never started, and the log held only the shell's *"Argument list too long"*. `grep -c '^lib/'` then counted zero findings **in that error text**, and the gate reported:

```
[gate-17] redundant-controller: FAIL — 0 pass-through method(s)
```

A crashed checker wearing a finding count — and a count of zero at that.

**Measured on openregister**: the root-scoped file list is **404,828 bytes across 7,224 files**, over 3× the limit. The pre-fix baseline prints exactly that `FAIL — 0` line. After the fix, the same run reports a real **PASS** having actually inspected all 7,224 files.

- the scope list now travels in a **file** (`--changed-files-file`), which has no size ceiling
- a run that never prints its terminal `# count=` marker is reported as **`SKIPPED (wiring)`**, never as a finding count it did not measure

## gate-60 (#233) — the same mistake, inverted

The gate reported **43 confident FAILs** (*"Calendar does not exist"*) when `node_modules` was absent. That was fixed on `main` by guarding the existence check on `available is not None` — which swapped it for the **opposite** error: the rule silently stops running, the helper returns `0`, and the runner prints **PASS** over a check that never executed.

Neither reading is honest. "I could not look" is a third state.

- the helper returns a distinct status when `vue-material-design-icons` is missing; the runner maps it to `SKIPPED (wiring)` **and names the dependency**
- **every rule that can run offline still runs** — a Tier-A concept on a non-canonical icon is still caught, asserted as a control so this is not "skip the gate whenever a dependency is missing"
- the no-manifest branch reports `na` instead of PASS

## Tests

`test_gate_crashed_checker_is_not_a_finding.sh`, including a direct assertion of the mechanism itself (a 200 KiB single argv string raises `E2BIG`) — because the fact the fix rests on is not obvious: `ARG_MAX` says 2 MB, and the limit that bites is a different, per-argument one.

Mutation-checked against the pre-fix runner: gate-17 reproduces `FAIL — 0 pass-through method(s)` **verbatim**, and no scope file is written.

One honest caveat on that mutant: it pairs the pre-fix *runner* with the post-fix *helper*, so the gate-60 arm goes red as `FAIL` rather than `PASS`. The original 43-FAIL symptom was already fixed on `main` by the `available is not None` guard; what this PR removes is the **silent PASS** that replaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)