### PR TITLE
fix(gates): nine checkers matched prose, not code (#191, #196, #220, #224, #226, #230, #235, #236, #266)

### DIFF
--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -399,6 +399,37 @@ protection. So every run states how many waivers it honoured:
 
 A green earned by passing is then distinguishable from one earned by waiving.
 
+### Declaring an admin-only endpoint (gate 5)
+
+`@auth admin-only <reason>` is a **declaration**, not a waiver, and it exists
+because gate 5 was otherwise unsatisfiable for a whole class of correct code.
+
+In Nextcloud, **admin is the default and is expressed by the ABSENCE of an
+attribute**: `#[NoAdminRequired]` *widens* access, so an admin-only controller
+method has no attribute available to declare itself with. Gate 5's finding is
+precisely "no attribute", so before 2026-08-08 such a method could only be
+reported — or silently exempted by the bug in
+[#196](https://github.com/ConductionNL/.github/issues/196), where a docblock
+*mentioning* `#[NoAdminRequired]` satisfied the grep. Two methods with
+identical auth posture got opposite verdicts depending on their prose.
+
+Closing that false negative without adding a declaration would have converted a
+silent false negative into a **permanent** false positive on correct code — the
+no-honest-end-state shape. So the posture is stated instead:
+
+```php
+/**
+ * @auth admin-only writes billing state for every tenant; admin posture is the absence of NoAdminRequired
+ */
+public function update(string $id): JSONResponse
+```
+
+The reason must be at least 20 characters and sit at docblock-tag position.
+**Making mere absence sufficient was considered and rejected**: absence is the
+only thing gate 5 reports, so accepting it would empty the gate completely.
+gate 9 (semantic-auth) still owns whether the declared posture matches the
+method body.
+
 ---
 
 ## Testing the package

--- a/hydra-gates/scripts/lib/check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/check_csrf_removal.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-48 csrf-cochange — which removed lines actually DROPPED CSRF protection?
+
+WHY THIS EXISTS (#191)
+----------------------
+The gate found removed attributes like this::
+
+    git diff -U0 "${BASE_REF}...HEAD" -- 'lib/Controller/*.php' \\
+        | grep -E '^-.*(@NoCSRFRequired|#\\[NoCSRFRequired\\])'
+
+`^-.*` puts no constraint on where in the line the token sits, so a comment
+that NAMES the attribute is indistinguishable from an attribute that was
+deleted. Measured on nldesign (`development` vs `origin/beta`): the gate was
+red, nothing about CSRF had changed, and the matched line was one removed
+sentence from a class docblock —
+
+    - * (#[PublicPage] + #[NoCSRFRequired]) and the response contract are owned by
+
+— replaced by another sentence saying the same thing.
+
+WHY THIS ONE IS ESPECIALLY BAD TO LEAVE
+---------------------------------------
+The cheapest way to clear the finding is to REWORD A COMMENT. That changes
+nothing about CSRF and teaches exactly the habit the gate exists to prevent,
+so a gate satisfiable by prose is worse than no gate: it manufactures the
+appearance of a security review. Same family as #184, where gate-64 grepped a
+quoted string literal and so matched every comment and missed every constant.
+
+THE RULE
+--------
+A removed line counts only when the token is in a CODE POSITION:
+
+  attribute form  after the `-`, optional whitespace, the content STARTS with
+                  `#[`, and that attribute list contains `NoCSRFRequired`.
+                  `#[NoAdminRequired, NoCSRFRequired]` counts; a sentence with
+                  `#[NoCSRFRequired]` in the middle of it does not.
+
+  docblock form   after the `-`, optional whitespace, an optional leading `*`
+                  and optional whitespace, the content STARTS with
+                  `@NoCSRFRequired`. That is the only position PHP's own
+                  docblock parsers accept a tag in, and it is not a position
+                  prose reaches.
+
+The nldesign line fails both — its `#[NoCSRFRequired]` sits mid-sentence after
+`(` — while a genuine deletion of either form still matches.
+
+Usage::
+
+    check_csrf_removal.py < unified.diff
+
+Prints the removed lines that are real CSRF removals, one per line. Exits 0
+always; the OUTPUT is the answer (#209).
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# `-` then optional whitespace then `#[`, with NoCSRFRequired inside the
+# attribute group. `[^]]*` is bounded by the closing bracket so a `#[Foo]`
+# followed later on the line by the word NoCSRFRequired in prose cannot match.
+ATTRIBUTE_REMOVED = re.compile(r'^-\s*#\[[^]]*\bNoCSRFRequired\b')
+# `-` then optional whitespace, an optional docblock star, optional
+# whitespace, then the tag AT THE START of the content.
+DOCBLOCK_TAG_REMOVED = re.compile(r'^-\s*(?:\*\s*)?@NoCSRFRequired\b')
+
+# A diff header line is `---` / `---` shaped; it is not a removed line of code.
+DIFF_HEADER = re.compile(r'^---(\s|$)')
+
+
+def removals(diff: str) -> list[str]:
+    out = []
+    for line in diff.splitlines():
+        if not line.startswith('-') or DIFF_HEADER.match(line):
+            continue
+        if ATTRIBUTE_REMOVED.match(line) or DOCBLOCK_TAG_REMOVED.match(line):
+            out.append(line)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1:
+        print("usage: check_csrf_removal.py < unified.diff", file=sys.stderr)
+        return 2
+    for line in removals(sys.stdin.read()):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_js_call_sites.py
+++ b/hydra-gates/scripts/lib/check_js_call_sites.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-34 (window-confirm) and gate-58 (e2e-networkidle), over CODE only.
+
+Both gates grepped raw file text for a fixed spelling, and both failed in the
+two directions #184 named:
+
+GATE-34 (#224), measured in four arms on doriath
+------------------------------------------------
+  arm 1  a comment saying the component "deliberately avoids
+         window.confirm() and uses NcDialog"           -> FAIL, false RED
+  arm 2  the same file with that comment deleted       -> PASS  (the control
+         proving arm 1's finding IS the comment)
+  arm 3  `if (!window['confirm']('Delete everything?'))` -> PASS, false GREEN
+  arm 4  the same code written `window.confirm(...)`   -> FAIL  (the control
+         proving the probe can fire)
+
+Arm 1 punishes the code that did the right thing and teaches people not to
+write down why. Arm 3 is the serious one: the native call it hid on doriath
+guarded a CASCADING DELETE. `window['confirm']` is not a contrived bypass —
+it is what several minifiers and some lint autofixes emit, and
+`const { confirm } = window` is ordinary style.
+
+GATE-58 (#230), measured on larpingapp
+--------------------------------------
+The gate reported one finding. The line was::
+
+    // live `waitForLoadState('networkidle')` in the suite; every other mention
+
+i.e. a comment explaining that the LAST live call had been removed. The repo
+has zero live calls; all ten occurrences under tests/ are comments. This is
+doubly perverse — the more carefully a repo documents the ADR-074 rule 4
+removal, the more findings it accrues — and unfixable in the leaf, because
+the only remedies are deleting the explanation or putting an `exclude` marker
+on a comment, which is comment-satisfaction.
+
+WHY A MASK AND NOT A LINE FILTER
+--------------------------------
+#230 suggested dropping lines that START with `//`. That would still count::
+
+    const wait = 1 // waitForLoadState('networkidle') is banned
+
+and would still fire on a block comment's interior lines that begin with a
+letter. The mask blanks the comment REGIONS, whatever column they start in,
+and leaves a real call with a trailing comment intact — asserted both ways.
+
+STRING LITERALS ARE KEPT. Gate-19's mask blanks string CONTENTS, because for
+gate-19 "is argument 1 a string" is the discriminator. Here the string IS the
+evidence: `'networkidle'` and `window['confirm']` are both string literals.
+Using the wrong mask would have turned a fixed gate into a dead one — the
+failure mode this package has already shipped eleven times.
+
+OFFSETS SURVIVE, WHICH IS WHAT MAKES THE SUPPRESSION MARKER WORK. The
+`e2e-networkidle exclude <reason>` marker lives IN a comment — exactly what
+the mask blanks — so the match is found in the mask and the marker is read
+out of the ORIGINAL text at the same line number.
+
+Usage::
+
+    check_js_call_sites.py --rule native-dialog|networkidle <file> [<file>...]
+
+One finding per line, `path:line: <text>`; exits 0 always (#209).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import js_code_mask, js_exec_mask, read_text  # noqa: E402
+
+_DIALOGS = "confirm|alert|prompt"
+
+# ANCHOR, THEN READ THE ORIGINAL.
+#
+# The anchor patterns run against a mask whose STRING CONTENTS are blanked,
+# so a sentence of documentation is not a call site::
+#
+#     const doc = 'do not use window.confirm here'
+#
+# But the evidence for the two defects being fixed IS a string literal —
+# `window['confirm']`, `'networkidle'`. Both cannot be true of one mask, so
+# they are two questions asked of two texts at ONE coordinate: the anchor says
+# "this offset is code", and the full pattern is then matched against the
+# ORIGINAL text at that same offset. Every mask in source_scope preserves
+# offsets precisely so this is available.
+DIALOG_ANCHOR = re.compile(
+    r"(?<![.\w$])window\s*[.\[]"
+    r"|\{[^}\n]*\}\s*=\s*window\b"
+)
+NETWORKIDLE_ANCHOR = re.compile(r"waitForLoadState\s*\(|waitUntil\s*:")
+
+# `window.confirm(`, `window . confirm (`, and the bracket form. Anchored on
+# `window` so a component's own `this.confirm()` — an NcDialog wrapper, which
+# is the REMEDY this gate asks for — is not reported.
+NATIVE_DIALOG = re.compile(
+    rf"""
+    (?<![.\w$])window\s*\.\s*(?:{_DIALOGS})\b            # window.confirm
+  | (?<![.\w$])window\s*\[\s*(['"])(?:{_DIALOGS})\1\s*\] # window['confirm']
+  | \{{[^}}\n]*\b(?:{_DIALOGS})\b[^}}\n]*\}}\s*=\s*window\b   # const {{confirm}} = window
+    """,
+    re.VERBOSE,
+)
+
+NETWORKIDLE = re.compile(
+    r"""waitForLoadState\(\s*['"]networkidle['"]"""
+    r"""|waitUntil:\s*['"]networkidle['"]"""
+)
+
+NETWORKIDLE_EXCLUDE = "e2e-networkidle exclude"
+
+
+def _hits(src: str, masked: str, anchor: re.Pattern, full: re.Pattern) -> list[int]:
+    """Line numbers where *anchor* sits at a code position in *masked* AND
+    *full* matches the ORIGINAL text starting there.
+
+    Overlapping anchors on one construct (`window[` matches once) cannot
+    double-count, because the offsets are de-duplicated by line and start.
+    """
+    seen: set[int] = set()
+    out: list[int] = []
+    for m in anchor.finditer(masked):
+        start = m.start()
+        if not full.match(src, start):
+            continue
+        if start in seen:
+            continue
+        seen.add(start)
+        out.append(src.count("\n", 0, start) + 1)
+    return out
+
+
+def _native_dialog(path: str, src: str) -> list[str]:
+    masked = js_exec_mask(src, path)
+    original = src.splitlines()
+    out = []
+    for line_no in _hits(src, masked, DIALOG_ANCHOR, NATIVE_DIALOG):
+        text = original[line_no - 1].strip() if line_no <= len(original) else ""
+        out.append(f"{path}:{line_no}:{text}")
+    return out
+
+
+def _networkidle(path: str, src: str) -> list[str]:
+    masked = js_code_mask(src)
+    original = src.splitlines()
+    out = []
+    for line_no in _hits(src, masked, NETWORKIDLE_ANCHOR, NETWORKIDLE):
+        text = original[line_no - 1] if line_no <= len(original) else ""
+        # The suppression marker is written in a comment, which the mask
+        # blanked — so it is read from the ORIGINAL line.
+        if NETWORKIDLE_EXCLUDE in text:
+            continue
+        out.append(f"{path}:{line_no}:{text.strip()}")
+    return out
+
+
+RULES = {
+    "native-dialog": _native_dialog,
+    "networkidle": _networkidle,
+}
+
+
+def scan_source(rule: str, path: str, src: str) -> list[str]:
+    return RULES[rule](path, src)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 4 or argv[1] != "--rule" or argv[2] not in RULES:
+        print("usage: check_js_call_sites.py --rule native-dialog|networkidle <file>...",
+              file=sys.stderr)
+        return 2
+    rule = argv[2]
+    for path in argv[3:]:
+        try:
+            src = read_text(path)
+        except OSError:
+            continue
+        for line in scan_source(rule, path, src):
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_js_call_sites.py
+++ b/hydra-gates/scripts/lib/check_js_call_sites.py
@@ -85,8 +85,15 @@ _DIALOGS = "confirm|alert|prompt"
 # "this offset is code", and the full pattern is then matched against the
 # ORIGINAL text at that same offset. Every mask in source_scope preserves
 # offsets precisely so this is available.
+# ⚠️ The `=` alternative is a LOOKAHEAD, so it consumes only the `=` itself.
+# Written as `=\s*window\s*[.\[]` it swallowed the `window` that follows, and
+# `finditer` (which returns NON-OVERLAPPING matches) then never offered the
+# `window` anchor — so `const r = window.confirm('x')` matched the alias rule,
+# failed it because a `(` follows, and reported NOTHING. A real call, silently
+# dropped by an anchor that was one character too greedy.
 DIALOG_ANCHOR = re.compile(
     r"(?<![.\w$])window\s*[.\[]"
+    r"|=(?=\s*window\s*[.\[])"
     r"|\{[^}\n]*\}\s*=\s*window\b"
 )
 NETWORKIDLE_ANCHOR = re.compile(r"waitForLoadState\s*\(|waitUntil\s*:")
@@ -94,11 +101,34 @@ NETWORKIDLE_ANCHOR = re.compile(r"waitForLoadState\s*\(|waitUntil\s*:")
 # `window.confirm(`, `window . confirm (`, and the bracket form. Anchored on
 # `window` so a component's own `this.confirm()` — an NcDialog wrapper, which
 # is the REMEDY this gate asks for — is not reported.
+# A USE, not a mention of the API.
+#
+# ⚠️ MEASURED BEFORE LANDING. The first cut accepted any `window.confirm`
+# reference, called or not. On openbuild that took the gate from 7 findings to
+# 14 — every native dialog there is written as
+#
+#     const ok = typeof window !== 'undefined' && window.confirm
+#         ? window.confirm(t('openbuild', 'Delete this automation?'))
+#         : true
+#
+# so the FEATURE-DETECTION GUARD and the call it guards were reported
+# separately. Seven defects, fourteen findings: a count that is not a defect
+# count, which is #254's lesson in another gate. A guard is not a second
+# native dialog, and inflating a security-adjacent number is its own kind of
+# false report.
+#
+# So a reference counts only when it is an ALIAS — bound to a name, where the
+# call site is elsewhere and invisible:
+#     const c = window.confirm            counts (aliased)
+#     const { confirm } = window          counts (destructured)
+#     x && window.confirm ? … : …         does NOT count (a truthiness test)
 NATIVE_DIALOG = re.compile(
     rf"""
-    (?<![.\w$])window\s*\.\s*(?:{_DIALOGS})\b            # window.confirm
-  | (?<![.\w$])window\s*\[\s*(['"])(?:{_DIALOGS})\1\s*\] # window['confirm']
-  | \{{[^}}\n]*\b(?:{_DIALOGS})\b[^}}\n]*\}}\s*=\s*window\b   # const {{confirm}} = window
+    (?<![.\w$])window\s*\.\s*(?:{_DIALOGS})\s*\(              # window.confirm(
+  | (?<![.\w$])window\s*\[\s*(['"])(?:{_DIALOGS})\1\s*\]\s*\( # window['confirm'](
+  | =\s*window\s*\.\s*(?:{_DIALOGS})\b(?!\s*\()               # const c = window.confirm
+  | =\s*window\s*\[\s*(['"])(?:{_DIALOGS})\2\s*\](?!\s*\()    # const c = window['confirm']
+  | \{{[^}}\n]*\b(?:{_DIALOGS})\b[^}}\n]*\}}\s*=\s*window\b     # const {{confirm}} = window
     """,
     re.VERBOSE,
 )

--- a/hydra-gates/scripts/lib/check_markup_a11y.py
+++ b/hydra-gates/scripts/lib/check_markup_a11y.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-31 (img-alt) and gate-32 (semantic-controls), over MARKUP only.
+
+WHY THIS MOVED OUT OF THE BASH GATES
+------------------------------------
+Both gates read a file like this::
+
+    _flat=$(tr '\\n' ' ' < "${vue}")
+    echo "${_flat}" | grep -oE '<img\\b[^>]*>'
+
+Two defects in three lines, and both were measured live:
+
+1. THE WHOLE FILE IS FLATTENED, so `<script>` and comments are scanned as
+   markup. On openbuild ALL THREE gate-31 findings were JSDoc prose —
+   ``* @param {Event} e - The `<img>` `error` event`` (#235). On launchpad the
+   single finding was a docblock in `<script>` explaining that
+   `CnDashboardIcon` resolves a URL to an `<img>` (#220). The finding text was
+   the tell: a real tag prints with its attributes, these printed as the bare
+   four characters `<img>`.
+
+   gate-32 has the same hole with the opposite sign. On softwarecatalog the
+   comment written ABOVE a repaired element — "role/tabindex/keydown rather
+   than a bare `<div @click>`" — was itself scored as the bad element, and
+   REWORDING THE COMMENT cleared the gate with the markup byte-identical
+   (#236). A gate a comment can clear is a gate a comment can also defeat.
+
+2. `[^>]*` ENDS THE ELEMENT AT THE FIRST `>`, which in Vue is very often the
+   arrow of `:reduce="option => option.value"` — gate-12's #236 defect, and
+   the same shape as gate-9's `[^)]*` in #198. It is fixed here for all three
+   gates at once by extracting through `source_scope.iter_open_tags`.
+
+WHAT DOES NOT CHANGE
+--------------------
+The RULES are untouched — the accepted alt spellings, the required
+role/tabindex/key-handler trio, the `<a href>` and `@click.stop` exemptions
+are all carried over verbatim from the bash blocks. This changes WHERE the
+gate looks, not what it asks, so before/after counts stay comparable and a
+drop in findings is attributable to prose leaving the scope.
+
+Usage::
+
+    check_markup_a11y.py --rule img-alt|semantic-controls <file> [<file>...]
+
+Prints one finding per line in the shape the bash gates emitted, so the
+runner still counts lines. Exits 0 always; the count is the answer and the
+exit status is a status (#209 — gate-19 returned its finding count as an exit
+byte and 266 was reported as 10).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import iter_open_tags, markup_mask, read_text  # noqa: E402
+
+# --- gate-31 ---------------------------------------------------------------
+# `alt=`, `:alt=`, `v-bind:alt=`, `alt-text=` (some Conduction components
+# proxy the prop under that name). Carried over unchanged from the bash gate.
+ALT_ATTR = re.compile(r'(^|[\s])(:?alt|v-bind:alt|alt-text)=')
+
+# --- gate-32 ---------------------------------------------------------------
+NON_SEMANTIC = {
+    "div", "span", "a", "p", "li", "article", "section",
+    "header", "footer", "aside", "main", "nav",
+}
+CLICK = re.compile(r'@click|v-on:click')
+HREF = re.compile(r'(^|\s)(:?href|v-bind:href)=')
+ROLE = re.compile(r'(^|[\s])(:?role|v-bind:role)=')
+TABINDEX = re.compile(r'(^|[\s])(:?tabindex|v-bind:tabindex)=')
+KEYHANDLER = re.compile(r'@keydown|@keyup|@keypress|v-on:keydown|v-on:keyup|v-on:keypress')
+# `@click.stop` with no handler (or an empty one) is event management, not a
+# user interaction. opencatalogi's PublicationCard wrappers are the fleet
+# example; the bash gate already exempted them.
+CLICK_WITH_HANDLER = re.compile(r'@click(\.[a-z]+)*\s*=\s*"[^"]+"|v-on:click(\.[a-z]+)*\s*=\s*"[^"]+"')
+CLICK_STOP_BARE = re.compile(r'@click\.stop(\s|/|>|$|=\s*("\s*"|\'\s*\'))')
+
+
+def _img_alt(path: str, masked: str) -> list[str]:
+    out = []
+    for tag in iter_open_tags(masked, {"img"}):
+        if ALT_ATTR.search(tag.attrs):
+            continue
+        out.append(f"{path}:{tag.line}: {tag.flat}")
+    return out
+
+
+def _semantic_controls(path: str, masked: str) -> list[str]:
+    out = []
+    for tag in iter_open_tags(masked, NON_SEMANTIC):
+        if not CLICK.search(tag.attrs):
+            continue
+        if tag.name == "a" and HREF.search(tag.attrs):
+            continue
+        if CLICK_STOP_BARE.search(tag.attrs) and not CLICK_WITH_HANDLER.search(tag.attrs):
+            continue
+        missing = []
+        if not ROLE.search(tag.attrs):
+            missing.append("role=")
+        if not TABINDEX.search(tag.attrs):
+            missing.append("tabindex=")
+        if not KEYHANDLER.search(tag.attrs):
+            missing.append("@keydown")
+        if missing:
+            out.append(f"{path}:{tag.line}: {tag.flat} rule=missing[{','.join(missing)}]")
+    return out
+
+
+RULES = {
+    "img-alt": _img_alt,
+    "semantic-controls": _semantic_controls,
+}
+
+
+def scan_source(rule: str, path: str, src: str) -> list[str]:
+    return RULES[rule](path, markup_mask(src, path))
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 4 or argv[1] != "--rule" or argv[2] not in RULES:
+        print(
+            "usage: check_markup_a11y.py --rule img-alt|semantic-controls <file>...",
+            file=sys.stderr,
+        )
+        return 2
+    rule = argv[2]
+    for path in argv[3:]:
+        try:
+            src = read_text(path)
+        except OSError:
+            continue
+        for line in scan_source(rule, path, src):
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_nc_select_labels.py
+++ b/hydra-gates/scripts/lib/check_nc_select_labels.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-12 nc-input-labels — every `<NcSelect>` must name itself.
+
+A manual `<label>` next to an `NcSelect` does not associate with the
+component's internal combobox input, so the accessible name has to come
+from the component's own API: `input-label` (rendered as the visible
+label) or `aria-label-combobox`. WCAG 2.2 AA SC 1.3.1 / 4.1.2, ADR-004
+hard rule. Observed 2026-04-30 on doriath.
+
+WHY THIS MOVED OUT OF THE BASH GATE
+-----------------------------------
+The gate used to flatten the file's newlines and run::
+
+    grep -oE '<NcSelect[^>]*>'
+
+`[^>]*` ends the element at the FIRST `>` character in the source. In an
+`NcSelect` that is almost never the end of the tag, because the idiomatic
+vue-select usage puts an arrow function in an attribute value::
+
+    <NcSelect
+        v-model="selectedRoundId"
+        :options="roundOptions"
+        :reduce="(o) => o.id"
+        :input-label="t('scholiq', 'Round')"
+        :aria-label-combobox="t('scholiq', 'Round')" />
+                  ^
+                  the `>` of `=>` — extraction stops here
+
+Everything after `:reduce` is invisible to the gate, so the very props it
+is looking for are cut off and the element is reported as unnamed.
+Measured on scholiq 2026-08-08: **18 findings, 18 of them false** — every
+flagged `NcSelect` already carried `:input-label` AND
+`:aria-label-combobox`, in every case written after the `:reduce` prop.
+
+`:reduce` is not exotic. It is how vue-select maps an option object to the
+stored value, so a project that uses object options at all hits this on
+most of its selects. The gate was anti-correlated with its own subject in
+those files: adding the label prop could not clear it, and deleting
+`:reduce` could.
+
+The fix is to end the tag at a `>` that is not inside a quoted attribute
+value. That is the same tag pattern ``check_form_labels.py`` already uses,
+so the two a11y gates now agree on where an element stops.
+
+WHAT STILL FAILS, AND MUST
+--------------------------
+An `NcSelect` carrying none of `input-label` / `inputLabel` /
+`aria-label-combobox` / `ariaLabelCombobox` is still reported, including
+when it sits next to a hand-written `<label for=…>` — that is the whole
+point of the rule. The accepted prop set is unchanged from the bash gate
+on purpose, so the before/after numbers stay comparable: this change fixes
+where an element ENDS, not what counts as a name.
+
+Markup inside an HTML comment is not scanned. A commented-out `NcSelect`
+renders nothing and can carry no accessible name. Neither is an `NcSelect`
+written inside the `<script>` block — a JSDoc line naming the component is
+prose about markup, which is what put three false findings on openbuild's
+gate-31 (#235) and one on launchpad's (#220). Both scopes come from
+`source_scope.markup_mask`, so gates 12, 31 and 32 agree on what "markup"
+means instead of each carrying its own answer.
+
+Usage::
+
+    check_nc_select_labels.py <vue-file> [<vue-file> ...]
+
+Prints one `path: <tag…>` line per violation, the same shape the bash gate
+emitted, so the runner counts lines unchanged. Exits 0 always.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import iter_open_tags, markup_mask  # noqa: E402
+
+# The name-bearing props NcSelect publishes. Both the kebab and camel
+# spellings, bare or bound (`:input-label`, `v-bind:inputLabel`).
+LABEL_PROP = re.compile(
+    r'(^|\s)(:|v-bind:)?'
+    r'(input-label|inputLabel|aria-label-combobox|ariaLabelCombobox)\s*='
+)
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    """Return one finding line per unnamed `<NcSelect>` in *src*."""
+    out: list[str] = []
+    for tag in iter_open_tags(markup_mask(src, fname), {'NcSelect'}):
+        if LABEL_PROP.search(tag.attrs):
+            continue
+        # Report the element as one line, the way the bash gate did, so an
+        # existing consumer of the log still reads it.
+        out.append(f'{fname}: {tag.flat}')
+    return out
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_stub_run_body.py
+++ b/hydra-gates/scripts/lib/check_stub_run_body.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-3 stub-scan — is a BackgroundJob's `run()` actually a stub?
+
+WHY THIS EXISTS (#226)
+----------------------
+The gate counted surviving lines::
+
+    _body=$(awk "/function run\\(/,/^    }/" "${job}" \\
+      | grep -vE "^\\s*(//|\\*|\\s*\\{|\\s*\\}|\\s*$)" \\
+      | grep -vE "function run|logger->(info|warning|debug|error|notice)|try\\s*\\{|\\}\\s*catch|return;?$")
+    _lc=$(echo "${_body}" | grep -cE "\\S")
+    [ "${_lc}" -lt 2 ] && echo "... run() body has no non-logger statements (stub)"
+
+Measured on portaliq, `lib/BackgroundJob/NotificationDispatchJob.php` — 530
+lines, 11 private methods, a complete notification pipeline — reported as a
+stub. The filters strip `try {`, `} catch` and every logger call, so the
+canonical fail-safe wrapper::
+
+    protected function run($argument): void
+    {
+        try {
+            $this->doRun(argument: $argument);
+        } catch (Throwable $e) {
+            $this->logger->error("...", ["reason" => $e->getMessage()]);
+        }
+    }
+
+leaves EXACTLY ONE line, and the threshold is `< 2`.
+
+THE ARITHMETIC, AND WHY BOTH DIRECTIONS ARE BROKEN
+--------------------------------------------------
+    A  genuine stub (logger->info() only)     0 lines   flagged   correct
+    B  real fail-safe delegation to doRun()   1 line    FLAGGED   FALSE POSITIVE
+    C  B plus one inert `$unused = 1;`        2 lines   passes    FALSE NEGATIVE
+
+C is the real damage. The gate is CLOSED by adding a dead line and cannot be
+closed by writing correct code. The two remedies available to a builder were
+to pad the method with a no-op, or to inline the whole pipeline back into
+`run()` — deleting the single try/catch that stops an exception escaping to
+the NC cron runner. Both make the code worse, which is why portaliq reported
+the finding instead of "fixing" it.
+
+THE RULE HERE
+-------------
+Count CALLS, not lines. A `run()` body is implemented when it contains at
+least one call that is not a logger call — `$this->doRun(...)`,
+`$service->handle(...)`, a static call, a plain function call. It is a stub
+when it contains none.
+
+That flips B to clean (one delegating call IS the implementation, one level
+down) and, just as importantly, keeps C flagged when the padding is all it
+has: `$unused = 1;` is not a call, so a body of logger calls plus dead
+assignments is still a stub. The gate stops being closable by a dead line.
+
+Comments are removed before any of this, via source_scope.php_mask — a
+`// $this->doRun();` left behind by someone mid-refactor is not an
+implementation, and the old line filters counted `*`-prefixed lines out but
+not a commented-out statement written at column 0.
+
+Usage::
+
+    check_stub_run_body.py <job-file> [<job-file>...]
+
+Prints `path: run() body has no non-logger statements (stub)` per finding —
+the same string the bash gate emitted. Exits 0 always (#209).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask, read_text  # noqa: E402
+
+RUN_DECL = re.compile(
+    r'(?:^|\n)[ \t]*(?:(?:public|protected|private|final|static)[ \t]+)*'
+    r'function[ \t]+run[ \t]*\(',
+)
+
+# A logger call is a method from the PSR-3 vocabulary invoked on a receiver
+# whose name ends in `logger` / `log`. Both halves are required: `$this->
+# logger->error(...)` is discounted, `$mailer->error(...)` is not, and
+# `$this->logger->rotate()` is a call to a logger that is not a log line.
+LOGGER_METHODS = frozenset({
+    'info', 'warning', 'warn', 'debug', 'error', 'notice',
+    'critical', 'alert', 'emergency', 'log',
+})
+LOGGER_RECEIVER = re.compile(r'(?:logger|log)\s*$', re.IGNORECASE)
+
+# Any call at all: `->m(`, `::m(`, `name(`. `function` / control keywords are
+# excluded so `if (`, `foreach (`, `catch (` are not mistaken for work.
+ANY_CALL = re.compile(
+    r'(?:->|::)\s*[A-Za-z_]\w*\s*\('
+    r'|(?<![>:\w$])[A-Za-z_]\w*\s*\('
+)
+NOT_A_CALL = frozenset({
+    'if', 'elseif', 'else', 'while', 'for', 'foreach', 'switch', 'match',
+    'catch', 'try', 'return', 'fn', 'function', 'echo', 'print', 'and', 'or',
+    'xor', 'new', 'clone', 'throw', 'yield', 'array', 'list', 'isset',
+    'unset', 'empty', 'exit', 'die',
+})
+
+
+def run_body(src: str) -> str | None:
+    """The masked body of `run()`, or None when the file has no `run()`.
+
+    Braces are matched rather than trusting `/^    }/`, which is an indentation
+    guess: a job whose `run()` closes at a different indent had its body run to
+    the end of the file.
+    """
+    # String CONTENTS are blanked too, so a `'}'` in a message cannot close
+    # the body. Nothing below reads a string's value.
+    masked = php_mask(src, blank_strings=True)
+    m = RUN_DECL.search(masked)
+    if not m:
+        return None
+    # Find the `{` that opens the body, skipping the parameter list and any
+    # return type.
+    i = masked.find('(', m.end() - 1)
+    depth = 0
+    while i < len(masked):
+        if masked[i] == '(':
+            depth += 1
+        elif masked[i] == ')':
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    brace = masked.find('{', i)
+    semi = masked.find(';', i)
+    if brace < 0 or (0 <= semi < brace):
+        # Abstract or interface declaration — no body to judge.
+        return None
+    depth = 0
+    j = brace
+    while j < len(masked):
+        if masked[j] == '{':
+            depth += 1
+        elif masked[j] == '}':
+            depth -= 1
+            if depth == 0:
+                return masked[brace + 1:j]
+        j += 1
+    return masked[brace + 1:]
+
+
+def _calls(body: str) -> list[str]:
+    """Non-logger call sites in *body*."""
+    out = []
+    for m in ANY_CALL.finditer(body):
+        text = m.group(0)
+        name = re.sub(r'[\s(]+$', '', text.lstrip('->:').strip()).lower()
+        if name in NOT_A_CALL:
+            continue
+        if name in LOGGER_METHODS and LOGGER_RECEIVER.search(body[:m.start()]):
+            continue
+        out.append(text)
+    return out
+
+
+def is_stub(src: str) -> bool | None:
+    """True when `run()` does no non-logger work. None when there is no run()."""
+    body = run_body(src)
+    if body is None:
+        return None
+    return not _calls(body)
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out = []
+    for path in files:
+        try:
+            src = read_text(path)
+        except OSError:
+            continue
+        verdict = is_stub(src)
+        if verdict:
+            out.append(f'{path}: run() body has no non-logger statements (stub)')
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_stub_run_body.py <job-file>...", file=sys.stderr)
+        return 2
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/php_template_scope.py
+++ b/hydra-gates/scripts/lib/php_template_scope.py
@@ -30,9 +30,30 @@ ways at once — so the classification is done on EMITTED MARKUP only:
   * `<!-- … -->` HTML comments are removed. Commented-out markup ships
     nothing.
 
+GATE-41 SHARES THIS, IT DOES NOT ADD A THIRD ANSWER (#266)
+----------------------------------------------------------
+gate-41 (html-lang, WCAG 3.1.1) asked the same question of the same files
+with `re.search(r'<html\\b([^>]*)>', txt)` over the RAW text, and had gate-38's
+pre-fix defect verbatim:
+
+    <?php
+    // This mount point is substituted into core's page. Core emitted the
+    // <html> element for it, with its lang attribute, long before this file.
+    ?>
+    <div id="app-settings"></div>
+
+    [gate-41] html-lang: FAIL — 1 <html> tag(s) without lang=
+
+The file contains no `<html>` element; the gate matched the comment
+explaining that it doesn't. It fails the other way too — a commented-out
+`<html lang="en">` would VOUCH for a template that really does emit an
+unlangged one. `--html-lang` below answers it from `emitted_markup`, so the
+two gates cannot drift into disagreeing about what a template emits.
+
 Usage:
     php_template_scope.py --owns-document <file>   # exit 0 = owns, 1 = fragment
     php_template_scope.py --classify <file>...     # "<path>: page-root|fragment"
+    php_template_scope.py --html-lang <file>...    # SC 3.1.1 findings
 """
 from __future__ import annotations
 
@@ -46,6 +67,13 @@ PHP_BLOCK = re.compile(r'<\?(?:php\b|=)?.*?(?:\?>|\Z)', re.DOTALL | re.IGNORECAS
 HTML_COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
 
 DOCUMENT_TAG = re.compile(r'<(?:html|body)\b', re.IGNORECASE)
+# The opening `<html>` element and its attribute text. Quote-aware, so a `>`
+# inside an attribute value does not end the tag — the `[^>]*` shape it
+# replaces is the same character-class-as-delimiter bug as gate-9's `[^)]*`
+# (#198) and gate-12's (#236).
+HTML_TAG = re.compile(
+    r'<html\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*)>', re.IGNORECASE | re.DOTALL)
+LANG_ATTR = re.compile(r'(^|\s)(?:xml:)?lang\s*=', re.IGNORECASE)
 
 
 def emitted_markup(src: str) -> str:
@@ -68,6 +96,22 @@ def owns_document(src: str) -> bool:
     return bool(DOCUMENT_TAG.search(emitted_markup(src)))
 
 
+def html_lang_findings(path: str, src: str) -> list[str]:
+    """SC 3.1.1 findings for one template: an emitted `<html>` with no `lang`.
+
+    Asked of EMITTED MARKUP, so neither a PHP comment naming the tag nor a
+    commented-out `<html lang="en">` can decide it. Every emitted `<html>` is
+    checked, not just the first — a template with two would previously have
+    been judged by whichever came first.
+    """
+    out = []
+    for m in HTML_TAG.finditer(emitted_markup(src)):
+        if LANG_ATTR.search(m.group(1) or ''):
+            continue
+        out.append(f'{path}: <html> rule=html-tag-without-lang')
+    return out
+
+
 def _read(path: str) -> str:
     with open(path, encoding='utf-8', errors='replace') as f:
         return f.read()
@@ -88,6 +132,18 @@ def main(argv: list[str]) -> int:
             except OSError:
                 kind = 'unreadable'
             print(f'{path}: {kind}')
+        return 0
+    if len(argv) >= 3 and argv[1] == '--html-lang':
+        for path in argv[2:]:
+            try:
+                src = _read(path)
+            except OSError:
+                # Unreadable is NOT clean. Say so on stderr and exit non-zero
+                # so the caller reports a wiring failure rather than a pass.
+                print(f'php_template_scope: cannot read {path}', file=sys.stderr)
+                return 2
+            for line in html_lang_findings(path, src):
+                print(line)
         return 0
     print(__doc__, file=sys.stderr)
     return 2

--- a/hydra-gates/scripts/lib/source_scope.py
+++ b/hydra-gates/scripts/lib/source_scope.py
@@ -398,8 +398,14 @@ _PHP_BLOCK = re.compile(r'<\?(?:php\b|=)?.*?(?:\?>|\Z)', re.DOTALL | re.IGNORECA
 # it is the exact failure this whole change exists to prevent, so the block
 # boundaries are found by DEPTH, not by a lazy quantifier.
 _TEMPLATE_TAG = re.compile(r'<(/?)template\b[^>]*?(/?)>', re.IGNORECASE | re.DOTALL)
-_SCRIPT_BLOCK = re.compile(r'<script(\s[^>]*)?>(.*?)</script\s*>', re.DOTALL | re.IGNORECASE)
-_STYLE_BLOCK = re.compile(r'<style(\s[^>]*)?>(.*?)</style\s*>', re.DOTALL | re.IGNORECASE)
+# ⚠️ THE END TAG MAY CARRY JUNK. `</script\s*>` does not match `</script bar>`
+# or `</script\t\n foo>`, and an HTML parser ends the element at both — so the
+# regex would run the "script body" on past the real close and blank markup
+# that ships. Caught by CodeQL (py/bad-tag-filter, high) on this very change:
+# a mask that over-blanks is a gate that reports nothing, which is the failure
+# mode this whole change exists to remove.
+_SCRIPT_BLOCK = re.compile(r'<script(\s[^>]*)?>(.*?)</script(?:\s[^>]*)?>', re.DOTALL | re.IGNORECASE)
+_STYLE_BLOCK = re.compile(r'<style(\s[^>]*)?>(.*?)</style(?:\s[^>]*)?>', re.DOTALL | re.IGNORECASE)
 
 
 def _blank_span(buf: list[str], a: int, b: int) -> None:

--- a/hydra-gates/scripts/lib/source_scope.py
+++ b/hydra-gates/scripts/lib/source_scope.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Where does CODE live in a source file, and where does PROSE live?
+
+WHY THIS EXISTS
+---------------
+Nine gates in this package decided a question about code by grepping the raw
+bytes of a file. Prose is made of the same bytes, so every one of them failed
+in BOTH directions at once — the shape first written down in #184:
+
+    "a checker that greps a STRING LITERAL misses every constant and matches
+     every comment — it fails BOTH ways at once."
+
+Measured instances, all of them live in the fleet:
+
+  #191  gate-48  a REMOVED COMMENT naming `#[NoCSRFRequired]` read as a
+                 removed attribute — nldesign red for a docblock rewrite.
+  #196  gate-5   a docblock sentence saying `#[NoAdminRequired]` is
+                 deliberately NOT used SATISFIED the auth gate. A false
+                 NEGATIVE on a security gate: prose switched the gate off.
+  #220  gate-31  `` `<img>` `` inside a JSDoc comment in the <script> block
+                 reported as an image with no alt (launchpad).
+  #235  gate-31  same, three times, on openbuild. The finding text was the
+                 tell: a real tag prints with attributes, these printed as
+                 the bare four characters `<img>`.
+  #224  gate-34  false RED on a comment saying the component avoids
+                 window.confirm, AND false GREEN on `window['confirm']()`.
+  #226  gate-3   a `run()` that delegates to one helper read as a stub, and
+                 the gate was closable by an inert `$unused = 1;`.
+  #230  gate-58  a comment WARNING AGAINST `networkidle` counted as a use of
+                 it — the better the documentation, the redder the repo.
+  #236  gate-12  `<NcSelect[^>]*>` truncated at the `>` of `option =>`.
+  #236  gate-32  a comment describing the `<div @click>` an element replaced
+                 scored as that `<div @click>`.
+  #266  gate-41  a PHP comment mentioning `<html>` made a mount point read
+                 as a page root.
+
+THE SHAPE OF THE FIX
+--------------------
+Two precedents in this package already got it right, and this module is their
+generalisation rather than a third dialect:
+
+  * `check_apphost_autoload_prelude.strip_comments` (#184) — knows that `#`
+    opens a PHP comment but `#[` opens an ATTRIBUTE.
+  * `check_e2e_coverage._code_mask` (#249) — tokenises ONCE, blanks comments,
+    string contents and regex literals, and PRESERVES OFFSETS so a line
+    number computed on the mask still names the right line of the original.
+    It deliberately KEEPS string delimiters, because "is argument 1 a string
+    literal" is sometimes the only discriminator available.
+
+That second one is the strongest available model, so `js_mask` below is it,
+generalised by one keyword argument.
+
+WHY GATE-19 STILL CARRIES ITS OWN COPY
+--------------------------------------
+`check_e2e_coverage._code_mask` was NOT deleted in favour of this one. Ripping
+a 180-line tokeniser out from under the gate whose 60-assertion suite is the
+only thing that proves it correct is a bad trade in a change already touching
+nine gates. What replaces the deletion is a DRIFT TEST: the shared mask and
+gate-19's are asserted byte-identical over a corpus in
+`test_source_scope.py::TestSharedWithGate19`, including gate-19's own
+fixtures. Two copies that are proven equal are a maintenance cost; two copies
+that MIGHT differ are a defect. The test is mutation-checked — flip one branch
+of either copy and it goes red — so this is a coupling, not a comment.
+
+MASK, NOT STRIP
+---------------
+Every function here returns a string the SAME LENGTH as its input, with the
+out-of-scope regions replaced by spaces and newlines kept. That is what lets
+a gate:
+
+  * report a line number computed on the mask, and
+  * read a suppression marker (`e2e-networkidle exclude …`) out of the
+    ORIGINAL text at the same line,
+
+which matters because every suppression marker in this package lives in a
+comment — the exact region the mask blanks.
+
+TWO TRAPS THAT ALREADY BIT AGENTS ON THIS WORK
+----------------------------------------------
+1. A fixture written to DISPROVE a rule exempted itself with its own
+   explanatory docblock — the very bug under repair. The fixtures in
+   test_source_scope.py keep that trap deliberately.
+2. When a gate ignores your planted true positive, suspect the PLANT. Two of
+   an earlier agent's first plants were wrong and the gates were right.
+
+Usage as a CLI (the bash gates call it this way):
+
+    source_scope.py --mask php|js|js-comments|markup <file>   # masked text
+    source_scope.py --mask <kind> -                           # from stdin
+    source_scope.py --tags NcSelect,img <file>                # open tags
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+#
+# Moved here from check_e2e_coverage.py (#249) so gate-19, gate-34 and gate-58
+# share one tokeniser instead of three greps. Behaviour is unchanged; gate-19's
+# suite is the proof.
+# ---------------------------------------------------------------------------
+
+# Keywords after which a `/` opens a regular expression rather than dividing.
+_JS_REGEX_KEYWORDS = frozenset({
+    "return", "typeof", "instanceof", "in", "of", "new", "delete", "void",
+    "throw", "case", "do", "else", "yield", "await",
+})
+
+
+def _skip_string(text: str, i: int) -> int:
+    """Index just past the quoted string whose opening quote is at *i*.
+
+    An unterminated literal stops at the newline rather than swallowing the
+    rest of the file — a lone apostrophe in a comment must not blank a suite.
+    """
+    quote = text[i]
+    n = len(text)
+    j = i + 1
+    while j < n:
+        c = text[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == quote:
+            return j + 1
+        if c == "\n":
+            return j
+        j += 1
+    return n
+
+
+def _skip_template(text: str, i: int) -> int:
+    """Index just past the template literal whose backtick is at *i*.
+
+    `${ … }` substitutions are walked (they may contain braces, quotes and
+    further templates) but their contents are blanked along with the rest: a
+    test declaration inside a template substitution is not a thing.
+    """
+    n = len(text)
+    j = i + 1
+    depth = 0                       # ${ } nesting inside this template
+    while j < n:
+        c = text[j]
+        if c == "\\":
+            j += 2
+            continue
+        if depth == 0:
+            if c == "`":
+                return j + 1
+            if c == "$" and j + 1 < n and text[j + 1] == "{":
+                depth += 1
+                j += 2
+                continue
+            j += 1
+            continue
+        if c == "`":
+            j = _skip_template(text, j)
+            continue
+        if c in "'\"":
+            j = _skip_string(text, j)
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        j += 1
+    return n
+
+
+def _skip_regex(text: str, i: int) -> int:
+    """Index just past the regex literal starting at *i*, or -1 if it is not
+    one. A regex literal cannot span a newline, which is the cheap and
+    reliable disambiguator against division."""
+    n = len(text)
+    j = i + 1
+    in_class = False
+    while j < n:
+        c = text[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == "\n":
+            return -1
+        if in_class:
+            if c == "]":
+                in_class = False
+        elif c == "[":
+            in_class = True
+        elif c == "/":
+            j += 1
+            while j < n and (text[j].isalpha()):
+                j += 1
+            return j
+        j += 1
+    return -1
+
+
+def _regex_can_start(prev_char: str, prev_word: str) -> bool:
+    """Whether a `/` at this point opens a regex rather than dividing."""
+    if prev_char == "":
+        return True
+    if prev_char in ")]":
+        return False
+    if prev_char in "'\"`":
+        return False
+    if prev_char.isalnum() or prev_char in "_$":
+        return prev_word in _JS_REGEX_KEYWORDS
+    return True
+
+
+def js_mask(text: str, *, blank_strings: bool = True) -> str:
+    """A same-length copy of *text* with the non-code regions blanked.
+
+    Comments and regex literals always go. String / template CONTENTS go only
+    when *blank_strings* — the two callers want opposite things and both are
+    right:
+
+      * gate-19 asks "is argument 1 a string literal", which needs the
+        contents gone but the DELIMITERS kept, so
+        `test.skip('name', fn)` (a switched-off declaration) stays
+        distinguishable from `test.skip(cond, 'reason')` (a live statement).
+      * gate-34 and gate-58 look FOR string literals — `window['confirm']`,
+        `waitForLoadState('networkidle')`. Blanking the contents would delete
+        the evidence and turn a fixed gate into a dead one.
+
+    Either way the scanner must understand strings and regexes, because that
+    is the only way to know where a comment really starts: the `//` inside
+    `'http://x'` or inside `/[a-z]//` opens nothing.
+
+    Newlines survive in both modes, so line numbers and offsets computed on
+    the mask address the original text.
+    """
+    out = list(text)
+    n = len(text)
+
+    def blank(a: int, b: int) -> None:
+        for k in range(max(a, 0), min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    i = 0
+    prev_char = ""          # last significant code character
+    prev_word = ""          # identifier ending at prev_char, when it is one
+    while i < n:
+        c = text[i]
+        if c == "/" and text.startswith("//", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            blank(i, j)
+            i = j
+            continue
+        if c == "/" and text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            blank(i, j)
+            i = j
+            continue
+        if c in "'\"":
+            j = _skip_string(text, i)
+            if blank_strings:
+                blank(i + 1, j)
+                if j - 1 > i and text[j - 1] == c:
+                    out[j - 1] = c
+            prev_char, prev_word = c, ""
+            i = j
+            continue
+        if c == "`":
+            j = _skip_template(text, i)
+            if blank_strings:
+                blank(i + 1, j)
+                if j - 1 > i and text[j - 1] == "`":
+                    out[j - 1] = "`"
+            prev_char, prev_word = "`", ""
+            i = j
+            continue
+        if c == "/" and _regex_can_start(prev_char, prev_word):
+            j = _skip_regex(text, i)
+            if j > 0:
+                blank(i, j)
+                prev_char, prev_word = ")", ""   # a regex literal is a value
+                i = j
+                continue
+        if c.isalnum() or c in "_$":
+            k = i
+            while k < n and (text[k].isalnum() or text[k] in "_$"):
+                k += 1
+            prev_word = text[i:k]
+            prev_char = text[k - 1]
+            i = k
+            continue
+        if not c.isspace():
+            prev_char, prev_word = c, ""
+        i += 1
+    return "".join(out)
+
+
+def js_code_mask(text: str) -> str:
+    """Gate-19's mask: comments, string CONTENTS and regex literals blanked."""
+    return js_mask(text, blank_strings=True)
+
+
+def js_comment_mask(text: str) -> str:
+    """Comments and regex literals blanked; string literals left INTACT.
+
+    For gates whose evidence IS a string literal (gate-34's
+    `window['confirm']`, gate-58's `'networkidle'`).
+    """
+    return js_mask(text, blank_strings=False)
+
+
+# ---------------------------------------------------------------------------
+# PHP
+# ---------------------------------------------------------------------------
+
+def php_mask(text: str, *, blank_strings: bool = False) -> str:
+    """A same-length copy of *text* with PHP comments blanked.
+
+    `#[` opens a PHP 8 ATTRIBUTE, not a comment. Treating it as one would
+    swallow the rest of the line — including `#[NoAdminRequired]`, which is
+    the single most load-bearing token in this package. That distinction is
+    #184's, kept verbatim; the only thing added here is offset preservation,
+    so gate-5 can compute a line number on the mask and read a docblock tag
+    out of the original at the same line.
+
+    String contents are kept by default: `class_exists('OCA\\OpenRegister…')`
+    is evidence about code, and blanking it would delete the evidence.
+    """
+    out = list(text)
+    n = len(text)
+
+    def blank(a: int, b: int) -> None:
+        for k in range(max(a, 0), min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    i = 0
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if c == "'" or c == '"':
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                j += 1
+            else:
+                j = n
+            if blank_strings:
+                blank(i + 1, j - 1)
+            i = j
+            continue
+        if c == "/" and nxt == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            blank(i, j)
+            i = j
+            continue
+        if c == "#" and nxt != "[":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            blank(i, j)
+            i = j
+            continue
+        if c == "/" and nxt == "*":
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            blank(i, j)
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Markup — .vue / .php / .html
+# ---------------------------------------------------------------------------
+
+_HTML_COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+# `<?php … ?>` and the short echo form. An unterminated opener runs to end of
+# file, which is the language's own rule. Same pattern php_template_scope.py
+# uses (#247); the two agree deliberately.
+_PHP_BLOCK = re.compile(r'<\?(?:php\b|=)?.*?(?:\?>|\Z)', re.DOTALL | re.IGNORECASE)
+# `<template>` NESTS. A slot is written `<template #default>` INSIDE the SFC's
+# own template, and a non-greedy `<template…>(.*?)</template>` therefore ends
+# the block at the first slot close — silently dropping everything after it.
+# Measured while fixing gate-12: openconnector's EditMapping.vue has a real
+# unlabelled `<NcSelect>` at line 376, below two nested slot templates, and the
+# first cut of this function made it vanish. That is the fix over-applied, and
+# it is the exact failure this whole change exists to prevent, so the block
+# boundaries are found by DEPTH, not by a lazy quantifier.
+_TEMPLATE_TAG = re.compile(r'<(/?)template\b[^>]*?(/?)>', re.IGNORECASE | re.DOTALL)
+_SCRIPT_BLOCK = re.compile(r'<script(\s[^>]*)?>(.*?)</script\s*>', re.DOTALL | re.IGNORECASE)
+_STYLE_BLOCK = re.compile(r'<style(\s[^>]*)?>(.*?)</style\s*>', re.DOTALL | re.IGNORECASE)
+
+
+def _blank_span(buf: list[str], a: int, b: int) -> None:
+    for k in range(max(a, 0), min(b, len(buf))):
+        if buf[k] != "\n":
+            buf[k] = " "
+
+
+def _top_level_template_spans(text: str) -> list[tuple[int, int]]:
+    """(start, end) of each TOP-LEVEL `<template>` body, nesting respected.
+
+    A self-closing `<template … />` opens nothing. An unbalanced open runs to
+    end of file rather than being discarded — dropping it would blank the
+    whole template, which is the same false-green a missing helper produces.
+    """
+    spans: list[tuple[int, int]] = []
+    depth = 0
+    start = -1
+    for m in _TEMPLATE_TAG.finditer(text):
+        closing, self_closing = m.group(1), m.group(2)
+        if self_closing and not closing:
+            continue
+        if closing:
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start >= 0:
+                    spans.append((start, m.start()))
+                    start = -1
+        else:
+            if depth == 0:
+                start = m.end()
+            depth += 1
+    if depth > 0 and start >= 0:
+        spans.append((start, len(text)))
+    return spans
+
+
+def vue_markup_mask(text: str) -> str:
+    """The RENDERED markup of a `.vue` SFC, everything else blanked.
+
+    Kept: the contents of every top-level `<template>` block, minus its HTML
+    comments.
+    Blanked: `<script>`, `<style>`, and anything outside a `<template>`.
+
+    Nothing in `<script>` renders an `<img>`, and the three gates that read
+    `.vue` files as one flat string (31, 32, 12) all reported JSDoc prose as
+    markup because of it. On openbuild all three gate-31 findings were
+    ``* @param {Event} e - The `<img>` `error` event`` — a docblock, in the
+    wrong SFC block, about a tag the template does not contain.
+
+    A commented-out element renders nothing, so `<!-- … -->` goes too. That
+    direction matters as much: gate-32 could be CLEARED by describing the
+    `<div @click>` an element replaced, which is the finding buying its own
+    exemption.
+    """
+    buf = list(text)
+    n = len(text)
+    keep = _top_level_template_spans(text)
+    if not keep:
+        # No <template> block at all: nothing renders. `render()` functions in
+        # <script> are out of scope for these gates by construction — they were
+        # never matched by the greps this replaces either.
+        _blank_span(buf, 0, n)
+        return "".join(buf)
+    cursor = 0
+    for a, b in keep:
+        _blank_span(buf, cursor, a)
+        cursor = b
+    _blank_span(buf, cursor, n)
+    masked = "".join(buf)
+    # HTML comments last, over the kept regions only (they are all that is
+    # left to comment).
+    out = list(masked)
+    for m in _HTML_COMMENT.finditer(masked):
+        _blank_span(out, m.start(), m.end())
+    return "".join(out)
+
+
+def php_markup_mask(text: str) -> str:
+    """The markup a PHP template EMITS, everything else blanked.
+
+    `<?php … ?>` regions are code, docblocks and `//` comments — none of it
+    reaches the browser. `<!-- … -->` ships nothing. Inline `<script>` bodies
+    are JS, not markup, and get their comments blanked so a JSDoc `<img>` in a
+    template behaves the way it does in an SFC.
+
+    This is `php_template_scope.emitted_markup` (#247) plus the script-block
+    handling; that module answers a narrower question (does the template own
+    the document) and keeps its own copy on purpose, because gate-38's wiring
+    guard is written against it.
+    """
+    buf = list(text)
+    for m in _PHP_BLOCK.finditer(text):
+        _blank_span(buf, m.start(), m.end())
+    masked = "".join(buf)
+    out = list(masked)
+    for m in _HTML_COMMENT.finditer(masked):
+        _blank_span(out, m.start(), m.end())
+    result = "".join(out)
+    return _mask_script_bodies(result)
+
+
+def html_markup_mask(text: str) -> str:
+    """HTML comments blanked; `<script>` bodies comment-masked."""
+    buf = list(text)
+    for m in _HTML_COMMENT.finditer(text):
+        _blank_span(buf, m.start(), m.end())
+    return _mask_script_bodies("".join(buf))
+
+
+def _mask_script_bodies(text: str) -> str:
+    """Blank JS comments inside every `<script>` body, offsets preserved."""
+    out = list(text)
+    for m in _SCRIPT_BLOCK.finditer(text):
+        body = text[m.start(2):m.end(2)]
+        masked = js_comment_mask(body)
+        out[m.start(2):m.end(2)] = list(masked)
+    return "".join(out)
+
+
+def markup_mask(text: str, path: str = "") -> str:
+    """Dispatch on extension. Unknown extensions get the HTML treatment."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".vue":
+        return vue_markup_mask(text)
+    if ext == ".php":
+        return php_markup_mask(text)
+    return html_markup_mask(text)
+
+
+def js_exec_mask(text: str, path: str = "") -> str:
+    """Every region of *text* where JavaScript EXECUTES, string contents blanked.
+
+    This is the anchor mask for gates that look for a call site. Blanking
+    string contents means a sentence of documentation cannot be a call:
+
+        const doc = 'do not use window.confirm here'   -> not a call site
+
+    but it also blanks the evidence for `window['confirm']`, whose method
+    name IS a string. That is fine, and is the reason every mask in this
+    module preserves offsets: the caller ANCHORS on this mask (which answers
+    "is this position code?") and then re-reads the ORIGINAL text at the same
+    offset to answer "what does it say?". Two questions, two sources, one
+    coordinate system.
+
+    Regions kept, by file type:
+      * `.js` / `.ts` / …  — the whole file.
+      * `.vue`             — `<script>` bodies, plus the ATTRIBUTE text of
+                             every template element. A Vue binding's value is
+                             an expression; a template TEXT NODE is not, so
+                             `<p>never use window.confirm</p>` is prose here
+                             and is deliberately blanked.
+      * `.php` / `.html`   — the same, over emitted markup.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".js", ".ts", ".mjs", ".cjs", ".jsx", ".tsx"):
+        return js_code_mask(text)
+    out = [" " if c != "\n" else "\n" for c in text]
+    # <script> bodies.
+    for m in _SCRIPT_BLOCK.finditer(text):
+        body = text[m.start(2):m.end(2)]
+        out[m.start(2):m.end(2)] = list(js_code_mask(body))
+    # Template attribute regions, taken from the markup scope so a commented
+    # or PHP-side occurrence never gets here.
+    for tag in iter_open_tags(markup_mask(text, path)):
+        a, b = tag.start, tag.end
+        out[a:b] = list(text[a:b])
+    return "".join(out)
+
+
+def script_mask(text: str, path: str = "") -> str:
+    """The SCRIPT side of a file, comment-masked, string literals intact.
+
+    For gates that look for a JS call anywhere it can execute:
+      * `.js` / `.ts`  — the whole file.
+      * `.vue`         — `<script>` bodies AND the template (an inline
+                          `@click="window.confirm(…)"` executes too), with
+                          HTML comments blanked.
+      * `.php`/`.html` — `<script>` bodies plus inline handler attributes,
+                          with PHP regions and HTML comments blanked.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".js", ".ts", ".mjs", ".cjs", ".jsx", ".tsx"):
+        return js_comment_mask(text)
+    if ext == ".vue":
+        # Blank HTML comments across the whole file, then comment-mask every
+        # <script> and <style> body. What remains is template markup (whose
+        # attribute values are live JS) plus script code.
+        buf = list(text)
+        for m in _HTML_COMMENT.finditer(text):
+            _blank_span(buf, m.start(), m.end())
+        step = "".join(buf)
+        out = list(_mask_script_bodies(step))
+        for m in _STYLE_BLOCK.finditer(step):
+            _blank_span(out, m.start(2), m.end(2))
+        return "".join(out)
+    # PHP / HTML template.
+    buf = list(text)
+    if ext == ".php":
+        for m in _PHP_BLOCK.finditer(text):
+            _blank_span(buf, m.start(), m.end())
+    step = "".join(buf)
+    out = list(step)
+    for m in _HTML_COMMENT.finditer(step):
+        _blank_span(out, m.start(), m.end())
+    return _mask_script_bodies("".join(out))
+
+
+# ---------------------------------------------------------------------------
+# Quote-aware element extraction
+# ---------------------------------------------------------------------------
+
+# A `>` inside a quoted attribute value does NOT end the element. `[^>]*`
+# does not know that, and in Vue the first `>` in a tag is very often the
+# arrow of `:reduce="option => option.value"` (#236) — so every prop written
+# after the reducer was invisible and a correctly labelled <NcSelect> was
+# reported as unnamed. Same failure as gate-9's `[^)]*` in #198.
+_OPEN_TAG = re.compile(
+    r'<(/?)([A-Za-z][A-Za-z0-9._:-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/?)>',
+    re.DOTALL,
+)
+
+
+class Tag:
+    """One opening element: its name, its attribute text and where it starts."""
+
+    __slots__ = ("name", "attrs", "start", "end", "raw", "line")
+
+    def __init__(self, name: str, attrs: str, start: int, end: int, raw: str, line: int):
+        self.name = name
+        self.attrs = attrs
+        self.start = start
+        self.end = end
+        self.raw = raw
+        self.line = line
+
+    @property
+    def flat(self) -> str:
+        """The element on one line — the shape the bash gates logged."""
+        return re.sub(r'\s+', ' ', self.raw).strip()
+
+
+def iter_open_tags(masked: str, names: set[str] | None = None):
+    """Every OPENING element in *masked*, optionally filtered by name.
+
+    *masked* must already be markup scope (see markup_mask) — this function
+    deliberately does no comment handling of its own, so a caller cannot
+    accidentally scan prose by forgetting the mask.
+    """
+    for m in _OPEN_TAG.finditer(masked):
+        if m.group(1):          # closing tag
+            continue
+        name = m.group(2)
+        if names is not None and name not in names:
+            continue
+        line = masked.count("\n", 0, m.start()) + 1
+        yield Tag(name, m.group(3) or "", m.start(), m.end(), m.group(0), line)
+
+
+def read_text(path: str) -> str:
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+_MASKS = {
+    "js": js_code_mask,
+    "js-comments": js_comment_mask,
+    "php": php_mask,
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 4 and argv[1] == "--mask":
+        kind, target = argv[2], argv[3]
+        fn = _MASKS.get(kind)
+        if kind == "markup":
+            src = sys.stdin.read() if target == "-" else read_text(target)
+            sys.stdout.write(markup_mask(src, "" if target == "-" else target))
+            return 0
+        if kind == "script":
+            src = sys.stdin.read() if target == "-" else read_text(target)
+            sys.stdout.write(script_mask(src, "" if target == "-" else target))
+            return 0
+        if fn is None:
+            print(f"source_scope: unknown mask kind {kind!r}", file=sys.stderr)
+            return 2
+        src = sys.stdin.read() if target == "-" else read_text(target)
+        sys.stdout.write(fn(src))
+        return 0
+    if len(argv) >= 4 and argv[1] == "--tags":
+        names = {n for n in argv[2].split(",") if n}
+        for path in argv[3:]:
+            try:
+                src = read_text(path)
+            except OSError:
+                continue
+            for tag in iter_open_tags(markup_mask(src, path), names or None):
+                print(f"{path}:{tag.line}: {tag.flat}")
+        return 0
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_removal.py
@@ -57,6 +57,19 @@ class TestMustGoRed(unittest.TestCase):
         line = "-    #[NoCSRFRequired]"
         self.assertEqual(gate.removals(line), [line])
 
+    def test_a_fully_qualified_attribute(self):
+        """FOUND BY MEASUREMENT, not by the issue.
+
+        The pre-fix regex alternated on the literal `#[NoCSRFRequired]`, so
+        the fully-qualified spelling — which is what an app that does not
+        import the attribute writes, and what several fleet controllers use —
+        matched NOTHING. Running arm 2 end-to-end through the runner reported
+        PASS on a genuine removal. The old gate had a false NEGATIVE of its
+        own hiding behind the false positive #191 reported.
+        """
+        line = "-    #[\\OCP\\AppFramework\\Http\\Attribute\\NoCSRFRequired]"
+        self.assertEqual(gate.removals(line), [line])
+
     def test_a_grouped_attribute_list(self):
         line = "-    #[NoAdminRequired, NoCSRFRequired]"
         self.assertEqual(gate.removals(line), [line])

--- a/hydra-gates/scripts/lib/test_check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_removal.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_csrf_removal (gate-48).
+
+Run with:  python3 scripts/lib/test_check_csrf_removal.py
+
+#191 asks for both arms explicitly, and says why: "Arm 2 is the one that
+proves the fix did not simply disable the gate." A security gate that stopped
+firing looks exactly like a security gate with nothing to report.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_csrf_removal as gate  # noqa: E402
+
+# The nldesign line, verbatim from the issue.
+NLDESIGN = "- * (#[PublicPage] + #[NoCSRFRequired]) and the response contract are owned by"
+
+
+class TestMustStayGreen(unittest.TestCase):
+    def test_the_nldesign_docblock_sentence(self):
+        self.assertEqual(gate.removals(NLDESIGN), [])
+
+    def test_a_whole_docblock_rewrite_around_it(self):
+        diff = "\n".join([
+            "--- a/lib/Controller/PageController.php",
+            "+++ b/lib/Controller/PageController.php",
+            "@@ -8,4 +8,4 @@",
+            "- * The auth posture of this endpoint",
+            NLDESIGN,
+            "- * the AppHost generic in openregister.",
+            "+ * Auth posture and response contract are owned upstream.",
+        ])
+        self.assertEqual(gate.removals(diff), [])
+
+    def test_a_prose_line_naming_the_tag_mid_sentence(self):
+        self.assertEqual(gate.removals("-     * we removed the @NoCSRFRequired tag once"), [])
+
+    def test_a_line_comment_naming_the_attribute(self):
+        self.assertEqual(gate.removals("-    // #[NoCSRFRequired] was never needed here"), [])
+
+    def test_the_diff_file_header_is_not_a_removal(self):
+        self.assertEqual(gate.removals("--- a/lib/Controller/X.php"), [])
+
+    def test_an_added_line_is_not_a_removal(self):
+        self.assertEqual(gate.removals("+    #[NoCSRFRequired]"), [])
+
+
+class TestMustGoRed(unittest.TestCase):
+    """Arm 2 of #191 — the arm that proves the gate was fixed, not disabled."""
+
+    def test_a_real_attribute_line(self):
+        line = "-    #[NoCSRFRequired]"
+        self.assertEqual(gate.removals(line), [line])
+
+    def test_a_grouped_attribute_list(self):
+        line = "-    #[NoAdminRequired, NoCSRFRequired]"
+        self.assertEqual(gate.removals(line), [line])
+
+    def test_a_legacy_docblock_tag(self):
+        line = "-     * @NoCSRFRequired"
+        self.assertEqual(gate.removals(line), [line])
+
+    def test_a_docblock_tag_without_the_star(self):
+        line = "-@NoCSRFRequired"
+        self.assertEqual(gate.removals(line), [line])
+
+    def test_a_real_removal_inside_a_docblock_rewrite_is_still_seen(self):
+        """The mixed case: prose AND a real deletion in one diff. Reporting
+        zero here would be the fix over-applied."""
+        diff = "\n".join([
+            NLDESIGN,
+            "-    #[NoCSRFRequired]",
+            "-     * still more prose about #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_an_attribute_with_arguments_before_the_name_does_not_match(self):
+        """`#[Route('/x', name: 'NoCSRFRequired')]` is a route name, not the
+        attribute. The bracket-bounded class is what keeps them apart."""
+        self.assertEqual(gate.removals("-    #[Route('/x')] // NoCSRFRequired"), [])
+
+
+class TestCli(unittest.TestCase):
+    def test_arguments_are_rejected(self):
+        self.assertEqual(gate.main(["check_csrf_removal.py", "extra"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_check_js_call_sites.py
+++ b/hydra-gates/scripts/lib/test_check_js_call_sites.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_js_call_sites (gate-34 window-confirm, gate-58 networkidle).
+
+Run with:  python3 scripts/lib/test_check_js_call_sites.py
+
+The four arms of #224 are reproduced literally, because the issue reported
+them as a control set and losing either control makes the fix unfalsifiable:
+arm 2 is what proves arm 1's finding was the comment, and arm 4 is what proves
+the probe can still fire after arm 3 is fixed.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_js_call_sites as gate  # noqa: E402
+
+
+def dialog(src: str, path: str = "src/components/X.vue") -> list[str]:
+    return gate.scan_source("native-dialog", path, src)
+
+
+def idle(src: str, path: str = "tests/e2e/a.spec.ts") -> list[str]:
+    return gate.scan_source("networkidle", path, src)
+
+
+class TestNativeDialogTheFourArms(unittest.TestCase):
+    ARM1 = """<template>
+	<div>
+		<!-- This component deliberately avoids window.confirm() and uses NcDialog. -->
+		<NcDialog :open="open" />
+	</div>
+</template>
+"""
+    ARM2 = """<template>
+	<div>
+		<NcDialog :open="open" />
+	</div>
+</template>
+"""
+    ARM3 = """<script>
+export default {
+	methods: {
+		destroyAll() {
+			if (!window['confirm']('Delete everything?')) {
+				return
+			}
+			this.destroy()
+		},
+	},
+}
+</script>
+"""
+    ARM4 = ARM3.replace("window['confirm']", "window.confirm")
+
+    def test_arm1_comment_only_is_not_a_finding(self):
+        self.assertEqual(dialog(self.ARM1), [])
+
+    def test_arm2_control_the_same_file_without_the_comment(self):
+        """If arm 2 ever produced a finding, arm 1's zero would mean nothing."""
+        self.assertEqual(dialog(self.ARM2), [])
+
+    def test_arm3_bracket_access_is_a_native_dialog(self):
+        """The false GREEN. On doriath this hid a cascading delete."""
+        found = dialog(self.ARM3)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("window['confirm']", found[0])
+
+    def test_arm4_control_the_dotted_spelling_still_fires(self):
+        self.assertEqual(len(dialog(self.ARM4)), 1)
+
+    def test_arm1_plus_a_real_call_reports_only_the_call(self):
+        """The two halves together: the comment stays silent, the code does not."""
+        src = self.ARM1 + self.ARM3
+        found = dialog(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("confirm", found[0])
+
+
+class TestNativeDialogSpellings(unittest.TestCase):
+    def test_destructuring_from_window(self):
+        src = "<script>const { confirm } = window\nconfirm('x')\n</script>"
+        self.assertEqual(len(dialog(src)), 1)
+
+    def test_double_quoted_bracket_access(self):
+        src = '<script>window["prompt"]("name")</script>'
+        self.assertEqual(len(dialog(src)), 1)
+
+    def test_alias_without_a_call_is_still_the_native_api(self):
+        src = "<script>const c = window.confirm\n</script>"
+        self.assertEqual(len(dialog(src)), 1)
+
+    def test_a_component_method_named_confirm_is_not_reported(self):
+        """The gate's own remedy is a `confirm()` method on an NcDialog
+        wrapper. Reporting it would make the gate unclosable."""
+        src = "<script>await this.confirm('Delete?')\nawait dialog.confirm()\n</script>"
+        self.assertEqual(dialog(src), [])
+
+    def test_a_string_containing_the_spelling_is_not_a_call(self):
+        src = "<script>const doc = 'do not use window.confirm here'\n</script>"
+        self.assertEqual(dialog(src), [])
+
+    def test_inline_handler_in_a_template_is_a_call(self):
+        src = '<template><button @click="window.confirm(\'x\') && go()">g</button></template>'
+        self.assertEqual(len(dialog(src)), 1)
+
+    def test_a_php_template_inline_script_is_in_scope(self):
+        """#225: a native dialog from a PHP template breaks theming too."""
+        src = "<?php // window.confirm is never used here ?>\n<script>window.confirm('x')</script>\n"
+        found = dialog(src, "templates/settings/admin.php")
+        self.assertEqual(len(found), 1, found)
+
+    def test_a_php_comment_naming_it_is_not_a_call(self):
+        src = "<?php // window.confirm is never used here ?>\n<div id=x></div>\n"
+        self.assertEqual(dialog(src, "templates/settings/admin.php"), [])
+
+    def test_prose_in_a_template_text_node_is_not_a_call(self):
+        """A text node is not an expression; only attribute values are."""
+        src = "<template><p>Never use window.confirm in this app.</p></template>"
+        self.assertEqual(dialog(src), [])
+
+    def test_line_number_addresses_the_original_file(self):
+        src = "<script>\n\n\nwindow.confirm('x')\n</script>\n"
+        self.assertTrue(dialog(src)[0].startswith("src/components/X.vue:4:"))
+
+    def test_one_construct_is_reported_once(self):
+        """`window[` matches the anchor once; a double count would inflate a
+        security-adjacent number, which is how gate-22 shipped 3 findings for
+        one defect (#254)."""
+        src = "<script>window['confirm']('a')\n</script>"
+        self.assertEqual(len(dialog(src)), 1)
+
+
+class TestNetworkidle(unittest.TestCase):
+    LARPINGAPP = """// ADR-074 rule 4: `networkidle` never settles on Nextcloud — the
+// notification poll keeps the network permanently busy. This was the LAST
+// live `waitForLoadState('networkidle')` in the suite; every other mention
+// is a comment warning against it.
+await page.waitForLoadState('domcontentloaded')
+"""
+
+    def test_the_larpingapp_comment_block_reports_nothing(self):
+        self.assertEqual(idle(self.LARPINGAPP), [])
+
+    def test_the_same_file_with_one_live_call_reports_it(self):
+        """Anti-widening control on the real file shape."""
+        src = self.LARPINGAPP + "await page.waitForLoadState('networkidle')\n"
+        found = idle(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("networkidle", found[0])
+
+    def test_a_live_call_with_a_trailing_comment_still_matches(self):
+        """A line-position filter (the cheap fix #230 sketched) loses this."""
+        src = "await page.waitForLoadState('networkidle') // TODO: remove\n"
+        self.assertEqual(len(idle(src)), 1)
+
+    def test_a_mention_after_code_on_the_same_line_is_not_a_call(self):
+        src = "const x = 1 // waitForLoadState('networkidle') is banned\n"
+        self.assertEqual(idle(src), [])
+
+    def test_a_block_comment_interior_line_is_not_a_call(self):
+        """This line starts with a letter, so `grep -v '^[0-9]+:\\s*(//|\\*)'`
+        would have counted it."""
+        src = "/*\nwaitForLoadState('networkidle') must never be used.\n*/\nawait f()\n"
+        self.assertEqual(idle(src), [])
+
+    def test_wait_until_form_is_matched(self):
+        src = "await page.goto(u, { waitUntil: 'networkidle' })\n"
+        self.assertEqual(len(idle(src)), 1)
+
+    def test_the_exclude_marker_still_suppresses(self):
+        src = "await page.waitForLoadState('networkidle') // e2e-networkidle exclude legacy upload probe\n"
+        self.assertEqual(idle(src), [])
+
+    def test_the_exclude_marker_on_a_neighbouring_line_does_not_suppress(self):
+        src = ("// e2e-networkidle exclude something else entirely\n"
+               "await page.waitForLoadState('networkidle')\n")
+        self.assertEqual(len(idle(src)), 1)
+
+    def test_the_pattern_inside_a_string_literal_is_not_a_call(self):
+        """A helper that documents the banned call in a message string."""
+        src = "throw new Error(\"waitForLoadState('networkidle') is banned by ADR-074\")\n"
+        self.assertEqual(idle(src), [])
+
+    def test_line_number_addresses_the_original_file(self):
+        src = "\n\n\nawait page.waitForLoadState('networkidle')\n"
+        self.assertTrue(idle(src)[0].startswith("tests/e2e/a.spec.ts:4:"))
+
+
+class TestCli(unittest.TestCase):
+    def test_unknown_rule_is_an_error_not_an_empty_answer(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = gate.main(["check_js_call_sites.py", "--rule", "nope", "x.ts"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_an_unreadable_file_is_skipped_not_fatal(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = gate.main(["check_js_call_sites.py", "--rule", "networkidle", "/nope.ts"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_check_js_call_sites.py
+++ b/hydra-gates/scripts/lib/test_check_js_call_sites.py
@@ -95,6 +95,38 @@ class TestNativeDialogSpellings(unittest.TestCase):
         src = "<script>const c = window.confirm\n</script>"
         self.assertEqual(len(dialog(src)), 1)
 
+    def test_a_feature_detection_guard_is_not_a_second_dialog(self):
+        """MEASURED ON openbuild BEFORE THIS LANDED.
+
+        Every native dialog in that repo is written with a guard on the line
+        above the call. The first cut of this rule accepted a bare reference,
+        so 7 defects were reported as 14 findings — a count that is not a
+        defect count (#254). A guard is a truthiness test, not a use; only an
+        ALIAS (a binding, whose call site is elsewhere) counts without a call.
+        """
+        src = (
+            "<script>\n"
+            "const ok = typeof window !== 'undefined' && window.confirm\n"
+            "\t? window.confirm(t('openbuild', 'Delete this automation?'))\n"
+            "\t: true\n"
+            "</script>\n"
+        )
+        found = dialog(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn(":3:", found[0], "the CALL is the finding, not the guard")
+
+    def test_the_guard_alone_with_no_call_is_not_reported(self):
+        src = "<script>const has = typeof window !== 'undefined' && window.confirm\n</script>"
+        self.assertEqual(dialog(src), [])
+
+    def test_a_call_assigned_to_a_variable_is_reported_once(self):
+        src = "<script>const r = window.confirm('x')\n</script>"
+        self.assertEqual(len(dialog(src)), 1)
+
+    def test_an_aliased_bracket_access_counts(self):
+        src = "<script>const c = window['confirm']\nc('x')\n</script>"
+        self.assertEqual(len(dialog(src)), 1)
+
     def test_a_component_method_named_confirm_is_not_reported(self):
         """The gate's own remedy is a `confirm()` method on an NcDialog
         wrapper. Reporting it would make the gate unclosable."""

--- a/hydra-gates/scripts/lib/test_check_markup_a11y.py
+++ b/hydra-gates/scripts/lib/test_check_markup_a11y.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_markup_a11y (gate-31 img-alt, gate-32 semantic-controls).
+
+Run with:  python3 scripts/lib/test_check_markup_a11y.py
+
+Every case that must NOT fire has a neighbour built from the same fixture, one
+edit apart, that MUST. A gate that has only ever been observed passing is
+indistinguishable from a gate that cannot fail — and the whole reason these
+two gates needed repair is that they were firing on prose, which is exactly
+the failure a careless relaxation converts into firing on nothing.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_markup_a11y as gate  # noqa: E402
+
+
+def scan(rule: str, src: str, path: str = "src/components/X.vue") -> list[str]:
+    return gate.scan_source(rule, path, src)
+
+
+# The launchpad file that produced `[gate-31] img-alt: FAIL — 1 <img> tag(s)`
+# with no `<img>` anywhere in the component (#220).
+LAUNCHPAD = """<template>
+  <div class="org-nav-item">
+    <CnDashboardIcon :icon="item.icon" />
+    <span>{{ item.label }}</span>
+  </div>
+</template>
+
+<script>
+/**
+ * OrgNavigationItem
+ *
+ * `CnDashboardIcon` resolves any value the icon picker emits — a URL
+ * (→ `<img>`), an SVG string, or a Material icon name.
+ */
+export default { name: 'OrgNavigationItem' }
+</script>
+"""
+
+# openbuild's IconUploadSection shape (#235): two REAL images that already
+# carry `:alt`, plus two JSDoc mentions that were reported as images.
+OPENBUILD = """<template>
+  <div>
+    <img v-if="iconLightUrl" :src="iconLightUrl" :alt="t('openbuild', 'Light icon')">
+    <img v-if="iconDarkUrl" :src="iconDarkUrl" :alt="t('openbuild', 'Dark icon')">
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    /**
+     * @param {Event} e - The `<img>` `error` event fired when the light icon
+     *                    fails to load.
+     */
+    onLightError(e) { this.iconLightUrl = null },
+    /**
+     * @param {Event} e - The `<img>` `error` event fired when the dark icon
+     *                    fails to load.
+     */
+    onDarkError(e) { this.iconDarkUrl = null },
+  },
+}
+</script>
+"""
+
+
+class TestImgAlt(unittest.TestCase):
+    def test_launchpad_component_reports_nothing(self):
+        self.assertEqual(scan("img-alt", LAUNCHPAD), [])
+
+    def test_launchpad_component_with_one_real_bad_image_reports_one(self):
+        """Anti-widening control. Same file, one tag added."""
+        src = LAUNCHPAD.replace(
+            '<span>{{ item.label }}</span>',
+            '<img src="/badge.png"><span>{{ item.label }}</span>')
+        found = scan("img-alt", src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("/badge.png", found[0])
+
+    def test_openbuild_three_findings_become_zero(self):
+        self.assertEqual(scan("img-alt", OPENBUILD, "src/dialogs/IconUploadSection.vue"), [])
+
+    def test_openbuild_with_alt_deleted_from_one_image_reports_that_one(self):
+        """The measurement that separates 'fixed' from 'switched off'."""
+        src = OPENBUILD.replace(' :alt="t(\'openbuild\', \'Dark icon\')"', '')
+        found = scan("img-alt", src, "src/dialogs/IconUploadSection.vue")
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("iconDarkUrl", found[0])
+
+    def test_a_finding_names_the_tag_with_its_attributes(self):
+        """The bare `<img>` in a log was the tell that a comment was scored."""
+        src = '<template><img src="/a.png" class="x"></template>'
+        found = scan("img-alt", src)
+        self.assertEqual(len(found), 1)
+        self.assertIn('src="/a.png"', found[0])
+        self.assertNotEqual(found[0].split(": ", 1)[1], "<img>")
+
+    def test_alt_written_after_an_arrow_function_is_seen(self):
+        """`[^>]*` ended the tag at the arrow and lost every later prop."""
+        src = ('<template><img :src="items.find(i => i.id === id).url" '
+               ':alt="t(\'app\', \'Item\')"></template>')
+        self.assertEqual(scan("img-alt", src), [])
+
+    def test_the_same_tag_without_alt_still_fires(self):
+        src = '<template><img :src="items.find(i => i.id === id).url"></template>'
+        self.assertEqual(len(scan("img-alt", src)), 1)
+
+    def test_commented_out_image_is_not_an_image(self):
+        src = '<template><!-- <img src="/old.png"> --></template>'
+        self.assertEqual(scan("img-alt", src), [])
+
+    def test_php_template_image_is_in_scope(self):
+        """#225: WCAG does not care which templating language made the DOM."""
+        src = "<?php // renders an <img> when set ?>\n<img src=\"/logo.png\">\n"
+        found = scan("img-alt", src, "templates/settings/admin.php")
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("/logo.png", found[0])
+
+    def test_php_comment_mentioning_img_is_not_an_image(self):
+        src = "<?php // this template renders no <img> at all ?>\n<div id=x></div>\n"
+        self.assertEqual(scan("img-alt", src, "templates/settings/admin.php"), [])
+
+    def test_alt_empty_is_accepted(self):
+        """Decorative images are declared with alt=\"\" — unchanged rule."""
+        self.assertEqual(scan("img-alt", '<template><img src="/d.png" alt=""></template>'), [])
+
+    def test_line_number_addresses_the_original_file(self):
+        src = '<template>\n\n  <img src="/a.png">\n</template>\n'
+        self.assertTrue(scan("img-alt", src)[0].startswith("src/components/X.vue:3:"))
+
+
+class TestSemanticControls(unittest.TestCase):
+    # softwarecatalog's repaired element plus the comment that described what
+    # it replaced. Pre-fix, gate-32 scored the COMMENT and rewording it
+    # cleared the gate with the markup byte-identical (#236).
+    REPAIRED = """<template>
+  <!-- role/tabindex/keydown rather than a bare <div @click>: picking the
+       merge target is the consequential choice in this dialog, so it has to
+       be reachable from the keyboard. -->
+  <div v-for="obj in availableObjects"
+       :key="obj.id"
+       role="option"
+       tabindex="0"
+       @click="selectTargetObject(obj)"
+       @keydown.enter.prevent="selectTargetObject(obj)">
+    {{ obj.title }}
+  </div>
+</template>
+"""
+
+    def test_the_repaired_element_reports_nothing(self):
+        self.assertEqual(scan("semantic-controls", self.REPAIRED), [])
+
+    def test_the_comment_alone_reports_nothing(self):
+        src = "<template>\n  <!-- a bare <div @click> is what this replaced -->\n  <p>x</p>\n</template>\n"
+        self.assertEqual(scan("semantic-controls", src), [])
+
+    def test_a_real_bare_click_div_below_that_comment_still_fires(self):
+        """Anti-widening control, and the direction that matters most: a bad
+        element must not be explainable away by a comment above it."""
+        src = ("<template>\n"
+               "  <!-- a bare <div @click> is what this replaced -->\n"
+               '  <div @click="pick(obj)">x</div>\n'
+               "</template>\n")
+        found = scan("semantic-controls", src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("role=", found[0])
+        self.assertIn("tabindex=", found[0])
+        self.assertIn("@keydown", found[0])
+
+    def test_removing_one_of_the_trio_from_the_repaired_element_fires(self):
+        src = self.REPAIRED.replace('       tabindex="0"\n', "")
+        found = scan("semantic-controls", src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("missing[tabindex=]", found[0])
+
+    def test_anchor_with_href_is_exempt(self):
+        src = '<template><a href="/x" @click="go">x</a></template>'
+        self.assertEqual(scan("semantic-controls", src), [])
+
+    def test_anchor_without_href_is_not_exempt(self):
+        src = '<template><a @click="go">x</a></template>'
+        self.assertEqual(len(scan("semantic-controls", src)), 1)
+
+    def test_click_stop_with_no_handler_is_event_management(self):
+        src = "<template><div @click.stop><span/></div></template>"
+        self.assertEqual(scan("semantic-controls", src), [])
+
+    def test_click_stop_with_a_real_handler_is_not_exempt(self):
+        src = '<template><div @click.stop="pick(o)"><span/></div></template>'
+        self.assertEqual(len(scan("semantic-controls", src)), 1)
+
+    def test_click_written_after_an_arrow_function_is_seen(self):
+        """The truncation hid violations too — this is a finding the pre-fix
+        gate could not report at all."""
+        src = ('<template><div :title="opts.find(o => o.id === id).label" '
+               '@click="pick()">x</div></template>')
+        self.assertEqual(len(scan("semantic-controls", src)), 1)
+
+    def test_component_wrappers_are_out_of_scope(self):
+        src = '<template><NcButton @click="go">x</NcButton></template>'
+        self.assertEqual(scan("semantic-controls", src), [])
+
+
+class TestCli(unittest.TestCase):
+    def test_unknown_rule_is_an_error_not_an_empty_answer(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = gate.main(["check_markup_a11y.py", "--rule", "nonsense", "x.vue"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_missing_arguments_is_an_error(self):
+        self.assertEqual(gate.main(["check_markup_a11y.py"]), 2)
+
+    def test_an_unreadable_file_is_skipped_not_fatal(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = gate.main(["check_markup_a11y.py", "--rule", "img-alt", "/nope/x.vue"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_check_nc_select_labels.py
+++ b/hydra-gates/scripts/lib/test_check_nc_select_labels.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_nc_select_labels (gate-12). Run with:
+
+    python3 scripts/lib/test_check_nc_select_labels.py
+
+BOTH WAYS, EVERY TIME
+---------------------
+The bug this helper replaces made the gate ANTI-CORRELATED with its own
+subject: an `NcSelect` that named itself after a `:reduce` prop was
+reported, and deleting the label prop changed nothing while deleting
+`:reduce` cleared it. So the arrow-function fixtures below are paired,
+element for element, with the same markup minus the label prop — which
+must still be reported. A relaxation that cannot be shown to still fire is
+indistinguishable from switching the gate off.
+
+Fixtures are the real fleet markup: scholiq's ConferenceScheduleBoard
+(`:reduce` then `id`+`:input-label`), its LessonComposer (`:reduce` then
+both label props), and a genuinely unnamed select next to a hand-written
+`<label for=…>`, which is the shape the rule exists for.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_nc_select_labels as c  # noqa: E402
+
+
+def scan(src: str) -> list[str]:
+    return c.scan_source('x.vue', src)
+
+
+class ArrowFunctionAttributes(unittest.TestCase):
+    """A `>` inside a quoted attribute value must not end the element."""
+
+    REDUCE_THEN_LABEL = '''
+    <template>
+      <NcSelect id="csb-round"
+        v-model="selectedRoundId"
+        :options="roundOptions"
+        :reduce="(o) => o.id"
+        :input-label="t('scholiq', 'Round')" />
+    </template>
+    '''
+
+    def test_label_after_reduce_is_seen(self):
+        self.assertEqual(scan(self.REDUCE_THEN_LABEL), [])
+
+    def test_same_element_without_the_label_still_fires(self):
+        src = self.REDUCE_THEN_LABEL.replace(
+            ":input-label=\"t('scholiq', 'Round')\"", '')
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('NcSelect', found[0])
+
+    def test_both_label_props_after_reduce(self):
+        src = '''
+        <template>
+          <NcSelect
+            v-model="block.materialId"
+            :options="materialOptions"
+            :reduce="(opt) => opt.id"
+            :input-label="t('scholiq', 'Material')"
+            :aria-label-combobox="t('scholiq', 'Material')" />
+        </template>
+        '''
+        self.assertEqual(scan(src), [])
+
+    def test_aria_label_combobox_alone_after_reduce(self):
+        src = '''
+        <template>
+          <NcSelect :reduce="(o) => o.id"
+                    :aria-label-combobox="t('a', 'Teacher')" />
+        </template>
+        '''
+        self.assertEqual(scan(src), [])
+
+    def test_two_selects_one_named_one_not(self):
+        """The greedy-match trap: a fix that runs past the first element
+        would swallow the second and report neither."""
+        src = '''
+        <template>
+          <NcSelect :reduce="(o) => o.id" :input-label="t('a', 'One')" />
+          <NcSelect :reduce="(o) => o.id" :options="two" />
+        </template>
+        '''
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn(':options="two"', found[0])
+
+
+class StillFails(unittest.TestCase):
+    """Everything the rule exists for is still reported."""
+
+    def test_bare_select(self):
+        self.assertEqual(len(scan('<template><NcSelect /></template>')), 1)
+
+    def test_manual_label_element_does_not_count(self):
+        src = '''
+        <template>
+          <label for="cohort">Cohort</label>
+          <NcSelect id="cohort" :options="opts" />
+        </template>
+        '''
+        self.assertEqual(len(scan(src)), 1)
+
+    def test_aria_label_is_not_an_accepted_name(self):
+        """Unchanged remit: the bash gate accepted only the four props, and
+        widening it here would make the before/after numbers incomparable."""
+        src = '<template><NcSelect aria-label="Cohort" /></template>'
+        self.assertEqual(len(scan(src)), 1)
+
+    def test_unclosed_angle_bracket_does_not_swallow_the_file(self):
+        src = '<template><NcSelect :options="a"><div>x</div></template>'
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertNotIn('div', found[0])
+
+
+class Spellings(unittest.TestCase):
+    def test_camel_case(self):
+        self.assertEqual(scan('<template><NcSelect :inputLabel="x" /></template>'), [])
+
+    def test_v_bind_prefix(self):
+        self.assertEqual(
+            scan('<template><NcSelect v-bind:input-label="x" /></template>'), [])
+
+    def test_unbound_literal(self):
+        self.assertEqual(scan('<template><NcSelect input-label="Cohort" /></template>'), [])
+
+    def test_a_prop_that_merely_ends_in_label_is_not_enough(self):
+        """`my-input-label` must not satisfy the rule by substring."""
+        self.assertEqual(
+            len(scan('<template><NcSelect :my-input-label="x" /></template>')), 1)
+
+
+class Comments(unittest.TestCase):
+    def test_commented_out_select_is_not_a_finding(self):
+        src = '<template><!-- <NcSelect :options="a" /> --></template>'
+        self.assertEqual(scan(src), [])
+
+    def test_a_real_select_after_a_comment_is_still_found(self):
+        src = '<template><!-- old --><NcSelect :options="a" /></template>'
+        self.assertEqual(len(scan(src)), 1)
+
+
+class OtherComponents(unittest.TestCase):
+    def test_ncselectableitem_is_not_ncselect(self):
+        self.assertEqual(scan('<template><NcSelectableItem /></template>'), [])
+
+    def test_closing_tag_is_not_an_element(self):
+        src = '<template><NcSelect :input-label="x">slot</NcSelect></template>'
+        self.assertEqual(scan(src), [])
+
+
+class ScriptBlockIsNotMarkup(unittest.TestCase):
+    """Convergence onto source_scope.markup_mask (#220 / #235).
+
+    The helper's first cut stripped `<!-- … -->` only, so an `NcSelect`
+    written in a JSDoc line — the exact shape that put three false gate-31
+    findings on openbuild — would still have been scanned as an element.
+    """
+
+    JSDOC = '''<template>
+  <NcSelect :options="o" input-label="Round" />
+</template>
+
+<script>
+/**
+ * The picker is a `<NcSelect>` whose name comes from `input-label`; a
+ * hand-written `<label for>` next to it would associate with nothing.
+ */
+export default { name: 'X' }
+</script>
+'''
+
+    def test_a_select_named_in_a_docblock_is_not_an_element(self):
+        self.assertEqual(scan(self.JSDOC), [])
+
+    def test_an_unnamed_select_in_the_template_still_fires(self):
+        """Anti-widening control for the case above."""
+        src = self.JSDOC.replace(' input-label="Round"', '')
+        found = scan(src)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('NcSelect', found[0])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_stub_run_body.py
+++ b/hydra-gates/scripts/lib/test_check_stub_run_body.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_stub_run_body (gate-3, the BackgroundJob arm).
+
+Run with:  python3 scripts/lib/test_check_stub_run_body.py
+
+The three fixtures from #226 are reproduced exactly, because the issue's table
+IS the specification:
+
+    A  genuine stub                       -> flagged  (correct before and after)
+    B  real fail-safe delegation          -> was FLAGGED, must now be clean
+    C  B plus one inert `$unused = 1;`    -> PASSED, and the padding is why
+
+C is the false-NEGATIVE half, and it is the one that decides whether this is a
+fix or a relaxation: a gate closable by a dead line is a gate that rewards
+padding over code. The C-shaped case here therefore keeps the padding and
+REMOVES the delegation, and must still be flagged.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_stub_run_body as gate  # noqa: E402
+
+
+def job(body: str) -> str:
+    return (
+        "<?php\n"
+        "namespace OCA\\Fixture\\BackgroundJob;\n"
+        "use OCP\\BackgroundJob\\QueuedJob;\n"
+        "class NotificationDispatchJob extends QueuedJob\n"
+        "{\n"
+        "    protected function run($argument): void\n"
+        "    {\n"
+        f"{body}"
+        "    }\n"
+        "    private function doRun(array $argument): void\n"
+        "    {\n"
+        "        $this->send($this->render($argument));\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+FAILSAFE = (
+    "        try {\n"
+    "            $this->doRun(argument: $argument);\n"
+    "        } catch (\\Throwable $e) {\n"
+    "            $this->logger->error('dispatch failed', ['reason' => $e->getMessage()]);\n"
+    "        }\n"
+)
+
+
+class TestTheThreeFixtures(unittest.TestCase):
+    def test_a_genuine_stub_is_flagged(self):
+        """The positive control. Everything else is only meaningful because
+        this one is still red."""
+        src = job("        $this->logger->info('not implemented yet');\n")
+        self.assertTrue(gate.is_stub(src))
+
+    def test_b_fail_safe_delegation_is_not_a_stub(self):
+        """The false positive: 530 lines and 11 private methods on portaliq."""
+        self.assertFalse(gate.is_stub(job(FAILSAFE)))
+
+    def test_c_padding_alone_does_not_close_the_gate(self):
+        """The false NEGATIVE. `$unused = 1;` used to take the line count from
+        1 to 2 and the gate went quiet."""
+        src = job(
+            "        $unused = 1;\n"
+            "        $this->logger->info('todo');\n"
+        )
+        self.assertTrue(gate.is_stub(src), "an inert assignment is not work")
+
+    def test_c_padding_plus_delegation_is_still_not_a_stub(self):
+        """And the padding must not turn a real body into a finding either."""
+        self.assertFalse(gate.is_stub(job("        $unused = 1;\n" + FAILSAFE)))
+
+
+class TestWhatMustStillBeFlagged(unittest.TestCase):
+    def test_an_empty_body(self):
+        self.assertTrue(gate.is_stub(job("")))
+
+    def test_logger_only_with_several_levels(self):
+        src = job(
+            "        $this->logger->debug('start');\n"
+            "        $this->logger->info('nothing to do');\n"
+            "        $this->logger->warning('really nothing');\n"
+        )
+        self.assertTrue(gate.is_stub(src))
+
+    def test_a_commented_out_implementation(self):
+        """Written at column 0 so the old `^\\s*(//|\\*)` filter would have
+        skipped it as a comment line — and it must not count as work either
+        way. #184's false GREEN, in this gate's dialect."""
+        src = job("// $this->doRun($argument);\n$this->logger->info('x');\n")
+        self.assertTrue(gate.is_stub(src))
+
+    def test_try_catch_with_nothing_inside(self):
+        src = job(
+            "        try {\n"
+            "        } catch (\\Throwable $e) {\n"
+            "            $this->logger->error('x');\n"
+            "        }\n"
+        )
+        self.assertTrue(gate.is_stub(src))
+
+    def test_control_flow_alone_is_not_work(self):
+        """`if (` and `foreach (` look like calls to a naive matcher."""
+        src = job(
+            "        if ($argument === []) {\n"
+            "            return;\n"
+            "        }\n"
+            "        $this->logger->info('nope');\n"
+        )
+        self.assertTrue(gate.is_stub(src))
+
+
+class TestWhatMustNotBeFlagged(unittest.TestCase):
+    def test_a_direct_service_call(self):
+        self.assertFalse(gate.is_stub(job("        $this->service->dispatch($argument);\n")))
+
+    def test_a_static_call(self):
+        self.assertFalse(gate.is_stub(job("        Dispatcher::send($argument);\n")))
+
+    def test_a_plain_function_call(self):
+        self.assertFalse(gate.is_stub(job("        dispatch_now($argument);\n")))
+
+    def test_a_non_logger_method_named_error(self):
+        """`$mailer->error(...)` is work; only a logger receiver is discounted."""
+        self.assertFalse(gate.is_stub(job("        $this->mailer->error($argument);\n")))
+
+    def test_a_logger_method_that_is_not_a_log_line(self):
+        self.assertFalse(gate.is_stub(job("        $this->logger->rotate();\n")))
+
+
+class TestStructure(unittest.TestCase):
+    def test_a_file_with_no_run_method_is_not_judged(self):
+        src = "<?php\nclass X { public function handle(): void { } }\n"
+        self.assertIsNone(gate.is_stub(src))
+
+    def test_an_abstract_declaration_has_no_body_to_judge(self):
+        src = "<?php\nabstract class X { abstract protected function run($a): void; }\n"
+        self.assertIsNone(gate.is_stub(src))
+
+    def test_braces_are_matched_not_guessed_by_indentation(self):
+        """`awk '/function run\\(/,/^    }/'` guessed the close from four
+        spaces. A job whose run() closes at a different indent had its body
+        run to the end of the file — and then never looked like a stub."""
+        src = (
+            "<?php\n"
+            "class X {\n"
+            "  protected function run($a): void {\n"
+            "    $this->logger->info('stub');\n"
+            "  }\n"
+            "  private function real(): void { $this->work(); }\n"
+            "}\n"
+        )
+        self.assertTrue(gate.is_stub(src),
+                        "the sibling method's work must not be read as run()'s")
+
+    def test_a_string_containing_a_brace_does_not_end_the_body(self):
+        """A `}` inside a message must not truncate the body — if it did, the
+        work below it would be invisible and the job would read as a stub."""
+        src = job(
+            "        $this->logger->info('closing }');\n"
+            "        $this->doRun($argument);\n"
+        )
+        self.assertFalse(gate.is_stub(src))
+
+
+class TestCli(unittest.TestCase):
+    def test_no_arguments_is_an_error(self):
+        self.assertEqual(gate.main(["check_stub_run_body.py"]), 2)
+
+    def test_an_unreadable_file_is_skipped(self):
+        self.assertEqual(gate.scan_files(["/nope/Job.php"]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
@@ -37,18 +37,56 @@ _bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
 # A minimal app tree with something for each gate to find, so "no finding" can
 # never be confused with "nothing to look at".
 _APP="$(mktemp -d "${TMPDIR:-/tmp}/hydra-a11y-app.XXXXXXXX")" || exit 1
-mkdir -p "${_APP}/src" "${_APP}/lib" "${_APP}/appinfo"
+mkdir -p "${_APP}/src" "${_APP}/lib" "${_APP}/appinfo" \
+         "${_APP}/lib/BackgroundJob" "${_APP}/templates" "${_APP}/tests/e2e"
 cat > "${_APP}/src/Thing.vue" <<'VUE'
 <template>
 	<div>
 		<div tabindex="0" aria-hidden="true">unreachable-but-tabbable</div>
+		<img src="/no-alt.png">
+		<div @click="go()">click-only</div>
+		<NcSelect :options="opts" />
 		<table>
 			<tr><th>Name</th><th>Size</th></tr>
 			<tr><td>a</td><td>1</td></tr>
 		</table>
 	</div>
 </template>
+
+<script>
+export default { methods: { go() { window.confirm('really?') } } }
+</script>
 VUE
+
+# One true positive per gate whose helper wiring is asserted below (#191,
+# #196, #220, #224, #226, #230, #235, #236, #266). "No finding" must never be
+# confusable with "nothing to look at" — that confusion IS the defect this
+# suite exists to catch.
+cat > "${_APP}/lib/BackgroundJob/EmptyJob.php" <<'PHP'
+<?php
+namespace OCA\Fixture\BackgroundJob;
+class EmptyJob extends \OCP\BackgroundJob\QueuedJob
+{
+    protected function run($argument): void
+    {
+        $this->logger->info('not implemented yet');
+    }
+}
+PHP
+
+cat > "${_APP}/templates/page.php" <<'PHP'
+<?php // a standalone page that really does own the document ?>
+<html>
+<body><div id="x"></div></body>
+</html>
+PHP
+
+cat > "${_APP}/tests/e2e/thing.spec.ts" <<'TS'
+import { test } from '@playwright/test'
+test('thing', async ({ page }) => {
+	await page.waitForLoadState('networkidle')
+})
+TS
 
 _STAGE=""
 _stage() {   # copy the package so a helper can be broken without touching it
@@ -83,8 +121,25 @@ _check() {  # <gate-n> <gate-name> <how-broken> <out>
     fi
 }
 
-echo "== gate-37 / gate-43 helper wiring =="
+echo "== a11y / prose-family helper wiring =="
 echo
+
+# The gates whose findings now come from a helper, and the helper each one
+# depends on. Nine of these moved out of the runner on 2026-08-08 when their
+# raw-text matching was replaced (#191, #196, #220, #224, #226, #230, #235,
+# #236, #266); every one of them can now go falsely green by losing its
+# helper, which is what this table exists to prevent.
+_WIRED=(
+    "37:aria-hidden-focusable:check_aria_hidden_focusable.py"
+    "43:table-headers:check_table_headers.py"
+    "3:stub-scan:check_stub_run_body.py"
+    "12:nc-input-labels:check_nc_select_labels.py"
+    "31:img-alt:check_markup_a11y.py"
+    "32:semantic-controls:check_markup_a11y.py"
+    "34:window-confirm:check_js_call_sites.py"
+    "41:html-lang:php_template_scope.py"
+    "58:e2e-networkidle:check_js_call_sites.py"
+)
 
 # ---------------------------------------------------------------------------
 # 0. POSITIVE CONTROL. With both helpers intact the fixture app must FAIL both
@@ -92,7 +147,8 @@ echo
 # ---------------------------------------------------------------------------
 if _stage; then
     _out="$(_verdict)"
-    for _g in 37 43; do
+    for _case in "${_WIRED[@]}"; do
+        _g="${_case%%:*}"
         _line="$(printf '%s' "${_out}" | grep -E "^\[gate-${_g}\] " | head -1)"
         case "${_line}" in
             *": FAIL"*) _ok "positive control: gate-${_g} FAILS on the fixture app — ${_line%%—*}" ;;
@@ -107,8 +163,7 @@ fi
 # ---------------------------------------------------------------------------
 # 1. MISSING helper (#147).
 # ---------------------------------------------------------------------------
-for _case in "37:aria-hidden-focusable:check_aria_hidden_focusable.py" \
-             "43:table-headers:check_table_headers.py"; do
+for _case in "${_WIRED[@]}"; do
     _n="${_case%%:*}"; _rest="${_case#*:}"; _name="${_rest%%:*}"; _file="${_rest#*:}"
     if _stage; then
         rm -f "${_STAGE}/scripts/lib/${_file}"
@@ -121,8 +176,7 @@ done
 # 2. CRASHING helper (#249). Present, importable path, dies on invocation.
 #    This is the case `2>/dev/null || true` could not tell from "no findings".
 # ---------------------------------------------------------------------------
-for _case in "37:aria-hidden-focusable:check_aria_hidden_focusable.py" \
-             "43:table-headers:check_table_headers.py"; do
+for _case in "${_WIRED[@]}"; do
     _n="${_case%%:*}"; _rest="${_case#*:}"; _name="${_rest%%:*}"; _file="${_rest#*:}"
     if _stage; then
         printf 'raise SystemExit("boom")\n' > "${_STAGE}/scripts/lib/${_file}"
@@ -130,6 +184,68 @@ for _case in "37:aria-hidden-focusable:check_aria_hidden_focusable.py" \
         rm -rf "${_STAGE}"
     fi
 done
+
+# ---------------------------------------------------------------------------
+# 3. THE SHARED MASK (#196). gate-5's attribute test runs over a comment-masked
+#    copy of the controller. If source_scope.py is gone — or is present but
+#    returns its input unchanged, which no file-existence check can see — the
+#    gate falls straight back into the false NEGATIVE it was fixed for, and a
+#    false negative leaves NO log to notice. So the gate runs a positive
+#    control on the mask first and must decline rather than pass.
+#
+#    The "silently identity" case is the one worth having: it is the shape
+#    #184 shipped (a checker that matched everything and nothing), and it is
+#    invisible to `[ -f helper ]`.
+# ---------------------------------------------------------------------------
+mkdir -p "${_APP}/lib/Controller"
+cat > "${_APP}/appinfo/routes.php" <<'PHP'
+<?php
+return ['routes' => [
+    ['name' => 'widget#update', 'url' => '/api/widgets/{id}', 'verb' => 'PUT'],
+]];
+PHP
+cat > "${_APP}/lib/Controller/WidgetController.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Controller;
+class WidgetController extends \OCP\AppFramework\Controller
+{
+    #[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
+    public function update(string $id): \OCP\AppFramework\Http\JSONResponse
+    {
+        return new \OCP\AppFramework\Http\JSONResponse(['id' => $id]);
+    }
+}
+PHP
+
+if _stage; then
+    _line="$(printf '%s' "$(_verdict)" | grep -E '^\[gate-5\] ' | head -1)"
+    case "${_line}" in
+        *": PASS"*) _ok "positive control: gate-5 PASSes on a correctly attributed method — ${_line}" ;;
+        *) _bad "positive control: gate-5 did not pass a method carrying #[NoAdminRequired] — ${_line:-<none>}" ;;
+    esac
+    rm -rf "${_STAGE}"
+fi
+
+if _stage; then
+    rm -f "${_STAGE}/scripts/lib/source_scope.py"
+    _check 5 "route-auth" "MISSING mask" "$(_verdict)"
+    rm -rf "${_STAGE}"
+fi
+
+if _stage; then
+    # Present, exits 0, and echoes its input unchanged: a mask that masks
+    # nothing. `[ -f ]` cannot tell this from a working helper.
+    cat > "${_STAGE}/scripts/lib/source_scope.py" <<'PY'
+import sys
+if len(sys.argv) >= 4 and sys.argv[1] == "--mask":
+    t = sys.argv[3]
+    sys.stdout.write(sys.stdin.read() if t == "-" else open(t).read())
+    raise SystemExit(0)
+raise SystemExit(2)
+PY
+    _check 5 "route-auth" "IDENTITY (masks nothing)" "$(_verdict)"
+    rm -rf "${_STAGE}"
+fi
 
 rm -rf "${_APP}"
 

--- a/hydra-gates/scripts/lib/test_gate_route_auth.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_auth.sh
@@ -117,7 +117,7 @@ _expect_log() {   # <snapshot-var-contents> <regex> <description>
 echo "== gate-5 route-auth / gate-14 reachability control pairs =="
 echo
 
-for _f in unguarded guarded apphost apphost-unguarded orphan-route di-registered-generic; do
+for _f in unguarded guarded apphost apphost-unguarded orphan-route di-registered-generic prose-exempt auth-declared; do
     if [ ! -d "${FIXTURES}/${_f}" ]; then
         _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
     fi
@@ -221,6 +221,44 @@ if _run "${FIXTURES}/di-registered-generic"; then
     _expect_gate 5 PASS "di-registered-generic fixture: the absent generic is not an auth finding either"
     _expect_log "${_UNRES}" 'genericPreferences#getPreference' \
         "di-registered-generic fixture: gate-5 states the generic was NOT JUDGED rather than dropping it"
+fi
+
+# ---------------------------------------------------------------------------
+# 5c. DEFECT (c) — #196. A COMMENT SATISFIED THE GATE.
+#
+#     This is a false-NEGATIVE fix, so the acceptance test runs the other way
+#     round from every pair above: the assertion is that the gate now CATCHES
+#     what it used to wave through. Measured against main before the fix, the
+#     prose-exempt fixture reported ONE finding (`analytics`); `subscribe`,
+#     whose only difference is a docblock sentence naming `#[NoAdminRequired]`,
+#     PASSED. Two methods, identical auth posture, opposite verdicts, decided
+#     by prose. It must now report TWO.
+#
+#     ⚠️ The count matters more than the verdict here. FAIL alone would still
+#     be FAIL if only `analytics` were found, so a suite asserting only the
+#     verdict would have been green BEFORE the fix.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/prose-exempt"; then
+    _expect_gate 5 FAIL "prose-exempt fixture: a docblock naming an attribute is not an attribute"
+    _expect_out 'gate-5\] route-auth: FAIL — 2 routed method' \
+        "prose-exempt fixture: BOTH methods are reported (pre-fix main reported 1)"
+    _RALOG="$(cat "${_LOGDIR}/hydra-gate-route-auth.log" 2>/dev/null || true)"
+    _expect_log "${_RALOG}" 'method=subscribe' \
+        "prose-exempt fixture: the method that used to pass on prose is named"
+    _expect_log "${_RALOG}" 'method=analytics' \
+        "prose-exempt fixture: its unchanged neighbour is still named"
+fi
+
+# 5d. THE CLOSING MOVE, and the anti-unclosable control. Absence of
+#     #[NoAdminRequired] IS the admin gate, so an admin-only method has no
+#     attribute to satisfy the check with — the tightening ships with an
+#     explicit `@auth admin-only <reason>` declaration. All three declaration
+#     forms must pass, and the class docblock in this fixture mentions
+#     `#[NoAdminRequired]` in prose exactly like prose-exempt's does, so a
+#     PASS here cannot come from the old raw-text behaviour creeping back.
+if _run "${FIXTURES}/auth-declared"; then
+    _expect_gate 5 PASS "auth-declared fixture: attribute, legacy docblock tag and @auth admin-only all satisfy the gate"
+    _expect_no_out 'NOT JUDGED' "auth-declared fixture: nothing unresolved"
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_php_template_scope.py
+++ b/hydra-gates/scripts/lib/test_php_template_scope.py
@@ -118,6 +118,59 @@ class UnterminatedPhp(unittest.TestCase):
         self.assertFalse(pts.owns_document("<?php\n// <html> mentioned here\n$x = 1;\n"))
 
 
+class HtmlLang(unittest.TestCase):
+    """gate-41 (SC 3.1.1), #266 — the same defect gate-38 shipped a fix for.
+
+    The reproduction from the issue is a mount point whose PHP comment
+    mentions the tag. Both directions are asserted, because a checker that
+    greps raw text fails both ways at once: it fires on prose, and it is
+    SATISFIED by prose.
+    """
+
+    FRAGMENT = (
+        "<?php\n"
+        "// This mount point is substituted into core's page. Core emitted the\n"
+        "// <html> element for it, with its lang attribute, long before this file.\n"
+        "?>\n"
+        '<div id="app-settings"></div>\n'
+    )
+
+    def test_a_php_comment_naming_the_tag_is_not_the_tag(self):
+        self.assertEqual(pts.html_lang_findings('templates/fragment.php', self.FRAGMENT), [])
+
+    def test_a_template_that_really_emits_an_unlangged_html_is_reported(self):
+        """The positive control. Without it the fix is indistinguishable from
+        deleting the gate — and gate-41 is quiet across the fleet today
+        because all 30 app templates are fragments, so 'no findings' proves
+        nothing on its own."""
+        src = "<?php // standalone ?>\n<html>\n<body>hi</body>\n</html>\n"
+        self.assertEqual(len(pts.html_lang_findings('templates/page.php', src)), 1)
+
+    def test_a_lang_attribute_satisfies_it(self):
+        src = '<html lang="en">\n<body>hi</body>\n</html>\n'
+        self.assertEqual(pts.html_lang_findings('templates/page.php', src), [])
+
+    def test_a_commented_out_lang_does_not_vouch_for_a_real_tag(self):
+        """The other direction #266 names, and the more dangerous one."""
+        src = '<!-- <html lang="en"> -->\n<html>\n<body>hi</body>\n</html>\n'
+        self.assertEqual(len(pts.html_lang_findings('templates/page.php', src)), 1)
+
+    def test_an_html_tag_written_only_inside_a_php_string_is_not_emitted(self):
+        src = "<?php echo '<html>'; ?>\n<div id=x></div>\n"
+        self.assertEqual(pts.html_lang_findings('templates/x.php', src), [])
+
+    def test_every_emitted_html_tag_is_checked_not_just_the_first(self):
+        src = '<html lang="en"></html>\n<html></html>\n'
+        self.assertEqual(len(pts.html_lang_findings('templates/two.php', src)), 1)
+
+    def test_a_greater_than_in_an_attribute_value_does_not_end_the_tag(self):
+        src = '<html data-expr="a > b" lang="en">\n<body>x</body>\n</html>\n'
+        self.assertEqual(pts.html_lang_findings('templates/page.php', src), [])
+
+    def test_html_lang_cli_reports_an_unreadable_file_rather_than_passing_it(self):
+        self.assertEqual(pts.main(['x', '--html-lang', '/nope/does-not-exist.php']), 2)
+
+
 class Cli(unittest.TestCase):
     """The bash caller keys on the EXIT STATUS, so the status is a contract.
 

--- a/hydra-gates/scripts/lib/test_source_scope.py
+++ b/hydra-gates/scripts/lib/test_source_scope.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for source_scope — the shared "where is the code" masks.
+
+Run with:  python3 scripts/lib/test_source_scope.py
+
+EVERY relaxation here is paired with the true positive it must not swallow.
+The whole family of bugs this module fixes came from a checker that could not
+tell code from prose; the way to reintroduce it is to write a mask that blanks
+too much and then only ever test that it stops firing. So each "must not
+match" case has a neighbouring "must still match" case built from the same
+fixture with one edit.
+
+⚠️ A TRAP KEPT ON PURPOSE
+-------------------------
+`test_a_fixture_cannot_exempt_itself_with_its_own_docblock` reproduces the
+thing that bit an earlier agent on exactly this work: a fixture written to
+DISPROVE a rule exempted itself with its own explanatory comment, because the
+comment named the construct under test. The fixture below keeps its
+explanatory docblock AND the real construct, and asserts the mask separates
+them.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import source_scope as ss  # noqa: E402
+import check_e2e_coverage as cec  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestOffsetsSurvive(unittest.TestCase):
+    """A mask that moves offsets is useless: every caller reports line numbers
+    from the mask and reads suppression markers out of the ORIGINAL."""
+
+    CORPUS = [
+        ("js", "const a = 1 // note\nconst b = 'x'\n"),
+        ("js", "/* block\n   spanning */\nlet q = `t${1}`\n"),
+        ("php", "<?php\n// c\n#[Attr]\n$x = 'y'; # trailing\n"),
+        ("markup", "<template>\n<!-- c -->\n<img src=x>\n</template>\n<script>\n// j\n</script>\n"),
+    ]
+
+    def test_same_length_and_same_line_count(self):
+        for kind, src in self.CORPUS:
+            fn = {"js": ss.js_code_mask, "php": ss.php_mask,
+                  "markup": lambda s: ss.markup_mask(s, "f.vue")}[kind]
+            out = fn(src)
+            self.assertEqual(len(out), len(src), f"{kind}: length changed")
+            self.assertEqual(out.count("\n"), src.count("\n"), f"{kind}: lines changed")
+
+    def test_line_number_of_a_kept_token_is_unchanged(self):
+        src = "// <img>\n// <img>\n<img src=a>\n"
+        masked = ss.html_markup_mask(src)
+        # `//` is not an HTML comment, so this one is deliberately still there.
+        self.assertEqual(masked.count("<img"), 3)
+        src2 = "<!-- <img> -->\n<!-- <img> -->\n<img src=a>\n"
+        masked2 = ss.html_markup_mask(src2)
+        idx = masked2.index("<img")
+        self.assertEqual(masked2.count("\n", 0, idx) + 1, 3,
+                         "the surviving tag must still be on line 3")
+
+
+class TestPhpMask(unittest.TestCase):
+    def test_hash_bracket_is_an_attribute_not_a_comment(self):
+        """#184's distinction. Losing it deletes every NC auth attribute."""
+        src = "#[NoAdminRequired]\npublic function f() {}\n"
+        self.assertIn("#[NoAdminRequired]", ss.php_mask(src))
+
+    def test_bare_hash_is_a_comment(self):
+        src = "# NoAdminRequired is not used here\n$x = 1;\n"
+        self.assertNotIn("NoAdminRequired", ss.php_mask(src))
+        self.assertIn("$x = 1;", ss.php_mask(src))
+
+    def test_docblock_mention_of_an_attribute_is_blanked(self):
+        """#196 in one assertion: the sentence that switched gate-5 off."""
+        src = (
+            "    /**\n"
+            "     * ADMIN ONLY: `#[NoAdminRequired]` is deliberately NOT used here.\n"
+            "     */\n"
+            "    public function analytics(): JSONResponse\n"
+        )
+        masked = ss.php_mask(src)
+        self.assertNotIn("NoAdminRequired", masked)
+        self.assertIn("public function analytics", masked)
+
+    def test_a_real_attribute_above_the_same_method_survives(self):
+        """The anti-widening control for the case above."""
+        src = (
+            "    /**\n"
+            "     * Analytics.\n"
+            "     */\n"
+            "    #[NoAdminRequired]\n"
+            "    public function analytics(): JSONResponse\n"
+        )
+        self.assertIn("#[NoAdminRequired]", ss.php_mask(src))
+
+    def test_slash_slash_inside_a_string_does_not_open_a_comment(self):
+        src = "$u = 'https://example.test/x'; $keep = 1;\n"
+        self.assertIn("$keep = 1;", ss.php_mask(src))
+
+    def test_commented_out_code_is_blanked_both_ways(self):
+        """#184's false GREEN: a commented-OUT prelude counted as a prelude."""
+        src = "// \\OC_App::registerAutoloading('openregister', $p);\n"
+        self.assertNotIn("registerAutoloading", ss.php_mask(src))
+
+
+class TestVueMarkupMask(unittest.TestCase):
+    LAUNCHPAD = (
+        "<template>\n"
+        '  <div class="nav"><CnDashboardIcon :icon="icon" /></div>\n'
+        "</template>\n"
+        "\n"
+        "<script>\n"
+        "/**\n"
+        " * resolves any value the icon picker emits — a URL (→ `<img>`), an SVG\n"
+        " */\n"
+        "export default {}\n"
+        "</script>\n"
+    )
+
+    def test_img_inside_a_jsdoc_comment_is_not_markup(self):
+        """#220 / #235, on the real shape from launchpad and openbuild."""
+        masked = ss.vue_markup_mask(self.LAUNCHPAD)
+        self.assertNotIn("<img", masked)
+
+    def test_a_real_img_in_the_template_survives(self):
+        """Anti-widening control: the same file with one real tag added."""
+        src = self.LAUNCHPAD.replace(
+            '<div class="nav">', '<div class="nav"><img src="/a.png">')
+        masked = ss.vue_markup_mask(src)
+        self.assertIn("<img", masked)
+        tags = list(ss.iter_open_tags(masked, {"img"}))
+        self.assertEqual(len(tags), 1)
+
+    def test_openbuild_finding_shape_is_gone(self):
+        """The finding text was the tell: a bare `<img>` with no attributes."""
+        src = (
+            "<template><span/></template>\n"
+            "<script>\n"
+            " * @param {Event} e - The `<img>` `error` event fired when the icon\n"
+            "</script>\n"
+        )
+        self.assertEqual(list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"})), [])
+
+    def test_html_comment_in_the_template_is_blanked(self):
+        """#236 part 2: the comment describing the div it replaced was scored."""
+        src = (
+            "<template>\n"
+            "  <!-- role/tabindex/keydown rather than a bare <div @click>: picking\n"
+            "       the merge target is the consequential choice here -->\n"
+            '  <div role="option" tabindex="0" @click="pick" @keydown.enter="pick" />\n'
+            "</template>\n"
+        )
+        masked = ss.vue_markup_mask(src)
+        tags = [t for t in ss.iter_open_tags(masked, {"div"})]
+        self.assertEqual(len(tags), 1)
+        self.assertIn("role=", tags[0].attrs)
+
+    def test_a_real_bad_div_next_to_that_comment_still_matches(self):
+        """Anti-widening control for the case above."""
+        src = (
+            "<template>\n"
+            "  <!-- a bare <div @click> is what this replaced -->\n"
+            '  <div @click="pick" />\n'
+            "</template>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"div"}))
+        self.assertEqual(len(tags), 1)
+        self.assertIn("@click", tags[0].attrs)
+
+    def test_a_fixture_cannot_exempt_itself_with_its_own_docblock(self):
+        """THE TRAP, kept deliberately.
+
+        A fixture written to disprove the rule described the construct in its
+        own explanatory comment. Under the pre-fix flat grep the comment WAS
+        the finding, so the fixture "proved" whatever the author wanted. Here
+        the comment and the construct are both present and the mask must
+        separate them: one real tag, not two, and not zero.
+        """
+        src = (
+            "<template>\n"
+            "  <!-- This fixture exists to show that `<img>` written in prose is\n"
+            "       not an image. The tag below IS one and must still count. -->\n"
+            '  <img src="/real.png">\n'
+            "</template>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"}))
+        self.assertEqual(len(tags), 1, "exactly the real tag, not the prose one")
+        self.assertIn("src=", tags[0].attrs)
+
+    def test_no_template_block_means_no_markup(self):
+        src = "<script>\n// <img> in prose\n</script>\n"
+        self.assertEqual(ss.vue_markup_mask(src).strip(), "")
+
+    def test_a_nested_slot_template_does_not_end_the_block(self):
+        """MEASURED REGRESSION, caught on openconnector before this landed.
+
+        `<template #default>` is a slot, written INSIDE the SFC's template. A
+        lazy `<template…>(.*?)</template>` ends the block at the first slot
+        close, and everything below it — including a real unlabelled
+        `<NcSelect>` at EditMapping.vue:376 — silently stops being scanned.
+        A relaxation that deletes true positives is the fix over-applied, and
+        the whole point of this change is that it must not happen.
+        """
+        src = (
+            "<template>\n"
+            "  <NcDialog>\n"
+            "    <template #default>\n"
+            "      <span>a</span>\n"
+            "    </template>\n"
+            "    <template #actions>\n"
+            "      <span>b</span>\n"
+            "    </template>\n"
+            "  </NcDialog>\n"
+            '  <img src="/late.png">\n'
+            "</template>\n"
+            "<script>\n// <img> in prose\n</script>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"}))
+        self.assertEqual(len(tags), 1, "the tag after the slots must survive")
+        self.assertIn("/late.png", tags[0].attrs)
+        self.assertNotIn("in prose", ss.vue_markup_mask(src))
+
+    def test_a_self_closing_template_opens_nothing(self):
+        src = '<template>\n  <template v-if="x" />\n  <img src="/a.png">\n</template>\n'
+        self.assertEqual(len(list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"}))), 1)
+
+    def test_an_unbalanced_template_open_keeps_the_rest_of_the_file(self):
+        """Dropping it would blank everything — a false green by parse error."""
+        src = '<template>\n  <img src="/a.png">\n'
+        self.assertEqual(len(list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"}))), 1)
+
+
+class TestPhpMarkupMask(unittest.TestCase):
+    FRAGMENT = (
+        "<?php\n"
+        "// This mount point is substituted into core's page. Core emitted the\n"
+        "// <html> element for it, with its lang attribute, long before this file.\n"
+        "?>\n"
+        '<div id="app-settings"></div>\n'
+    )
+
+    def test_html_named_in_a_php_comment_is_not_emitted(self):
+        """#266 verbatim."""
+        self.assertNotIn("<html", ss.php_markup_mask(self.FRAGMENT))
+
+    def test_a_template_that_really_emits_html_still_matches(self):
+        """Anti-widening control."""
+        src = "<?php // a standalone page ?>\n<html>\n<body>x</body>\n</html>\n"
+        self.assertIn("<html>", ss.php_markup_mask(src))
+
+    def test_html_comment_hiding_a_lang_attribute_does_not_satisfy_the_gate(self):
+        """The other direction #266 names: a commented-out `<html lang>` must
+        not vouch for a real unlangged one."""
+        src = '<!-- <html lang="en"> -->\n<html>\n'
+        masked = ss.php_markup_mask(src)
+        self.assertEqual(masked.count("<html"), 1)
+        self.assertNotIn("lang=", masked)
+
+    def test_jsdoc_img_in_an_inline_script_is_not_markup(self):
+        src = (
+            "<div id=x></div>\n"
+            "<script>\n"
+            "// renders an `<img>` when a URL is picked\n"
+            "</script>\n"
+        )
+        self.assertEqual(list(ss.iter_open_tags(ss.php_markup_mask(src), {"img"})), [])
+
+
+class TestTagExtraction(unittest.TestCase):
+    def test_an_arrow_function_does_not_end_the_element(self):
+        """#236 part 1: `[^>]*` stopped at the `>` of `option => option.value`."""
+        src = (
+            "<template>\n"
+            "  <NcSelect\n"
+            '    :reduce="option => option.value"\n'
+            '    :options="opts"\n'
+            '    input-label="Transport Type" />\n'
+            "</template>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"NcSelect"}))
+        self.assertEqual(len(tags), 1)
+        self.assertIn("input-label", tags[0].attrs,
+                      "the prop written after the reducer must be visible")
+
+    def test_the_same_element_without_the_label_is_still_extracted(self):
+        """Anti-widening control: fixing extraction must not stop findings."""
+        src = (
+            "<template>\n"
+            '  <NcSelect :reduce="option => option.value" :options="opts" />\n'
+            "</template>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"NcSelect"}))
+        self.assertEqual(len(tags), 1)
+        self.assertNotIn("input-label", tags[0].attrs)
+
+    def test_two_elements_are_not_greedily_merged(self):
+        """The trap a naive `.*?`-less fix falls into."""
+        src = (
+            "<template>\n"
+            '  <NcSelect input-label="A" />\n'
+            '  <NcSelect :options="o" />\n'
+            "</template>\n"
+        )
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"NcSelect"}))
+        self.assertEqual(len(tags), 2)
+        self.assertIn("input-label", tags[0].attrs)
+        self.assertNotIn("input-label", tags[1].attrs)
+
+    def test_closing_tags_are_not_reported(self):
+        src = "<template><div>x</div></template>"
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"div"}))
+        self.assertEqual(len(tags), 1)
+
+    def test_line_numbers_address_the_original_file(self):
+        src = "<template>\n\n\n  <img src=a>\n</template>\n"
+        tags = list(ss.iter_open_tags(ss.vue_markup_mask(src), {"img"}))
+        self.assertEqual(tags[0].line, 4)
+
+
+class TestScriptMask(unittest.TestCase):
+    def test_a_comment_mentioning_window_confirm_is_blanked(self):
+        """#224 arm 1: the false RED."""
+        src = (
+            "<template>\n"
+            "  <!-- This component deliberately avoids window.confirm() and uses NcDialog. -->\n"
+            '  <NcDialog :open="open" />\n'
+            "</template>\n"
+        )
+        self.assertNotIn("window.confirm", ss.script_mask(src, "a.vue"))
+
+    def test_a_real_call_in_the_same_file_still_shows(self):
+        """#224 arm 4: the control that proves the probe can fire."""
+        src = (
+            "<template>\n"
+            "  <!-- avoids window.confirm() -->\n"
+            "</template>\n"
+            "<script>\n"
+            "export default { methods: { d() { if (window.confirm('x')) {} } } }\n"
+            "</script>\n"
+        )
+        masked = ss.script_mask(src, "a.vue")
+        self.assertEqual(masked.count("window.confirm"), 1)
+
+    def test_string_literals_survive_the_comment_mask(self):
+        """gate-58's whole evidence is a string literal."""
+        src = "await page.goto(u, { waitUntil: 'networkidle' })\n"
+        self.assertIn("'networkidle'", ss.js_comment_mask(src))
+
+    def test_a_comment_warning_against_networkidle_is_blanked(self):
+        """#230, the larpingapp line verbatim."""
+        src = (
+            "// live `waitForLoadState('networkidle')` in the suite; every other mention\n"
+            "await page.waitForLoadState('domcontentloaded')\n"
+        )
+        masked = ss.js_comment_mask(src)
+        self.assertNotIn("networkidle", masked)
+        self.assertIn("domcontentloaded", masked)
+
+    def test_a_real_call_with_a_trailing_comment_still_matches(self):
+        """Anti-widening control: a line-position filter would lose this."""
+        src = "await page.waitForLoadState('networkidle') // TODO remove\n"
+        self.assertIn("waitForLoadState('networkidle')", ss.js_comment_mask(src))
+
+    def test_a_slash_inside_a_string_does_not_open_a_comment(self):
+        src = "const u = 'http://x/networkidle'\nawait f()\n"
+        self.assertIn("await f()", ss.js_comment_mask(src))
+
+    def test_an_inline_handler_in_a_vue_template_is_script(self):
+        src = "<template><button @click=\"window.confirm('x') && go()\">g</button></template>\n"
+        self.assertIn("window.confirm", ss.script_mask(src, "a.vue"))
+
+    def test_style_block_is_blanked(self):
+        src = "<template><i/></template>\n<style>/* window.confirm */ .a{}</style>\n"
+        self.assertNotIn("window.confirm", ss.script_mask(src, "a.vue"))
+
+
+class TestSharedWithGate19(unittest.TestCase):
+    """The shared mask and gate-19's own must be byte-identical.
+
+    Gate-19 keeps its copy because its 60-assertion suite is what proves the
+    tokeniser correct, and moving it under that suite mid-change would be a
+    bad trade. Two copies that are PROVEN equal are a maintenance cost; two
+    copies that MIGHT differ are a defect. This test is the proof, and it is
+    mutation-checked: flip one branch of either copy and it goes red.
+    """
+
+    CORPUS = [
+        "const a = 1 // note\n",
+        "/* b */ test('x', async () => {})\n",
+        "const r = /a\\/b/g; const d = 4 / 2\n",
+        "const t = `a${'b'}c`\n",
+        "test.skip('name', fn)\ntest.skip(cond, 'reason')\n",
+        "const s = 'unterminated\nnext()\n",
+        "if (x) test.skip(true, 'why') // trailing\n",
+        "const u = 'http://x//y'\n",
+        "await page.waitForLoadState('networkidle')\n",
+        # One per regex-position keyword. Dropping any single entry from
+        # either copy's keyword set must be caught, and a corpus that only
+        # exercises `return` cannot do that — measured: the first draft of
+        # this test SURVIVED deleting "await" from the shared set.
+        *[f"x = {kw} /a'b/.test(s)\n" for kw in sorted(cec._JS_REGEX_KEYWORDS)],
+    ]
+
+    def test_the_keyword_sets_are_the_same(self):
+        """The cheapest drift there is, and the corpus alone did not see it."""
+        self.assertEqual(ss._JS_REGEX_KEYWORDS, cec._JS_REGEX_KEYWORDS)
+
+    def test_identical_over_the_corpus(self):
+        for src in self.CORPUS:
+            self.assertEqual(ss.js_code_mask(src), cec._code_mask(src),
+                             f"masks diverged on {src!r}")
+
+    def test_identical_over_this_packages_own_js_sources(self):
+        seen = 0
+        for name in sorted(os.listdir(HERE)):
+            if not name.endswith(".js"):
+                continue
+            with open(os.path.join(HERE, name), encoding="utf-8", errors="replace") as f:
+                src = f.read()
+            self.assertEqual(ss.js_code_mask(src), cec._code_mask(src), name)
+            seen += 1
+        self.assertGreater(seen, 0, "no .js sources found — this test measured nothing")
+
+
+class TestCli(unittest.TestCase):
+    """The bash gates call this module as a process; a broken CLI is a dead
+    gate, so it is exercised the way they call it."""
+
+    def _run(self, args, stdin=""):
+        return subprocess.run(
+            [sys.executable, os.path.join(HERE, "source_scope.py"), *args],
+            input=stdin, capture_output=True, text=True,
+        )
+
+    def test_php_mask_from_stdin(self):
+        r = self._run(["--mask", "php", "-"], "// x NoAdminRequired\n#[NoAdminRequired]\n")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.count("NoAdminRequired"), 1)
+
+    def test_unknown_kind_is_an_error_not_an_empty_answer(self):
+        r = self._run(["--mask", "nonsense", "-"], "x")
+        self.assertEqual(r.returncode, 2)
+        self.assertEqual(r.stdout, "")
+
+    def test_no_arguments_is_an_error(self):
+        self.assertEqual(self._run([]).returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_source_scope.py
+++ b/hydra-gates/scripts/lib/test_source_scope.py
@@ -375,6 +375,38 @@ class TestScriptMask(unittest.TestCase):
         src = "<template><button @click=\"window.confirm('x') && go()\">g</button></template>\n"
         self.assertIn("window.confirm", ss.script_mask(src, "a.vue"))
 
+    def test_a_script_end_tag_with_junk_still_ends_the_script(self):
+        """CodeQL py/bad-tag-filter, HIGH, raised against this change.
+
+        `</script\\s*>` does not match `</script bar>`, and an HTML parser DOES
+        end the element there. The block regex then fails to match AT ALL, the
+        script body is never comment-masked, and a JSDoc `<img>` inside it is
+        scanned as markup — which is #235 exactly, reintroduced by the mask
+        meant to fix it.
+
+        ⚠️ The first version of this test used `vue_markup_mask`, which does
+        not go through `_SCRIPT_BLOCK` at all, and the mutant SURVIVED. Assert
+        the mutation applies AND kills before believing a mutation test.
+        """
+        src = (
+            "<script>\n"
+            "// renders an <img src=x> when a URL is picked\n"
+            "</script bar>\n"
+            '<img src="/real.png">\n'
+        )
+        tags = list(ss.iter_open_tags(ss.html_markup_mask(src), {"img"}))
+        self.assertEqual(len(tags), 1, "only the real tag; the JSDoc one is in script")
+        self.assertIn("/real.png", tags[0].attrs)
+
+    def test_a_script_end_tag_with_whitespace_and_junk(self):
+        src = (
+            "<div id=x></div>\n"
+            "<script>\n"
+            "// this template avoids window.confirm entirely\n"
+            "</script\t\n foo>\n"
+        )
+        self.assertNotIn("window.confirm", ss.script_mask(src, "templates/a.php"))
+
     def test_style_block_is_blanked(self):
         src = "<template><i/></template>\n<style>/* window.confirm */ .a{}</style>\n"
         self.assertNotIn("window.confirm", ss.script_mask(src, "a.vue"))

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1299,14 +1299,53 @@ fi
 _stub_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-stub-scan.log
 : > "${_stub_log}"
 grep -rn "In a complete implementation" lib/ src/ 2>/dev/null | _filter_grep_by_scope | head -5 >> "${_stub_log}" || true
+# A DELEGATING run() IS NOT A STUB, AND A DEAD LINE MUST NOT CLOSE THE GATE
+# (#226).
+#
+# This arm counted surviving lines after filtering out `try {`, `} catch` and
+# every logger call. For the canonical fail-safe wrapper —
+#
+#     protected function run($argument): void {
+#         try { $this->doRun(argument: $argument); }
+#         catch (Throwable $e) { $this->logger->error(...); }
+#     }
+#
+# — exactly ONE line survived, and the threshold was `< 2`. Measured on
+# portaliq: `lib/BackgroundJob/NotificationDispatchJob.php`, 530 lines and 11
+# private methods implementing a complete notification pipeline, reported as a
+# stub. Worse, the gate was CLOSED by adding an inert `$unused = 1;` and could
+# not be closed by writing correct code — the only other remedy was to inline
+# the pipeline back into run(), deleting the try/catch that keeps an exception
+# out of the NC cron runner. Both remedies are regressions, which is why
+# portaliq reported the finding instead of fixing it.
+#
+# scripts/lib/check_stub_run_body.py counts non-logger CALLS instead of lines,
+# over a comment-masked body with matched braces. Delegation passes; padding
+# does not.
+_stub_ran=1
 if [ -d lib/BackgroundJob ]; then
+    _stub_helper="${SCRIPT_DIR}/lib/check_stub_run_body.py"
+    _stub_jobs=()
     while IFS= read -r job; do
         [ -f "${job}" ] || continue
         _in_scope "${job}" || continue
-        _body=$(awk '/function run\(/,/^    }/' "${job}" | grep -vE '^\s*(//|\*|\s*\{|\s*\}|\s*$)' | grep -vE 'function run|logger->(info|warning|debug|error|notice)|try\s*\{|\}\s*catch|return;?$' || true)
-        _lc=$(echo "${_body}" | grep -cE '\S' || true)
-        [ "${_lc}" -lt 2 ] && echo "${job}: run() body has no non-logger statements (stub)" >> "${_stub_log}"
+        _stub_jobs+=("${job}")
     done < <(_enum_tracked '\.php$' lib/BackgroundJob)
+    if [ "${#_stub_jobs[@]}" -eq 0 ]; then
+        : # nothing in scope.
+    elif [ ! -f "${_stub_helper}" ]; then
+        _stub_ran=0
+        _skip 3 "stub-scan" wiring "check_stub_run_body.py not found at ${_stub_helper} — ${#_stub_jobs[@]} background job(s) were in scope and NONE had their run() body inspected."
+    else
+        set +e
+        _stub_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-stub-scan.err"
+        python3 "${_stub_helper}" "${_stub_jobs[@]}" >> "${_stub_log}" 2>"${_stub_err}"
+        _stub_rc=$?
+        if [ "${_stub_rc}" -ne 0 ]; then
+            _stub_ran=0
+            _skip 3 "stub-scan" wiring "check_stub_run_body.py exited ${_stub_rc} — ${#_stub_jobs[@]} background job(s) were in scope and NONE were judged. See ${_stub_err}."
+        fi
+    fi
 fi
 if [ -d src ]; then
     while IFS= read -r vue; do
@@ -1349,10 +1388,12 @@ while IFS= read -r f; do
             fi
         done
 done < <(_enum_tracked '\.php$' lib/Service lib/Controller)
-if [ -s "${_stub_log}" ]; then
-    _fail 3 "stub-scan" "$(wc -l < "${_stub_log}") finding(s) — see ${_stub_log}"
-else
-    _pass 3 "stub-scan"
+if [ "${_stub_ran}" -eq 1 ]; then
+    if [ -s "${_stub_log}" ]; then
+        _fail 3 "stub-scan" "$(wc -l < "${_stub_log}") finding(s) — see ${_stub_log}"
+    else
+        _pass 3 "stub-scan"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -1469,12 +1510,94 @@ fi
 #     Per ADR-020 a routed method is now judged when the PR touched EITHER the
 #     controller that serves it OR appinfo/routes.php itself (adding/altering a
 #     route is exactly when its auth posture must be re-checked).
+#
+# (c) FIFTH DEFECT, 2026-08-08 (#196): A COMMENT SATISFIED THE GATE. The head
+#     block is raw text and the test was one grep, so an attribute NAME
+#     appearing anywhere — including inside a docblock — counted:
+#
+#         /**
+#          * ADMIN ONLY: `#[NoAdminRequired]` is deliberately NOT used here.
+#          */
+#         public function analytics(string $productId): JSONResponse
+#
+#     passed with no attribute at all. This is the EXPENSIVE direction for a
+#     security gate: a pass leaves no log, so any method whose prose mentions
+#     one of the four names was silently exempt, and anyone could switch the
+#     gate off for a method by writing about it. Live on openconnector's
+#     ProductSubscriptionsController, where `subscribe()` passed on exactly
+#     that sentence and its neighbour `analytics()` — identical auth posture,
+#     no such sentence — was reported (openconnector#1165). Two methods,
+#     opposite verdicts, decided entirely by prose.
+#
+#     The attribute test now runs over a COMMENT-MASKED copy of the file
+#     (scripts/lib/source_scope.py --mask php, which knows `#` opens a comment
+#     but `#[` opens an attribute — #184's distinction). The legacy docblock
+#     form is still accepted, but only at DOCBLOCK-TAG POSITION: preceded on
+#     its line by nothing but whitespace and comment punctuation. That is
+#     where PHP's own docblock parsers require it, and it is not a position
+#     prose reaches.
+#
+#     ⚠️ AND A DECLARATION, BECAUSE THE ALTERNATIVE IS AN UNCLOSABLE GATE.
+#     There is no way to say "admin only" with an attribute: the ABSENCE of
+#     `#[NoAdminRequired]` IS the admin gate, and adding `@NoAdminRequired`
+#     would make the endpoint non-admin. Documenting the posture was
+#     genuinely the only option available, and it happened to satisfy the
+#     regex — which is why this went unnoticed. Tightening alone would flag
+#     every such method across the fleet with no correct fix available, so
+#     the tightening lands WITH a marker in the `@spec exclude` family:
+#
+#         @auth admin-only <reason of at least 20 characters>
+#
+#     at docblock-tag position. An attribute is an attribute, a deliberate
+#     admin-only endpoint is DECLARED, and prose stops being load-bearing.
+#     gate-9 (semantic-auth) still owns the question of whether the declared
+#     posture matches the body.
 # ---------------------------------------------------------------------------
 if [ -f appinfo/routes.php ]; then
     _ra_fail=0 _ra_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-route-auth.log
     _ra_unresolved_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-route-auth-unresolved.log
     : > "${_ra_log}"
     : > "${_ra_unresolved_log}"
+    _ra_ran=1
+    _ra_helper="${SCRIPT_DIR}/lib/source_scope.py"
+    _ra_maskdir="${HYDRA_GATE_LOG_DIR}/route-auth-masked"
+    mkdir -p "${_ra_maskdir}" 2>/dev/null || true
+    # POSITIVE CONTROL ON THE MASK ITSELF. A helper that is missing, or that
+    # silently emits its input unchanged, would put the gate straight back
+    # into the false-negative it is here to close — and a false negative
+    # leaves no log to notice. So the mask is asked a question with a known
+    # answer before anything is judged: of these two lines, exactly ONE must
+    # survive. Anything else and the gate declines to run (#147, #245).
+    _ra_mask_ok=1
+    if [ ! -f "${_ra_helper}" ]; then
+        _ra_mask_ok=0
+    else
+        set +e
+        _ra_probe=$(printf '// #[NoAdminRequired]\n#[NoAdminRequired]\n' \
+            | python3 "${_ra_helper}" --mask php - 2>/dev/null \
+            | grep -c 'NoAdminRequired')
+        [ "${_ra_probe}" = "1" ] || _ra_mask_ok=0
+    fi
+    if [ "${_ra_mask_ok}" -eq 0 ]; then
+        _ra_ran=0
+        _skip 5 "route-auth" wiring "source_scope.py at ${_ra_helper} could not blank a PHP comment (positive control failed) — NO routed method was judged. Without it a docblock mentioning an attribute name would satisfy this gate silently (#196), so the run declines rather than reporting a pass it cannot support."
+    fi
+    # Comment-masked copy of a controller, cached per path. Echoes the masked
+    # path on success and nothing on failure — the caller treats an empty
+    # answer as UNRESOLVED, never as "no attribute".
+    _ra_masked_copy() {
+        local _src="$1" _dst
+        _dst="${_ra_maskdir}/$(printf '%s' "${_src}" | tr '/' '_')"
+        if [ ! -f "${_dst}" ]; then
+            set +e
+            if ! python3 "${_ra_helper}" --mask php "${_src}" > "${_dst}.tmp" 2>/dev/null; then
+                rm -f "${_dst}.tmp"
+                return 1
+            fi
+            mv "${_dst}.tmp" "${_dst}"
+        fi
+        printf '%s' "${_dst}"
+    }
     # Touching appinfo/routes.php puts every routed method back in scope.
     _ra_routes_touched=0
     _in_scope "appinfo/routes.php" && _ra_routes_touched=1
@@ -1492,6 +1615,8 @@ if [ -f appinfo/routes.php ]; then
     # was written — had never once been reached from either gate.
     while IFS='#' read -r ctrl method; do
             [ -n "${ctrl:-}" ] || continue
+            # The mask's positive control failed; nothing here can be judged.
+            [ "${_ra_ran}" -eq 1 ] || continue
             path=$(_ctrl_path_from_name "${ctrl}")
             if [ ! -f "$path" ]; then
                 if _apphost_serves "${ctrl}" || _di_binds_controller "${path}" \
@@ -1528,8 +1653,33 @@ if [ -f appinfo/routes.php ]; then
             # now go through _head_block, which takes the contiguous annotation
             # run OR the 20-line slice, whichever starts earlier, and keeps the
             # previous-member clamp.
+            #
+            # THREE QUESTIONS, THREE TEXTS (#196).
+            #
+            #   1. an ATTRIBUTE — asked of the comment-MASKED head block, so
+            #      `#[NoAdminRequired]` quoted in a docblock is not one.
+            #   2. a LEGACY DOCBLOCK TAG — asked of the ORIGINAL, because the
+            #      tag lives in a comment by definition, but only at
+            #      tag position: nothing before it on the line except
+            #      whitespace and comment punctuation.
+            #   3. an explicit ADMIN-ONLY DECLARATION with a reason.
+            #
             head_block=$(_head_block "$path" "${def_line}")
-            if ! echo "$head_block" | grep -qE '#\[(PublicPage|NoAdminRequired|NoCSRFRequired|AuthorizedAdminSetting)\b|@(PublicPage|NoAdminRequired|NoCSRFRequired)\b'; then
+            _ra_masked_path=$(_ra_masked_copy "$path")
+            if [ -z "${_ra_masked_path}" ]; then
+                echo "${path}:${def_line} method=${method} — the file could not be comment-masked; NOT JUDGED (a raw-text match here would be the #196 false negative)" >> "${_ra_unresolved_log}"
+                continue
+            fi
+            head_masked=$(_head_block "${_ra_masked_path}" "${def_line}")
+            _ra_declared=0
+            echo "$head_masked" | grep -qE '#\[[^]]*\b(PublicPage|NoAdminRequired|NoCSRFRequired|AuthorizedAdminSetting)\b' && _ra_declared=1
+            if [ "${_ra_declared}" -eq 0 ]; then
+                echo "$head_block" | grep -qE '^[[:space:]]*(/?\*+[[:space:]]*)?@(PublicPage|NoAdminRequired|NoCSRFRequired)\b' && _ra_declared=1
+            fi
+            if [ "${_ra_declared}" -eq 0 ]; then
+                echo "$head_block" | grep -qE '^[[:space:]]*(/?\*+[[:space:]]*)?@auth[[:space:]]+admin-only[[:space:]]+.{20,}' && _ra_declared=1
+            fi
+            if [ "${_ra_declared}" -eq 0 ]; then
                 echo "${path}:${def_line} method=${method} rule=missing-auth-attribute" >> "${_ra_log}"
             fi
     done < <(grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
@@ -1541,10 +1691,12 @@ if [ -f appinfo/routes.php ]; then
     if [ "${_ra_unres}" -gt 0 ]; then
         echo "[hydra-gates] gate-5 route-auth: ${_ra_unres} routed entr(ies) NOT JUDGED (controller class unresolvable here) — see ${_ra_unresolved_log}. This is not a pass for them; reachability is gate-14's."
     fi
-    if [ "${_ra_fail}" -eq 0 ]; then
-        _pass 5 "route-auth"
-    else
-        _fail 5 "route-auth" "${_ra_fail} routed method(s) missing auth attribute — see ${_ra_log}"
+    if [ "${_ra_ran}" -eq 1 ]; then
+        if [ "${_ra_fail}" -eq 0 ]; then
+            _pass 5 "route-auth"
+        else
+            _fail 5 "route-auth" "${_ra_fail} routed method(s) missing auth attribute — see ${_ra_log}"
+        fi
     fi
 fi
 
@@ -1861,29 +2013,60 @@ fi
 # inputLabel (or ariaLabelCombobox). Manual <label> elements break the
 # component's internal a11y wiring (WCAG 1.3.1 / 4.1.2). ADR-004 hard
 # rule. Observed 2026-04-30 on doriath.
+#
+# THE ELEMENT ENDS AT A `>` THAT IS NOT INSIDE AN ATTRIBUTE VALUE (#236).
+#
+# This gate used to extract elements with `grep -oE '<NcSelect[^>]*>'`.
+# `[^>]*` stops at the FIRST `>` in the source, and in an NcSelect that is
+# usually the arrow of `:reduce="(o) => o.id"` — so every prop written after
+# `:reduce` was cut off, including the two this gate looks for. Measured on
+# scholiq 2026-08-08: 18 findings, 18 of them false; each flagged element
+# already carried `:input-label` AND `:aria-label-combobox`, both after
+# `:reduce`. The gate was anti-correlated with its subject there — adding the
+# label could not clear it, removing `:reduce` could. Same shape as gate-9's
+# `[^)]*` in #198.
+#
+# The accepted prop set is UNCHANGED, deliberately — this fixes where an
+# element ends and which regions of the file are markup, not what counts as a
+# name, so the numbers stay comparable.
 # ---------------------------------------------------------------------------
 if [ -d src ]; then
     _il_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-nc-input-labels.log
     : > "${_il_log}"
+    _il_ran=1
+    _il_helper="${SCRIPT_DIR}/lib/check_nc_select_labels.py"
+    _il_files=()
     while IFS= read -r vue; do
+        [ -f "${vue}" ] || continue
         _in_scope "${vue}" || continue
-        _flat=$(tr '\n' ' ' < "${vue}")
-        echo "${_flat}" \
-            | grep -oE '<NcSelect[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                if ! echo "${tag}" | grep -qE "(input-label|inputLabel|aria-label-combobox|ariaLabelCombobox)"; then
-                    echo "${vue}: ${tag}" >> "${_il_log}"
-                fi
-            done
+        _il_files+=("${vue}")
         # .vue only: <NcSelect> is a Vue component. Gate 40 covers the
         # language-agnostic <input>/<select> label rule for PHP templates.
     done < <(find src -name '*.vue' 2>/dev/null)
-    _il_fail=$(wc -l < "${_il_log}" 2>/dev/null || echo 0)
-    if [ "${_il_fail}" -eq 0 ]; then
-        _pass 12 "nc-input-labels"
+    if [ "${#_il_files[@]}" -eq 0 ]; then
+        : # nothing in scope — ordinary diff scoping.
+    elif [ ! -f "${_il_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _il_ran=0
+        _skip 12 "nc-input-labels" wiring "check_nc_select_labels.py not found at ${_il_helper} — ${#_il_files[@]} component(s) were in scope and NONE had their NcSelect elements inspected; unnamed comboboxes are UNVERIFIED by this run."
     else
-        _fail 12 "nc-input-labels" "${_il_fail} NcSelect without inputLabel/ariaLabelCombobox — see ${_il_log}"
+        set +e
+        _il_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-nc-input-labels.err"
+        python3 "${_il_helper}" "${_il_files[@]}" >> "${_il_log}" 2>"${_il_err}"
+        _il_rc=$?
+        if [ "${_il_rc}" -ne 0 ]; then
+            _il_ran=0
+            _skip 12 "nc-input-labels" wiring "check_nc_select_labels.py exited ${_il_rc} — ${#_il_files[@]} component(s) were in scope and NONE were judged. See ${_il_err}."
+        fi
+    fi
+    _il_fail=$(wc -l < "${_il_log}" 2>/dev/null || echo 0)
+    [ -z "${_il_fail}" ] && _il_fail=0
+    if [ "${_il_ran}" -eq 1 ]; then
+        if [ "${_il_fail}" -eq 0 ]; then
+            _pass 12 "nc-input-labels"
+        else
+            _fail 12 "nc-input-labels" "${_il_fail} NcSelect without inputLabel/ariaLabelCombobox — see ${_il_log}"
+        fi
     fi
 fi
 
@@ -3436,38 +3619,67 @@ fi
 # `<img>` elements need a text alternative; decorative images get `alt=""`.
 # Without it, screen-reader users hear the image filename or nothing.
 #
-# Scope: literal `<img ...>` tags in template/SFC sections of `.vue` files.
+# Scope: literal `<img ...>` tags in the RENDERED MARKUP of the file.
 # Excludes `<NcAvatarMenu>` / `<NcUserBubble>` / other component wrappers —
 # those handle accessibility internally per their own component contract.
+#
+# PROSE IS NOT MARKUP (#220, #235).
+#
+# This gate used to `tr '\n' ' '` the whole file and grep the result, so
+# `<script>`, `<style>` and every comment were scanned as if they rendered.
+# Measured: on openbuild ALL THREE findings were JSDoc lines reading
+# `* @param {Event} e - The `<img>` `error` event`, and on launchpad the one
+# finding was a docblock explaining that CnDashboardIcon resolves a URL to an
+# `<img>`. Neither repository contained an unlabelled image. The log itself
+# said so — a real tag prints with its attributes, those printed as the bare
+# four characters `<img>`.
+#
+# Extraction moved to scripts/lib/check_markup_a11y.py, which reads the
+# markup scope only (source_scope.markup_mask) and ends an element at a `>`
+# that is not inside a quoted attribute value. The RULE is unchanged — same
+# accepted alt spellings — so the numbers stay comparable.
 #
 # References:
 #   - ADR-010 (NL Design — WCAG 2.2 AA)
 #   - openspec/architecture/wcag-coverage.md SC 1.1.1
+#   - ConductionNL/.github#220, #235
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+if _a11y_has_markup_dir; then
     _ia_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt.log
     : > "${_ia_log}"
+    _ia_ran=1
+    _ia_helper="${SCRIPT_DIR}/lib/check_markup_a11y.py"
+    _ia_files=()
     while IFS= read -r vue; do
+        [ -f "${vue}" ] || continue
         _in_scope "${vue}" || continue
-        # Flatten multi-line attribute lists so a single grep can match the
-        # opening tag including all its attributes.
-        _flat=$(tr '\n' ' ' < "${vue}")
-        echo "${_flat}" \
-            | grep -oE '<img\b[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                # Any of: `alt=`, `:alt=`, `v-bind:alt=`, `alt-text=` (some
-                # Conduction components proxy the prop under this name).
-                if ! echo "${tag}" | grep -qE '(^|[[:space:]])(:?alt|v-bind:alt|alt-text)='; then
-                    echo "${vue}: ${tag}" >> "${_ia_log}"
-                fi
-            done
+        _ia_files+=("${vue}")
     done < <(_a11y_markup_files)
-    _ia_fail=$(wc -l < "${_ia_log}" 2>/dev/null || echo 0)
-    if [ "${_ia_fail}" -eq 0 ]; then
-        _pass 31 "img-alt"
+    if [ "${#_ia_files[@]}" -eq 0 ]; then
+        : # nothing in scope; the verdict below describes the diff.
+    elif [ ! -f "${_ia_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _ia_ran=0
+        _skip 31 "img-alt" wiring "check_markup_a11y.py not found at ${_ia_helper} — ${#_ia_files[@]} markup file(s) were in scope and NONE were inspected; images without a text alternative (WCAG 1.1.1) are UNVERIFIED by this run."
     else
-        _fail 31 "img-alt" "${_ia_fail} <img> tag(s) without alt attribute — see ${_ia_log}"
+        set +e
+        _ia_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt.err"
+        python3 "${_ia_helper}" --rule img-alt "${_ia_files[@]}" >> "${_ia_log}" 2>"${_ia_err}"
+        _ia_rc=$?
+        if [ "${_ia_rc}" -ne 0 ]; then
+            # A CRASHED CHECKER IS NOT A CLEAN FILE (#245, #249). stderr kept.
+            _ia_ran=0
+            _skip 31 "img-alt" wiring "check_markup_a11y.py exited ${_ia_rc} — ${#_ia_files[@]} markup file(s) were in scope and NONE were judged. See ${_ia_err}."
+        fi
+    fi
+    _ia_fail=$(wc -l < "${_ia_log}" 2>/dev/null || echo 0)
+    [ -z "${_ia_fail}" ] && _ia_fail=0
+    if [ "${_ia_ran}" -eq 1 ]; then
+        if [ "${_ia_fail}" -eq 0 ]; then
+            _pass 31 "img-alt"
+        else
+            _fail 31 "img-alt" "${_ia_fail} <img> tag(s) without alt attribute — see ${_ia_log}"
+        fi
     fi
 fi
 
@@ -3492,62 +3704,63 @@ fi
 #   - ADR-010 (NL Design — WCAG 2.2 AA)
 #   - openspec/architecture/wcag-coverage.md SC 2.1.1, 4.1.2
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+# A COMMENT IS NOT AN ELEMENT — IN EITHER DIRECTION (#236).
+#
+# This gate flattened the whole file and grepped it, so the explanatory
+# comment above a repaired element was itself scored as the element. Measured
+# on softwarecatalog: three files reported, the logged "tag" was `<div
+# @click>` with no attributes — the comment, not the markup — and REWORDING
+# THE COMMENTS took the gate FAIL(3) -> PASS with the elements byte-identical
+# across both runs.
+#
+# The false positive is the cheap half. The expensive half is that a
+# genuinely bad element could be explained away by writing a comment about
+# it, and writing a comment is the natural next step for someone chasing this
+# gate. Scanning proceeds over markup scope only (comments and <script>
+# blanked) via scripts/lib/check_markup_a11y.py, which also ends an element at
+# a `>` outside a quoted value — so a `@click` written after
+# `:title="o.find(x => x.id)"` is now visible, which the old `[^>]*` could
+# not see at all.
+#
+# The RULE is carried over unchanged: same required trio, same `<a href>` and
+# bare-`@click.stop` exemptions.
+#
+#   - ConductionNL/.github#236
+# ---------------------------------------------------------------------------
+if _a11y_has_markup_dir; then
     _sc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-semantic-controls.log
     : > "${_sc_log}"
+    _sc_ran=1
+    _sc_helper="${SCRIPT_DIR}/lib/check_markup_a11y.py"
+    _sc_files=()
     while IFS= read -r vue; do
+        [ -f "${vue}" ] || continue
         _in_scope "${vue}" || continue
-        _flat=$(tr '\n' ' ' < "${vue}")
-        # Match opening tags of non-semantic block/inline elements that have
-        # a click binding. `<a` is included but filtered below if `href` is
-        # also present.
-        echo "${_flat}" \
-            | grep -oE '<(div|span|a|p|li|article|section|header|footer|aside|main|nav)\b[^>]*(@click|v-on:click)[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                # Real anchor with href = native keyboard-accessible; skip.
-                if echo "${tag}" | grep -qE '^<a\b[^>]*\bhref='; then
-                    continue
-                fi
-                # Event-management-only handlers don't represent user
-                # interactions and shouldn't trigger the gate:
-                #   - `@click.stop` with no value     — pure event stop-propagation
-                #   - `@click.stop=""`                — same, explicit empty
-                # Only skip when the click is .stop AND there's no other
-                # `@click` (i.e. no real action handler on the tag). This
-                # closes the false-positive observed on opencatalogi
-                # PublicationCard.vue `<div @click.stop>` wrappers.
-                _stop_only=0
-                if echo "${tag}" | grep -qE '@click\.stop(\s|>|=("\s*"|'\''\s*'\''))'; then
-                    # Any `@click` outside the .stop form? If not, this is
-                    # event-mgmt-only.
-                    if ! echo "${tag}" | grep -qE '@click(\.[a-z]+)*\s*=\s*"[^"]+"' \
-                       || ! echo "${tag}" | grep -qE '@click(\.[a-z]+)*\s*=\s*"[^"]+"' | grep -qv '@click\.stop\s*=\s*""'; then
-                        _stop_only=1
-                    fi
-                fi
-                if [ "${_stop_only}" -eq 1 ]; then continue; fi
-                # Required trio: role= , tabindex= , and a key handler
-                _has_role=0
-                _has_tabindex=0
-                _has_keyhandler=0
-                echo "${tag}" | grep -qE '(^|[[:space:]])(:?role|v-bind:role)=' && _has_role=1
-                echo "${tag}" | grep -qE '(^|[[:space:]])(:?tabindex|v-bind:tabindex)=' && _has_tabindex=1
-                echo "${tag}" | grep -qE '(@keydown|@keyup|@keypress|v-on:keydown|v-on:keyup|v-on:keypress)' && _has_keyhandler=1
-                if [ "${_has_role}" -eq 0 ] || [ "${_has_tabindex}" -eq 0 ] || [ "${_has_keyhandler}" -eq 0 ]; then
-                    _missing=""
-                    [ "${_has_role}" -eq 0 ] && _missing="${_missing}role="
-                    [ "${_has_tabindex}" -eq 0 ] && _missing="${_missing}${_missing:+,}tabindex="
-                    [ "${_has_keyhandler}" -eq 0 ] && _missing="${_missing}${_missing:+,}@keydown"
-                    echo "${vue}: ${tag} rule=missing[${_missing}]" >> "${_sc_log}"
-                fi
-            done
+        _sc_files+=("${vue}")
     done < <(_a11y_markup_files)
-    _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)
-    if [ "${_sc_fail}" -eq 0 ]; then
-        _pass 32 "semantic-controls"
+    if [ "${#_sc_files[@]}" -eq 0 ]; then
+        : # nothing in scope; the verdict below describes the diff.
+    elif [ ! -f "${_sc_helper}" ]; then
+        _sc_ran=0
+        _skip 32 "semantic-controls" wiring "check_markup_a11y.py not found at ${_sc_helper} — ${#_sc_files[@]} markup file(s) were in scope and NONE were inspected; keyboard-inaccessible click targets (WCAG 2.1.1 / 4.1.2) are UNVERIFIED by this run."
     else
-        _fail 32 "semantic-controls" "${_sc_fail} non-semantic element(s) with @click but missing role/tabindex/keyboard handler — use <NcButton> or <button> — see ${_sc_log}"
+        set +e
+        _sc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-semantic-controls.err"
+        python3 "${_sc_helper}" --rule semantic-controls "${_sc_files[@]}" >> "${_sc_log}" 2>"${_sc_err}"
+        _sc_rc=$?
+        if [ "${_sc_rc}" -ne 0 ]; then
+            _sc_ran=0
+            _skip 32 "semantic-controls" wiring "check_markup_a11y.py exited ${_sc_rc} — ${#_sc_files[@]} markup file(s) were in scope and NONE were judged. See ${_sc_err}."
+        fi
+    fi
+    _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)
+    [ -z "${_sc_fail}" ] && _sc_fail=0
+    if [ "${_sc_ran}" -eq 1 ]; then
+        if [ "${_sc_fail}" -eq 0 ]; then
+            _pass 32 "semantic-controls"
+        else
+            _fail 32 "semantic-controls" "${_sc_fail} non-semantic element(s) with @click but missing role/tabindex/keyboard handler — use <NcButton> or <button> — see ${_sc_log}"
+        fi
     fi
 fi
 
@@ -3677,20 +3890,74 @@ fi
 # (Name, Role, Value) — native window dialogs don't expose a queryable
 # role to assistive tech that matches the surrounding NC shell.
 # ---------------------------------------------------------------------------
+#
+# IT GREPPED PROSE, AND IT MISSED THE BRACKET FORM (#224).
+#
+# `grep -rnE '\bwindow\.(confirm|alert|prompt)\s*\('` failed in both
+# directions, measured in four arms on doriath:
+#
+#   arm 1  a comment saying the component deliberately AVOIDS
+#          window.confirm()                             -> FAIL, false RED
+#   arm 2  the same file, comment deleted                -> PASS  (control)
+#   arm 3  `if (!window['confirm']('Delete everything?'))` -> PASS, false GREEN
+#   arm 4  the same code as `window.confirm(...)`        -> FAIL  (control)
+#
+# Arm 1 punishes the code that did the right thing and teaches people not to
+# write down why. Arm 3 is the serious one — on doriath the native call it
+# hid guarded a CASCADING DELETE, and `window['confirm']` is what several
+# minifiers and some lint autofixes emit. `const { confirm } = window` sails
+# through the old regex too.
+#
+# scripts/lib/check_js_call_sites.py anchors on the executable regions of the
+# file (comments blanked, string CONTENTS blanked) and then reads the
+# original text at the same offset, so a documentation string is not a call
+# and a bracket-access call is.
+#
+#   - ConductionNL/.github#224
+# ---------------------------------------------------------------------------
 if _a11y_has_markup_dir; then
     _wc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-window-confirm.log
     : > "${_wc_log}"
+    _wc_ran=1
+    _wc_helper="${SCRIPT_DIR}/lib/check_js_call_sites.py"
+    _wc_files=()
     # templates/ too (#225): a native dialog opened from an inline <script> in a
     # PHP template breaks theming and WCAG exactly as one in a .vue does.
-    grep -rnE '\bwindow\.(confirm|alert|prompt)\s*\(' src/ templates/ appinfo/templates/ \
-        --include='*.vue' --include='*.js' --include='*.ts' \
-        --include='*.php' --include='*.html' --include='*.htm' 2>/dev/null \
-        | _filter_grep_by_scope >> "${_wc_log}" || true
-    _wc_fail=$(wc -l < "${_wc_log}" 2>/dev/null || echo 0)
-    if [ "${_wc_fail}" -eq 0 ]; then
-        _pass 34 "window-confirm"
+    while IFS= read -r _f; do
+        [ -f "${_f}" ] || continue
+        case "${_f}" in
+            *.vue|*.js|*.ts|*.php|*.html|*.htm) ;;
+            *) continue ;;
+        esac
+        _in_scope "${_f}" || continue
+        _wc_files+=("${_f}")
+    done < <(find src templates appinfo/templates -type f \
+        \( -name '*.vue' -o -name '*.js' -o -name '*.ts' \
+           -o -name '*.php' -o -name '*.html' -o -name '*.htm' \) 2>/dev/null \
+        | grep -vE '(^|/)(node_modules|vendor|dist|build|coverage|phpmetrics|\.git)/' || true)
+    if [ "${#_wc_files[@]}" -eq 0 ]; then
+        : # nothing in scope; the verdict below describes the diff.
+    elif [ ! -f "${_wc_helper}" ]; then
+        _wc_ran=0
+        _skip 34 "window-confirm" wiring "check_js_call_sites.py not found at ${_wc_helper} — ${#_wc_files[@]} file(s) were in scope and NONE were inspected; native browser dialogs are UNVERIFIED by this run."
     else
-        _fail 34 "window-confirm" "${_wc_fail} native dialog call(s) — use NcDialog / CnFormDialog — see ${_wc_log}"
+        set +e
+        _wc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-window-confirm.err"
+        python3 "${_wc_helper}" --rule native-dialog "${_wc_files[@]}" >> "${_wc_log}" 2>"${_wc_err}"
+        _wc_rc=$?
+        if [ "${_wc_rc}" -ne 0 ]; then
+            _wc_ran=0
+            _skip 34 "window-confirm" wiring "check_js_call_sites.py exited ${_wc_rc} — ${#_wc_files[@]} file(s) were in scope and NONE were judged. See ${_wc_err}."
+        fi
+    fi
+    _wc_fail=$(wc -l < "${_wc_log}" 2>/dev/null || echo 0)
+    [ -z "${_wc_fail}" ] && _wc_fail=0
+    if [ "${_wc_ran}" -eq 1 ]; then
+        if [ "${_wc_fail}" -eq 0 ]; then
+            _pass 34 "window-confirm"
+        else
+            _fail 34 "window-confirm" "${_wc_fail} native dialog call(s) — use NcDialog / CnFormDialog — see ${_wc_log}"
+        fi
     fi
 fi
 
@@ -4215,37 +4482,83 @@ fi
 # inherit it. Detect templates that emit an `<html>` element without a `lang`
 # attribute. Per WCAG 2.2 AA SC 3.1.1 (Language of Page).
 #
-# Heuristic: PHP template files containing `<html>` (opening tag) must also
-# carry `lang=` on that tag. Pure partial templates that never render
-# `<html>` are skipped.
+# Rule: a template that EMITS an `<html>` opening tag must carry `lang=` on
+# it. Templates that never render one are out of scope — measured, all 30 app
+# templates in this fleet are fragments substituted into core's page, and core
+# emitted their `<html lang>` long before the template's first byte.
+#
+# THREE DEFECTS FIXED 2026-08-08 (#266):
+#
+# (a) A PHP COMMENT MENTIONING `<html>` MADE A MOUNT POINT A PAGE ROOT. The
+#     search ran `re.search(r'<html\b([^>]*)>', txt)` over the RAW file, so
+#
+#         <?php
+#         // Core emitted the <html> element for it, with its lang attribute,
+#         // long before this file.
+#         ?>
+#         <div id="app-settings"></div>
+#
+#     reported `1 <html> tag(s) without lang=` for a file containing no
+#     `<html>` element at all. This is gate-64's defect (#184) and the one
+#     gate-38 shipped a fix for (#247), verbatim — and it fails the other way
+#     too: a commented-out `<html lang="en">` would have SATISFIED the gate
+#     for a template that really does emit an unlangged one. The search now
+#     runs over `php_template_scope.emitted_markup`, which is the same answer
+#     gate-38 uses. `[^>]*` also went — a `>` inside an attribute value is not
+#     the end of the tag (#198, #236).
+#
+# (b) A THIRD SCOPE DEFINITION. This gate enumerated its own
+#     `find templates appinfo/templates -name '*.php'`, which is
+#     `_a11y_markup_files` minus the exclusions, so a generated `phpmetrics/`
+#     or `vendor/` template was audited here and nowhere else. It was the last
+#     a11y gate with a private enumeration; there are now two definitions in
+#     the family, not three, and one of them is shared.
+#
+# (c) NO WIRING GUARD. The block was an inline `python3 - <<'PYHL' >> log
+#     2>/dev/null`, so a crashed interpreter left an empty log and the gate
+#     reported PASS (#147 / #249). Note this gate is quiet across the fleet
+#     today for a reason unrelated to it being correct — no app emits a
+#     document — so a silent failure here would have been invisible
+#     indefinitely.
 #
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 3.1.1
+#   - ConductionNL/.github#266
 # ---------------------------------------------------------------------------
 if [ -d templates ] || [ -d appinfo/templates ]; then
     _hl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-html-lang.log
     : > "${_hl_log}"
+    _hl_ran=1
+    _hl_helper="${SCRIPT_DIR}/lib/php_template_scope.py"
+    _hl_files=()
     while IFS= read -r _f; do
         [ -z "$_f" ] && continue
-        _in_scope "$_f" || continue
-        python3 - "$_f" <<'PYHL' >> "${_hl_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    txt = open(fname).read()
-except Exception:
-    sys.exit(0)
-m = re.search(r'<html\b([^>]*)>', txt, re.IGNORECASE)
-if not m: sys.exit(0)
-if not re.search(r'(^|\s)lang\s*=', m.group(1) or ''):
-    print(f'{fname}: <html> rule=html-tag-without-lang')
-PYHL
-    done < <(find templates appinfo/templates -name '*.php' 2>/dev/null)
-    _hl_fail=$(wc -l < "${_hl_log}" 2>/dev/null || echo 0)
-    if [ "${_hl_fail}" -eq 0 ]; then
-        _pass 41 "html-lang"
+        case "$_f" in *.php) ;; *) continue ;; esac
+        _in_scope "$_f" && _hl_files+=("$_f")
+    done < <(_a11y_markup_files)
+    if [ "${#_hl_files[@]}" -eq 0 ]; then
+        : # nothing in scope; the verdict below describes the diff.
+    elif [ ! -f "${_hl_helper}" ]; then
+        _hl_ran=0
+        _skip 41 "html-lang" wiring "php_template_scope.py not found at ${_hl_helper} — ${#_hl_files[@]} PHP template(s) were in scope and NONE were inspected; a document without a declared language (WCAG 3.1.1) is UNVERIFIED by this run."
     else
-        _fail 41 "html-lang" "${_hl_fail} <html> tag(s) without lang= — see ${_hl_log}"
+        set +e
+        _hl_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-html-lang.err"
+        python3 "${_hl_helper}" --html-lang "${_hl_files[@]}" >> "${_hl_log}" 2>"${_hl_err}"
+        _hl_rc=$?
+        if [ "${_hl_rc}" -ne 0 ]; then
+            _hl_ran=0
+            _skip 41 "html-lang" wiring "php_template_scope.py exited ${_hl_rc} — ${#_hl_files[@]} PHP template(s) were in scope and NONE were judged. See ${_hl_err}."
+        fi
+    fi
+    _hl_fail=$(wc -l < "${_hl_log}" 2>/dev/null || echo 0)
+    [ -z "${_hl_fail}" ] && _hl_fail=0
+    if [ "${_hl_ran}" -eq 1 ]; then
+        if [ "${_hl_fail}" -eq 0 ]; then
+            _pass 41 "html-lang"
+        else
+            _fail 41 "html-lang" "${_hl_fail} <html> tag(s) without lang= — see ${_hl_log}"
+        fi
     fi
 fi
 
@@ -4600,10 +4913,43 @@ fi
 # ---------------------------------------------------------------------------
 _csrf_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-cochange.log
 : > "${_csrf_log}"
+_csrf_ran=1
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
-    # Find removed @NoCSRFRequired lines in changed PHP files
-    _csrf_removed=$(git diff -U0 "${BASE_REF}...HEAD" -- 'lib/Controller/*.php' 2>/dev/null \
-        | grep -E '^-.*(@NoCSRFRequired|#\[NoCSRFRequired\])' || true)
+    # Find removed @NoCSRFRequired lines in changed PHP files.
+    #
+    # A REMOVED COMMENT IS NOT A REMOVED ATTRIBUTE (#191).
+    #
+    # This used to be `grep -E '^-.*(@NoCSRFRequired|#\[NoCSRFRequired\])'`.
+    # `^-.*` puts no constraint on where the token sits, so nldesign went red
+    # for ONE removed sentence of a class docblock —
+    #
+    #   - * (#[PublicPage] + #[NoCSRFRequired]) and the response contract are owned by
+    #
+    # replaced by another sentence saying the same thing. Nothing about CSRF
+    # changed in that diff, and the cheapest way to clear the finding was to
+    # REWORD A COMMENT: a gate satisfiable by prose manufactures the
+    # appearance of a security review. scripts/lib/check_csrf_removal.py
+    # requires the token in a code position — `#[` at the start of the
+    # content, or `@NoCSRFRequired` at docblock-tag position.
+    _csrf_helper="${SCRIPT_DIR}/lib/check_csrf_removal.py"
+    if [ ! -f "${_csrf_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147). Without it the gate
+        # sees no removals at all and goes green on every diff.
+        _csrf_ran=0
+        _skip 48 "csrf-cochange" wiring "check_csrf_removal.py not found at ${_csrf_helper} — the controller diff was NOT examined; a dropped @NoCSRFRequired is UNVERIFIED by this run."
+        _csrf_removed=""
+    else
+        set +e
+        _csrf_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-cochange.err"
+        _csrf_removed=$(git diff -U0 "${BASE_REF}...HEAD" -- 'lib/Controller/*.php' 2>/dev/null \
+            | python3 "${_csrf_helper}" 2>"${_csrf_err}")
+        _csrf_rc=$?
+        if [ "${_csrf_rc}" -ne 0 ]; then
+            _csrf_ran=0
+            _csrf_removed=""
+            _skip 48 "csrf-cochange" wiring "check_csrf_removal.py exited ${_csrf_rc} — the controller diff was NOT examined. See ${_csrf_err}."
+        fi
+    fi
     if [ -n "${_csrf_removed}" ]; then
         # Look for frontend co-change signals in the diff.
         #
@@ -4633,10 +4979,12 @@ set +e
 _csrf_fail=$(wc -l < "${_csrf_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_csrf_fail}" ] && _csrf_fail=0
-if [ "${_csrf_fail}" -eq 0 ]; then
-    _pass 48 "csrf-cochange"
-else
-    _fail 48 "csrf-cochange" "@NoCSRFRequired dropped without frontend CSRF co-change — see ${_csrf_log}"
+if [ "${_csrf_ran}" -eq 1 ]; then
+    if [ "${_csrf_fail}" -eq 0 ]; then
+        _pass 48 "csrf-cochange"
+    else
+        _fail 48 "csrf-cochange" "@NoCSRFRequired dropped without frontend CSRF co-change — see ${_csrf_log}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -5450,25 +5798,65 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-e2e-networkidle/SKILL.md
 # ---------------------------------------------------------------------------
+#
+# A COMMENT WARNING AGAINST IT IS NOT A USE OF IT (#230).
+#
+# The only filter this gate had was the `exclude` marker, so a comment
+# explaining why the last live call was removed counted as a live call.
+# Measured on larpingapp@development: FAIL — 1 finding, and the line was
+#
+#   // live `waitForLoadState('networkidle')` in the suite; every other mention
+#
+# The repo has ZERO live calls; all ten occurrences under tests/ are comments.
+# Doubly perverse: the more carefully a repo documents the ADR-074 rule 4
+# removal, the more findings it accrues — and larpingapp is the repo this gate
+# was written against, so it has the most such comments in the fleet. It was
+# also unfixable in the leaf: the only remedies were deleting the explanation
+# or putting an `exclude` marker on a comment.
+#
+# The naive fix — drop lines starting with `//` — was rejected: it still
+# counts a mention after code on the same line and every block-comment
+# interior line that begins with a letter, and it LOSES a real call carrying a
+# trailing comment. scripts/lib/check_js_call_sites.py blanks the comment
+# REGIONS instead, keeps offsets, and reads the `exclude` marker out of the
+# ORIGINAL line — the marker lives in a comment, which is precisely what the
+# mask removes.
+# ---------------------------------------------------------------------------
 _nwi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-networkidle.log
 : > "${_nwi_log}"
+_nwi_ran=1
+_nwi_helper="${SCRIPT_DIR}/lib/check_js_call_sites.py"
+_nwi_files=()
 while IFS= read -r f; do
     [ -f "$f" ] || continue
     _in_scope "$f" || continue
-    grep -nE "waitForLoadState\([[:space:]]*['\"]networkidle['\"]|waitUntil:[[:space:]]*['\"]networkidle['\"]" "$f" 2>/dev/null \
-        | grep -v "e2e-networkidle exclude" \
-        | while IFS= read -r hit; do
-            echo "${f}:${hit}" >> "${_nwi_log}"
-        done
+    _nwi_files+=("$f")
 done < <(find tests/e2e -type f \( -name '*.ts' -o -name '*.js' \) 2>/dev/null)
+if [ "${#_nwi_files[@]}" -eq 0 ]; then
+    : # nothing in scope; ADR-020 diff scoping working as designed.
+elif [ ! -f "${_nwi_helper}" ]; then
+    _nwi_ran=0
+    _skip 58 "e2e-networkidle" wiring "check_js_call_sites.py not found at ${_nwi_helper} — ${#_nwi_files[@]} e2e file(s) were in scope and NONE were inspected; a wait that never settles is UNVERIFIED by this run."
+else
+    set +e
+    _nwi_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-networkidle.err"
+    python3 "${_nwi_helper}" --rule networkidle "${_nwi_files[@]}" >> "${_nwi_log}" 2>"${_nwi_err}"
+    _nwi_rc=$?
+    if [ "${_nwi_rc}" -ne 0 ]; then
+        _nwi_ran=0
+        _skip 58 "e2e-networkidle" wiring "check_js_call_sites.py exited ${_nwi_rc} — ${#_nwi_files[@]} e2e file(s) were in scope and NONE were judged. See ${_nwi_err}."
+    fi
+fi
 set +e
 _nwi_fail=$(wc -l < "${_nwi_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_nwi_fail}" ] && _nwi_fail=0
-if [ "${_nwi_fail}" -eq 0 ]; then
-    _pass 58 "e2e-networkidle"
-else
-    _fail 58 "e2e-networkidle" "${_nwi_fail} networkidle wait(s) in changed e2e file(s) — never settles on Nextcloud, use waitUntil:'domcontentloaded' (ADR-074 rule 4); see ${_nwi_log}"
+if [ "${_nwi_ran}" -eq 1 ]; then
+    if [ "${_nwi_fail}" -eq 0 ]; then
+        _pass 58 "e2e-networkidle"
+    else
+        _fail 58 "e2e-networkidle" "${_nwi_fail} networkidle wait(s) in changed e2e file(s) — never settles on Nextcloud, use waitUntil:'domcontentloaded' (ADR-074 rule 4); see ${_nwi_log}"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/test-fixtures/route-auth/auth-declared/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/auth-declared/appinfo/routes.php
@@ -1,0 +1,18 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture for ConductionNL/.github#196 — the closing move.
+//
+// The same two endpoints as ../prose-exempt, now DECLARING their posture:
+// one with a real attribute, one with the `@auth admin-only <reason>` marker
+// the tightening ships alongside. Gate-5 must PASS here.
+//
+// Without this arm the fix would be an unclosable gate: absence of
+// #[NoAdminRequired] IS the admin gate, so an admin-only method has no
+// attribute available to satisfy the check with.
+return [
+    'routes' => [
+        ['name' => 'productSubscriptions#subscribe', 'url' => '/api/products/{id}/subscribe', 'verb' => 'POST'],
+        ['name' => 'productSubscriptions#analytics', 'url' => '/api/products/{id}/analytics', 'verb' => 'GET'],
+        ['name' => 'productSubscriptions#legacy',    'url' => '/api/products/{id}/legacy',    'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/auth-declared/lib/Controller/ProductSubscriptionsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/auth-declared/lib/Controller/ProductSubscriptionsController.php
@@ -1,0 +1,48 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+
+/**
+ * Fixture for #196 — the three ways a posture can be DECLARED.
+ *
+ * Note this class docblock deliberately mentions `#[NoAdminRequired]` in
+ * prose, exactly like the ../prose-exempt fixture does. It must buy nothing
+ * for any method here; each one has to declare its own posture.
+ */
+class ProductSubscriptionsController extends Controller
+{
+    /**
+     * Admin-only, declared. The reason is required and must be long enough to
+     * be a reason rather than a shrug.
+     *
+     * @auth admin-only writes billing state for every tenant; admin posture is the absence of NoAdminRequired
+     */
+    public function subscribe(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+
+    /**
+     * An ordinary attribute, in code position.
+     */
+    #[NoAdminRequired]
+    public function analytics(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+
+    /**
+     * The legacy docblock form, at tag position. Still accepted.
+     *
+     * @NoAdminRequired
+     */
+    public function legacy(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/prose-exempt/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/prose-exempt/appinfo/routes.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture for ConductionNL/.github#196 — openconnector's
+// ProductSubscriptionsController shape. Two routed methods with the SAME auth
+// posture (admin-only: no attribute at all). Before the fix, `subscribe` PASSED
+// and `analytics` FAILED, decided entirely by one sentence of prose.
+//
+// Both must now be reported. This fixture is the false-NEGATIVE arm: the
+// acceptance test is that the gate now CATCHES what it used to wave through.
+return [
+    'routes' => [
+        ['name' => 'productSubscriptions#subscribe', 'url' => '/api/products/{id}/subscribe', 'verb' => 'POST'],
+        ['name' => 'productSubscriptions#analytics', 'url' => '/api/products/{id}/analytics', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/prose-exempt/lib/Controller/ProductSubscriptionsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/prose-exempt/lib/Controller/ProductSubscriptionsController.php
@@ -1,0 +1,39 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * Fixture for #196 — prose must not be an auth attribute.
+ *
+ * Both methods below are admin-only endpoints with NO auth attribute. They
+ * differ only in what their docblocks SAY. Under the pre-fix gate that was
+ * the whole difference between a pass and a finding.
+ */
+class ProductSubscriptionsController extends Controller
+{
+    /**
+     * ADMIN ONLY: `#[NoAdminRequired]` is deliberately NOT used here, because
+     * the absence of that attribute is what makes the endpoint admin-only.
+     *
+     * There is no attribute on this method. Before #196 the gate passed it
+     * on this sentence alone.
+     */
+    public function subscribe(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+
+    /**
+     * Same posture, no such sentence. Reported before the fix and after it —
+     * this is the control that proves the pair is decided by CODE now, not by
+     * which docblock happens to name an attribute.
+     */
+    public function analytics(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}


### PR DESCRIPTION
Nine checkers decided a question about **code** by grepping the raw bytes of a file. Prose is made of the same bytes, so every one of them failed in **both directions at once** — the shape #184 named: *"a checker that greps a STRING LITERAL misses every constant and matches every comment."*

| issue | gate | what the gate actually matched |
|---|---|---|
| #191 | 48 csrf-cochange | a **removed comment** naming `#[NoCSRFRequired]` — nldesign red for one rewritten docblock sentence |
| #196 | 5 route-auth | a docblock saying `#[NoAdminRequired]` is *deliberately NOT used* **satisfied the auth gate** |
| #220 | 31 img-alt | an `<img>` in a JSDoc comment in `<script>` (launchpad) |
| #235 | 31 img-alt | the same — **3 of 3** findings on openbuild |
| #224 | 34 window-confirm | false RED on a comment **and** false GREEN on `window['confirm']()` |
| #226 | 3 stub-scan | a `run()` delegating to one helper read as a stub; gate closable by `$unused = 1;` |
| #230 | 58 e2e-networkidle | a comment **warning against** `networkidle` counted as a use of it |
| #236 | 12 nc-input-labels | `<NcSelect[^>]*>` truncated at the `>` of `option =>` |
| #236 | 32 semantic-controls | a comment describing the `<div @click>` an element replaced, scored as that element |
| #266 | 41 html-lang | a PHP comment mentioning `<html>` made a mount point a page root |

`#236` part 3 (gate-38 on `templates/settings/admin.php`) needs no change — **#247 already fixed it**; measured PASS on softwarecatalog in both arms, because that template is a fragment.

---

## One scope definition, not nine

`scripts/lib/source_scope.py` generalises the two precedents that already got this right, rather than inventing a third dialect:

* **#184's PHP stripper** — knows `#` opens a comment but `#[` opens an **attribute**.
* **#249's gate-19 tokeniser** — blank once, **preserve offsets**, keep string *delimiters*.

Every mask returns a **same-length** string. That is what lets a gate report a line number computed on the mask and read a suppression marker out of the **original** at that line — which matters because every suppression marker in this package lives in a comment.

Gate-19 keeps its own copy of the JS tokeniser (moving 180 lines out from under the suite that proves it correct is a bad trade mid-change). A **drift test** asserts the two byte-identical over a corpus, over this package's own `.js` sources, and asserts the keyword sets equal — *the corpus alone survived deleting `"await"` from one set*, so the corpus alone was not enough.

## #196 ships with a declaration, not just a tightening

Admin-only is expressed in Nextcloud by the **absence** of an attribute, and absence is the only thing gate-5 reports. `#[NoAdminRequired]` *widens*; so does `AuthorizedAdminSetting` (to delegated admins). Closing the false negative alone would have converted a silent false negative into a **permanent** false positive on correct code — pipelinq alone would pull 17 routed methods into scope with no legitimate fix available. So the tightening lands **with** a declaration in the `@spec exclude` family:

```php
/**
 * @auth admin-only writes billing state for every tenant; admin posture is the absence of NoAdminRequired
 */
public function update(string $id): JSONResponse
```

**Making bare absence sufficient was considered and rejected**: absence is the *only* thing gate-5 reports, so accepting it would empty the gate completely. gate-9 (semantic-auth) still owns whether the declared posture matches the body. Documented in `hydra-gates/README.md`.

⚠️ gate-5 is **diff-scoped** (ADR-020) — a routed method is judged only when the PR touches its controller or `appinfo/routes.php` — so the fleet impact is per-PR, not a one-off wave.

---

## Evidence

**Planted true positives, both directions, on the real files named in the issues.** Read from the runner's **stdout**, never its exit byte.

| repo | gate | before | after | what changed |
|---|---|---|---|---|
| larpingapp | 58 | **FAIL 1** | **PASS** | the single finding was the comment saying the last live call was removed |
| openbuild | 31 | **FAIL 3** | **PASS** | all three logged as the bare four characters `<img>` — the tell from #235 |
| openbuild | 58 | FAIL 22 | FAIL 14 | 8 dropped, each verified a comment explaining why `networkidle` is *not* used |
| openbuild | 34 | FAIL 7 | FAIL 7 | identical seven lines (see the second commit) |
| openconnector | 12 | FAIL 13 | FAIL 10 | 3 dropped, each carrying `input-label` written **after** `:reduce="(o) => …"` |
| softwarecatalog | 3 | FAIL 2 | **PASS** | one delegating `run()`, one file with **no `run()` at all** |
| portaliq | 3 | **FAIL 1** | **PASS** | `NotificationDispatchJob` — 530 lines, 11 private methods |
| softwarecatalog | 32 | FAIL 2 | **FAIL 3** | **+1 true positive recovered**: `:class="{ clickable: … total_errors > 0 }"` — the `>` inside the attribute value truncated the tag, so `@click` was never seen |
| nldesign | 31/32 | NOT APPLICABLE | PASS | `[ -d src ]` gated them out of a templates-only repo; now `_a11y_has_markup_dir` (residual #225) |
| procest | all | — | unchanged | |

**#196, end-to-end on the fixture built from openconnector's `ProductSubscriptionsController`:** pre-fix `main` reports **1** finding (`analytics`); `subscribe()`, whose only difference is a docblock sentence naming `#[NoAdminRequired]`, **passes**. Post-fix reports **2**. The suite asserts the **count**, because FAIL alone would have been FAIL before the fix too.

**#191, end-to-end through the runner, three arms:**

| arm | pre-fix | post-fix |
|---|---|---|
| the nldesign comment line removed, verbatim | **FAIL** | **PASS** |
| a real `#[\OCP\…\NoCSRFRequired]` attribute removed | **PASS** ← a *second*, unreported false negative | **FAIL** |
| a real ` * @NoCSRFRequired` docblock tag removed | FAIL | FAIL |

## Tests

* **49 suites discovered, 47 pass, 0 fail, 2 pre-existing quarantines** (`tests/run-helper-suites.sh`).
* New: `test_source_scope.py` (41), `test_check_markup_a11y.py` (25), `test_check_js_call_sites.py` (32), `test_check_stub_run_body.py` (20), `test_check_csrf_removal.py` (14), `test_check_nc_select_labels.py` (19, carried from #219). Extended: `test_gate_route_auth.sh` (36), `test_php_template_scope.py` (23), `test_gate_a11y_helper_wiring.sh` (50).
* Every relaxation is paired with the true positive it must not swallow. The fixture that keeps its own explanatory docblock **and** the real construct is deliberate — that trap (a fixture exempting itself with the bug under repair) has already caught an agent on this work.
* **Wiring, both ways, for all nine gates**: a MISSING helper and a CRASHING helper must report `SKIPPED (wiring)`, never PASS (#147, #245, #249). gate-5 additionally runs a **positive control on the mask itself** — a mask that silently returns its input is invisible to `[ -f helper ]` and would put the gate straight back into the false negative.
* **Mutation-checked**, `old in source` asserted before each: reverting each gate's fix to its pre-fix expression — the whole pre-fix behaviour, not one site — kills its suite. 7 of 7 mutants killed. Two earlier mutants on `source_scope` killed too, and one **survived** (deleting a regex keyword), which is why the drift test now compares the keyword sets directly.

## Caught by measurement before landing

* A lazy `<template…>(.*?)</template>` ended the SFC template at the first **nested slot** close and deleted a real finding at openconnector `EditMapping.vue:376`. Boundaries are found by depth now.
* gate-34 reported openbuild's 7 dialogs as **14** by counting the feature-detection guard separately.
* The gate-34 anchor consumed one character too many and silently dropped `const r = window.confirm('x')`.

Closes #191, #196, #220, #224, #226, #230, #235, #266
Refs #236 (parts 1 and 2; part 3 already fixed by #247)
Supersedes #219 — its gate-12 helper and 17 tests are carried here, rebased onto current `main` and converged onto the shared scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
