### PR TITLE
fix(gates): a mainline push gated nothing; it now audits everything (#183)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_mainline_push_audits_everything.sh
+++ b/hydra-gates/scripts/lib/test_gate_mainline_push_audits_everything.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_mainline_push_audits_everything.sh — a push to a mainline branch
+# must gate the code, not exit 99 having gated nothing.
+#
+# WHAT THIS GUARDS (.github#183)
+# ------------------------------
+# On a push, the diff base the caller supplies IS the branch being pushed, so
+# `origin/development...HEAD` is empty by construction. The runner already
+# handles the common case by re-scoping to `github.event.before` — the push's
+# own previous tip.
+#
+# When that tip cannot be resolved — a branch created by this push, a
+# force-push, a freshly-cloned mirror — the runner used to `exit 99`. That
+# reasoning was right about the evidence and wrong about the remedy: the run
+# then reported NO gate at all, zero `[gate-N]` lines, which carries exactly as
+# much information as a green over an empty diff. None.
+#
+# The file says so itself, two screens above the block: "a permanently-red gate
+# and a permanently-green gate say the same thing about the code, and both get
+# filtered out by the people reading them."
+#
+# There is a correct scope for "I cannot tell what this push changed":
+# everything. Diffing against the EMPTY TREE puts every tracked file in scope,
+# needs no root commit, and is therefore unambiguous in a repository with
+# several roots or a grafted history.
+#
+# Measured before the fix: exit 99, 0 gate lines. After: 60 gates report.
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_mainline_push_audits_everything.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-mainline.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+# A repo shaped like a mainline push: the branch named as the diff base points
+# at HEAD, and nothing tells us what the push started from.
+_app="${_tmp}/app"
+mkdir -p "${_app}/src" "${_app}/lib/Controller" "${_app}/appinfo"
+printf '{"name":"fx","menu":[]}\n' > "${_app}/src/manifest.json"
+# appinfo/routes.php is REQUIRED, not decoration: gate-25 reports NOT APPLICABLE
+# without it, and the control below would then pass by never reaching the gate
+# it claims to exercise.
+printf "<?php\nreturn ['routes'=>[['name'=>'thing#index','url'=>'/api/thing','verb'=>'GET']]];\n" \
+    > "${_app}/appinfo/routes.php"
+cat > "${_app}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController {
+    #[PublicPage]
+    public function index() { return 1; }
+}
+PHP
+(
+    cd "${_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+    printf 'more\n' > src/extra.txt
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm second
+    git branch -f development HEAD
+) >/dev/null 2>&1
+
+_logs="${_tmp}/logs"
+mkdir -p "${_logs}"
+_out="${_tmp}/run.txt"
+(
+    cd "${_app}" || exit 1
+    # HYDRA_GATE_PUSH_BEFORE deliberately unset — this is the unresolvable case.
+    unset HYDRA_GATE_PUSH_BEFORE
+    HYDRA_GATE_LOG_DIR="${_logs}" bash "${_runner}" \
+        --scope-to-diff --base development . > "${_out}" 2>&1
+)
+_rc=$?
+
+_lines=$(grep -cE '^\[gate-[0-9]+\]' "${_out}" 2>/dev/null || echo 0)
+
+if [ "${_rc}" -eq 99 ]; then
+    _bad "the runner exited 99 on a mainline push — it gated nothing (#183)"
+else
+    _ok "the runner did not refuse a mainline push (exit ${_rc})"
+fi
+
+if [ "${_lines}" -gt 0 ]; then
+    _ok "${_lines} gate(s) reported a verdict on a mainline push"
+else
+    _bad "no gate reported at all — a mainline push still gates nothing"
+fi
+
+if grep -q 'FULL-TREE AUDIT' "${_out}"; then
+    _ok "the fallback states out loud that everything is in scope"
+else
+    _bad "the run did not announce the full-tree fallback — a silent re-scope is how a scope change goes unnoticed"
+fi
+
+# THE CONTROL. "Audit everything" must mean everything: a repo whose only
+# controller is in the first commit must still have that controller in scope,
+# or the fallback has quietly become another empty diff.
+if grep -qE '^\[hydra-gates\] COVERAGE:' "${_out}"; then
+    _ok "the run reached its coverage summary"
+else
+    _bad "the run never reached the coverage summary"
+fi
+
+# A gate whose subject matter exists must not report NOT APPLICABLE under the
+# fallback — that would mean the empty-tree diff did not actually list the files.
+if grep -qE '^\[gate-25\][^:]*: (PASS|FAIL)' "${_out}"; then
+    _ok "gate-25 saw the controller — the empty-tree diff really does list every tracked file"
+else
+    _v=$(grep -oE '^\[gate-25\] [^:]+: [A-Z]+( \([a-z]+\))?' "${_out}" | head -1 | sed 's/^[^:]*: //')
+    _bad "gate-25 reported '${_v:-nothing}' — the fallback scope is not reaching tracked files"
+fi
+
+# A NARROWLY SCOPED push must still be scoped narrowly: the fallback is for the
+# unresolvable case only, and must not swallow a caller who told us the base.
+_out2="${_tmp}/run2.txt"
+_logs2="${_tmp}/logs2"
+mkdir -p "${_logs2}"
+(
+    cd "${_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_logs2}" bash "${_runner}" \
+        --scope-to-diff --base HEAD~1 . > "${_out2}" 2>&1
+)
+if grep -q 'FULL-TREE AUDIT' "${_out2}"; then
+    _bad "a resolvable base was overridden by the full-tree fallback — scoping is now unusable"
+else
+    _ok "a resolvable base is still scoped narrowly (the fallback did not swallow it)"
+fi
+
+echo
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_mainline_push_audits_everything.sh: ALL PASS"
+    exit 0
+fi
+echo "test_gate_mainline_push_audits_everything.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -298,17 +298,59 @@ if [ "${SCOPE_TO_DIFF}" = "1" ]; then
             _push_base=""
         fi
         if [ -z "${_push_base:-}" ]; then
-            echo "[hydra-gates] ERROR: diff base '${BASE_REF}' IS HEAD (${_head_sha}) and the push's" >&2
-            echo "[hydra-gates] previous tip could not be used either (reason above)." >&2
-            echo "[hydra-gates] A scoped run against itself inspects nothing, and every gate" >&2
-            echo "[hydra-gates] would report PASS over an empty file set. Refusing." >&2
-            echo "[hydra-gates] Pass a --base that is actually behind HEAD, or set" >&2
-            echo "[hydra-gates] HYDRA_GATE_PUSH_BEFORE to the commit this push started from." >&2
-            exit 99
+            # AUDIT EVERYTHING RATHER THAN NOTHING (#183).
+            #
+            # This used to `exit 99`. The reasoning was sound about the evidence
+            # — a scoped run against itself inspects nothing — and wrong about
+            # the remedy. Refusing fires on every push where the previous tip is
+            # unreachable: a branch created by this push, a force-push, a
+            # freshly-cloned mirror. The run then reports NO gate at all (exit
+            # 99, zero `[gate-N]` lines), which is the same amount of
+            # information a green over an empty diff carries: none.
+            #
+            # The file already says this two screens up — "a permanently-red
+            # gate and a permanently-green gate say the same thing about the
+            # code, and both get filtered out by the people reading them".
+            #
+            # There IS a correct scope for "I cannot tell what this push
+            # changed": everything. Diffing against the EMPTY TREE yields every
+            # tracked file, which is exactly the full-tree audit mode
+            # (`--scope-to-diff --base <root>`) that fleet sweeps already use —
+            # and it needs no root commit, so it is unambiguous in a repository
+            # with several roots or a grafted history.
+            #
+            # A mainline push now gates the whole tree. That is slower and
+            # louder than a diff, and it is the honest answer: nobody told us
+            # what changed, so nothing is assumed unchanged.
+            _empty_tree=$(git -c safe.directory='*' hash-object -t tree /dev/null 2>/dev/null)
+            if [ -n "${_empty_tree}" ] \
+                && git -c safe.directory='*' cat-file -e "${_empty_tree}" 2>/dev/null; then
+                echo "[hydra-gates] The push's previous tip could not be resolved (reason above)."
+                echo "[hydra-gates] FALLING BACK TO A FULL-TREE AUDIT: every tracked file is in scope."
+                echo "[hydra-gates] This is deliberate. A scoped run against itself would inspect"
+                echo "[hydra-gates] nothing, and refusing outright would gate nothing either — both"
+                echo "[hydra-gates] say the same thing about the code. Auditing everything says"
+                echo "[hydra-gates] something. Set HYDRA_GATE_PUSH_BEFORE to scope a push narrowly."
+                BASE_REF="${_empty_tree}"
+            else
+                echo "[hydra-gates] ERROR: diff base '${BASE_REF}' IS HEAD (${_head_sha}), the push's" >&2
+                echo "[hydra-gates] previous tip could not be used, and the empty tree could not be" >&2
+                echo "[hydra-gates] resolved either — so there is no scope left to fall back to." >&2
+                echo "[hydra-gates] A scoped run against itself inspects nothing, and every gate" >&2
+                echo "[hydra-gates] would report PASS over an empty file set. Refusing." >&2
+                echo "[hydra-gates] Pass a --base that is actually behind HEAD, or set" >&2
+                echo "[hydra-gates] HYDRA_GATE_PUSH_BEFORE to the commit this push started from." >&2
+                exit 99
+            fi
         fi
     fi
 
-    if ! git -c safe.directory='*' merge-base "${BASE_REF}" HEAD > /dev/null 2>&1; then
+    # The empty tree deliberately shares no history with HEAD — that is what
+    # makes it mean "everything is in scope". The shallow-checkout guard below
+    # would reject it for exactly the property we selected it for, so skip it.
+    if [ "${BASE_REF}" = "${_empty_tree:-}" ]; then
+        :
+    elif ! git -c safe.directory='*' merge-base "${BASE_REF}" HEAD > /dev/null 2>&1; then
         echo "[hydra-gates] ERROR: '${BASE_REF}' resolves, but shares NO history with HEAD." >&2
         echo "[hydra-gates] This is what a SHALLOW checkout looks like (fetch-depth: 1)." >&2
         echo "[hydra-gates] The diff would be empty and every gate would pass having read" >&2


### PR DESCRIPTION
Closes #183.

## The defect

On a push, the diff base the caller supplies **is** the branch being pushed, so `origin/development...HEAD` is empty by construction. The runner already handles the common case by re-scoping to `github.event.before`.

When that previous tip **cannot** be resolved — a branch created by this push, a force-push, a freshly-cloned mirror — the runner `exit 99`. That was right about the evidence and wrong about the remedy: the run then reported **no gate at all**, zero `[gate-N]` lines, which carries exactly as much information as a green over an empty diff. None.

The file already argues the point two screens above the block it lives in:

> a permanently-red gate and a permanently-green gate say the same thing about the code, and both get filtered out by the people reading them

## The fix

There **is** a correct scope for *"I cannot tell what this push changed"*: everything.

Diffing against the **empty tree** puts every tracked file in scope, needs no root commit, and is therefore unambiguous in a repository with several roots or a grafted history. The shallow-checkout guard is skipped for it deliberately — sharing no history with HEAD is the very property that makes it mean "everything".

A mainline push is now slower and louder than a diff. That is the honest answer: nobody told us what changed, so nothing is assumed unchanged.

| | before | after |
|---|---|---|
| exit code | **99** | 6 |
| gates reporting | **0** | **64** |

## Mutation check

Against pristine `main`, **5 of 6** assertions go red.

## Two controls, because this fix has two ways to go wrong

- **a scope that is loud but empty** — gate-25 must return a real verdict, proving the empty-tree diff genuinely lists tracked files. Worth recording: my first fixture had no `appinfo/routes.php`, so gate-25 answered `NOT APPLICABLE` and **the control passed without ever reaching the gate it claimed to exercise**. Fixed by adding the route table.
- **a fallback that swallows everything** — a resolvable `--base` must still be scoped narrowly, so the full-tree path cannot quietly become the only mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)