### PR TITLE
fix(gates 35,40,42,44): four a11y gates excused themselves from a repo full of markup, and three reported PASS over a crashed checker

### DIFF
--- a/hydra-gates/scripts/lib/check_autocomplete.py
+++ b/hydra-gates/scripts/lib/check_autocomplete.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+r"""Gate-44 autocomplete-attr — an `<input>` whose name/id/model says it
+collects a well-known personal detail must declare `autocomplete=`, so browser
+autofill and password managers can fill it. WCAG 2.2 AA SC 1.3.5 (Identify
+Input Purpose).
+
+WHY THIS IS A FILE AND NOT A HEREDOC
+------------------------------------
+gate-44 ran an inline `python3 - "$vue" <<'PYAC' >> log 2>/dev/null` once per
+file and never read the exit status. Measured 2026-08-08 on opencatalogi with
+a `python3` that exits 1 on every invocation, gates 40, 42 and 44 all reported
+PASS — gate-40 over the 13 real findings it had reported one run earlier —
+while every a11y gate whose checker lived in a file reported SKIPPED (wiring).
+An empty log is not a clean sheet (ConductionNL/.github#147 / #249). Moving
+the logic here buys the return-code guard the runner already applies
+everywhere else in the family.
+
+A SINGLE-QUOTED ATTRIBUTE IS THE SAME ATTRIBUTE
+-----------------------------------------------
+The previous regex read values out of DOUBLE QUOTES ONLY:
+
+    re.search(r'(^|\s)(?:name|id|:name|:id|v-model)\s*=\s*"([^"]+)"', attrs)
+
+so `<input id='b44-tel' type='text' name='telephone'>` — identical rendered
+DOM, identical defect — was invisible. Proven by control fixture: the
+double-quoted form fired in both a .vue app and a PHP-template app, the
+single-quoted form reported PASS in both. Zero occurrences in the fleet
+today, which is exactly why it could sit there indefinitely.
+
+`[^>]*` went for the same reason it went from gate-39: a `>` inside an
+attribute value is not the end of the tag (#259, #198, #236).
+
+WHAT IS NOT FLAGGED
+-------------------
+  * `type=` in hidden/submit/button/reset/image/file/checkbox/radio/color/range
+    — nothing to autofill
+  * anything already carrying `autocomplete=`, literal or bound
+  * markup inside comments or `<script>`/`<style>` blocks — an `<input>` in a
+    JS string is not a control. The heredoc this replaces scanned the raw
+    file, so a commented-out example counted; that is the gate-64 defect
+    (#184) and the one gate-38 (#247) and gate-41 (#266) each shipped a fix
+    for.
+
+Usage:
+    check_autocomplete.py <file>...     # findings on stdout, exit 0
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+
+# Quote-aware attribute run: whole quoted values are consumed, so a `>` inside
+# one cannot terminate the tag early.
+INPUT = re.compile(r'<input\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)/?>',
+                   re.IGNORECASE | re.DOTALL)
+
+SKIP_TYPE = re.compile(
+    r'(?:^|\s)type\s*=\s*["\']'
+    r'(?:hidden|submit|button|reset|image|file|checkbox|radio|color|range)["\']',
+    re.IGNORECASE)
+HAS_AUTOCOMPLETE = re.compile(r'(?:^|\s)(?::|v-bind:)?autocomplete\s*=')
+# Both quote styles. The name is captured so the finding can name it.
+NAME_LIKE = re.compile(
+    r'(?:^|\s)(?::|v-bind:)?(?:name|id|v-model)\s*=\s*'
+    r'(?:"([^"]+)"|\'([^\']+)\')')
+SEMANTIC = re.compile(
+    r'(email|tel(?:ephone)?|phone|firstname|lastname|fullname|address|street'
+    r'|city|postal|postcode|zip|country|password|username|organization'
+    r'|birthday|dob)', re.IGNORECASE)
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    txt = BLOCK.sub(' ', COMMENT.sub(' ', src)).replace('\n', ' ')
+    findings: list[str] = []
+    for m in INPUT.finditer(txt):
+        attrs = m.group(1) or ''
+        if SKIP_TYPE.search(attrs):
+            continue
+        if HAS_AUTOCOMPLETE.search(attrs):
+            continue
+        # EVERY name-like attribute, not just the first one found. The regex
+        # this replaces used `re.search`, so the FIRST of name/id/v-model
+        # decided the verdict alone:
+        #
+        #     <input id="e" type="text" name="email">
+        #
+        # matched `id="e"`, found no semantic noun in `e`, and stopped — while
+        # `name="email"` sat one attribute to the right. Caught by
+        # test_a_semantic_input_without_autocomplete, which is the plainest
+        # textbook case this gate has.
+        for name_m in NAME_LIKE.finditer(attrs):
+            val = name_m.group(1) if name_m.group(1) is not None else name_m.group(2)
+            if SEMANTIC.search(val):
+                findings.append(
+                    f'{fname}: <input name/id="{val}" ...> '
+                    f'rule=semantic-input-without-autocomplete')
+                break
+    return findings
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_link_text.py
+++ b/hydra-gates/scripts/lib/check_link_text.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+r"""Gate-42 link-text-quality — a link whose text does not describe its
+destination ("click here", "read more", or nothing at all) fails WCAG 2.2 AA
+SC 2.4.4 (Link Purpose — In Context).
+
+WHY THIS IS A FILE AND NOT A HEREDOC
+------------------------------------
+Until now gate-42 ran an inline `python3 - "$vue" <<'PYLQ' >> log 2>/dev/null`
+ONCE PER FILE, and never looked at the exit status. Measured 2026-08-08 on
+opencatalogi with a `python3` on PATH that exits 1 on every invocation:
+
+    [gate-40] form-label-association: PASS      <- 13 real findings a run earlier
+    [gate-42] link-text-quality:      PASS
+    [gate-44] autocomplete-attr:      PASS
+
+while gates 34, 37, 38, 39, 41 and 43 — the ones whose checker already lived in
+a file behind a return-code guard — all correctly reported SKIPPED (wiring).
+A crashed checker left an empty log, and an empty log was read as a clean
+sheet. That is ConductionNL/.github#147 / #249 exactly, surviving in the three
+a11y gates that still inlined their Python. `2>/dev/null` made the traceback
+invisible on top of it.
+
+Moving the logic here buys the wiring guard the runner already applies to
+every other a11y helper: the findings are STDOUT, the exit code is a STATUS,
+and a non-zero status is a wiring failure rather than a verdict.
+
+WHAT IS FLAGGED
+---------------
+`<a>`, `<router-link>` and `<RouterLink>` whose visible body, after nested
+markup is stripped, is empty or one of the known non-descriptive phrases.
+
+WHAT IS NOT
+-----------
+  * a link carrying `aria-label` / `aria-labelledby`, bound or literal — it
+    names itself, and the accessible name is what SC 2.4.4 is about
+  * a link whose body contains a Vue interpolation `{{ … }}` — the text is
+    computed and this checker cannot read it
+  * anything inside an HTML comment or a `<script>`/`<style>` block: markup
+    that does not ship is not a link
+
+QUOTE AND `>` HANDLING
+----------------------
+The attribute run is matched quote-aware rather than with `[^>]*`. A `>`
+inside an attribute value is not the end of a tag — the defect that hid 19
+buttons across 6 apps from gate-39 (#259, #198, #236) — and
+`<a :title="a > b" href="…">click here</a>` must still be read as one tag.
+
+Usage:
+    check_link_text.py <file>...        # findings on stdout, exit 0
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
+
+# Quote-aware attribute run — see the docstring. `(?:"[^"]*"|'[^']*'|[^>"'])*?`
+# consumes whole quoted values, so a `>` inside one cannot terminate the tag.
+_ATTRS = r'((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)'
+LINKS = [
+    (re.compile(r'<a\b' + _ATTRS + r'>(.*?)</a\s*>', re.IGNORECASE | re.DOTALL), 'a'),
+    (re.compile(r'<router-link\b' + _ATTRS + r'>(.*?)</router-link\s*>',
+                re.IGNORECASE | re.DOTALL), 'router-link'),
+    (re.compile(r'<RouterLink\b' + _ATTRS + r'>(.*?)</RouterLink\s*>',
+                re.DOTALL), 'RouterLink'),
+]
+
+# A BOUND NAME IS STILL A NAME (#259). `:?` binds to the FIRST alternative
+# only, which is how gate-39 came to read `:title` as missing for all 22 of
+# openbuild's findings. The prefix group is factored out so every alternative
+# accepts the bound form.
+NAMED = re.compile(r'(?:^|\s)(?::|v-bind:)?(?:aria-label|aria-labelledby)\s*=')
+BAD = re.compile(
+    r'^(click\s*here|here|read\s*more|learn\s*more|more|continue|see\s*more|details)'
+    r'[.!…]?$', re.IGNORECASE)
+ANY_TAG = re.compile(r'<[^>]*>', re.DOTALL)
+
+
+def scan_source(fname: str, src: str) -> list[str]:
+    txt = BLOCK.sub(' ', COMMENT.sub(' ', src)).replace('\n', ' ')
+    findings: list[str] = []
+    for pat, tagname in LINKS:
+        for m in pat.finditer(txt):
+            attrs = m.group(1) or ''
+            body = m.group(2) or ''
+            if NAMED.search(attrs):
+                continue
+            if '{{' in body and '}}' in body:
+                continue
+            body_text = re.sub(r'\s+', ' ', ANY_TAG.sub('', body)).strip()
+            if not body_text or BAD.match(body_text):
+                findings.append(
+                    f'{fname}: <{tagname}> body="{body_text}" '
+                    f'rule=link-text-not-descriptive')
+    return findings
+
+
+def scan_files(files: list[str]) -> list[str]:
+    out: list[str] = []
+    for fname in files:
+        try:
+            with open(fname, encoding='utf-8', errors='replace') as f:
+                src = f.read()
+        except OSError:
+            continue
+        out.extend(scan_source(fname, src))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    for line in scan_files(argv[1:]):
+        print(line)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/test_check_autocomplete.py
+++ b/hydra-gates/scripts/lib/test_check_autocomplete.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_autocomplete (gate-44). Run with:
+
+    python3 scripts/lib/test_check_autocomplete.py
+
+THE CONTROL THAT NAMED THE DEFECT
+---------------------------------
+`test_a_single_quoted_name_is_the_same_defect` is the fixture experiment run
+as an assertion: the double-quoted form fired in both a .vue app and a
+PHP-template app, and the byte-for-byte equivalent single-quoted form reported
+PASS in both, because the value regex read out of double quotes only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_autocomplete as cac  # noqa: E402
+
+
+def rules(markup: str, fname: str = "Component.vue") -> list[str]:
+    return [line.rsplit("rule=", 1)[1]
+            for line in cac.scan_source(fname, markup)]
+
+
+class ItCatchesTheTextbookCase(unittest.TestCase):
+    def test_a_semantic_input_without_autocomplete(self):
+        self.assertEqual(rules('<input id="e" type="text" name="email">'),
+                         ["semantic-input-without-autocomplete"])
+
+    def test_every_semantic_noun(self):
+        for name in ("email", "telephone", "phone", "firstname", "lastname",
+                     "address", "street", "city", "postcode", "country",
+                     "password", "username", "organization", "birthday"):
+            with self.subTest(name=name):
+                self.assertEqual(rules(f'<input type="text" name="{name}">'),
+                                 ["semantic-input-without-autocomplete"], name)
+
+    def test_a_php_template_input_is_the_same_defect(self):
+        self.assertEqual(
+            rules('<div id="x"><input type="text" name="email"></div>',
+                  "templates/settings/admin.php"),
+            ["semantic-input-without-autocomplete"])
+
+    def test_a_single_quoted_name_is_the_same_defect(self):
+        # THE MEASURED BLIND SPOT. Identical rendered DOM, identical defect;
+        # the pre-fix regex matched double quotes only and reported PASS.
+        self.assertEqual(
+            rules("<input id='b44-tel' type='text' name='telephone'>"),
+            ["semantic-input-without-autocomplete"])
+
+    def test_the_double_quoted_positive_control(self):
+        # Absence is what a wrong lookup manufactures for free: the same
+        # markup in the quoting style that already worked must still fire, or
+        # the assertion above could be passing for the wrong reason.
+        self.assertEqual(
+            rules('<input id="b44-tel" type="text" name="telephone">'),
+            ["semantic-input-without-autocomplete"])
+
+
+class ItLeavesCorrectAndIrrelevantInputsAlone(unittest.TestCase):
+    def test_autocomplete_present(self):
+        self.assertEqual(
+            rules('<input type="email" name="email" autocomplete="email">'), [])
+
+    def test_a_bound_autocomplete_is_still_an_autocomplete(self):
+        for attr in (':autocomplete="mode"', 'v-bind:autocomplete="mode"'):
+            with self.subTest(attr=attr):
+                self.assertEqual(
+                    rules(f'<input type="text" name="email" {attr}>'), [], attr)
+
+    def test_types_with_nothing_to_autofill(self):
+        for t in ("hidden", "submit", "button", "reset", "image", "file",
+                  "checkbox", "radio", "color", "range"):
+            with self.subTest(t=t):
+                self.assertEqual(rules(f'<input type="{t}" name="email">'), [], t)
+
+    def test_a_non_semantic_name(self):
+        self.assertEqual(rules('<input type="text" name="publicationTitle">'), [])
+
+    def test_an_input_with_no_name_id_or_model(self):
+        self.assertEqual(rules('<input type="text">'), [])
+
+
+class ItReadsOnlyMarkupThatShips(unittest.TestCase):
+    def test_a_commented_out_input_is_not_a_control(self):
+        self.assertEqual(
+            rules('<!-- <input type="text" name="email"> was the old field -->'),
+            [])
+
+    def test_an_input_in_a_script_string_is_not_a_control(self):
+        self.assertEqual(
+            rules('<script>el.innerHTML = \'<input type="text" name="email">\'</script>'),
+            [])
+
+    def test_the_positive_control_for_both(self):
+        self.assertEqual(rules('<input type="text" name="email"> was the old field'),
+                         ["semantic-input-without-autocomplete"])
+
+
+class TheTagBoundaryIsQuoteAware(unittest.TestCase):
+    def test_a_gt_inside_an_attribute_does_not_end_the_tag(self):
+        # `[^>]*` ended the tag at the `>` in the expression, so `name=` fell
+        # outside the attribute run and the input read as nameless — the
+        # false-NEGATIVE half of #259.
+        self.assertEqual(
+            rules('<input type="text" :class="n > 5 ? \'a\' : \'b\'" name="email">'),
+            ["semantic-input-without-autocomplete"])
+
+    def test_and_an_autocomplete_past_that_gt_is_still_honoured(self):
+        self.assertEqual(
+            rules('<input type="text" :class="n > 5 ? \'a\' : \'b\'" '
+                  'name="email" autocomplete="email">'),
+            [])
+
+
+class TheMutantIsTheWholePreFixChecker(unittest.TestCase):
+    """The pre-fix heredoc, verbatim from run-hydra-gates.sh, replayed over
+    the fixtures above. It must DISAGREE with the current checker on every one
+    of them — otherwise the rewrite changed nothing."""
+
+    PRE_FIX_INPUTS = [
+        "<input id='b44-tel' type='text' name='telephone'>",
+        '<!-- <input type="text" name="email"> was the old field -->',
+        '<input type="text" :class="n > 5 ? \'a\' : \'b\'" name="email">',
+        # first-name-like-attribute-wins: `id="e"` is not semantic, `name` is
+        '<input id="e" type="text" name="email">',
+    ]
+
+    def _pre_fix(self, markup: str) -> int:
+        import re
+        txt = markup.replace('\n', ' ')
+        sem = re.compile(
+            r'(email|tel(?:ephone)?|phone|firstname|lastname|fullname|address'
+            r'|street|city|postal|postcode|zip|country|password|username'
+            r'|organization|birthday|dob)', re.IGNORECASE)
+        n = 0
+        for m in re.finditer(r'<input\b([^>]*)>', txt, re.IGNORECASE):
+            attrs = m.group(1) or ''
+            if re.search(r'(^|\s)type\s*=\s*"(hidden|submit|button|reset|image'
+                         r'|file|checkbox|radio|color|range)"', attrs,
+                         re.IGNORECASE):
+                continue
+            if re.search(r'(^|\s)(:?autocomplete|v-bind:autocomplete)\s*=', attrs):
+                continue
+            nm = re.search(r'(^|\s)(?:name|id|:name|:id|v-model)\s*=\s*"([^"]+)"',
+                           attrs)
+            if not nm:
+                continue
+            if sem.search(nm.group(2)):
+                n += 1
+        return n
+
+    def test_the_pre_fix_checker_answers_differently(self):
+        differed = 0
+        for markup in self.PRE_FIX_INPUTS:
+            if self._pre_fix(markup) != len(rules(markup)):
+                differed += 1
+        self.assertEqual(
+            differed, len(self.PRE_FIX_INPUTS),
+            "the pre-fix implementation agrees with the current one on every "
+            "fixture — the rewrite is unverified")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_link_text.py
+++ b/hydra-gates/scripts/lib/test_check_link_text.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_link_text (gate-42). Run with:
+
+    python3 scripts/lib/test_check_link_text.py
+
+EVERY RELAXATION SHIPS WITH THE TRUE POSITIVE IT MUST NOT SWALLOW. gate-42 is
+the highest-false-positive gate in the a11y family — "Read more" can be
+descriptive in context — so each exemption below is paired with the
+non-descriptive link that must still fail through it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_link_text as clt  # noqa: E402
+
+
+def rules(markup: str, fname: str = "Component.vue") -> list[str]:
+    return [line.rsplit("rule=", 1)[1]
+            for line in clt.scan_source(fname, markup)]
+
+
+class ItCatchesTheTextbookCase(unittest.TestCase):
+    def test_click_here(self):
+        self.assertEqual(rules('<a href="/docs">click here</a>'),
+                         ["link-text-not-descriptive"])
+
+    def test_read_more_and_friends(self):
+        for body in ("Read more", "Learn more", "Details", "Here", "more",
+                     "See more", "Continue"):
+            with self.subTest(body=body):
+                self.assertEqual(rules(f'<a href="/x">{body}</a>'),
+                                 ["link-text-not-descriptive"], body)
+
+    def test_an_empty_link_body(self):
+        self.assertEqual(rules('<a href="/x"><span class="icon-arrow" /></a>'),
+                         ["link-text-not-descriptive"])
+
+    def test_router_link_forms(self):
+        self.assertEqual(rules('<router-link to="/x">click here</router-link>'),
+                         ["link-text-not-descriptive"])
+        self.assertEqual(rules('<RouterLink to="/x">click here</RouterLink>'),
+                         ["link-text-not-descriptive"])
+
+    def test_trailing_punctuation_does_not_rescue_it(self):
+        self.assertEqual(rules('<a href="/x">Click here!</a>'),
+                         ["link-text-not-descriptive"])
+
+    def test_a_php_template_link_is_the_same_defect(self):
+        # The whole reason #225/#261 exists: WCAG does not care which
+        # templating language produced the DOM.
+        self.assertEqual(
+            rules('<div id="x"><a href="/docs">click here</a></div>',
+                  "templates/settings/admin.php"),
+            ["link-text-not-descriptive"])
+
+
+class ItLeavesDescriptiveLinksAlone(unittest.TestCase):
+    def test_descriptive_text(self):
+        self.assertEqual(rules('<a href="/docs">Read the publication guide</a>'),
+                         [])
+
+    def test_aria_label_names_the_link(self):
+        self.assertEqual(
+            rules('<a href="/x" aria-label="Open the publication guide">more</a>'),
+            [])
+
+    def test_a_BOUND_aria_label_is_still_a_name(self):
+        # The `:?`-binds-to-the-first-alternative defect that produced all 22
+        # of openbuild's gate-39 findings (#259). Every alternative must
+        # accept the bound form, not just the first one.
+        for attr in (':aria-label="t(\'app\', \'Open guide\')"',
+                     'v-bind:aria-label="label"',
+                     ':aria-labelledby="labelId"',
+                     'v-bind:aria-labelledby="labelId"'):
+            with self.subTest(attr=attr):
+                self.assertEqual(rules(f'<a href="/x" {attr}>more</a>'), [], attr)
+
+    def test_an_interpolated_body_is_not_readable_here(self):
+        self.assertEqual(rules('<a href="/x">{{ publication.title }}</a>'), [])
+
+
+class ItReadsOnlyMarkupThatShips(unittest.TestCase):
+    def test_a_commented_out_link_is_not_a_link(self):
+        # gate-64's defect (#184), the one gate-38 (#247) and gate-41 (#266)
+        # each had to ship a fix for: a checker that greps raw text matches
+        # every comment. The heredoc this replaced did exactly that.
+        self.assertEqual(
+            rules('<!-- <a href="/x">click here</a> was the old copy -->'), [])
+
+    def test_a_link_inside_a_script_block_is_not_a_link(self):
+        self.assertEqual(
+            rules('<script>const s = \'<a href="/x">click here</a>\'</script>'),
+            [])
+
+    def test_the_positive_control_for_both(self):
+        # Absence is what a wrong lookup manufactures for free. Same two
+        # inputs with the wrapper removed MUST fire, or the two assertions
+        # above prove nothing.
+        self.assertEqual(rules('<a href="/x">click here</a> was the old copy'),
+                         ["link-text-not-descriptive"])
+
+
+class TheTagBoundaryIsQuoteAware(unittest.TestCase):
+    def test_a_gt_inside_an_attribute_does_not_end_the_tag(self):
+        # `[^>]*` ended a tag at the `>` inside `pin.length >= 6` and hid 19
+        # buttons across 6 apps from gate-39 (#259). Same class of parse, same
+        # trap.
+        self.assertEqual(
+            rules('<a href="/x" :title="count > 5 ? a : b">click here</a>'),
+            ["link-text-not-descriptive"])
+
+    def test_and_it_still_honours_an_aria_label_past_that_gt(self):
+        self.assertEqual(
+            rules('<a href="/x" :class="n > 5 ? \'a\' : \'b\'" '
+                  'aria-label="Open the guide">more</a>'),
+            [])
+
+
+class TheMutantIsTheWholePreFixChecker(unittest.TestCase):
+    """The honest mutant for a repeated defect is the pre-fix implementation.
+
+    gate-42's pre-fix body, verbatim from run-hydra-gates.sh: raw text, no
+    comment or script stripping, `[^>]*` attribute runs. Replaying it over the
+    fixtures above must produce a DIFFERENT answer from the current checker —
+    otherwise the rewrite changed nothing and these tests are decoration.
+    """
+
+    PRE_FIX_INPUTS = [
+        '<!-- <a href="/x">click here</a> was the old copy -->',
+        '<a href="/x" :title="count > 5 ? a : b">click here</a>',
+    ]
+
+    def _pre_fix(self, markup: str) -> int:
+        import re
+        txt = markup.replace('\n', ' ')
+        bad = re.compile(
+            r'^(click\s*here|here|read\s*more|learn\s*more|more|continue'
+            r'|see\s*more|details)\.?$', re.IGNORECASE)
+        n = 0
+        for m in re.finditer(r'<a\b([^>]*)>(.*?)</a>', txt,
+                             re.IGNORECASE | re.DOTALL):
+            attrs, body = m.group(1) or '', m.group(2) or ''
+            if re.search(r'(:?aria-label|aria-labelledby)\s*=', attrs):
+                continue
+            if '{{' in body and '}}' in body:
+                continue
+            body_text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', body)).strip()
+            if not body_text or bad.match(body_text):
+                n += 1
+        return n
+
+    def test_the_pre_fix_checker_answers_differently(self):
+        differed = 0
+        for markup in self.PRE_FIX_INPUTS:
+            if self._pre_fix(markup) != len(rules(markup)):
+                differed += 1
+        self.assertEqual(
+            differed, len(self.PRE_FIX_INPUTS),
+            "the pre-fix implementation agrees with the current one on "
+            "every fixture — the rewrite is unverified")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_helper_wiring.sh
@@ -46,6 +46,10 @@ cat > "${_APP}/src/Thing.vue" <<'VUE'
 		<img src="/no-alt.png">
 		<div @click="go()">click-only</div>
 		<NcSelect :options="opts" />
+		<button type="button"><span class="icon-delete" /></button>
+		<a href="/docs">click here</a>
+		<input type="text" name="email">
+		<NcCheckboxRadioSwitch :checked="on" @update:checked="v => on = v" />
 		<table>
 			<tr><th>Name</th><th>Size</th></tr>
 			<tr><td>a</td><td>1</td></tr>
@@ -139,6 +143,18 @@ _WIRED=(
     "34:window-confirm:check_js_call_sites.py"
     "41:html-lang:php_template_scope.py"
     "58:e2e-networkidle:check_js_call_sites.py"
+    # Added 2026-08-08. Gates 40, 42 and 44 were the last three a11y gates
+    # whose checker ran without a return-code guard: 40 as
+    # `python3 helper … 2>/dev/null || true`, 42 and 44 as per-file inline
+    # heredocs. Measured on opencatalogi with a `python3` that exits 1 on
+    # every call, all three reported PASS — gate-40 over the 13 real findings
+    # it had reported one run earlier — while every gate already in this table
+    # reported SKIPPED (wiring). gate-39 was wired correctly but never listed
+    # here, so nothing held it to that.
+    "39:button-name:check_button_name.py"
+    "40:form-label-association:check_form_labels.py"
+    "42:link-text-quality:check_link_text.py"
+    "44:autocomplete-attr:check_autocomplete.py"
 )
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
@@ -251,7 +251,9 @@ _nosrc_caught=0
 _nosrc_total=0
 while IFS=: read -r _g _what; do
     [ -z "${_g}" ] && continue
-    case " 38 45 " in *" ${_g} "*) continue ;; esac   # not in the list above
+    # gate-45 (prefers-reduced-motion) is outside the 34-44 band this arm
+    # repairs and still guards on `[ -d src ]`; gate-38 is not in _expect.
+    case "${_g}" in 38|45) continue ;; esac
     _nosrc_total=$((_nosrc_total + 1))
     if grep -qE "^\[gate-${_g}\][^:]*: FAIL" "${_nosrc_out}"; then
         _nosrc_caught=$((_nosrc_caught + 1))

--- a/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
@@ -193,6 +193,77 @@ else
     _bad "gate-31 stopped catching a .vue <img> without alt — the widening REPLACED the Vue scope instead of adding to it"
 fi
 
+# ---------------------------------------------------------------------------
+# ARM 4 — A REPO WITH NO src/ AT ALL MUST NOT SILENCE HALF THE FAMILY.
+#
+# ARM 1 above passes with `src/` present but empty of markup, which is
+# nldesign's real shape. Delete that directory — a templates-only app — and
+# the guards diverge. Measured 2026-08-08 at package sha cdfbd7a, same files,
+# same run:
+#
+#   gate-34/36/37/38/39/41/43   ran; four of them FAILED on the plants
+#   gate-35/40/42/44            NOT APPLICABLE — "this repo ships no frontend,
+#                               so there is no .vue/.js/.ts source for this
+#                               gate to inspect"
+#
+# Those four still guarded on `[ -d src ]` while their siblings had moved to
+# `_a11y_has_markup_dir`, and the central applicability table listed the whole
+# family under `[ -d src ]`. `na` is the one verdict that removes a gate from
+# coverage accounting — so four accessibility gates excused themselves from a
+# repo full of markup, giving a reason the same run's own output contradicted.
+#
+# The assertion is deliberately about NOT-APPLICABLE rather than about the
+# findings: a gate that has become blind can still be caught by ARM 1, but a
+# gate that has declared itself irrelevant is invisible to every arm above.
+# ---------------------------------------------------------------------------
+_nosrc_app="${_tmp}/nosrc"
+_mkapp "${_nosrc_app}"
+cp "${_bad_app}/templates/settings/admin.php" "${_nosrc_app}/templates/settings/admin.php"
+rm -rf "${_nosrc_app}/src"
+(
+    cd "${_nosrc_app}" || exit 1
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm nosrc
+) >/dev/null 2>&1
+_nosrc_out="${_tmp}/nosrc.txt"
+_run "${_nosrc_app}" "${_nosrc_out}"
+
+_excused=""
+_still=""
+for _g in 31 32 34 35 36 37 39 40 42 43 44; do
+    if grep -qE "^\[gate-${_g}\][^:]*: NOT APPLICABLE" "${_nosrc_out}"; then
+        _excused="${_excused} ${_g}"
+    elif ! grep -qE "^\[gate-${_g}\]" "${_nosrc_out}"; then
+        _still="${_still} ${_g}"
+    fi
+done
+if [ -n "${_excused}" ]; then
+    _bad "templates-only repo: gate(s)${_excused} declared NOT APPLICABLE over a templates/ full of markup — an accessibility gate excused itself from a DOM it can read"
+elif [ -n "${_still}" ]; then
+    _bad "templates-only repo: gate(s)${_still} emitted no verdict line at all — silence is byte-identical to success"
+else
+    _ok "a templates-only repo (no src/) keeps every accessibility gate applicable"
+fi
+
+# ...and the plants in it are still CAUGHT, not merely "not excused". A gate
+# that reports PASS over markup it never opened is the #225 defect itself.
+_nosrc_caught=0
+_nosrc_total=0
+while IFS=: read -r _g _what; do
+    [ -z "${_g}" ] && continue
+    case " 38 45 " in *" ${_g} "*) continue ;; esac   # not in the list above
+    _nosrc_total=$((_nosrc_total + 1))
+    if grep -qE "^\[gate-${_g}\][^:]*: FAIL" "${_nosrc_out}"; then
+        _nosrc_caught=$((_nosrc_caught + 1))
+    else
+        _v=$(grep -oE "^\[gate-${_g}\] [^:]+: [A-Z ]+" "${_nosrc_out}" | head -1 | sed 's/^[^:]*: //')
+        _bad "templates-only repo: gate-${_g} did not catch: ${_what} (verdict: ${_v:-none emitted})"
+    fi
+done <<< "${_expect}"
+if [ "${_nosrc_caught}" -eq "${_nosrc_total}" ]; then
+    _ok "all ${_nosrc_total} accessibility gates caught their planted true positive with NO src/ directory at all"
+fi
+
 echo
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_a11y_markup_scope.sh: ALL PASS"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -4067,7 +4067,7 @@ fi
 #   - ADR-010 (NL Design — WCAG 2.2 AA)
 #   - openspec/architecture/wcag-coverage.md SC 1.1.1 (Non-text Content)
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+if _a11y_has_markup_dir; then
     _iae_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt-empty-only.log
     : > "${_iae_log}"
     while IFS= read -r vue; do
@@ -4080,14 +4080,18 @@ if [ -d src ]; then
                 # Must have literal alt="" (not bound `:alt=""` — bound expressions
                 # with computed-default-empty are out of scope; the developer there
                 # at least went through a prop pipeline).
-                echo "${tag}" | grep -qE 'alt\s*=\s*"\s*"' || continue
+                # Both quote styles: `alt=''` renders identically to `alt=""`
+                # and was invisible here. Measured as a PASS on a planted
+                # `<img src='/img/avatar.png' alt=''> in both a .vue app and a
+                # PHP-template app.
+                echo "${tag}" | grep -qE 'alt[[:space:]]*=[[:space:]]*("[[:space:]]*"|'"'"'[[:space:]]*'"'"')' || continue
                 # Must have a src that names a semantic noun. A BOUND :src /
                 # v-bind:src carries the noun in its expression; a PHP template
                 # or plain HTML carries it in the literal attribute value
                 # (`src="<?php p($avatarUrl) ?>"`, `src="/img/avatar.png"`).
                 # Both mean the same thing — the author knew the image was a
                 # person or a picture and still gave it an empty alt (#225).
-                _src_expr=$(echo "${tag}" | grep -oE '(:src|v-bind:src|src)\s*=\s*"[^"]*"' | head -1 || true)
+                _src_expr=$(echo "${tag}" | grep -oE '(:src|v-bind:src|src)[[:space:]]*=[[:space:]]*("[^"]*"|'"'"'[^'"'"']*'"'"')' | head -1 || true)
                 [ -z "${_src_expr}" ] && continue
                 if echo "${_src_expr}" | grep -qiE '\b(avatar|photo|thumbnail|picture|headshot|portrait|profilePicture)\b'; then
                     echo "${vue}: ${tag} rule=empty-alt-on-semantic-bound-src" >> "${_iae_log}"
@@ -4123,7 +4127,12 @@ if _a11y_has_markup_dir; then
     # form where the value is bound (`:tabindex="..."` is reviewer-judgment).
     # templates/ too (#225): focus order is a property of the rendered DOM, not
     # of the language that emitted it.
-    grep -rnE 'tabindex[[:space:]]*=[[:space:]]*"[[:space:]]*[1-9][0-9]*[[:space:]]*"' src/ templates/ appinfo/templates/ \
+    #
+    # BOTH QUOTE STYLES. The pattern read `"` only, so `tabindex='5'` — the
+    # same rendered DOM, the same defect — reported PASS in both a .vue app
+    # and a PHP-template app when it was planted there. Zero occurrences in
+    # the fleet today, which is precisely why it could sit here unnoticed.
+    grep -rnE 'tabindex[[:space:]]*=[[:space:]]*["'"'"'][[:space:]]*[1-9][0-9]*[[:space:]]*["'"'"']' src/ templates/ appinfo/templates/ \
         --include='*.vue' --include='*.js' --include='*.ts' \
         --include='*.php' --include='*.html' --include='*.htm' 2>/dev/null \
         | _filter_grep_by_scope >> "${_tp_log}" || true
@@ -4526,7 +4535,7 @@ fi
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 1.3.1, 3.3.2
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+if _a11y_has_markup_dir; then
     _fl_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-form-label-association.log
     : > "${_fl_log}"
     _fl_ran=1
@@ -4536,8 +4545,8 @@ if [ -d src ]; then
         _in_scope "${vue}" || continue
         _fl_files+=("${vue}")
     done < <(_a11y_markup_files)
-    # NOTE: an empty in-scope set is NOT declared `na` here. Every other
-    # `[ -d src ]` gate reports PASS over an empty diff scope — that is what
+    # NOTE: an empty in-scope set is NOT declared `na` here. Every other gate
+    # in this family reports PASS over an empty diff scope — that is what
     # ADR-020 diff scoping MEANS — and tests/test-hydra-gates-bin.sh asserts
     # that none of gates 10/12/13/26/31..45 goes NOT APPLICABLE while src/
     # exists. Making gate-40 alone answer differently would drift the
@@ -4553,7 +4562,24 @@ if [ -d src ]; then
         # ONE python process for the whole file set, not one per file. The
         # per-file heredoc this replaced took over two minutes on a 21-repo
         # sweep, almost all of it interpreter startup.
-        python3 "${_fl_helper}" "${_fl_files[@]}" >> "${_fl_log}" 2>/dev/null || true
+        #
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249). `2>/dev/null
+        # || true` discarded the traceback AND the failure, so a broken
+        # interpreter left an empty log and this gate called it clean.
+        # Measured 2026-08-08 on opencatalogi with a `python3` that exits 1 on
+        # every call: gate-40 printed PASS over the 13 real findings it had
+        # reported one run earlier, while every a11y gate that read its
+        # helper's return code correctly reported SKIPPED (wiring).
+        #
+        # `set +e` only, never `set -e` after — errexit is OFF for this whole
+        # script and nothing may turn it on (see the invariant at the top).
+        set +e
+        python3 "${_fl_helper}" "${_fl_files[@]}" >> "${_fl_log}" 2>>"${_fl_log}.err"
+        _fl_rc=$?
+        if [ "${_fl_rc}" -ne 0 ]; then
+            _fl_ran=0
+            _skip 40 "form-label-association" wiring "check_form_labels.py exited ${_fl_rc} — ${#_fl_files[@]} markup file(s) were in scope and no verdict was produced; unlabelled form controls (WCAG 1.3.1 / 3.3.2) are UNVERIFIED by this run. See ${_fl_log}.err."
+        fi
     fi
     _fl_fail=$(wc -l < "${_fl_log}" 2>/dev/null || echo 0)
     if [ "${_fl_ran}" -eq 1 ]; then
@@ -4662,45 +4688,60 @@ fi
 # make "Read more" accessible-in-context. Links with aria-label or Vue
 # interpolations are accepted unconditionally.
 #
+# A CRASHED CHECKER REPORTED PASS (#147 / #249)
+# --------------------------------------------
+# This gate ran `python3 - "$vue" <<'PYLQ' >> log 2>/dev/null` once per file
+# and never read an exit status. Measured 2026-08-08 on opencatalogi with a
+# `python3` on PATH that exits 1 on every call:
+#
+#   gate-40 PASS   gate-42 PASS   gate-44 PASS      <- the three inline ones
+#   gate-34/37/38/39/41/43 SKIPPED (wiring)         <- the six behind a helper
+#
+# gate-40 printed PASS over the 13 real findings it had reported a run
+# earlier. An empty log is not a clean sheet, and `2>/dev/null` hid the
+# traceback that would have said so. Implementation moved to
+# scripts/lib/check_link_text.py so this gate gets the same return-code guard
+# as the rest of the family — and one interpreter start for the whole file
+# set instead of one per file.
+#
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 2.4.4
+#   - ConductionNL/.github#147, #249
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+if _a11y_has_markup_dir; then
     _lq_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-link-text-quality.log
     : > "${_lq_log}"
+    _lq_ran=1
+    _lq_helper="${SCRIPT_DIR}/lib/check_link_text.py"
+    _lq_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYLQ' >> "${_lq_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    src = open(fname).read()
-except Exception:
-    sys.exit(0)
-txt = src.replace('\n', ' ')
-patterns = [
-    (r'<a\b([^>]*)>(.*?)</a>', 'a'),
-    (r'<router-link\b([^>]*)>(.*?)</router-link>', 'router-link'),
-    (r'<RouterLink\b([^>]*)>(.*?)</RouterLink>', 'RouterLink'),
-]
-BAD = re.compile(r'^(click\s*here|here|read\s*more|learn\s*more|more|continue|see\s*more|details)\.?$', re.IGNORECASE)
-for pat, tagname in patterns:
-    for m in re.finditer(pat, txt, re.IGNORECASE | re.DOTALL):
-        attrs = m.group(1) or ''
-        body = m.group(2) or ''
-        if re.search(r'(:?aria-label|aria-labelledby)\s*=', attrs): continue
-        if '{{' in body and '}}' in body: continue
-        body_text = re.sub(r'<[^>]+>', '', body)
-        body_text = re.sub(r'\s+', ' ', body_text).strip()
-        if not body_text or BAD.match(body_text):
-            print(f'{fname}: <{tagname}> body="{body_text}" rule=link-text-not-descriptive')
-PYLQ
+        _lq_files+=("${vue}")
     done < <(_a11y_markup_files)
-    _lq_fail=$(wc -l < "${_lq_log}" 2>/dev/null || echo 0)
-    if [ "${_lq_fail}" -eq 0 ]; then
-        _pass 42 "link-text-quality"
+    if [ "${#_lq_files[@]}" -eq 0 ]; then
+        :   # nothing in scope; the PASS below describes the diff, as everywhere else.
+    elif [ ! -f "${_lq_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _lq_ran=0
+        _skip 42 "link-text-quality" wiring "check_link_text.py not found at ${_lq_helper} — ${#_lq_files[@]} markup file(s) were in scope and NONE were inspected; non-descriptive link text (WCAG 2.4.4) is UNVERIFIED by this run."
     else
-        _fail 42 "link-text-quality" "${_lq_fail} link(s) with non-descriptive text — see ${_lq_log}"
+        # `set +e` only, never `set -e` after — errexit is OFF for this whole
+        # script and nothing may turn it on (see the invariant at the top).
+        set +e
+        python3 "${_lq_helper}" "${_lq_files[@]}" >> "${_lq_log}" 2>>"${_lq_log}.err"
+        _lq_rc=$?
+        if [ "${_lq_rc}" -ne 0 ]; then
+            _lq_ran=0
+            _skip 42 "link-text-quality" wiring "check_link_text.py exited ${_lq_rc} — ${#_lq_files[@]} markup file(s) were in scope and no verdict was produced; non-descriptive link text (WCAG 2.4.4) is UNVERIFIED by this run. See ${_lq_log}.err."
+        fi
+    fi
+    _lq_fail=$(wc -l < "${_lq_log}" 2>/dev/null || echo 0)
+    if [ "${_lq_ran}" -eq 1 ]; then
+        if [ "${_lq_fail}" -eq 0 ]; then
+            _pass 42 "link-text-quality"
+        else
+            _fail 42 "link-text-quality" "${_lq_fail} link(s) with non-descriptive text — see ${_lq_log}"
+        fi
     fi
 fi
 
@@ -4789,40 +4830,64 @@ fi
 # attribute so password managers + browser autofill work. Per WCAG 2.2 AA
 # SC 1.3.5 (Identify Input Purpose).
 #
+# THREE DEFECTS FIXED 2026-08-08:
+#
+# (a) A CRASHED CHECKER REPORTED PASS. Inline `python3 - "$vue" <<'PYAC' >>
+#     log 2>/dev/null`, once per file, exit status never read — so a broken
+#     interpreter left an empty log and the gate called it clean (#147 /
+#     #249). Measured with a `python3` that exits 1: gates 40, 42 and 44 all
+#     said PASS while the six a11y gates behind a helper correctly said
+#     SKIPPED (wiring).
+#
+# (b) DOUBLE-QUOTED VALUES ONLY. `name\s*=\s*"([^"]+)"` never saw
+#     `<input id='b44-tel' type='text' name='telephone'>` — same rendered
+#     DOM, same defect, PASS in both a .vue app and a PHP-template app.
+#
+# (c) FIRST NAME-LIKE ATTRIBUTE WINS. `re.search` over name/id/v-model
+#     stopped at the first hit, so `<input id="e" type="text" name="email">`
+#     was judged on `e` alone. The plainest textbook case for this gate.
+#
+# `[^>]*` also went: a `>` inside an attribute value is not the end of the
+# tag (#259, #198, #236). Implementation in scripts/lib/check_autocomplete.py.
+#
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 1.3.5
+#   - ConductionNL/.github#147, #249, #259
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+if _a11y_has_markup_dir; then
     _ac_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-autocomplete-attr.log
     : > "${_ac_log}"
+    _ac_ran=1
+    _ac_helper="${SCRIPT_DIR}/lib/check_autocomplete.py"
+    _ac_files=()
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYAC' >> "${_ac_log}" 2>/dev/null
-import re, sys
-fname = sys.argv[1]
-try:
-    src = open(fname).read()
-except Exception:
-    sys.exit(0)
-txt = src.replace('\n', ' ')
-SEM_RE = re.compile(r'(email|tel(?:ephone)?|phone|firstname|lastname|fullname|address|street|city|postal|postcode|zip|country|password|username|organization|birthday|dob)', re.IGNORECASE)
-for m in re.finditer(r'<input\b([^>]*)>', txt, re.IGNORECASE):
-    attrs = m.group(1) or ''
-    type_m = re.search(r'(^|\s)type\s*=\s*"(hidden|submit|button|reset|image|file|checkbox|radio|color|range)"', attrs, re.IGNORECASE)
-    if type_m: continue
-    if re.search(r'(^|\s)(:?autocomplete|v-bind:autocomplete)\s*=', attrs): continue
-    name_m = re.search(r'(^|\s)(?:name|id|:name|:id|v-model)\s*=\s*"([^"]+)"', attrs)
-    if not name_m: continue
-    val = name_m.group(2)
-    if SEM_RE.search(val):
-        print(f'{fname}: <input name/id="{val}" ...> rule=semantic-input-without-autocomplete')
-PYAC
+        _ac_files+=("${vue}")
     done < <(_a11y_markup_files)
-    _ac_fail=$(wc -l < "${_ac_log}" 2>/dev/null || echo 0)
-    if [ "${_ac_fail}" -eq 0 ]; then
-        _pass 44 "autocomplete-attr"
+    if [ "${#_ac_files[@]}" -eq 0 ]; then
+        :   # nothing in scope; the PASS below describes the diff, as everywhere else.
+    elif [ ! -f "${_ac_helper}" ]; then
+        # A MISSING HELPER MUST NOT REPORT PASS (#147).
+        _ac_ran=0
+        _skip 44 "autocomplete-attr" wiring "check_autocomplete.py not found at ${_ac_helper} — ${#_ac_files[@]} markup file(s) were in scope and NONE were inspected; inputs with no declared purpose (WCAG 1.3.5) are UNVERIFIED by this run."
     else
-        _fail 44 "autocomplete-attr" "${_ac_fail} semantic input(s) without autocomplete= — see ${_ac_log}"
+        # `set +e` only, never `set -e` after — errexit is OFF for this whole
+        # script and nothing may turn it on (see the invariant at the top).
+        set +e
+        python3 "${_ac_helper}" "${_ac_files[@]}" >> "${_ac_log}" 2>>"${_ac_log}.err"
+        _ac_rc=$?
+        if [ "${_ac_rc}" -ne 0 ]; then
+            _ac_ran=0
+            _skip 44 "autocomplete-attr" wiring "check_autocomplete.py exited ${_ac_rc} — ${#_ac_files[@]} markup file(s) were in scope and no verdict was produced; inputs with no declared purpose (WCAG 1.3.5) are UNVERIFIED by this run. See ${_ac_log}.err."
+        fi
+    fi
+    _ac_fail=$(wc -l < "${_ac_log}" 2>/dev/null || echo 0)
+    if [ "${_ac_ran}" -eq 1 ]; then
+        if [ "${_ac_fail}" -eq 0 ]; then
+            _pass 44 "autocomplete-attr"
+        else
+            _fail 44 "autocomplete-attr" "${_ac_fail} semantic input(s) without autocomplete= — see ${_ac_log}"
+        fi
     fi
 fi
 
@@ -6295,9 +6360,36 @@ _declare_na() {
     done
 }
 
-# `if [ -d src ]` — gates 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45
+# `if [ -d src ]` — gates 10 12 13 26 45
 [ -d src ] || _declare_na "no src/ directory — this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect." \
-    10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45
+    10 12 13 26 45
+# `if _a11y_has_markup_dir` — gates 31 32 34 35 36 37 39 40 42 43 44
+#
+# THE TABLE HAD DRIFTED FROM THE GUARDS IT CLAIMS TO MIRROR.
+#
+# The block above listed the whole accessibility family under `[ -d src ]`,
+# and gave them all the reason "this repo ships no frontend, so there is no
+# .vue/.js/.ts source for this gate to inspect." After #225/#261 that reason
+# is simply untrue: the a11y family reads `_a11y_markup_files`, which is
+# .vue AND .php AND .html under src/, templates/ and appinfo/templates/,
+# because WCAG does not care which templating language produced the DOM.
+#
+# Measured 2026-08-08 on an app with a `templates/` full of markup and no
+# `src/` — one textbook true positive per gate planted in it:
+#
+#   gate-34/36/37/38/39/41/43   ran, and 4 of them FAILED on the plants
+#   gate-35/40/42/44            NOT APPLICABLE — "this repo ships no frontend"
+#
+# in the SAME run, over the SAME files. Four gates removed themselves from
+# coverage accounting entirely, with a reason contradicted three lines above
+# it in their own output. No fleet app is templates-only today, but nldesign
+# is one `rm` away: its `src/` holds a single `manifest.json`, which is the
+# exact shape that made twelve gates pass over nothing in #225.
+#
+# The condition here is now the SAME FUNCTION the gates call, not a restated
+# copy of it, so the two cannot drift again.
+_a11y_has_markup_dir || _declare_na "no src/, templates/ or appinfo/templates/ — this repo renders no markup, so there is no DOM for this accessibility gate to inspect." \
+    31 32 34 35 36 37 39 40 42 43 44
 # `if [ -f appinfo/routes.php ]` — gates 5 25
 [ -f appinfo/routes.php ] || _declare_na "no appinfo/routes.php — this repo registers no HTTP routes, so there is no endpoint for this gate to inspect." \
     5 25
@@ -6310,8 +6402,10 @@ _declare_na() {
 # `if [ -d openspec/specs ] || [ -d tests/e2e ]` — gate 19
 { [ -d openspec/specs ] || [ -d tests/e2e ]; } || _declare_na "no openspec/specs/ and no tests/e2e/ — there is neither a spec scenario to trace nor an e2e suite to trace it to." \
     19
-# `if [ -d src ] || [ -d templates ]` — gate 38
-{ [ -d src ] || [ -d templates ]; } || _declare_na "no src/ and no templates/ — this repo renders no markup, so there is no document for a skip link to be missing from." \
+# `if [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]` — gate 38.
+# That is `_a11y_has_markup_dir` spelled out; the declaration omitted the
+# third arm, so it did not mirror the guard either.
+_a11y_has_markup_dir || _declare_na "no src/, templates/ or appinfo/templates/ — this repo renders no markup, so there is no document for a skip link to be missing from." \
     38
 # `if [ -d templates ] || [ -d appinfo/templates ]` — gate 41
 { [ -d templates ] || [ -d appinfo/templates ]; } || _declare_na "no templates/ and no appinfo/templates/ — this repo ships no server-rendered HTML document to carry a lang attribute." \


### PR DESCRIPTION
## What this is

The acceptance test for gates **34–44** (the accessibility band), run at package sha `cdfbd7a`: plant **one textbook true positive per gate** in **both** a `.vue` app (opencatalogi, 93 `.vue`) **and** a PHP-template app (nldesign, **zero** `.vue`, one template) — the asymmetry that made #225/#261 possible — require the gate to FAIL and **name** the plant in both, then remove it and require the prior verdict back.

**All 11 gates fired and named the plant in all 22 arms, and all 22 returned to baseline exactly.** The `_a11y_markup_files` fix holds. Two defects survive that test, and neither is visible from it.

## 1. Four gates declare themselves NOT APPLICABLE over a repo full of markup

Gates **35, 40, 42, 44** still guarded on `[ -d src ]` while 34/36/37/39/43 had moved to `_a11y_has_markup_dir`, and the central applicability table listed the whole family under `[ -d src ]`. On a repo with a `templates/` full of markup and no `src/` — same run, same files:

| | |
|---|---|
| gate-34/36/37/38/39/41/43 | ran; **four FAILED** on the plants |
| gate-35/40/42/44 | **NOT APPLICABLE** — *"this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect"* |

`na` is the one verdict that removes a gate from coverage accounting, and the reason is contradicted by the same run's own output three lines above it. The a11y family has read `.php` and `.html` since #261; the declaration never caught up.

No fleet app is templates-only today. **nldesign is one `rm` away** — its `src/` holds a single `manifest.json`, the exact shape that made twelve gates pass over nothing in #225.

The four guards now call `_a11y_has_markup_dir`, and the applicability declaration calls **the same function** instead of restating it, so the two cannot drift again. **No third scope definition was added** (#247/#261).

## 2. A crashed checker reported PASS — gates 40, 42, 44 (#147 / #249)

With a `python3` on PATH that exits 1 on every invocation, against opencatalogi:

```
[gate-40] form-label-association: PASS      <- 13 real findings one run earlier
[gate-42] link-text-quality:      PASS
[gate-44] autocomplete-attr:      PASS
[gate-34/37/38/39/41/43]:         SKIPPED (wiring)
```

gate-40 discarded its status with `2>/dev/null || true`; 42 and 44 ran **per-file inline heredocs** and never had one. 42 and 44 move into `check_link_text.py` / `check_autocomplete.py` — one interpreter for the whole file set, findings on stdout, exit code as a status — and 40 gains the same guard.

## Found while writing the tests

- **gate-44 judged an input on the FIRST of `name`/`id`/`v-model` and stopped**, so `<input id="e" type="text" name="email">` — the plainest textbook case this gate has — passed. Fleet effect, measured over 15 repos: **openregister 0 → 1** (an OpenAI *Organization ID* field), **pipelinq 4 → 5** (a *"Colleague email"* field). Both genuine.
- **Gates 35, 36 and 44 read attribute values out of double quotes only.** `tabindex='5'`, `alt=''`, `name='telephone'` render identically and reported PASS in both arms. Zero fleet occurrences today — which is why they could sit there indefinitely.
- **`[^>]*` in gates 42 and 44** — a `>` inside an attribute value is not the end of a tag; the parse that hid 19 buttons from gate-39 (#259, #198, #236).
- **Gates 42 and 44 scanned raw text**, so a commented-out `<a>click here</a>` counted. gate-64's defect (#184), the one #247 and #266 each shipped a fix for.

## Measured after, not only before

Tightening a gate creates its own false positives, so the after-measure is the load-bearing one:

- **15 repos, gates 34–44, before vs after: every verdict and every finding count identical**, except the two new gate-44 true positives. The rewrites of 42 and 44 removed nothing.
- opencatalogi and nldesign return to their exact pre-plant baselines.
- **ARM 4 was mutation-checked**: reverting gate-42's guard to `[ -d src ]` turns it red with the finding it was written for. A check that cannot fail is not a check.

## What the controls confirmed still holds

Verified independently, not assumed from the PR that claimed them: gate-34 both arms (#269 — the comment does not fire, `window['confirm']()` does) · gate-37 `tabindex="-1"` is not focusable (#251) · gate-38/41 a PHP **comment** mentioning `<html>` does not make a mount point a page root, and a **commented-out** `<html lang>` does not satisfy a real unlangged one (#247/#266) · gate-39 a bound `:title` / `:aria-labelledby` is a name, and a `>` inside an attribute does not hide the button (#259) · gate-40 a **slotted** `NcCheckboxRadioSwitch` is not flagged, a **self-closing** one is (#251) · gate-43 an `aria-hidden` spacer `<th>` is not flagged (the 8 false openconnector findings).

## One finding NOT fixed here, reported instead

**gate-40 flags `<input type="file" aria-hidden="true" tabindex="-1">`** — the exact element gate-37's #222 fix declared canonical and correct. Two gates in the same band contradict each other, and `aria-label` on an `aria-hidden` element is inert, so the finding cannot be closed honestly. Zero fleet occurrences today (nldesign's three are `display:none`, not `aria-hidden`), and excluding `display:none` would be blinding — a style can be toggled by JS. Filing rather than guessing.

## Tests

- `test_check_link_text.py`, `test_check_autocomplete.py` — 32 assertions. Every relaxation ships with the true positive it must not swallow; each comment/script exclusion ships with its positive control; each file ends with **the whole pre-fix checker replayed as the mutant**, asserting it answers *differently* on every fixture.
- `test_gate_a11y_helper_wiring.sh` gains gates 39, 40, 42, 44 — **39 was wired correctly but never listed, so nothing held it to that**. 70 assertions.
- `test_gate_a11y_markup_scope.sh` gains ARM 4, the templates-only repo.
- Full discovered suite **49 passed / 0 failed** (2 pre-existing quarantines); `test-hydra-gates-bin.sh` **59 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
