### PR TITLE
fix(gate-5,14,30,9): route names, delegated registrars, and a monitoring gate that passed on nothing (#213, #218, #221, #223, #237)

### DIFF
--- a/hydra-gates/scripts/lib/check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/check_semantic_auth.py
@@ -339,9 +339,136 @@ _SELF_AUTH_RE = re.compile(
     r"->\s*checkPassword\s*\(|"
     r"\$\w*[Pp]assword\b|"
     r"\$\w*[Cc]redentials?\b|"
-    r"->\s*(resolve|validate|verify|check)\w*[Cc]redentials?\s*\(",
+    r"->\s*(resolve|validate|verify|check)\w*[Cc]redentials?\s*\(|"
+    # THE SESSION IS A CREDENTIAL IN THE REQUEST (ConductionNL/.github#221).
+    #
+    # `#[PublicPage]` in Nextcloud means "a login is NOT REQUIRED". It does
+    # not mean "there is no session" — a logged-in user hitting a PublicPage
+    # route arrives with their session cookie intact. So the progressive
+    # shape
+    #
+    #     $user = $this->session->getUser();
+    #     if ($user === null) { ...policy... return 401; }   // anonymous
+    #     ...                                                 // authenticated
+    #
+    # resolves a real credential from the request and denies on a stated
+    # policy. doriath ApplicationController::create is exactly this: admin
+    # auto-approves, an authenticated non-admin gets a pending row, and an
+    # anonymous caller is admitted ONLY when the app-config opt-in
+    # `anonymous_application_registration_enabled` is set — otherwise 401.
+    # The gate called that "denying on something the annotation guarantees is
+    # absent". The annotation guarantees no such thing.
+    #
+    # ⚠️ This does NOT soften rule 1 (`_PUBLIC_SESSION_AUTH_RE`). That rule is
+    # tested FIRST and this branch is its `elif`, so `requireAdmin()` under
+    # #[PublicPage] — the decidesk defect the gate was built for — still
+    # fires. What survives here is the shape with no credential of any kind:
+    # a #[PublicPage] method that returns 401/403 off a config read, a
+    # feature flag or nothing at all.
+    r"->\s*getUser\s*\(\s*\)|"
+    r"->\s*getUID\s*\(|"
+    r"->\s*getUserId\s*\(|"
+    r"\bIUserSession\b",
     re.IGNORECASE,
 )
+
+
+_ANY_METHOD_RE = re.compile(
+    r"\bfunction\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+)
+
+# `$this->helper(`, `self::helper(`, `static::helper(` — a call to a sibling
+# method of the same class.
+_SIBLING_CALL_RE = re.compile(
+    r"(?:\$this\s*->|self\s*::|static\s*::)\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+)
+
+
+def _all_method_bodies(src: str) -> dict[str, str]:
+    """Every method in the file, at any visibility, as {name: body}.
+
+    ``_find_method_bodies`` deliberately only walks ``public function`` —
+    those are the routed entry points the rules judge. This one exists for a
+    different question: WHERE the credential is resolved, which is not
+    required to be in the entry point itself.
+    """
+    cleaned = _strip_strings_and_comments(src)
+    out: dict[str, str] = {}
+    for m in _ANY_METHOD_RE.finditer(cleaned):
+        start = m.start()
+        paren = 0
+        j = start
+        while j < len(cleaned):
+            c = cleaned[j]
+            if c == "(":
+                paren += 1
+            elif c == ")":
+                paren -= 1
+            elif c == "{" and paren == 0:
+                break
+            elif c == ";" and paren == 0:
+                # Abstract / interface declaration — no body.
+                j = len(cleaned)
+                break
+            j += 1
+        if j >= len(cleaned) or cleaned[j] != "{":
+            continue
+        depth = 0
+        k = j
+        while k < len(cleaned):
+            ck = cleaned[k]
+            if ck == "{":
+                depth += 1
+            elif ck == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            k += 1
+        if depth != 0:
+            continue
+        # Slice from the ORIGINAL source: the exemption is tested against real
+        # text (with strings intact), exactly as the caller's `head + body` is.
+        out.setdefault(m.group("name"), src[j:k + 1])
+    return out
+
+
+def _credential_surface(src: str, head: str, body: str, all_bodies: dict[str, str]) -> str:
+    """The text in which "does this endpoint name its credential?" is decided.
+
+    THE CREDENTIAL IS OFTEN ONE FRAME DOWN (ConductionNL/.github#221)
+    ----------------------------------------------------------------
+    A controller that authenticates several endpoints the same way does not
+    repeat the resolution in each — it writes it once, in a private helper,
+    and every action calls that:
+
+        #[PublicPage]
+        public function show(): JSONResponse {
+            $userId = $this->resolveUserId();
+            if ($userId === null) { return ...STATUS_UNAUTHORIZED; }
+            ...
+        }
+
+        private function resolveUserId(): ?string {
+            return $this->session->getUser()?->getUID();
+        }
+
+    Reading only the entry point, the gate sees a 401 and no credential, and
+    reports "unsourced denial". The credential is right there, one call away,
+    in the same file. Extracting a helper is the refactor every other quality
+    gate in this suite asks for; it must not manufacture a security finding.
+
+    ONE FRAME, and only sibling methods of the same file. Not transitive:
+    following the call graph arbitrarily deep would eventually reach a service
+    that touches a token for unrelated reasons and exempt everything. Depth 1
+    is the shape actually observed, and it keeps the "no credential ANYWHERE
+    near this endpoint" positive control intact.
+    """
+    surface = [head, body]
+    for call in _SIBLING_CALL_RE.finditer(_strip_strings_and_comments(body)):
+        helper = all_bodies.get(call.group("name"))
+        if helper is not None:
+            surface.append(helper)
+    return "\n".join(surface)
 
 
 def _has_admin_if_with_throw(body: str) -> bool:
@@ -411,6 +538,9 @@ def scan_file(path: str) -> int:
     except OSError:
         return 0
     violations = 0
+    # Computed once per file, not per method: the unsourced-denial rule needs
+    # the bodies of the private helpers a public action delegates to.
+    all_bodies = _all_method_bodies(src)
     for name, head_start, body_start, body_end, line_no in _find_method_bodies(src):
         head = src[head_start:body_start]
         body = src[body_start:body_end]
@@ -444,7 +574,9 @@ def scan_file(path: str) -> int:
             # docblock describing a check the body does not perform.
             elif (
                 _PUBLIC_DENY_STATUS_RE.search(body)
-                and not _SELF_AUTH_RE.search(_strip_comments(head + body))
+                and not _SELF_AUTH_RE.search(
+                    _strip_comments(_credential_surface(src, head, body, all_bodies))
+                )
             ):
                 print(
                     f"{path}:{line_no} method={name} "

--- a/hydra-gates/scripts/lib/test_check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/test_check_semantic_auth.py
@@ -488,5 +488,230 @@ class GateIsNotBlind(unittest.TestCase):
         self.assertEqual(len(_scan(php)), 2)
 
 
+class CredentialResolvedOneFrameDown(unittest.TestCase):
+    """ConductionNL/.github#221 — where the credential is resolved.
+
+    36 of gate-9's 39 fleet findings were false, and this class covers the
+    two shapes the token list still could not see. Both are correct code and
+    both had no closable remediation.
+
+    Every method here is one half of a control pair: for each shape that must
+    go quiet there is a sibling differing by the ONE thing the widening
+    accepts, and that sibling must still fire. Widening a rule that guards an
+    authorisation surface is the expensive direction, so the anti-widening
+    halves are the point of the class, not an afterthought.
+    """
+
+    # -- the session IS a credential in the request ------------------------
+    def test_fp_progressive_session_then_policy_denial_is_not_a_finding(self):
+        """doriath ApplicationController::create, structurally verbatim.
+
+        `#[PublicPage]` because the endpoint accepts anonymous registration
+        WHEN THE ADMIN HAS OPTED IN. The 401 is reached only for a caller
+        with no session on an instance that has not opted in — a stated
+        policy, not a check against something the annotation forbids.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function create(): JSONResponse
+    {
+        $user = $this->session->getUser();
+        if ($user === null) {
+            $anonEnabled = $this->appConfig->getValueString('doriath', 'anon_enabled', '0');
+            if ($anonEnabled !== '1') {
+                return new JSONResponse(['message' => 'Unauthorized'], Http::STATUS_UNAUTHORIZED);
+            }
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+"""
+        self.assertEqual(_scan(php), [])
+
+    def test_tp_a_denial_off_a_config_read_alone_still_fires(self):
+        """The anti-widening half of the test above.
+
+        Identical but for the ONE line that resolves an identity. Nothing
+        here authenticates anybody: the endpoint is public and 401s on a
+        feature flag. That is the shape the rule exists for and it must
+        survive making the session count.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function create(): JSONResponse
+    {
+        $anonEnabled = $this->appConfig->getValueString('doriath', 'anon_enabled', '0');
+        if ($anonEnabled !== '1') {
+            return new JSONResponse(['message' => 'Unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-unsourced-denial"])
+
+    # -- one frame down, in a private helper --------------------------------
+    def test_fp_credential_resolved_in_a_private_helper_is_not_a_finding(self):
+        """A controller that authenticates several actions the same way writes
+        the resolution ONCE. Extracting that helper is the refactor every
+        other gate in this suite asks for; it must not manufacture a finding.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function show(): JSONResponse
+    {
+        $userId = $this->resolveUserId();
+        if ($userId === null) {
+            return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+
+    private function resolveUserId(): ?string
+    {
+        return $this->session->getUser()?->getUID();
+    }
+"""
+        self.assertEqual(_scan(php), [])
+
+    def test_fp_a_helper_that_verifies_a_bearer_token_is_not_a_finding(self):
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function inbox(): JSONResponse
+    {
+        if ($this->authenticateCaller() === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+
+    private function authenticateCaller(): bool
+    {
+        $header = $this->request->getHeader('Authorization');
+        return hash_equals($this->expected, substr($header, 7));
+    }
+"""
+        self.assertEqual(_scan(php), [])
+
+    def test_tp_a_helper_that_resolves_no_credential_still_fires(self):
+        """Anti-widening: calling a helper is not itself evidence.
+
+        Same delegation shape as the two above; the helper reads a config
+        value. If merely *having* a sibling call earned the exemption, this
+        would go quiet — and the rule would be closable by extracting any
+        method at all.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function show(): JSONResponse
+    {
+        if ($this->featureEnabled() === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+
+    private function featureEnabled(): bool
+    {
+        return $this->appConfig->getValueString('thing', 'enabled', '0') === '1';
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-unsourced-denial"])
+
+    def test_tp_the_walk_is_one_frame_and_does_not_go_transitive(self):
+        """The documented bound, pinned.
+
+        The credential sits TWO calls away. Following the call graph to
+        arbitrary depth would eventually reach a service that touches a token
+        for unrelated reasons and exempt everything, so depth 1 is deliberate
+        — and a deliberate bound that no test asserts is a bound that will be
+        removed by the next person who reads the regex.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function show(): JSONResponse
+    {
+        if ($this->firstFrame() === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+
+    private function firstFrame(): bool
+    {
+        return $this->secondFrame();
+    }
+
+    private function secondFrame(): bool
+    {
+        return hash_equals($this->expected, $this->request->getHeader('X-Signature'));
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-unsourced-denial"])
+
+    # -- rule 1 is untouched -----------------------------------------------
+    def test_tp_require_admin_under_public_page_is_unaffected_by_the_widening(self):
+        """`getUser()` now counts as a credential source. That must not reach
+        rule 1, which is tested FIRST and owns the genuine contradiction:
+        #[PublicPage] admits a caller with no login, and requireAdmin() can
+        only ever reject that caller. decidesk#44, the defect the gate was
+        built for.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    public function load(): JSONResponse
+    {
+        $this->requireAdmin();
+        $user = $this->userSession->getUser();
+        return new JSONResponse(['user' => $user]);
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-session-auth-body"])
+
+    def test_tp_user_session_null_check_is_unaffected_by_the_widening(self):
+        php = CLASS % """
+    #[PublicPage]
+    public function load(): JSONResponse
+    {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-session-auth-body"])
+
+    def test_tp_prose_in_a_helper_docblock_does_not_earn_the_exemption(self):
+        """The gate-64 failure mode, one frame down. The helper is inlined
+        into the credential surface, and that surface is comment-stripped
+        before the question is asked — so a docblock describing a token check
+        the helper does not perform still fires.
+        """
+        php = CLASS % """
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function show(): JSONResponse
+    {
+        if ($this->allowed() === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+
+    /**
+     * Verifies the caller's bearer token against the stored HMAC signature.
+     */
+    private function allowed(): bool
+    {
+        return $this->appConfig->getValueString('thing', 'enabled', '0') === '1';
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), ["public-page-annotation-with-unsourced-denial"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_gate_route_registration.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_registration.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_route_registration.sh — control pairs for the route- and
+# registration-DETECTION defects in gates 5, 14 and 30.
+#
+# Closes ConductionNL/.github#213 (the gate-30 half), #218, #223, #237.
+#
+# WHY THIS EXISTS
+# ---------------
+# Two defects, over and over, in three gates:
+#
+#   (a) A SHELL OR REGEX DETAIL CORRUPTED THE INPUT, so the gate measured
+#       something other than the code. gate-30's selector alternation
+#       `(metrics|health|liveness|readiness|probe)` is lowercase-only under
+#       `grep -E`, so `genericHealth#index` and
+#       `AppHost\Controller\GenericMetrics#index` matched NOTHING — and the
+#       gate printed PASS over a 0-byte log in four repos, openregister among
+#       them, which OWNS the fleet's health/metrics engine. `read` without -r
+#       ate the backslash out of every namespaced route name (fixed for gates
+#       5 and 14 in #217; gate-30 carried the same line).
+#
+#   (b) THE GATES MODELLED **ONE** REGISTRATION IDIOM and flagged every other
+#       legitimate one. A route supplied by `Routes::standard()` is not in
+#       appinfo/routes.php (#223). A `Bootstrap::register()` call is not
+#       required to sit in Application.php — and this suite's own phpmd gate
+#       is what pushes it into a registrar (#237, procest#717). A controller
+#       whose name merely contains "health" is not a scrape target (#218).
+#
+# ⚠️ EVERY FIX HERE WIDENS SOMETHING, AND WIDENING IS HOW A GATE GOES QUIET.
+# gate-5 and gate-30 guard authorisation surfaces; over-widening them is the
+# failure that matters, not the false positives. So every fixture carries its
+# own anti-widening half — a sibling differing by the ONE thing the widening
+# accepts, which MUST still fail:
+#
+#   routes-standard/            5 canonical routes exempt   -> gate-14 PASS on them
+#                               `gadget#run` has no route   -> gate-14 FAILS
+#   delegated-registrar/        AppHost call in a registrar -> 3 generics exempt
+#                               `gadget#run` bound nowhere  -> gate-14 FAILS
+#   delegated-registrar-absent/ the SAME app minus that one file -> all 4 FAIL
+#   monitoring-capitalised/     a capitalised name is now SELECTED -> gate-30 FAILS
+#                               a metrics posture 20+ lines up   -> not a finding
+#   monitoring-per-object/      healthPing#show / #validate ignored
+#                               health#index in the same repo    -> gate-30 FAILS
+#   monitoring-per-object-only/ zero scrape targets -> NOT APPLICABLE, never PASS
+#   monitoring-none/            zero candidates     -> NOT APPLICABLE, never PASS
+#
+# Run: bash scripts/lib/test_gate_route_registration.sh   (exit 0 = all green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+FIXTURES="${PKG_ROOT}/scripts/test-fixtures/route-registration"
+
+_fail_n=0
+_pass_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+_OUT=""
+_RRLOG=""
+_RALOG=""
+_UNRES=""
+_PMLOG=""
+_PMNOTES=""
+_run() {
+    local _dir="$1"; shift
+    local _logdir
+    _logdir="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-test.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    _RRLOG="$(cat "${_logdir}/hydra-gate-route-reachability.log" 2>/dev/null || true)"
+    _RALOG="$(cat "${_logdir}/hydra-gate-route-auth.log" 2>/dev/null || true)"
+    _UNRES="$(cat "${_logdir}/hydra-gate-route-auth-unresolved.log" 2>/dev/null || true)"
+    _PMLOG="$(cat "${_logdir}/hydra-gate-public-monitoring.log" 2>/dev/null || true)"
+    _PMNOTES="$(cat "${_logdir}/hydra-gate-public-monitoring-notes.log" 2>/dev/null || true)"
+    # A run that aborts before its summary leaves the per-gate PASS lines on
+    # stdout and reads exactly like a clean run.
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "run in ${_dir} ABORTED before the summary — verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_expect_gate() {  # <n> <verdict-substring> <description>
+    local _n="$1" _want="$2" _desc="$3" _line
+    _line="$(printf '%s' "${_OUT}" | grep -E "^\[gate-${_n}\] " | head -1)"
+    if [ -z "${_line}" ]; then
+        _bad "${_desc} — gate-${_n} emitted NO verdict line at all"
+        return
+    fi
+    case "${_line}" in
+        *": ${_want}"*) _ok "${_desc} — ${_line}" ;;
+        *) _bad "${_desc} — wanted '${_want}', got: ${_line}" ;;
+    esac
+}
+
+_expect_log()     { if printf '%s' "$1" | grep -qE "$2"; then _ok "$3"; else _bad "$3 — no log line matching /$2/. Log was: $(printf '%s' "$1" | tr '\n' '|')"; fi; }
+_expect_not_log() { if printf '%s' "$1" | grep -qE "$2"; then _bad "$3 — unexpected: $(printf '%s' "$1" | grep -E "$2" | head -1)"; else _ok "$3"; fi; }
+_expect_lines()   { local _n; _n=$(printf '%s' "$1" | grep -c . ); if [ "${_n}" -eq "$2" ]; then _ok "$3"; else _bad "$3 — expected $2 line(s), got ${_n}: $(printf '%s' "$1" | tr '\n' '|')"; fi; }
+
+echo "== gate-5 / gate-14 / gate-30 route + registration detection =="
+echo
+
+for _f in routes-standard delegated-registrar delegated-registrar-absent \
+          monitoring-capitalised monitoring-per-object monitoring-per-object-only \
+          monitoring-none; do
+    [ -d "${FIXTURES}/${_f}" ] || _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
+done
+
+# ---------------------------------------------------------------------------
+# 1. #223 — routes supplied by Routes::standard()
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/routes-standard"; then
+    _expect_gate 14 "FAIL" "routes-standard: the unrouted method is still a finding"
+    _expect_log "${_RRLOG}" "GadgetController\.php method=run .*rule=missing-route" \
+        "routes-standard: gadget#run — no route anywhere — IS reported"
+    _expect_not_log "${_RRLOG}" "DashboardController" \
+        "routes-standard: dashboard#page / #catchAll come from Routes::standard() and are NOT reported"
+    _expect_not_log "${_RRLOG}" "SettingsController" \
+        "routes-standard: settings#index / #create / #load likewise"
+    _expect_lines "${_RRLOG}" 1 \
+        "routes-standard: exactly ONE finding — the exemption is ten names, not a blanket"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. #237 — the AppHost call in a delegated registrar, and its sibling
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/delegated-registrar"; then
+    _expect_gate 14 "FAIL" "delegated-registrar: the unbound controller is still a finding"
+    _expect_log "${_RRLOG}" "GadgetController\.php route='gadget#run' rule=controller-class-not-found" \
+        "delegated-registrar: gadget#run is bound by nothing and IS reported"
+    _expect_not_log "${_RRLOG}" "HealthController|MetricsController|PreferencesController" \
+        "delegated-registrar: the three AppHost generics are NOT reported"
+    _expect_lines "${_RRLOG}" 1 \
+        "delegated-registrar: exactly ONE finding"
+    _expect_log "${_UNRES}" "health#index — served by the OpenRegister AppHost generic" \
+        "delegated-registrar: gate-5 states health#index as NOT JUDGED, naming AppHost"
+fi
+
+if _run "${FIXTURES}/delegated-registrar-absent"; then
+    _expect_gate 14 "FAIL" "delegated-registrar-absent: nothing calls Bootstrap::register()"
+    _expect_lines "${_RRLOG}" 4 \
+        "delegated-registrar-absent: ALL FOUR absent controllers are reported — removing the one registrar file flips every verdict"
+    _expect_log "${_RRLOG}" "HealthController\.php route='health#index'" \
+        "delegated-registrar-absent: health#index is reported when nothing binds it"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. #213 — a capitalised monitoring word is SELECTED at all
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/monitoring-capitalised"; then
+    _expect_gate 30 "FAIL" "monitoring-capitalised: a capitalised route name is no longer invisible"
+    _expect_log "${_PMLOG}" "GenericHealthController\.php:[0-9]+ method=index" \
+        "monitoring-capitalised: genericHealth#index with no stated posture IS named"
+    _expect_log "${_PMLOG}" "AppHost/Controller/GenericLivenessController\.php:[0-9]+ method=index" \
+        "monitoring-capitalised: a NAMESPACED route name survives read -r and resolves to its file"
+    _expect_not_log "${_PMLOG}" "AppHostControllerGenericLiveness" \
+        "monitoring-capitalised: the flattened (backslash-eaten) path does NOT appear"
+    _expect_not_log "${_PMLOG}" "GenericMetricsController" \
+        "monitoring-capitalised: the ADR-006 admin-only carve-out survives case-folding …"
+    _expect_not_log "${_PMLOG}" "GenericMetricsController" \
+        "monitoring-capitalised: … and survives a docblock longer than the old 20-line window"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. #218 — a monitoring word in the name is not a monitoring endpoint
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/monitoring-per-object"; then
+    _expect_gate 30 "FAIL" "monitoring-per-object: a real scrape target in the same repo still fails"
+    _expect_log "${_PMLOG}" "HealthController\.php:[0-9]+ method=index" \
+        "monitoring-per-object: health#index — an unparameterised GET — IS reported"
+    _expect_not_log "${_PMLOG}" "HealthPingController" \
+        "monitoring-per-object: the per-placement badge is NOT reported (its remedy would strip auth)"
+    _expect_lines "${_PMLOG}" 1 \
+        "monitoring-per-object: exactly ONE finding"
+    _expect_log "${_PMNOTES}" "healthPing#show — not a monitoring scrape target: url .* is per-object" \
+        "monitoring-per-object: the notes SAY why healthPing#show was not judged"
+    _expect_log "${_PMNOTES}" "healthPing#validate — not a monitoring scrape target: verb is 'POST'" \
+        "monitoring-per-object: … and why healthPing#validate was not judged"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Zero inputs must never be printed as PASS
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/monitoring-per-object-only"; then
+    _expect_gate 30 "NOT APPLICABLE" \
+        "zero scrape targets: gate-30 says so out loud instead of passing over a 0-byte log"
+    _expect_log "${_OUT}" "\[gate-30\].*2 route name\(s\) contain a monitoring word but NONE is a monitoring scrape target" \
+        "zero scrape targets: the verdict line carries the candidate count"
+    _expect_lines "${_PMLOG}" 0 "zero scrape targets: the findings log is empty"
+fi
+
+if _run "${FIXTURES}/monitoring-none"; then
+    _expect_gate 30 "NOT APPLICABLE" \
+        "zero candidates: gate-30 states that no route name is monitoring-shaped"
+    _expect_log "${_OUT}" "\[gate-30\].*declares no route whose name contains" \
+        "zero candidates: the verdict line names the reason"
+fi
+
+echo
+echo "== summary =="
+printf '   passed: %d\n   failed: %d\n' "${_pass_n}" "${_fail_n}"
+[ "${_fail_n}" -eq 0 ] || exit 1
+echo
+echo "ALL route/registration control pairs held."

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -480,11 +480,59 @@ _count() {
 # its own e.g. SettingsController.php keeps it, and the file therefore exists
 # and is judged normally. This helper only ever fires when the file is ABSENT.
 # ---------------------------------------------------------------------------
+# WHERE THE CALL LIVES IS NOT PART OF THE INVARIANT (ConductionNL/.github#237)
+# ---------------------------------------------------------------------------
+# This used to grep lib/AppInfo/Application.php and nothing else. That is not
+# where the call has to be, and the fleet's own quality gates push it out of
+# there: phpmd complains about a long `register()`, the app decomposes it into
+# per-concern registrars, and the AppHost call moves one file down. Procest did
+# exactly that (procest#717) and its `Bootstrap::register()` now lives in
+# lib/AppInfo/Registrar/AppHostRegistrar.php — so _HYDRA_APPHOST read 0 and all
+# four of its AppHost routes came back as `controller-class-not-found`. The
+# decomposition the gates asked for is what blinded this one.
+#
+# So: the evidence is "some file this repository ships calls
+# `\OCA\OpenRegister\AppHost\Bootstrap::register()`", and it is looked for
+# across the whole tracked lib/ tree. BOTH conditions must hold in the SAME
+# file — `AppHost\Bootstrap` (the symbol) and `Bootstrap::register(` (the call).
+# Split across two files they prove nothing: a comment naming AppHost in one
+# place and an unrelated `Bootstrap::register()` in another would combine into
+# a blanket exemption.
+#
+# The site is remembered so the NOT-JUDGED lines can name it. "This gate
+# believes you adopt AppHost" is a claim, and a claim with no evidence attached
+# is how #199 came to look fixed while still firing.
+#
+# ⚠️ COMMENTS DO NOT COUNT, and this is not a hypothetical. The first cut of
+# this widening was two raw `grep`s, and the very first fixture written to
+# disprove it — `delegated-registrar-absent/`, whose Application.php docblock
+# reads "NOTHING in this app calls \OCA\OpenRegister\AppHost\Bootstrap::register()"
+# — was EXEMPTED BY ITS OWN EXPLANATION. Prose about a call is not a call. The
+# old narrow version only ever read one file and was much less likely to meet
+# a sentence like that; widening the search to lib/ makes it near-certain,
+# because the file that explains the architecture is exactly the file that
+# names it. Same defect as gate-64 (.github#184): a checker that greps a
+# string matches every comment.
+_php_code_only() {
+    # Whole-line comments removed. `#[` at line start is a PHP ATTRIBUTE, not
+    # a comment, and must survive.
+    grep -vE '^[[:space:]]*(//|/\*|\*|#([^[]|$))' "$1" 2>/dev/null
+}
 _HYDRA_APPHOST=0
-if [ -f lib/AppInfo/Application.php ] \
-    && grep -qE 'AppHost\\+Bootstrap' lib/AppInfo/Application.php \
-    && grep -qE 'Bootstrap::register[[:space:]]*\(' lib/AppInfo/Application.php; then
-    _HYDRA_APPHOST=1
+_HYDRA_APPHOST_SITE=""
+if [ -d lib ]; then
+    while IFS= read -r _ah_f; do
+        [ -f "${_ah_f}" ] || continue
+        _ah_code=$(_php_code_only "${_ah_f}")
+        printf '%s\n' "${_ah_code}" | grep -qE 'Bootstrap::register[[:space:]]*\(' || continue
+        printf '%s\n' "${_ah_code}" | grep -qE 'AppHost\\+Bootstrap' || continue
+        _HYDRA_APPHOST=1
+        _HYDRA_APPHOST_SITE="${_ah_f}"
+        break
+    done < <(_enum_tracked '\.php$' lib \
+        | tr '\n' '\0' \
+        | xargs -0 -r grep -lE 'Bootstrap::register[[:space:]]*\(' 2>/dev/null \
+        || true)
 fi
 # The five controller class names Bootstrap::register() aliases, as route
 # slugs. Source of truth: openregister lib/AppHost/Bootstrap.php
@@ -500,6 +548,52 @@ if [ -f lib/AppInfo/Application.php ]; then
     _HYDRA_APP_NS=$(grep -m1 -oE '^namespace[[:space:]]+OCA\\[A-Za-z0-9_]+' lib/AppInfo/Application.php \
         | awk '{print $2}')
 fi
+
+# ---------------------------------------------------------------------------
+# THE CANONICAL APPHOST ROUTE TABLE (ConductionNL/.github#223)
+#
+# `appinfo/routes.php` is not the only place a route can be declared. An app
+# that adopts ADR-040 returns
+#
+#     \OCA\OpenRegister\AppHost\Routes::standard($extra)
+#
+# and that builder PREPENDS ten canonical route entries to `$extra` — the
+# dashboard page, the SPA catch-all, the settings quartet, the two preference
+# routes and the two observability routes. Their names never appear as literals
+# in the leaf's routes.php.
+#
+# Gate-14 invariant 1 asks "is there a route for this controller method?" with
+# `grep -qF "'slug#method'" appinfo/routes.php`. For an AppHost adopter that
+# question is being asked of the wrong file, and the answer is always no. Every
+# app that ships its OWN DashboardController / SettingsController — which is
+# the supported shape, `aliasControllerUnlessLeafDefinesIt` exists precisely to
+# allow it — was told its working `/` and `/api/settings` endpoints were
+# unroutable: 7/7 findings on launchpad, 5 on doriath, 5 on shillinq, and the
+# same on openconnector and procest.
+#
+# The list is explicit and mirrors openregister lib/AppHost/Routes.php
+# ::canonicalRoutes() + ::catchAllRoute() (verified against
+# openregister@1dcc92cf9, lines 110-126 + 165-176). NOT a wildcard and NOT
+# "AppHost adopters are exempt from invariant 1": a controller method with no
+# route is still a 404 and still fails, unless its route is one of these ten.
+# ---------------------------------------------------------------------------
+_HYDRA_APPHOST_ROUTE_NAMES="dashboard#page dashboard#catchAll settings#index settings#create settings#update settings#load preferences#getPreference preferences#setPreference metrics#index health#index"
+
+_HYDRA_APPHOST_ROUTE_TABLE=0
+if [ -f appinfo/routes.php ] \
+    && grep -qE 'AppHost\\+Routes::standard[[:space:]]*\(' appinfo/routes.php; then
+    _HYDRA_APPHOST_ROUTE_TABLE=1
+fi
+
+# _apphost_supplies_route <controller#method> — 0 when this app's routes.php
+# defers to Routes::standard() AND the name is one of the ten it supplies.
+_apphost_supplies_route() {
+    [ "${_HYDRA_APPHOST_ROUTE_TABLE}" -eq 1 ] || return 1
+    case " ${_HYDRA_APPHOST_ROUTE_NAMES} " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
 # _apphost_serves <route-slug> — 0 when this app adopts AppHost AND the slug is
 # one of the generics AppHost provides, i.e. the missing file is expected.
@@ -519,10 +613,20 @@ _apphost_serves() {
 # derive a class name in their own way and then hand it here, so a change to
 # the matching rule can never apply to one shape and silently not the other.
 # ---------------------------------------------------------------------------
+# THE REGISTRATION SURFACE IS lib/AppInfo/, NOT Application.php
+# (ConductionNL/.github#237). Same argument as `_HYDRA_APPHOST` above: nothing
+# requires a `registerService()` call to sit in Application.php, and this
+# suite's own phpmd gate pushes it out — an app splits `register()` into
+# per-concern registrars and every binding moves one file down. Reading only
+# Application.php then answers "no such binding" for every controller, which
+# is indistinguishable from a correct verdict.
 _app_php_binds_class() {
     local _fqcn="$1"
-    [ -f lib/AppInfo/Application.php ] || return 1
     [ -n "${_fqcn}" ] || return 1
+
+    local _reg_files
+    _reg_files=$(_enum_tracked '\.php$' lib/AppInfo)
+    [ -n "${_reg_files}" ] || return 1
 
     # In PHP source the literal carries escaped backslashes.
     local _needle="${_fqcn//\\/\\\\}"
@@ -532,15 +636,28 @@ _app_php_binds_class() {
     # backslashes and never match the PHP literal. Silently — the helper just
     # answers "no such binding" for every controller, which reads exactly like
     # a correct verdict.
-    _HYDRA_DI_NEEDLE="${_needle}" awk '
-        BEGIN { needle = ENVIRON["_HYDRA_DI_NEEDLE"] }
-        /registerService(Alias)?[[:space:]]*\(/ { window = 6 }
-        window > 0 {
-            if (index($0, needle) > 0) { found = 1; exit }
-            window--
-        }
-        END { exit(found ? 0 : 1) }
-    ' lib/AppInfo/Application.php
+    # Comment lines removed first, for the reason spelled out at
+    # `_HYDRA_APPHOST` above: a docblock explaining which class a route
+    # resolves to is not a binding, and the file that explains the
+    # architecture is exactly the file that spells the class name out.
+    local _f
+    while IFS= read -r _f; do
+        [ -f "${_f}" ] || continue
+        if _php_code_only "${_f}" | _HYDRA_DI_NEEDLE="${_needle}" awk '
+            BEGIN { needle = ENVIRON["_HYDRA_DI_NEEDLE"] }
+            /registerService(Alias)?[[:space:]]*\(/ { window = 6 }
+            window > 0 {
+                if (index($0, needle) > 0) { found = 1; exit }
+                window--
+            }
+            END { exit(found ? 0 : 1) }
+        '; then
+            return 0
+        fi
+    done <<EOF
+${_reg_files}
+EOF
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -569,10 +686,39 @@ _app_php_binds_class() {
 # class name appearing as a literal within a few lines of a registerService
 # call — i.e. this repository can be shown to bind that specific name. A
 # controller that is simply missing still fails, which is the invariant.
+#
+# TWO WIDENINGS, both narrow (ConductionNL/.github#213, #237)
+# ----------------------------------------------------------
+# (1) THE REGISTRATION FILE. Same argument as `_HYDRA_APPHOST` above: a
+#     `registerService()` call is not required to sit in Application.php, and
+#     the phpmd pressure that decomposes Application.php into per-concern
+#     registrars moves it out. Every tracked .php under lib/AppInfo/ is read,
+#     not just Application.php.
+#
+# (2) THE UNPREFIXED DI KEY. NC's RouteParser::buildControllerName() appends
+#     'Controller' to the route-name segment VERBATIM and does NOT prefix the
+#     app namespace when the route name already contains a backslash. So
+#
+#         ['name' => 'AppHost\Controller\GenericHealth#index', ...]
+#
+#     is looked up in the container under the bare string
+#     'AppHost\Controller\GenericHealthController' — no OCA\<App>\Controller\
+#     prefix at all. openregister binds exactly that key (lib/AppInfo/
+#     Application.php::registerAppHostObservability, and its own comment
+#     records the 503 that taught it), and this helper — which only ever built
+#     the prefixed name — answered "no such binding" for both, so gate-14
+#     reported OR's own /api/health and /api/metrics as
+#     `controller-class-not-found`.
+#
+#     The bare key is accepted ONLY for a namespaced route name (one whose
+#     resolved class part contains a backslash), because that is the only case
+#     in which NC produces it. For a plain slug like `widget`, accepting the
+#     bare `WidgetController` as evidence would match any stray
+#     `WidgetController::class` near a registerService call and turn a genuine
+#     missing controller into an exemption.
 # ---------------------------------------------------------------------------
 _di_binds_controller() {
     local _p="$1"
-    [ -f lib/AppInfo/Application.php ] || return 1
 
     # lib/Controller/Sub/FooController.php -> Sub\FooController
     local _rel="${_p#lib/Controller/}"
@@ -580,7 +726,32 @@ _di_binds_controller() {
     local _cls="${_rel//\//\\}"
 
     [ -n "${_HYDRA_APP_NS}" ] || return 1
-    _app_php_binds_class "${_HYDRA_APP_NS}\\Controller\\${_cls}"
+    _app_php_binds_class "${_HYDRA_APP_NS}\\Controller\\${_cls}" && return 0
+
+    # ---------------------------------------------------------------------
+    # THE RELATIVE KEY (ConductionNL/.github#213). #217 fixed the FULLY
+    # QUALIFIED shape (`OCA\<App>\AppHost\Controller\GenericHealth`) and named
+    # this one as still-open rather than widening silently. It is the same
+    # mechanism one step over: NC's RouteParser appends 'Controller' to the
+    # route-name segment VERBATIM, so a route named
+    #
+    #     ['name' => 'AppHost\Controller\GenericHealth#index', …]
+    #
+    # is looked up under the bare string 'AppHost\Controller\GenericHealthController'
+    # — NOT prefixed with OCA\<App>\Controller\, because the name already
+    # contains a backslash. openregister binds exactly that key, and records
+    # the 503 that taught it, in
+    # lib/AppInfo/Application.php::registerAppHostObservability().
+    #
+    # Accepted ONLY for a namespaced name, because that is the only case in
+    # which NC produces the unprefixed key. For a plain slug the bare needle
+    # would be `WidgetController`, which any stray `WidgetController::class`
+    # near a registerService call would satisfy — turning a genuinely missing
+    # controller into an exemption.
+    case "${_cls}" in
+        *\\*) _app_php_binds_class "${_cls}" && return 0 ;;
+    esac
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -725,6 +896,72 @@ _ctrl_path_from_name() {
             echo "lib/Controller/${_cap}Controller.php"
             ;;
     esac
+}
+
+# ---------------------------------------------------------------------------
+# _head_block <php-file> <declaration-line> — the annotation region that
+# belongs to the method declared on <declaration-line>, as text.
+#
+# WHY NOT A FIXED 20-LINE SLICE
+# -----------------------------
+# Gate-5 and gate-30 both asked "is there an auth attribute above this
+# method?" by reading `sed -n "$((line-20)),${line}p"`. Twenty lines is an
+# arbitrary number and it is wrong in both directions:
+#
+#   TOO SHORT — openregister lib/Controller/Settings/FileSettingsController.php
+#               ::getFileExtractionStats() declares `@NoCSRFRequired` on line
+#               301 and opens on line 323, because a `@psalm-return` shape sits
+#               between them. The tag is 22 lines up, the window starts at 303,
+#               and gate-5 reported a correctly-annotated endpoint as
+#               `missing-auth-attribute`. Found 2026-08-08 the moment the
+#               backslash fix (#213) made `Settings\FileSettings#…` resolve at
+#               all — the route had never been judged before, so the window
+#               defect had never been reachable there.
+#   TOO LONG  — a short guarded method sitting within 20 lines above an
+#               unguarded one donated its `#[NoAdminRequired]` to its
+#               neighbour. That is a false NEGATIVE in a security gate, and it
+#               is why the `prev_close` clamp below exists.
+#
+# The region that actually belongs to a declaration is the CONTIGUOUS run of
+# attribute lines, PHPDoc lines, `//` comments and blanks immediately above it.
+# This walks that run and takes whichever of {the run, the 20-line slice} starts
+# EARLIER, so the window can only ever grow — nothing that passes today can
+# start failing because of this — and then applies the previous-member clamp
+# unchanged, so nothing can borrow an attribute either. Taking the union rather
+# than the run alone matters for a multi-line attribute
+# (`#[AuthorizedAdminSetting(\n  Application::APP_ID\n)]`), whose middle lines
+# are ordinary code and would otherwise cut the run short.
+# ---------------------------------------------------------------------------
+_head_block() {
+    local _file="$1" _def="$2"
+    awk -v D="${_def}" '
+        NR <= D { line[NR] = $0 }
+        NR > D  { exit }
+        END {
+            # The contiguous annotation run immediately above the declaration.
+            run = D
+            for (i = D - 1; i >= 1; i--) {
+                l = line[i]
+                if (l ~ /^[[:space:]]*$/)              { run = i; continue }
+                if (l ~ /^[[:space:]]*\/\*\*/)         { run = i; continue }
+                if (l ~ /^[[:space:]]*\*/)             { run = i; continue }
+                if (l ~ /^[[:space:]]*\/\//)           { run = i; continue }
+                if (l ~ /^[[:space:]]*#\[/)            { run = i; continue }
+                break
+            }
+            slice = (D > 20) ? D - 20 : 1
+            start = (run < slice) ? run : slice
+
+            # Clamp to the line after the previous member closes. An attribute
+            # or docblock for THIS method can only appear after it, so this can
+            # never hide a genuine attribute — only stop one being borrowed.
+            prev = 0
+            for (i = start; i < D; i++) { if (line[i] ~ /^[[:space:]]*\}/) prev = i }
+            if (prev >= start) { start = prev + 1 }
+
+            for (i = start; i <= D; i++) print line[i]
+        }
+    ' "${_file}"
 }
 
 # The one regex both route gates read `appinfo/routes.php` through.
@@ -1161,24 +1398,25 @@ if [ -f appinfo/routes.php ]; then
                 echo "${path}: routed method ${method} does not exist on this class; UNRESOLVED (see gate-14, which owns route reachability)" >> "${_ra_unresolved_log}"
                 continue
             fi
-            start=$((def_line > 20 ? def_line - 20 : 1))
             # ⚠️ THIRD DEFECT, found 2026-08-05 by this gate's own positive
             # control (scripts/lib/test_gate_route_auth.sh). The 20-line
-            # lookback is not bounded by the START OF THE METHOD, so it reads
+            # lookback was not bounded by the START OF THE METHOD, so it read
             # back over the PREVIOUS member. A short guarded method sitting
             # within 20 lines above an unguarded one donated its
             # `#[NoAdminRequired]` to its neighbour and the unguarded method
             # passed. That is a false NEGATIVE in a security gate — the
             # expensive direction, and invisible because a pass leaves no log.
-            # Clamp the window to the line after the previous member's closing
-            # brace: an attribute or docblock for THIS method can only appear
-            # after it, so this can never hide a genuine attribute — it can
-            # only stop one being borrowed.
-            prev_close=$(awk -v L="${def_line}" 'NR < L && /^[[:space:]]*\}/ { n = NR } END { print n + 0 }' "$path")
-            if [ "${prev_close}" -ge "${start}" ]; then
-                start=$((prev_close + 1))
-            fi
-            head_block=$(sed -n "${start},${def_line}p" "$path")
+            #
+            # ⚠️ FOURTH DEFECT, found 2026-08-08 the moment the `read -r` fix
+            # made openregister's `Settings\…` routes resolve: 20 lines is also
+            # TOO SHORT. `Settings\FileSettings#getFileExtractionStats` declares
+            # `@NoCSRFRequired` 22 lines above its `public function`, because a
+            # `@psalm-return` shape sits in between — and a correctly annotated
+            # endpoint was reported `missing-auth-attribute`. Both directions
+            # now go through _head_block, which takes the contiguous annotation
+            # run OR the 20-line slice, whichever starts earlier, and keeps the
+            # previous-member clamp.
+            head_block=$(_head_block "$path" "${def_line}")
             if ! echo "$head_block" | grep -qE '#\[(PublicPage|NoAdminRequired|NoCSRFRequired|AuthorizedAdminSetting)\b|@(PublicPage|NoAdminRequired|NoCSRFRequired)\b'; then
                 echo "${path}:${def_line} method=${method} rule=missing-auth-attribute" >> "${_ra_log}"
             fi
@@ -1356,7 +1594,7 @@ while IFS= read -r f; do
     [ -f "$f" ] || continue
     _in_scope "$f" || continue
     grep -nE "^\s*(public|private|protected)\s+function\s+[a-zA-Z0-9_]*([Aa]uthori[sz]ation|[Aa]uth|[Pp]ermission|[Rr]ole|[Gg]uard)[a-zA-Z0-9_]*\s*\(" "$f" \
-        | while IFS=: read _line_no _; do
+        | while IFS=: read -r _line_no _; do
             _method=$(sed -n "${_line_no}p" "$f" | grep -oE 'function\s+[a-zA-Z0-9_]+' | awk '{print $2}')
             [ -z "$_method" ] && continue
             _body=$(awk -v start="${_line_no}" 'NR >= start { print; if (NR > start && /^    \}/) exit }' "$f")
@@ -1665,7 +1903,16 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
             # (single-quoted controller#method) is unique enough in the file
             # that false positives from comments / docstrings are vanishingly
             # rare.
-            if ! grep -qF "'${_ctrl_slug}#${_m}'" appinfo/routes.php; then
+            #
+            # ⚠️ A literal in appinfo/routes.php is not the only way a route
+            # gets declared (ConductionNL/.github#223). An ADR-040 adopter
+            # returns `Routes::standard($extra)` and receives ten canonical
+            # entries it never spells out — see `_apphost_supplies_route`. For
+            # those apps this grep was asking the wrong file and answering "no"
+            # every time, which is why five apps were told their working
+            # `dashboard#page` / `settings#index` endpoints 404.
+            if ! grep -qF "'${_ctrl_slug}#${_m}'" appinfo/routes.php \
+                && ! _apphost_supplies_route "${_ctrl_slug}#${_m}"; then
                 echo "${_ctrl_path} method=${_m} expected_route='${_ctrl_slug}#${_m}' rule=missing-route" >> "${_rr_log}"
             fi
         done
@@ -2784,30 +3031,140 @@ fi
 # (Prometheus scraper, kubelet, external uptime monitor). Gate-5 (route-auth)
 # only verifies SOME annotation is present — this gate verifies the right one
 # is present for monitoring callers.
+#
+# THREE DEFECTS FIXED (ConductionNL/.github#213, #218)
+# ---------------------------------------------------
+# (a) THE SELECTOR WAS LOWERCASE-ONLY. `(metrics|health|…)` under `grep -E`
+#     matches no capital, so `AppHost\Controller\GenericHealth#index`,
+#     `genericMetrics#index` and `chatHealth#…` matched NOTHING. Four repos
+#     — openregister among them — reported PASS over a 0-byte log while
+#     shipping exactly the endpoints this gate exists for. A gate that
+#     selects zero inputs and prints PASS is indistinguishable from a gate
+#     that checked everything, which is the whole failure mode.
+#
+# (b) `read` WITHOUT -r, the same defect as gates 5 and 14: a namespaced
+#     route name lost its backslash before the file lookup.
+#
+# (c) IT MATCHED ANY CONTROLLER WITH 'health' IN THE NAME, and its remedy was
+#     a security regression. launchpad's `healthPing#show` is a per-placement
+#     status badge: `GET /api/health-ping/{placementId}`, 401 anonymous, then
+#     `canViewPlacement()` BEFORE any work is done. It is not a scrape target
+#     and adding `#[PublicPage]` to satisfy this gate would publish an
+#     outbound-ping oracle to anonymous callers.
+#
+#     The discriminator is not the name — it is the SHAPE OF THE ROUTE. A
+#     Prometheus scraper, a kubelet probe or an uptime monitor has no session
+#     and no object in mind: it issues a GET against a FIXED url. So a
+#     monitoring endpoint for the purposes of this gate is a name-matching
+#     route that is ALSO an unparameterised GET. `healthPing#show` carries a
+#     `{placementId}` (per-object, so per-object authorisation is correct and
+#     required); `healthPing#validate` is a POST (it submits a candidate
+#     config). Neither is something a monitor can call. `health#index` on
+#     `/api/health` still is, and is still enforced strictly.
+#
+# HOW THIS GATE MAY END (acceptance: never a silent green)
+# -------------------------------------------------------
+# PASS is reserved for a run that actually OPENED a monitoring method. Every
+# other outcome says which of the four it was, with counts, so "nothing to
+# check" can never again be printed as "checked and fine".
 # ---------------------------------------------------------------------------
 _pm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-public-monitoring.log
+_pm_notes=${HYDRA_GATE_LOG_DIR}/hydra-gate-public-monitoring-notes.log
 : > "${_pm_log}"
+: > "${_pm_notes}"
+_pm_candidates=0
+_pm_targets=0
+_pm_scoped=0
+_pm_inspected=0
+_pm_absent=0
 if [ -f appinfo/routes.php ] && [ -d lib/Controller ]; then
-    # Find route entries whose `name` looks like `<monitoring-word>#<method>`
-    grep -oE "['\"]\s*name['\"]\s*=>\s*['\"][a-zA-Z0-9_\\\\]*(metrics|health|liveness|readiness|probe)[a-zA-Z0-9_]*#[a-zA-Z0-9_]+['\"]" appinfo/routes.php 2>/dev/null \
-        | grep -oE "[a-zA-Z0-9_\\\\]*(metrics|health|liveness|readiness|probe)[a-zA-Z0-9_]*#[a-zA-Z0-9_]+" | sort -u \
-        | while IFS='#' read _ctrl _method; do
-            [ -z "${_ctrl}" ] && continue
-            [ -z "${_method}" ] && continue
-            # Map snake_case route slug → PascalCase file basename. Real apps
-            # use `metrics_internal#index` (route) → `MetricsInternalController.php`.
-            # The single-char `toupper(substr(...,1,1))` form preserves underscores
-            # → `Metrics_internal` which doesn't exist on disk → silent skip.
-            # Gate-5 already uses the awk -F'_' pattern; copy it verbatim.
-            _ctrl_cap=$(printf '%s' "${_ctrl}" | awk -F'_' '{for(i=1;i<=NF;i++) printf toupper(substr($i,1,1)) substr($i,2); print ""}')
-            _ctrl_path="lib/Controller/${_ctrl_cap}Controller.php"
-            [ ! -f "${_ctrl_path}" ] && continue
-            _in_scope "${_ctrl_path}" || continue
-            _method_line=$(grep -nE "^[[:space:]]*public function ${_method}[[:space:]]*\(" "${_ctrl_path}" | head -1 | cut -d: -f1)
-            [ -z "${_method_line}" ] && continue
+    # Pull every route entry as `name<TAB>url<TAB>verb`. A route's url and verb
+    # are part of the evidence now (see (c) above), and grepping the name alone
+    # cannot see them. Entries are one-per-line in every fleet routes.php, but
+    # `requirements` sometimes wraps onto the next line, so the record is
+    # extended until both url and verb are in hand (bounded at 4 lines).
+    _pm_entries=$(awk '
+        /['"'"'"][[:space:]]*name[[:space:]]*['"'"'"][[:space:]]*=>/ {
+            buf = $0; n = 0
+            while (n < 4 && (buf !~ /['"'"'"]url['"'"'"][[:space:]]*=>/ || buf !~ /['"'"'"]verb['"'"'"][[:space:]]*=>/)) {
+                if ((getline nxt) <= 0) break
+                buf = buf " " nxt
+                n++
+            }
+            name = _val(buf, "name"); url = _val(buf, "url"); verb = _val(buf, "verb")
+            if (name != "") print name "\t" url "\t" verb
+        }
+        function _val(s, key,   rx, seg, q, rest, endq) {
+            rx = "[\"'"'"']" key "[\"'"'"'][[:space:]]*=>[[:space:]]*[\"'"'"']"
+            if (match(s, rx) == 0) return ""
+            rest = substr(s, RSTART + RLENGTH)
+            q = substr(s, RSTART + RLENGTH - 1, 1)
+            endq = index(rest, q)
+            if (endq == 0) return ""
+            return substr(rest, 1, endq - 1)
+        }
+    ' appinfo/routes.php 2>/dev/null)
+
+    # -i, so a capitalised or camelCased monitoring word is seen. Defect (a).
+    _pm_monitoring_rx='^[A-Za-z0-9_\]*(metrics|health|liveness|readiness|probe)[A-Za-z0-9_]*#[A-Za-z0-9_]+$'
+
+    while IFS=$'\t' read -r _pm_name _pm_url _pm_verb; do
+        [ -n "${_pm_name}" ] || continue
+        printf '%s' "${_pm_name}" | grep -qiE "${_pm_monitoring_rx}" || continue
+        _pm_candidates=$((_pm_candidates + 1))
+
+        # Defect (c): only an unparameterised GET is something an external
+        # monitor can call. Anything else is a domain endpoint that happens to
+        # have a monitoring word in its name, and demanding #[PublicPage] on it
+        # is asking for an authorisation bypass.
+        case "${_pm_verb}" in
+            GET|get|Get) ;;
+            *) echo "${_pm_name} — not a monitoring scrape target: verb is '${_pm_verb}', a monitor issues GET" >> "${_pm_notes}"; continue ;;
+        esac
+        case "${_pm_url}" in
+            *'{'*) echo "${_pm_name} — not a monitoring scrape target: url '${_pm_url}' is per-object (has a {placeholder}); its caller is a UI with a session, and per-object authorisation belongs here" >> "${_pm_notes}"; continue ;;
+        esac
+        _pm_targets=$((_pm_targets + 1))
+
+        # `read -r` above (defect (b)) plus the SHARED resolver, so a
+        # namespaced route name lands on the file gates 5 and 14 use. The
+        # private `awk -F'_'` copy this gate carried could not spell
+        # `AppHost\Controller\GenericHealth` at all.
+        _pm_ctrl="${_pm_name%%#*}"
+        _pm_method="${_pm_name#*#}"
+        _ctrl_path=$(_ctrl_path_from_name "${_pm_ctrl}")
+        if [ ! -f "${_ctrl_path}" ]; then
+            _pm_absent=$((_pm_absent + 1))
+            if _apphost_serves "${_pm_ctrl}" || _di_binds_controller "${_ctrl_path}"; then
+                echo "${_pm_name} — served by the OpenRegister AppHost generic controller (ADR-040); its posture lives in the openregister package and is NOT visible here" >> "${_pm_notes}"
+            else
+                echo "${_pm_name} — ${_ctrl_path} is not present in this repository; NOT JUDGED (reachability is gate-14's)" >> "${_pm_notes}"
+            fi
+            continue
+        fi
+        _in_scope "${_ctrl_path}" || { echo "${_pm_name} — ${_ctrl_path} not touched by this diff (ADR-020)" >> "${_pm_notes}"; continue; }
+        _pm_scoped=$((_pm_scoped + 1))
+        _ctrl="${_pm_ctrl}"
+        _method="${_pm_method}"
+        _method_line=$(grep -nE "^[[:space:]]*public function ${_method}[[:space:]]*\(" "${_ctrl_path}" | head -1 | cut -d: -f1)
+        if [ -z "${_method_line}" ]; then
+            echo "${_pm_name} — ${_ctrl_path} exists but has no public function ${_method}(); NOT JUDGED (gate-14 owns that)" >> "${_pm_notes}"
+            continue
+        fi
+        _pm_inspected=$((_pm_inspected + 1))
             # Inspect annotations above the method declaration (up to 20 lines back)
-            _ann_start=$((_method_line > 20 ? _method_line - 20 : 1))
-            _annotations=$(sed -n "${_ann_start},${_method_line}p" "${_ctrl_path}")
+            # Same window helper as gate-5. A monitoring controller's docblock
+            # is routinely longer than 20 lines (a `@psalm-return` shape, a
+            # metrics table), and this gate would then miss the `#[PublicPage]`
+            # sitting just above it — a false positive whose only remedy is to
+            # add an attribute that is already there.
+            _annotations=$(_head_block "${_ctrl_path}" "${_method_line}")
+            # Folded for the carve-out test below: the slug may be
+            # `GenericMetrics` or `AppHost\Controller\GenericMetrics`, and a
+            # case-sensitive `*metrics*` sees neither — the same lowercase-only
+            # blindness as defect (a), which would have applied the strict
+            # health rule to every capitalised metrics endpoint in the fleet.
+            _ctrl_fold=$(printf '%s' "${_ctrl}" | tr '[:upper:]' '[:lower:]')
             # An explicitly declared ADMIN posture is an answer too. What this
             # gate is really preventing is an ACCIDENTAL posture: in Nextcloud
             # the absence of `#[NoAdminRequired]` IS the admin gate, so a
@@ -2823,7 +3180,7 @@ if [ -f appinfo/routes.php ] && [ -d lib/Controller ]; then
             # this gate. Same anchoring gate-9 already applies for the same
             # reason (openregister#1419, 8 of 10 findings were prose).
             _pm_ok='^[[:space:]]*#\[PublicPage\]|^[[:space:]]*\*[[:space:]]*@PublicPage\b|^[[:space:]]*#\[AuthorizedAdminSetting\('
-            case "${_ctrl}" in
+            case "${_ctrl_fold}" in
                 *metrics*)
                     # ADR-006 makes /api/metrics admin-only ON PURPOSE, and the
                     # engine that owns the decision says so in prose rather than
@@ -2847,14 +3204,47 @@ if [ -f appinfo/routes.php ] && [ -d lib/Controller ]; then
             if ! echo "${_annotations}" | grep -qE "${_pm_ok}"; then
                 echo "${_ctrl_path}:${_method_line} method=${_method} rule=monitoring-endpoint-missing-public-page" >> "${_pm_log}"
             fi
-        done
+    # Process substitution, NOT a pipeline: the five counters below decide
+    # whether this gate is allowed to say PASS, and a `| while` runs the body
+    # in a subshell where every one of them stays 0. That is precisely how a
+    # gate reports "checked, fine" having opened nothing.
+    done < <(printf '%s\n' "${_pm_entries}")
 fi
 _filter_preexisting "${_pm_log}"
 _pm_fail=$(wc -l < "${_pm_log}" 2>/dev/null || echo 0)
-if [ "${_pm_fail}" -eq 0 ]; then
-    _pass 30 "public-monitoring"
-else
+# ---------------------------------------------------------------------------
+# THE VERDICT. PASS requires that a monitoring method was actually OPENED.
+#
+# Until 2026-08-08 this was `[ fail -eq 0 ] && PASS`, and an empty findings log
+# was the only input. An empty log has two causes that mean opposite things —
+# "every monitoring endpoint declares its posture" and "I selected no inputs" —
+# and the lowercase-only selector (defect (a)) made the second one common:
+# openregister, which OWNS the fleet's health/metrics engine, printed PASS over
+# a 0-byte log on every run. Each branch below states its counts so the reader
+# can tell which of the four happened without re-running anything.
+# ---------------------------------------------------------------------------
+if [ "${_pm_fail}" -gt 0 ]; then
     _fail 30 "public-monitoring" "${_pm_fail} monitoring endpoint(s) missing @PublicPage — see ${_pm_log}"
+elif [ "${_pm_inspected}" -gt 0 ]; then
+    # State the size of the evidence. A PASS with no number attached is the
+    # thing this whole block exists to stop being writable: gate-30 printed one
+    # over 0 inputs for months. Does NOT start with `[gate-` so it cannot be
+    # mistaken for a verdict line by any `^\[gate-` consumer — same convention
+    # as gate-5's NOT-JUDGED line.
+    echo "[hydra-gates] gate-30 public-monitoring: ${_pm_inspected} monitoring endpoint(s) inspected of ${_pm_candidates} name-matched candidate(s)${_pm_targets:+; ${_pm_targets} scrape target(s)}. See ${_pm_notes} for every candidate this run did NOT judge, and why."
+    _pass 30 "public-monitoring"
+elif [ ! -f appinfo/routes.php ] || [ ! -d lib/Controller ]; then
+    _skip 30 "public-monitoring" na "no appinfo/routes.php + lib/Controller in this repository — there is no routed monitoring endpoint to judge."
+elif [ "${_pm_candidates}" -eq 0 ]; then
+    _skip 30 "public-monitoring" na "appinfo/routes.php declares no route whose name contains metrics/health/liveness/readiness/probe."
+elif [ "${_pm_targets}" -eq 0 ]; then
+    _skip 30 "public-monitoring" na "${_pm_candidates} route name(s) contain a monitoring word but NONE is a monitoring scrape target (an unparameterised GET) — see ${_pm_notes}. Per-object and write endpoints keep their own authorisation; this gate deliberately did not judge them."
+elif [ "${_pm_absent}" -eq "${_pm_targets}" ]; then
+    _skip 30 "public-monitoring" na "${_pm_targets} monitoring endpoint(s) are routed here but their controller class is not in this repository (ADR-040 AppHost generics) — see ${_pm_notes}. Their posture lives in the openregister package; NOT a pass for them."
+elif [ "${_pm_scoped}" -eq 0 ]; then
+    _skip 30 "public-monitoring" na "${_pm_targets} monitoring endpoint(s) found; none of their controllers is touched by this diff (ADR-020) — see ${_pm_notes}."
+else
+    _skip 30 "public-monitoring" structural "${_pm_targets} monitoring endpoint(s) found and ${_pm_scoped} controller file(s) opened, but NOT ONE routed method could be located — see ${_pm_notes}. The posture of those endpoints is UNVERIFIED by this run."
 fi
 # ---------------------------------------------------------------------------
 # Gate 31: Img-alt — every `<img>` tag in .vue files must declare an `alt` /

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/appinfo/routes.php
@@ -1,0 +1,19 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// The AppHost canonical names written out as LITERALS (procest's shape: it
+// keeps a local fallback so the app still routes when openregister is
+// absent). None of the four controllers exists here — they are aliased into
+// the container by Bootstrap::register(), which this app calls from a
+// registrar, not from Application.php.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widget', 'verb' => 'GET'],
+        ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        // NOT an AppHost generic and bound by nothing: a real 500 at request
+        // time, and the anti-widening half of this fixture.
+        ['name' => 'gadget#run', 'url' => '/api/gadget', 'verb' => 'POST'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/lib/AppInfo/Application.php
@@ -1,0 +1,19 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+/**
+ * Byte-identical to `delegated-registrar/` except that NOTHING in this app
+ * calls \OCA\OpenRegister\AppHost\Bootstrap::register(). The four absent
+ * controllers are therefore genuinely absent, and every one of them must be
+ * reported. This is the control that stops #237's fix from becoming
+ * "an absent controller is fine".
+ */
+class Application
+{
+    public function register($context): void
+    {
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar-absent/lib/Controller/WidgetController.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/appinfo/routes.php
@@ -1,0 +1,19 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// The AppHost canonical names written out as LITERALS (procest's shape: it
+// keeps a local fallback so the app still routes when openregister is
+// absent). None of the four controllers exists here — they are aliased into
+// the container by Bootstrap::register(), which this app calls from a
+// registrar, not from Application.php.
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widget', 'verb' => 'GET'],
+        ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+        ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        // NOT an AppHost generic and bound by nothing: a real 500 at request
+        // time, and the anti-widening half of this fixture.
+        ['name' => 'gadget#run', 'url' => '/api/gadget', 'verb' => 'POST'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/AppInfo/Application.php
@@ -1,0 +1,20 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\Fixture\AppInfo\Registrar\AppHostRegistrar;
+
+/**
+ * Application.php contains NO Bootstrap::register() call. phpmd complains
+ * about a long register(), the app decomposes it into per-concern
+ * registrars, and the AppHost call moves one file down — procest#717.
+ */
+class Application
+{
+    public function register($context): void
+    {
+        (new AppHostRegistrar())->register(context: $context);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/AppInfo/Registrar/AppHostRegistrar.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/AppInfo/Registrar/AppHostRegistrar.php
@@ -1,0 +1,20 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo\Registrar;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+
+/**
+ * THE ONE FILE THIS FIXTURE PAIR DIFFERS BY. Its sibling
+ * `delegated-registrar-absent/` is byte-identical apart from this file not
+ * existing, and there gate-14 must report all four routes.
+ */
+class AppHostRegistrar
+{
+    public function register($context): void
+    {
+        Bootstrap::register($context, 'fixture', ['namespace' => 'OCA\\Fixture']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/delegated-registrar/lib/Controller/WidgetController.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/appinfo/routes.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// CAPITALISED monitoring words, and one of them NAMESPACED. `grep -E
+// '(metrics|health|…)'` matches no capital, so before #213 these names
+// selected NOTHING and gate-30 printed PASS over a 0-byte log — the shape
+// openregister shipped for months while owning the fleet's health/metrics
+// engine. `read` without -r then ate the backslashes out of the third one.
+return [
+    'routes' => [
+        ['name' => 'genericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
+        ['name' => 'genericMetrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+        ['name' => 'AppHost\Controller\GenericLiveness#index', 'url' => '/api/liveness', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/AppHost/Controller/GenericLivenessController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/AppHost/Controller/GenericLivenessController.php
@@ -1,0 +1,23 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller\AppHost\Controller;
+
+/**
+ * Reached only through a NAMESPACED route name. `read` without -r flattens
+ * `AppHost\Controller\GenericLiveness` to `AppHostControllerGenericLiveness`,
+ * whose file cannot exist, and gate-30 then skipped this endpoint silently —
+ * the same corruption #217 fixed in gates 5 and 14 while gate-30 kept the
+ * defective line.
+ *
+ * No stated posture, so once it is READ AT ALL it must be a finding.
+ */
+class GenericLivenessController extends Controller
+{
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['status' => 'ok']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/GenericHealthController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/GenericHealthController.php
@@ -1,0 +1,22 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class GenericHealthController extends Controller
+{
+    /**
+     * Health probe.
+     *
+     * Says NOTHING about its auth posture — neither #[PublicPage] nor
+     * #[AuthorizedAdminSetting]. In Nextcloud the absence of an attribute IS
+     * the admin gate, so the kubelet gets a redirect to /login. This is the
+     * true positive the whole gate exists for, and it must fire.
+     */
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['status' => 'ok']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/GenericMetricsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-capitalised/lib/Controller/GenericMetricsController.php
@@ -1,0 +1,41 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class GenericMetricsController extends Controller
+{
+    /**
+     * Prometheus exposition endpoint.
+     *
+     * ADR-006 makes /api/metrics admin-only ON PURPOSE, and the engine that
+     * owns the decision states it in prose: this endpoint is admin-only.
+     *
+     * The docblock below is deliberately longer than twenty lines. The
+     * posture sentence therefore sits OUTSIDE the fixed 20-line lookback
+     * both gate-5 and gate-30 used to take, which is how a correctly
+     * annotated method came to be reported as unannotated — measured on
+     * openregister Settings\FileSettings#getFileExtractionStats, whose
+     * @NoCSRFRequired sits 22 lines above its declaration.
+     *
+     * Series exposed:
+     *  - fixture_objects_total
+     *  - fixture_requests_total
+     *  - fixture_request_duration_seconds
+     *  - fixture_errors_total
+     *  - fixture_cache_hits_total
+     *  - fixture_cache_misses_total
+     *  - fixture_queue_depth
+     *  - fixture_worker_saturation
+     *  - fixture_storage_bytes
+     *  - fixture_index_lag_seconds
+     *
+     * @return JSONResponse
+     */
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-none/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-none/appinfo/routes.php
@@ -1,0 +1,7 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+return [
+    'routes' => [
+        ['name' => 'widget#show', 'url' => '/api/widget', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-none/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-none/lib/Controller/WidgetController.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object-only/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object-only/appinfo/routes.php
@@ -1,0 +1,8 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+return [
+    'routes' => [
+        ['name' => 'healthPing#validate', 'url' => '/api/health-ping/validate', 'verb' => 'POST'],
+        ['name' => 'healthPing#show', 'url' => '/api/health-ping/{placementId}', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object-only/lib/Controller/HealthPingController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object-only/lib/Controller/HealthPingController.php
@@ -1,0 +1,42 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE FALSE POSITIVE WHOSE REMEDY WAS A SECURITY REGRESSION (#218).
+ *
+ * Both methods 401 an anonymous caller and run a per-object permission
+ * check before doing any work. gate-30's advice — add #[PublicPage] — would
+ * have published an outbound-ping oracle to anonymous callers.
+ */
+class HealthPingController extends Controller
+{
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function show(int $placementId): JSONResponse
+    {
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($userId === null) {
+            return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->permissionService->canViewPlacement(userId: $userId, placementId: $placementId) === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+
+        return new JSONResponse($this->healthPingService->resolveForPlacement(placementId: $placementId));
+    }
+
+    #[NoAdminRequired]
+    public function validate(): JSONResponse
+    {
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($userId === null) {
+            return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        return new JSONResponse(['valid' => true]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/appinfo/routes.php
@@ -1,0 +1,13 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// launchpad's shape. `healthPing#show` is a per-placement status badge and
+// `healthPing#validate` submits a candidate config; neither is anything a
+// Prometheus scraper or a kubelet can call. `health#index` is.
+return [
+    'routes' => [
+        ['name' => 'healthPing#validate', 'url' => '/api/health-ping/validate', 'verb' => 'POST'],
+        ['name' => 'healthPing#show', 'url' => '/api/health-ping/{placementId}', 'verb' => 'GET'],
+        ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/lib/Controller/HealthController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/lib/Controller/HealthController.php
@@ -1,0 +1,21 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE ANTI-WIDENING HALF. An unparameterised GET on /api/health with no
+ * stated posture — exactly what a kubelet calls, exactly what silently
+ * redirects to /login. Sitting in the SAME fixture as the two shapes the
+ * gate must now ignore, so "the shape filter switched the gate off" cannot
+ * pass as "the false positives are gone".
+ */
+class HealthController extends Controller
+{
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['status' => 'ok']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/lib/Controller/HealthPingController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/monitoring-per-object/lib/Controller/HealthPingController.php
@@ -1,0 +1,42 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE FALSE POSITIVE WHOSE REMEDY WAS A SECURITY REGRESSION (#218).
+ *
+ * Both methods 401 an anonymous caller and run a per-object permission
+ * check before doing any work. gate-30's advice — add #[PublicPage] — would
+ * have published an outbound-ping oracle to anonymous callers.
+ */
+class HealthPingController extends Controller
+{
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function show(int $placementId): JSONResponse
+    {
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($userId === null) {
+            return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->permissionService->canViewPlacement(userId: $userId, placementId: $placementId) === false) {
+            return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
+        }
+
+        return new JSONResponse($this->healthPingService->resolveForPlacement(placementId: $placementId));
+    }
+
+    #[NoAdminRequired]
+    public function validate(): JSONResponse
+    {
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($userId === null) {
+            return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        return new JSONResponse(['valid' => true]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/appinfo/routes.php
@@ -1,0 +1,12 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// ADR-040 route table. The ten canonical entries — dashboard#page,
+// dashboard#catchAll, settings#index/create/update/load,
+// preferences#getPreference/setPreference, metrics#index, health#index —
+// are PREPENDED by Routes::standard() and appear nowhere in this file.
+// That is the whole point of #223: gate-14 invariant 1 was grepping here
+// for names that live in openregister.
+return \OCA\OpenRegister\AppHost\Routes::standard([
+    ['name' => 'widget#show', 'url' => '/api/widget', 'verb' => 'GET'],
+]);

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/AppInfo/Application.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+
+class Application
+{
+    public function register($context): void
+    {
+        Bootstrap::register($context, 'fixture', ['namespace' => 'OCA\\Fixture']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/DashboardController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/DashboardController.php
@@ -1,0 +1,28 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * The leaf ships its OWN dashboard controller — the supported shape;
+ * Bootstrap::aliasControllerUnlessLeafDefinesIt() exists precisely to allow
+ * it. Its two routes are supplied by Routes::standard(), so neither name
+ * appears in appinfo/routes.php.
+ */
+class DashboardController extends Controller
+{
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function page(): TemplateResponse
+    {
+        return new TemplateResponse('fixture', 'index');
+    }
+
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function catchAll(): TemplateResponse
+    {
+        return new TemplateResponse('fixture', 'index');
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/GadgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/GadgetController.php
@@ -1,0 +1,24 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE ANTI-WIDENING HALF of this fixture.
+ *
+ * `gadget#run` is not one of the ten names Routes::standard() supplies and
+ * it is not in appinfo/routes.php either — so it is a genuine 404 and
+ * gate-14 invariant 1 MUST still report it. If the #223 fix had been
+ * written as "an AppHost adopter is exempt from invariant 1" rather than as
+ * "these ten names are declared elsewhere", this method would go quiet and
+ * the gate would be retired for every ADR-040 app in the fleet.
+ */
+class GadgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function run(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/SettingsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/SettingsController.php
@@ -1,0 +1,26 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class SettingsController extends Controller
+{
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function create(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function load(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/WidgetController.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}


### PR DESCRIPTION
Closes #213. Closes #218. Closes #221. Closes #223. Closes #237.

Rebased on **#217**, which landed the `read -r` fix for gates 5 and 14 and explicitly left one shape open (see §1b). Nothing here duplicates it.

## Two defects, five issues, three gates

**(a) A shell or regex detail corrupted the input, so the gate measured something other than the code.**
**(b) The gates modelled ONE registration idiom and flagged every other legitimate one.**

---

### 1a. gate-30 selected NOTHING and printed PASS (#213)

The selector alternation is lowercase-only under `grep -E`:

```
'(metrics|health|liveness|readiness|probe)'
```

`AppHost\Controller\GenericMetrics#index`, `genericHealth#index`, `chatHealth#health` — no match. openregister, which **owns** the fleet's health/metrics engine, reported `[gate-30] public-monitoring: PASS` over a **0-byte log** on every run. Confirmed silently green in four repos.

gate-30 also still carried `while IFS='#' read _ctrl _method` — the line #217 fixed in gates 5 and 14 — so a namespaced monitoring route was resolved to a path that cannot exist and skipped without a word.

### 1b. The relative DI key #217 flagged and left open (#213)

openregister names two routes with a **relative** namespace and binds them verbatim:

```php
// appinfo/routes.php
['name' => 'AppHost\Controller\GenericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
// lib/AppInfo/Application.php::registerAppHostObservability()
$context->registerService('AppHost\\Controller\\GenericHealthController', …);
```

`RouteParser::buildControllerName()` appends `Controller` to the route-name segment **verbatim** and does not prefix `OCA\<App>\Controller\` when the name already contains a backslash — openregister's own comment records the 503 that taught it. `_di_binds_fq_controller` is scoped to `OCA\<App>\…` on purpose, so these two were still reported. `_di_binds_controller` now accepts the bare key **for a namespaced name only**: for a plain slug the needle would be `WidgetController`, which any stray `WidgetController::class` near a `registerService` call would satisfy.

**openregister gate-14: 2 → 0.**

### 2. Routes supplied by `Routes::standard()` are not in routes.php (#223)

An ADR-040 adopter returns `\OCA\OpenRegister\AppHost\Routes::standard($extra)` and receives **ten** canonical entries it never spells out. gate-14 invariant 1 asked `grep -qF "'slug#method'" appinfo/routes.php` — the wrong file, answer always no. Every app shipping its **own** DashboardController / SettingsController (the supported shape; `aliasControllerUnlessLeafDefinesIt` exists to allow it) was told its working `/` and `/api/settings` 404.

The ten names are an explicit list mirroring `openregister lib/AppHost/Routes.php::canonicalRoutes()` + `::catchAllRoute()` (verified at `openregister@1dcc92cf9`, lines 110–126 + 165–176). **Not** "AppHost adopters are exempt from invariant 1" — see the `gadget#run` half of the fixture.

**doriath gate-14: 5 → 0.**

### 3. The AppHost call is not required to be in Application.php (#237)

`_HYDRA_APPHOST` grepped `lib/AppInfo/Application.php` and nothing else. procest's `Bootstrap::register()` lives in `lib/AppInfo/Registrar/AppHostRegistrar.php` — **because phpmd asked for the decomposition** (procest#717). The evidence is now "some tracked file under `lib/` calls it", with **both** conditions required in the **same** file. #199 fixed a neighbouring symptom and this one kept firing; the fixture pair below is what makes that not repeatable.

**procest gate-14: 4 → 0.**

> ⚠️ The first cut of this widening was two raw `grep`s, and the very first fixture written to disprove it — `delegated-registrar-absent/`, whose docblock reads *"NOTHING in this app calls `\OCA\OpenRegister\AppHost\Bootstrap::register()`"* — **exempted itself with its own explanation.** Same failure as gate-64 (#184): a checker that greps a string matches every comment. Comment lines are now stripped before matching, in the AppHost detector **and** in `_app_php_binds_class`. The trap is kept in the fixture on purpose.

### 4. A monitoring word in the name is not a monitoring endpoint (#218)

launchpad's `HealthPingController` is a per-placement badge: 401 anonymous, then `canViewPlacement()` **before any work**. gate-30's only remedy — add `#[PublicPage]` — would have published an outbound-ping oracle to anonymous callers.

The discriminator is not the name, it is the **shape of the route**. A Prometheus scraper, a kubelet probe or an uptime monitor has no session and no object in mind: it issues a **GET against a fixed URL**. So a monitoring endpoint here is a name-matching route that is *also an unparameterised GET*.

- `healthPing#show` — `/api/health-ping/{placementId}`, per-object → not judged, reason logged
- `healthPing#validate` — POST, submits a candidate config → not judged, reason logged
- `health#index` — `/api/health` GET → **still enforced strictly**

**launchpad gate-30: FAIL 2 → PASS**, with 2 endpoints genuinely inspected.

### 5. The credential is often one frame down (#221)

`#[PublicPage]` in Nextcloud means *a login is not required* — **not** *there is no session*. Two shapes were being reported:

- **Progressive session-then-policy.** doriath `ApplicationController::create`: admin auto-approves, an authenticated non-admin gets a pending row, an anonymous caller is admitted **only** when the admin has set `anonymous_application_registration_enabled`. The 401 is a stated policy, not a check against something the annotation forbids.
- **A private helper.** A controller authenticating several actions the same way writes the resolution once. The credential surface now inlines sibling helper bodies — **one frame, same file**. Not transitive: following the call graph deeper would eventually reach a service that touches a token for unrelated reasons and exempt everything.

⚠️ This does **not** soften rule 1 (`_PUBLIC_SESSION_AUTH_RE`), which is tested first and still owns the genuine contradiction — `requireAdmin()` under `#[PublicPage]`, decidesk#44.

**doriath gate-9: FAIL 1 → PASS.**

### 6. A pre-existing window defect, surfaced by fixing #213

The moment openregister's `Settings\…` routes resolved at all, gate-5 reported

```
lib/Controller/Settings/FileSettingsController.php:323 method=getFileExtractionStats rule=missing-auth-attribute
```

⚠️ **#217's body calls this "a true finding the gate was blind to". Re-measured: it is false.** `@NoCSRFRequired` sits on **line 301** and the declaration on **323** — a `@psalm-return` shape in between — so the 20-line lookback started at 303 and the tag was outside it. Same for `FileExtractionController::stats` (tags at 559/563, declaration at 587). Both are correctly annotated by gate-5's own accepted-attribute set.

New shared `_head_block` takes the **contiguous annotation run** OR the 20-line slice, **whichever starts earlier**, and keeps the previous-member clamp from #153. The window can only grow, so nothing that passes today can start failing; and it still cannot borrow a neighbour's attribute. Used by gate-5 and gate-30.

### 7. gate-30 may no longer print PASS having opened nothing

`[ fail -eq 0 ] && PASS` had an empty findings log as its only input, and an empty log has two causes that mean opposite things. Now:

| outcome | condition |
|---|---|
| `FAIL` | a finding |
| `PASS` | **≥1 monitoring method actually opened** — and an info line states how many, of how many candidates |
| `NOT APPLICABLE` | no routes.php/lib/Controller · zero name-matched candidates · zero scrape targets (with the count) · all targets are AppHost generics absent from this repo · none touched by this diff (ADR-020) |
| `SKIPPED (structural)` | targets found, controller files opened, **not one routed method located** — visible to `--require-full-coverage` |

Every candidate the run did **not** judge is written to `hydra-gate-public-monitoring-notes.log` with its reason.

---

## Measured — full-tree, both arms, same 5 repos

`origin/main` (7511fb2, i.e. **with** #217) vs this branch. Numbers re-read from the runner's own stdout, not from memory.

| repo | gate-5 | gate-9 | gate-14 | gate-30 |
|---|---|---|---|---|
| **openregister** | FAIL 12 → **FAIL 10** | FAIL 3 → FAIL 3 | FAIL 2 → **PASS** | PASS *(0 inputs)* → **PASS, 1 of 3 inspected** |
| **launchpad** | PASS → PASS | PASS → PASS | PASS → PASS | **FAIL 2 → PASS, 2 of 4 inspected** |
| **procest** | FAIL 5 → FAIL 5 | FAIL 2 → FAIL 2 | **FAIL 4 → PASS** | PASS *(0 inputs)* → **NOT APPLICABLE** (2 AppHost generics, named) |
| **doriath** | PASS → PASS | **FAIL 1 → PASS** | **FAIL 5 → PASS** | PASS *(0 inputs)* → **NOT APPLICABLE** (no monitoring-shaped name) |
| **openconnector** | PASS → PASS | PASS → PASS | PASS → PASS | PASS → **PASS, 2 of 2 inspected** |

Runner exit: openregister 21→20, launchpad 14→13, procest 21→20, doriath 14→12, openconnector 4→4.

Against the pre-#217 baseline the openregister route pair reads **64 → 10**: gate-14 53→0 and gate-5's phantom UNRESOLVED list 53→2 (the two remaining are the real AppHost generics, correctly stated as NOT JUDGED).

**Every removal verified on the real file, named:**

- `launchpad lib/Controller/HealthPingController.php` — `show()` 401s + `canViewPlacement()`; `validate()` is a POST
- `doriath lib/Controller/ApplicationController.php::create` — `$this->session->getUser()`, then the app-config opt-in
- `procest lib/AppInfo/Registrar/AppHostRegistrar.php` — the delegated `Bootstrap::register()`
- `openregister lib/AppInfo/Application.php::registerAppHostObservability` — the two verbatim DI keys
- `openregister lib/Controller/Settings/FileSettingsController.php:301/323` and `lib/Controller/FileExtractionController.php:559/587` — the docblock window
- the `Routes::standard()` set — `openregister lib/AppHost/Routes.php:110–126` + `165–176`

## Tests — 30 new shell assertions, 9 new Python, mutation-checked

`scripts/lib/test_gate_route_registration.sh` (30 assertions, 7 fixtures, auto-discovered by `tests/run-helper-suites.sh`) + 9 cases in `test_check_semantic_auth.py`.

**Every fixture carries its own anti-widening half** — a sibling differing by the ONE thing the widening accepts, which must still fail. `delegated-registrar/` and `delegated-registrar-absent/` are byte-identical apart from a single registrar file.

**11 mutants, 11 killed, none survived:**

| mutant | assertions that go red |
|---|---|
| gate-30 selector back to lowercase-only | 3 — capitalised names become invisible again |
| gate-30 `read -r` reverted | 1 — the namespaced route stops resolving |
| gate-30 shape filter removed (pre-#218) | 6 — `healthPing` returns as a finding |
| **`_apphost_supplies_route` always true** | 3 — `gadget#run` goes quiet |
| **`_apphost_serves` always true** | 6 — every absent controller goes quiet |
| `_head_block` back to a blind 20-line slice | 2 — a long docblock hides a stated posture |
| gate-30 verdict back to "empty log = PASS" | 4 — both loud skips revert to green |
| comment-stripping removed from AppHost detection | 2 — the fixture exempts itself by its docblock |
| gate-9: session patterns removed | 2 |
| gate-9: helper inlining removed | 2 |
| **gate-9: credential surface = the whole file** | 1 — the depth-1 bound |

Regression, exit codes read directly (not through a pipe):

```
bash hydra-gates/tests/run-helper-suites.sh    -> EXIT=0  (29 passed, 2 quarantined, 0 failed)
bash hydra-gates/tests/test-hydra-gates-bin.sh -> EXIT=0  (59 passed, 0 failed)
docker run koalaman/shellcheck:stable …        -> EXIT=0
```

## Found, NOT fixed here — filed separately

`Routes::standard()` supplies `settings#update` (PUT `/api/settings`), and **doriath's `SettingsController` has no `update()`**. Because doriath ships its own controller the AppHost alias is skipped, so that route resolves to a method that does not exist. Feeding the canonical ten into **gate-5's judging stream and gate-14 invariant 2** would catch it — but that direction *adds* findings across 16 apps and belongs in its own change with its own measurement, not in a PR whose purpose is removing false positives. Flagging rather than smuggling.
