### PR TITLE
fix(gates 12-22): four gates could not detect the defect they exist for, and gate-20 had never fired at all

### DIFF
--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -120,6 +120,30 @@ The upside: **gate 53 becomes usable under `--scope-to-diff`**. It was
 previously unenablable on any repo with manifest debt, because a one-line change
 reproduced the full-repo finding count exactly.
 
+### Gates 12–22, audited by planting a defect in each (`.github#271`)
+
+Every gate in this band was given one textbook true positive in a real fleet
+repo and asked to catch it. Four could not, and their PASS lines meant nothing:
+
+| Gate | What it was doing instead |
+|---|---|
+| **20** or-objectservice-api | **Had never fired, anywhere.** Its search pattern began with `->`, which `grep` parses as options (`invalid option -- '>'`, exit 2); `2>/dev/null \|\| true` discarded both the message and the status. Now uses `grep -- …`, and the receiver (`$…objectService->`) is part of the pattern rather than "the file mentions ObjectService", which alone would have produced 14 false findings on openregister. |
+| **17** redundant-controller | Four of the six names in its ObjectService CRUD list do not exist on ObjectService — they are what gate-20 flags as fabricated — and `return new JSONResponse($this->objectService->findAll(…))` was discarded as "response wrapping" before the call inside it was ever looked at. The commonest pass-through shape was invisible. |
+| **14** route-reachability | The ten routes `AppHost\Routes::standard()` supplies are not literals in a leaf's `appinfo/routes.php`, so invariant 2 never judged them. Deleting `SettingsController::update()` from an adopter left `PUT /api/settings` resolving to nothing — a ReflectionException 500, not a 404 — and the gate reported PASS (`#265`, closed). |
+| **15, 16, 18** | `2>/dev/null \|\| true` + `wc -l`: a checker that crashed wrote nothing, so the count was 0, so the gate said PASS. With `python3` replaced by a stub that always exits 1, gates 12 and 17 said `SKIPPED (wiring)` and 15/16/18 said `PASS`. They now require the checker's terminal `# count=` marker. |
+
+Also: **gate-22's verdict no longer depends on where the gates were checked
+out.** `ajv` was resolved relative to this package, so an app with
+`node_modules/ajv` installed in its own root still got
+`SCHEMA VALIDATION DID NOT HAPPEN` when the package sat outside its tree —
+and the message asserted "no node_modules", which was false. Resolution is now
+anchored on the manifest's own repo root, then cwd, then this package, and the
+degradation names every directory it searched.
+
+Verdicts move: gate-20 and gate-17 can now produce findings in repos that were
+green. Gates 15/16/18 can now report `SKIPPED (wiring)`, which is a coverage
+gap, not a pass — see *Reading a green*.
+
 ---
 
 ## What it needs at runtime

--- a/hydra-gates/scripts/lib/check_dashboard_antipattern.py
+++ b/hydra-gates/scripts/lib/check_dashboard_antipattern.py
@@ -57,9 +57,27 @@ from pathlib import Path
 
 # Match an opening <template #widget-<id>> or <template #widget-<id>="...">
 # or the long-form <template v-slot:widget-<id>>. Group 1 captures the id.
+# THE TAG ENDS AT A `>`, NOT AT THE END OF THE SLOT BINDING (.github#271/#274).
+#
+# This used to be `(?:="[^"]*")?\s*>` — the slot name, an OPTIONAL double-quoted
+# binding, then immediately `>`. Anything else on the tag made the whole element
+# invisible:
+#
+#     <template #widget-kpis>                        matched
+#     <template #widget-kpis="{ item }">             matched
+#     <template #widget-kpis class="x">              NOT matched
+#     <template v-slot:widget-kpis="{ i }" class="x"> NOT matched
+#     <template #widget-kpis='a'>                    NOT matched  (single quotes)
+#
+# Same shape as gate-44's "judged on the FIRST of name/id/v-model and stopped"
+# (#272): a matcher that assumes an attribute is the LAST thing on the tag has a
+# blind spot shaped like attribute order, and one extra class attribute is
+# enough to hide the finding. The element now ends at a `>` that is not inside a
+# quoted attribute value — the same rule gate-12's helper and check_form_labels
+# already use.
 SLOT_OPEN_RE = re.compile(
     r"<template\s+(?:#|v-slot:)widget-([A-Za-z][A-Za-z0-9_\-]*)"
-    r"(?:=\"[^\"]*\")?\s*>",
+    r"(?:[^>\"']|\"[^\"]*\"|'[^']*')*>",
 )
 TEMPLATE_CLOSE_RE = re.compile(r"</template\s*>")
 TEMPLATE_OPEN_RE = re.compile(r"<template[\s>]")
@@ -252,7 +270,19 @@ def main(argv: list[str]) -> int:
 
     for line in findings:
         print(line)
-    return len(findings)
+    # TERMINAL MARKER (.github#271). The runner used to decide gate-15 with
+    # `wc -l` over this helper's stdout after `2>/dev/null || true`. A helper
+    # that CRASHED wrote nothing, so the log was empty, so the count was 0, so
+    # the gate reported PASS over a check that never executed — the exact shape
+    # #147/#233/#245 exist to remove, still live in three gates on 2026-08-08.
+    # Demonstrated by running the suite with a python3 that always exits 1:
+    # gates 12 and 17 said SKIPPED (wiring); gates 15, 16 and 18 said PASS.
+    #
+    # The marker is what makes "the checker finished" observable. Its absence
+    # is now a wiring skip, never a pass. The exit code is a STATUS (0 clean /
+    # 1 findings) and no longer the count — a count in one byte is #209.
+    print(f"# count={len(findings)}")
+    return 1 if findings else 0
 
 
 if __name__ == "__main__":

--- a/hydra-gates/scripts/lib/check_manifest.js
+++ b/hydra-gates/scripts/lib/check_manifest.js
@@ -279,26 +279,88 @@ function mergeAppHostBlocks(base, canonical) {
 	return merged
 }
 
+// WHERE THE GATE PACKAGE HAPPENS TO SIT IS NOT A PROPERTY OF THE MANIFEST
+// (.github#271).
+//
+// A bare `require('ajv/dist/2020')` resolves relative to THIS FILE — Node walks
+// `node_modules` up from `__dirname`, then falls back to NODE_PATH. It never
+// looks at the repository being validated. So the gate's verdict depended on
+// where the gates were checked out:
+//
+//   vendor/conduction/hydra-gates/…   the walk passes through the app root and
+//                                     finds the app's ajv           -> validated
+//   a sibling clone of ConductionNL/.github
+//                                     the walk never reaches the app -> exit 3,
+//                                     "SCHEMA VALIDATION DID NOT HAPPEN"
+//
+// Measured 2026-08-08: run from openregister's own root, with
+// `node_modules/ajv` PRESENT one directory up from cwd, the validator printed
+// "Ajv is not resolvable from this process (no node_modules, no NODE_PATH)" —
+// a statement that was simply false — and gate-22 went FAIL. Exporting
+// NODE_PATH to the very same directory flipped it to PASS. Same tree, same
+// package, two verdicts: that is not a gate.
+//
+// Resolution is now anchored on the SUBJECT: the manifest's own repo root and
+// the process cwd come first, the gate package's own tree last. All three are
+// stated in the degradation message so "not resolvable" can be checked rather
+// than believed.
+function _ajvSearchPaths() {
+	const roots = []
+	// The repo that owns the manifest under validation: <root>/src/manifest.json
+	const manifestRepoRoot = path.resolve(path.dirname(MANIFEST_PATH), '..')
+	roots.push(manifestRepoRoot)
+	roots.push(process.cwd())
+	roots.push(__dirname)
+	const seen = new Set()
+	const out = []
+	for (const r of roots) {
+		let dir = r
+		// Walk up from each root so a manifest in a monorepo sub-package still
+		// finds the hoisted install.
+		for (;;) {
+			const nm = path.join(dir, 'node_modules')
+			if (!seen.has(nm)) { seen.add(nm); out.push(nm) }
+			const parent = path.dirname(dir)
+			if (parent === dir) break
+			dir = parent
+		}
+	}
+	return out
+}
+
+function _requireFrom(name, paths) {
+	try {
+		return require(require.resolve(name, { paths }))
+	} catch (_) {
+		try {
+			// Last resort: the ambient resolution (NODE_PATH / this file's own
+			// ancestry). Kept so a working setup never regresses.
+			return require(name)
+		} catch (__) {
+			return null
+		}
+	}
+}
+
 function loadAjv() {
 	// The schema is JSON Schema draft 2020-12; Ajv needs the ajv/dist/2020
 	// entry point. ajv-formats is best-effort (the "uri" format on $schema).
+	const paths = _ajvSearchPaths()
 	let Ajv = null
 	let addFormats = null
-	try {
-		Ajv = require('ajv/dist/2020').default || require('ajv/dist/2020')
-	} catch (_) {
-		try {
-			Ajv = require('ajv').default || require('ajv')
-		} catch (__) {
-			return { Ajv: null, addFormats: null }
+	const mod2020 = _requireFrom('ajv/dist/2020', paths)
+	if (mod2020) {
+		Ajv = mod2020.default || mod2020
+	} else {
+		const modPlain = _requireFrom('ajv', paths)
+		if (!modPlain) {
+			return { Ajv: null, addFormats: null, searched: paths }
 		}
+		Ajv = modPlain.default || modPlain
 	}
-	try {
-		addFormats = require('ajv-formats').default || require('ajv-formats')
-	} catch (_) {
-		addFormats = null
-	}
-	return { Ajv, addFormats }
+	const fmt = _requireFrom('ajv-formats', paths)
+	addFormats = fmt ? (fmt.default || fmt) : null
+	return { Ajv, addFormats, searched: paths }
 }
 
 // Structural fallback: validates the AppHost observability + deepLinks blocks
@@ -409,7 +471,7 @@ function main() {
 	console.error('[check_manifest] AppHost blocks (observability, deepLinks) validated against the hydra-vendored canonical ADR-040 schema')
 	const schema = mergeAppHostBlocks(base, canonical)
 
-	const { Ajv, addFormats } = loadAjv()
+	const { Ajv, addFormats, searched } = loadAjv()
 	if (Ajv) {
 		let validate
 		try {
@@ -434,8 +496,18 @@ function main() {
 		return report(errors, null, manifest)
 	}
 
+	// NAME WHERE WE LOOKED. The old message asserted "no node_modules, no
+	// NODE_PATH" — which was false in the case that produced it (.github#271):
+	// the app root one directory up from cwd had `node_modules/ajv` installed,
+	// and the resolver simply never looked there. An unverifiable claim about
+	// the environment is how a wiring failure passes for a fact.
+	const _searchedNote = (searched || []).slice(0, 6).join(', ')
 	console.error('[check_manifest] Ajv not installed; using AppHost structural lint (observability/deepLinks still validated for-real)')
-	return finishStructural(manifest, 'Ajv is not resolvable from this process (no node_modules, no NODE_PATH)')
+	console.error(`[check_manifest] ajv searched (first 6 of ${(searched || []).length}): ${_searchedNote}`)
+	return finishStructural(
+		manifest,
+		`Ajv is not resolvable from the manifest's own repo root, the process cwd, or the gate package tree. Searched: ${_searchedNote}`,
+	)
 }
 
 function finishStructural(manifest, degradedReason) {

--- a/hydra-gates/scripts/lib/check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/check_spec_coverage.py
@@ -459,7 +459,19 @@ def run_gate(app_dir: Path) -> int:
 
     for line in sorted(set(findings)):
         print(line)
-    return len(set(findings))
+    # TERMINAL MARKER (.github#271) — see the note in
+    # check_dashboard_antipattern.py. gate-16 decided its verdict with `wc -l`
+    # over this helper's stdout after `2>/dev/null || true`, so a helper that
+    # crashed produced an empty log and the gate reported PASS. Verified
+    # 2026-08-08 by running the suite with a python3 stub that always exits 1:
+    # gate-16 said PASS while nothing had been inspected.
+    #
+    # The exit code is now a STATUS (0 clean / 1 findings), not the count. It
+    # used to be `len(set(findings))` — a count in one byte, which is #209:
+    # openregister's own root-scoped sweep is well past 255.
+    _count = len(set(findings))
+    print(f"# count={_count}")
+    return 1 if _count else 0
 
 
 def main(argv: list[str]) -> int:

--- a/hydra-gates/scripts/lib/check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/check_spec_coverage.py
@@ -176,6 +176,56 @@ def changed_lines(base_ref: str, cwd: Path) -> dict[str, set[int]]:
     return result
 
 
+def spec_tags_removed(base_ref: str, cwd: Path) -> set[str]:
+    """Return the files whose diff DELETES an ``@spec`` line.
+
+    WHY THIS EXISTS (.github#271)
+    -----------------------------
+    ``_overlaps`` walks FORWARD from the declaration line through the method
+    body. The docblock sits ABOVE the declaration, so it is outside the scope
+    window entirely — and the docblock is the only place ``@spec`` can live.
+
+    The consequence is that the one edit which REMOVES coverage is the one edit
+    this gate cannot see. Measured 2026-08-08 on a two-file fixture: delete the
+    ``@spec openspec/...`` line from a tagged method, leave the body
+    byte-identical, and the helper prints ``# count=0`` and exits 0. Every
+    ``@spec`` tag in a repository can be stripped and gate-16 stays green.
+
+    Worse, ``run_gate`` skips a file whose ``added`` set is empty, and a pure
+    deletion produces exactly that — so the file was never even opened.
+
+    Same family as the ``filter_preexisting_methods.py`` defect that lets an
+    auth-attribute removal be filed as pre-existing (gates 5/9/30): a
+    body-shaped scope cannot see a change that is not in the body. Gate-16 does
+    not route through that helper — its four call sites are gates 6, 7, 8 and
+    30 — it arrives at the same blind spot by its own path.
+
+    DELIBERATELY NARROW. This does NOT put every docblock edit in scope: fixing
+    a typo in a legacy untagged method's docblock must not surface that method
+    as a finding, because ADR-020 exists to stop inherited debt blocking
+    unrelated work. It fires only when the diff actually TOOK A TAG AWAY, which
+    is never inherited debt and is always the author's own doing.
+    """
+    removed: set[str] = set()
+    for form in ([f"{base_ref}...HEAD"], [base_ref]):
+        diff = _git(["diff", "-U0", "--diff-filter=ACMRD", *form], cwd)
+        if not diff.strip():
+            continue
+        current: str | None = None
+        for line in diff.splitlines():
+            if line.startswith("--- a/"):
+                current = line[6:]
+            elif line.startswith("+++ b/"):
+                # Prefer the new path for renames; fall back to the old one.
+                current = line[6:]
+            elif line.startswith("-") and not line.startswith("---"):
+                if current and (SPEC_RE.search(line) or SPEC_EXCLUDE_RE.search(line)):
+                    removed.add(current)
+        if removed:
+            break
+    return removed
+
+
 def _docblock_spec_status(lines: list[str], decl_idx: int) -> tuple[str, str | None]:
     """Classify the docblock immediately above ``decl_idx`` into one of:
       - ``("covered", None)``        — has ``@spec openspec/...``
@@ -432,16 +482,59 @@ def run_report(app_dir: Path) -> int:
     return 0
 
 
+def _git_show(base_ref: str, rel: str, cwd: Path) -> str:
+    """The file as it was at ``base_ref``; empty string when it did not exist."""
+    return _git(["show", f"{base_ref}:{rel}"], cwd)
+
+
+def _uncovered_in_text(rel: str, text: str) -> set[str]:
+    """Every in-scope method in ``text`` that carries no @spec, ignoring diff
+    scope. Used to diff a file against its own base version so only the methods
+    whose coverage CHANGED are reported (.github#271)."""
+    if not text:
+        return set()
+    out: list[str] = []
+    all_lines = set(range(1, len(text.splitlines()) + 2))
+    if rel.endswith(".php"):
+        if rel.startswith(BACKEND_EXEMPT_DIRS) or not rel.startswith(BACKEND_DIRS):
+            return set()
+        check_php_file(rel, text, all_lines, out)
+    elif _is_frontend_in_scope(rel):
+        check_frontend_file(rel, text, all_lines, out)
+    return set(out)
+
+
 def run_gate(app_dir: Path) -> int:
     base_ref = os.environ.get("HYDRA_GATE_BASE_REF", "origin/development")
     changed = changed_lines(base_ref, app_dir)
+    # Files this diff STRIPPED an @spec tag from (.github#271). A pure deletion
+    # produces an empty `added` set, which the loop below used to skip outright,
+    # so the file was not even opened.
+    stripped = spec_tags_removed(base_ref, app_dir)
     findings: list[str] = []
 
-    for rel, added in changed.items():
-        if not added:
-            continue
+    for rel in sorted(set(changed) | stripped):
+        added = changed.get(rel, set())
         path = app_dir / rel
         if not path.is_file():
+            continue
+        if rel in stripped:
+            # WHAT THIS PR TOOK AWAY, AND ONLY THAT.
+            #
+            # Evaluating the whole file here would name every untagged method in
+            # it, which on a legacy file is inherited debt the author did not
+            # touch — the thing ADR-020 exists to keep out of a PR. So the file
+            # is evaluated TWICE, once as it is and once as it was at the base,
+            # with the same walkers and therefore the same exemptions, and the
+            # findings are the DIFFERENCE. A file that lost one tag reports one
+            # finding; a file that lost none reports none, however much
+            # pre-existing debt it carries.
+            before = _uncovered_in_text(rel, _git_show(base_ref, rel, app_dir))
+            now = _uncovered_in_text(rel, path.read_text(encoding="utf-8"))
+            findings.extend(sorted(now - before))
+            if not added:
+                continue
+        elif not added:
             continue
         try:
             text = path.read_text(encoding="utf-8")

--- a/hydra-gates/scripts/lib/detect-redundant-controllers.py
+++ b/hydra-gates/scripts/lib/detect-redundant-controllers.py
@@ -53,13 +53,47 @@ from typing import Iterable
 # Methods on OpenRegister's ObjectService that are pure CRUD pass-throughs.
 # A method body that calls ONE of these and nothing else of substance is
 # a redundant wrapper.
+# THE REAL ObjectService SURFACE, PLUS THE FABRICATED NAMES (.github#271)
+# ----------------------------------------------------------------------
+# Four of the six names this tuple used to hold — `findObjects`,
+# `createFromArray`, `updateFromArray`, `deleteFromId` — DO NOT EXIST on
+# OpenRegister's ObjectService. gate-20 in run-hydra-gates.sh exists precisely
+# to flag them as fabricated. The real surface, read off
+# openregister lib/Service/ObjectService.php (2026-08-08), is
+#
+#     find / findAll / saveObject / createObject / updateObject / deleteObject
+#
+# and only `find` and `saveObject` were in the list. So a genuine ADR-022
+# pass-through written against the REAL API —
+#
+#     public function fetchAll(): JSONResponse
+#     {
+#         return new JSONResponse($this->objectService->findAll([]));
+#     }
+#
+# — was not recognised as an ObjectService call at all. It then fell through to
+# RESCUE_PATTERNS, whose `\$this->\w+Service->\w+\(` rule ("any non-objectService
+# call → escape") matched it and returned False. The gate did not merely miss
+# the modern shape: it actively rescued it. Planted verbatim in openregister
+# on 2026-08-08 and gate-17 reported PASS.
+#
+# The fabricated names stay in the tuple. A wrapper around a method that does
+# not exist is still a wrapper, and removing them would lose the detections
+# this gate was originally written for (decidesk#60's createFromArray quintet).
 OBJECT_SERVICE_CRUD = (
+    # Real surface.
+    "findAll",
     "find",
+    "saveObject",
+    "createObject",
+    "updateObject",
+    "deleteObject",
+    # Fabricated names seen in the wild — see gate-20. Kept so a wrapper
+    # around a non-existent method is still detected as a wrapper.
     "findObjects",
     "createFromArray",
     "updateFromArray",
     "deleteFromId",
-    "saveObject",  # legacy alias
 )
 
 # Calls / constructs that are considered "wrapper noise" — present in any
@@ -286,14 +320,34 @@ def _is_redundant_body(body: str) -> bool:
         # marker usually lives) AND against the joined form for
         # multi-line statements that begin with e.g. `return new`.
         first_line = stmt.splitlines()[0] if stmt else ""
+        # THE CALL IS TESTED BEFORE THE NOISE (.github#271).
+        #
+        # `^\s*return\s+new\s+JSONResponse` is in WRAPPER_NOISE_PATTERNS, and
+        # this check used to run AFTER it. So the single most common shape a
+        # pass-through takes —
+        #
+        #     return new JSONResponse($this->objectService->findAll([]));
+        #
+        # was discarded as "response wrapping" with the ObjectService call
+        # still inside it. object_service_hits stayed 0 and the method was
+        # declared not-redundant. The gate could only ever fire when the call
+        # sat on its OWN statement (`$r = $this->objectService->findAll();`
+        # then `return new JSONResponse($r);`), which is the less common of the
+        # two spellings. Planted verbatim in openregister 2026-08-08: gate-17
+        # reported PASS.
+        #
+        # The noise list is a set of shapes that carry NO work. A line that
+        # carries the call is not one of them, whatever its outer shape, so the
+        # call has to be looked for first. Nothing here changes what counts as
+        # a call, or the CRUD-name filter, or the `@spec exclude` escape hatch.
+        if OBJECT_SERVICE_CALL_RE.search(stmt):
+            object_service_hits += 1
+            significant += 1
+            continue
         if any(p.search(first_line) for p in WRAPPER_NOISE_PATTERNS):
             continue
         if any(p.search(stmt) for p in WRAPPER_NOISE_PATTERNS):
             # `\$this->logger->info(...)` may sit on the second line.
-            continue
-        if OBJECT_SERVICE_CALL_RE.search(stmt):
-            object_service_hits += 1
-            significant += 1
             continue
         if any(p.search(stmt) for p in RESCUE_PATTERNS):
             # Real domain logic — escape.

--- a/hydra-gates/scripts/lib/test_check_dashboard_antipattern.py
+++ b/hydra-gates/scripts/lib/test_check_dashboard_antipattern.py
@@ -125,6 +125,38 @@ class CheckFileTest(unittest.TestCase):
         cda.check_file(vue, {"my-work"}, findings)
         self.assertEqual(len(findings), 1)
 
+    def test_extra_attributes_on_the_slot_tag_do_not_hide_it(self):
+        # .github#271/#274 — the same defect class as gate-44's "judged on the
+        # FIRST of name/id/v-model and stopped" (#272): the opening-tag pattern
+        # assumed the slot binding was the LAST thing before `>`, so ONE extra
+        # attribute made the whole element invisible and the nested dashboard
+        # inside it went unreported.
+        #
+        # Each of these was a silent miss before the fix.
+        for markup in (
+            '<template #widget-my-work class="wide">',
+            '<template v-slot:widget-my-work="{ item }" class="wide">',
+            "<template #widget-my-work='{ item }'>",
+            '<template #widget-my-work="{ item }" :data-x="a > b">',
+        ):
+            with self.subTest(markup=markup):
+                vue = self.dir / "MyDashboard.vue"
+                _write(vue, f"""
+<template>
+  <CnDashboardPage>
+    {markup}
+      <CnDashboardPage />
+    </template>
+  </CnDashboardPage>
+</template>
+""")
+                findings: list[str] = []
+                cda.check_file(vue, {"my-work"}, findings)
+                self.assertEqual(
+                    len(findings), 1,
+                    f"nested dashboard hidden by the extra attribute in: {markup}",
+                )
+
     def test_unknown_widget_id_is_ignored(self):
         # If the slot template targets a widget id not declared as
         # type=custom in any dashboard page, we don't care about its body.
@@ -179,7 +211,13 @@ class FullRunTest(unittest.TestCase):
         with redirect_stdout(buf):
             rc = cda.main(["check_dashboard_antipattern.py", str(self.dir)])
         self.assertEqual(rc, 0)
-        self.assertEqual(buf.getvalue(), "")
+        # The ONLY line on a clean run is the terminal marker (.github#271).
+        # The marker exists because gate-15 decided its verdict with `wc -l`
+        # over this stdout after `2>/dev/null || true`: a helper that crashed
+        # wrote nothing, so the count was 0, so the gate said PASS over a check
+        # that never ran. Its presence is how the runner tells "clean" from
+        # "did not execute", so a clean run MUST still emit it.
+        self.assertEqual(buf.getvalue(), "# count=0\n")
 
     def test_custom_page_with_dashboard_not_referenced_as_widget_passes(self):
         # Regression (pipelinq Rapportage, 2026-06-12): a type=custom page
@@ -205,7 +243,7 @@ class FullRunTest(unittest.TestCase):
         with redirect_stdout(buf):
             rc = cda.main(["check_dashboard_antipattern.py", str(self.dir)])
         self.assertEqual(rc, 0)
-        self.assertEqual(buf.getvalue(), "")
+        self.assertEqual(buf.getvalue(), "# count=0\n")
 
     def test_pipelinq_style_antipattern(self):
         # Pipelinq pattern: a custom page named "Dashboard" with component

--- a/hydra-gates/scripts/lib/test_check_manifest.sh
+++ b/hydra-gates/scripts/lib/test_check_manifest.sh
@@ -104,6 +104,74 @@ else
 		"malformed manifest without Ajv → exit 1 (a real finding still wins over the degradation)"
 fi
 
+# --- WHERE THE GATE PACKAGE SITS IS NOT A PROPERTY OF THE MANIFEST (#271) ---
+#
+# `require('ajv/dist/2020')` resolves relative to check_manifest.js, so Node
+# walks node_modules up from THIS file and then falls back to NODE_PATH. It
+# never looked at the repository being validated. The verdict therefore
+# depended on the checkout layout:
+#
+#   vendor/conduction/hydra-gates/…  the walk crosses the app root -> validated
+#   a sibling clone of ConductionNL/.github  it does not          -> exit 3
+#
+# Measured 2026-08-08: run from openregister's own root, with node_modules/ajv
+# PRESENT in that root, the validator printed "Ajv is not resolvable from this
+# process (no node_modules, no NODE_PATH)" — false — and gate-22 went FAIL.
+# Setting NODE_PATH to that same directory flipped it to PASS. Same tree, same
+# gate package, two verdicts.
+#
+# The assertion below is the one that matters: an app that HAS ajv installed
+# must validate no matter where the gates were invoked from.
+echo
+echo "== ajv resolves from the SUBJECT's node_modules, not the gate package's =="
+_ajv_entry="$(node -e "process.stdout.write(require.resolve('ajv/dist/2020'))" 2>/dev/null || true)"
+if [ -z "${_ajv_entry}" ]; then
+	echo "SKIP — no ajv anywhere on this machine; the resolution anchor cannot be exercised."
+else
+	# .../node_modules/ajv/dist/2020.js  ->  .../node_modules
+	_ajv_nm="${_ajv_entry%/ajv/dist/2020.js}"
+	if [ "${_ajv_nm}" = "${_ajv_entry}" ]; then
+		_ajv_nm="$(cd "$(dirname "${_ajv_entry}")/../.." && pwd)"
+	fi
+	_anchor_app="$(mktemp -d "${TMPDIR:-/tmp}/hydra-anchor.XXXXXX")"
+	mkdir -p "${_anchor_app}/src" "${_anchor_app}/node_modules"
+	cp "${FIX}/valid-apphost.manifest.json" "${_anchor_app}/src/manifest.json"
+	ln -s "${_ajv_nm}/ajv" "${_anchor_app}/node_modules/ajv" 2>/dev/null || true
+	[ -d "${_ajv_nm}/ajv-formats" ] && ln -s "${_ajv_nm}/ajv-formats" "${_anchor_app}/node_modules/ajv-formats" 2>/dev/null
+	# NODE_PATH deliberately cleared and cwd deliberately NOT the app: the only
+	# route to ajv is the manifest path's own repo root. That is the anchor.
+	( cd / && env -u NODE_PATH node "${VALIDATOR}" "${_anchor_app}/src/manifest.json" ) >"${_TCM_LOG}" 2>&1
+	_anchor_rc=$?
+	if [ "${_anchor_rc}" -eq 0 ]; then
+		_ok "an app with its own node_modules/ajv validates even when cwd and NODE_PATH point elsewhere (rc=0)"
+	else
+		_no "the app's own node_modules/ajv was not used: expected rc=0, got ${_anchor_rc}"
+		sed 's/^/    /' "${_TCM_LOG}"
+	fi
+	_assert_log 'Ajv validation against merged canonical schema' \
+		"the run says the schema was actually applied"
+
+	# THE CONTROL: with the app's ajv removed and nothing else reachable, it must
+	# still degrade LOUDLY — this is not "always find an ajv somewhere".
+	rm -f "${_anchor_app}/node_modules/ajv" "${_anchor_app}/node_modules/ajv-formats"
+	( cd / && env -u NODE_PATH node "${VALIDATOR}" "${_anchor_app}/src/manifest.json" ) >"${_TCM_LOG}" 2>&1
+	_ctrl_rc=$?
+	if [ "${_ctrl_rc}" -eq 3 ] || [ "${_ctrl_rc}" -eq 0 ]; then
+		# rc=0 here means this machine has a system-wide ajv the walk found; say
+		# so rather than asserting a degradation that legitimately did not occur.
+		if [ "${_ctrl_rc}" -eq 3 ]; then
+			_ok "control: with no reachable ajv the run still exits 3 DEGRADED, never 0"
+			_assert_log 'Searched:' "the degradation NAMES the directories it looked in (the old message asserted 'no node_modules' and was wrong)"
+		else
+			echo "SKIP — an ajv is reachable from / on this machine, so the no-ajv control cannot be isolated."
+		fi
+	else
+		_no "control: expected rc=3 (degraded) or a stated skip, got ${_ctrl_rc}"
+		sed 's/^/    /' "${_TCM_LOG}"
+	fi
+	rm -rf "${_anchor_app}"
+fi
+
 # --- ADR-020 diff scoping ---------------------------------------------------
 echo
 echo "== --scope-ids: findings on untouched entries must not block =="

--- a/hydra-gates/scripts/lib/test_check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_spec_coverage.py
@@ -327,6 +327,88 @@ class FooService {
         self.assertNotIn("legacyUntagged", out)
         self.assertEqual(rc, 1)
 
+    def _spec_removal_fixture(self):
+        """A tagged method plus an untagged legacy one, committed as the base.
+        Returns the base sha."""
+        self._write("lib/Service/BarService.php", """<?php
+class BarService {
+    /**
+     * Does the thing.
+     *
+     * @spec openspec/specs/things/spec.md
+     */
+    public function doThing(string $id): array
+    {
+        return [$id];
+    }
+
+    /**
+     * Legacy, never tagged.
+     */
+    public function legacyThing(string $id): array
+    {
+        return [$id, 'legacy'];
+    }
+}
+""")
+        self._run("git", "add", "-A")
+        self._run("git", "commit", "-q", "-m", "base")
+        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(self.dir),
+                              capture_output=True, text=True).stdout.strip()
+
+    def _gate(self, base):
+        os.environ["HYDRA_GATE_BASE_REF"] = base
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = csc.main(["check_spec_coverage.py", str(self.dir)])
+        finally:
+            del os.environ["HYDRA_GATE_BASE_REF"]
+        return buf.getvalue(), rc
+
+    def test_deleting_an_at_spec_tag_is_caught(self):
+        # .github#271 — `_overlaps` walks FORWARD from the declaration, so the
+        # docblock is outside the scope window, and the docblock is the only
+        # place @spec can live. Deleting the tag left the body byte-identical:
+        # the helper printed `# count=0` and exited 0. Every @spec tag in a repo
+        # could be stripped and this gate stayed green — the one edit that
+        # removes coverage was the one it could not see.
+        #
+        # Worse, run_gate skipped any file whose `added` set was empty, and a
+        # pure deletion produces exactly that, so the file was never opened.
+        base = self._spec_removal_fixture()
+        text = (self.dir / "lib/Service/BarService.php").read_text()
+        old = "     *\n     * @spec openspec/specs/things/spec.md\n"
+        self.assertIn(old, text, "fixture premise: the @spec line must be there to delete")
+        self._write("lib/Service/BarService.php", text.replace(old, ""))
+        self._run("git", "add", "-A")
+        self._run("git", "commit", "-q", "-m", "strip the tag")
+
+        out, rc = self._gate(base)
+        self.assertIn("doThing", out, "the method that LOST its @spec must be named")
+        self.assertEqual(rc, 1)
+        # ...and ONLY that method. Naming every untagged method in the file
+        # would surface inherited debt the author never touched, which is what
+        # ADR-020 exists to keep out of a PR.
+        self.assertNotIn("legacyThing", out)
+
+    def test_an_unrelated_docblock_edit_does_not_surface_legacy_debt(self):
+        # The anti-widening control for the arm above. The fix must key on
+        # "a tag was TAKEN AWAY", not on "a docblock was touched" — otherwise a
+        # typo fix in a legacy untagged method's docblock becomes a finding.
+        base = self._spec_removal_fixture()
+        text = (self.dir / "lib/Service/BarService.php").read_text()
+        old = "     * Legacy, never tagged.\n"
+        self.assertIn(old, text)
+        self._write("lib/Service/BarService.php",
+                    text.replace(old, "     * Legacy, never tagged. Typo fixed.\n"))
+        self._run("git", "add", "-A")
+        self._run("git", "commit", "-q", "-m", "typo")
+
+        out, rc = self._gate(base)
+        self.assertEqual(out, "# count=0\n", f"expected a clean run, got: {out}")
+        self.assertEqual(rc, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
+++ b/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
@@ -212,6 +212,163 @@ else
     _bad "gate-60 returned '${_v}' for a real violation it can detect offline — the missing dependency is now suppressing rules that DO work"
 fi
 
+# ---------------------------------------------------------------------------
+# EVERY python-backed gate, with a python3 that cannot run (.github#271)
+#
+# The two arms above each test ONE gate against ONE way of failing. This arm
+# breaks the interpreter for the whole suite at once and asks the only question
+# that matters: which gates notice?
+#
+# MEASURED 2026-08-08 on pipelinq at gate package cdfbd7ab, with
+# `python3` shadowed by a stub that prints a traceback and exits 1 — so NOT ONE
+# file was inspected by ANY python-backed gate:
+#
+#     gate-12 nc-input-labels        SKIPPED (wiring)   <- honest
+#     gate-15 dashboard-antipattern  PASS               <- green over nothing
+#     gate-16 spec-coverage          PASS               <- green over nothing
+#     gate-17 redundant-controller   SKIPPED (wiring)   <- honest
+#     gate-18 notification-dialect   PASS               <- green over nothing
+#     gate-19 e2e-coverage           FAIL — "an unreported number of scenario(s)"
+#
+# Three greens and one blocking failure whose count nobody measured, from a run
+# in which nothing was read. 12 and 17 got this right because they check the
+# helper's exit status; 15, 16 and 18 wrote `2>/dev/null || true` and counted
+# lines in an empty log.
+#
+# This arm keeps that from coming back. It is deliberately GENERIC: any future
+# python-backed gate that lands with the `|| true` idiom fails here on its first
+# run, without anyone remembering to add it to a list.
+# ---------------------------------------------------------------------------
+_fakebin="${_tmp}/fakebin"
+mkdir -p "${_fakebin}"
+cat > "${_fakebin}/python3" <<'SH'
+#!/bin/sh
+echo "Traceback (most recent call last): simulated interpreter failure" >&2
+exit 1
+SH
+chmod +x "${_fakebin}/python3"
+
+_pyapp="${_tmp}/pyapp"
+mkdir -p "${_pyapp}/lib/Controller" "${_pyapp}/lib/Settings" "${_pyapp}/src/views" "${_pyapp}/openspec/specs/thing"
+cat > "${_pyapp}/src/manifest.json" <<'JSON'
+{"name":"fx","pages":[{"id":"Dash","route":"/","type":"dashboard","title":"Dash","config":{"widgets":[{"id":"kpis","type":"custom"}]}}]}
+JSON
+cat > "${_pyapp}/src/views/Dash.vue" <<'VUE'
+<template><div><NcSelect :options="o" /></div></template>
+VUE
+cat > "${_pyapp}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController {
+    public function index() { return 1; }
+}
+PHP
+cat > "${_pyapp}/lib/Settings/thing_register.json" <<'JSON'
+{"components":{"schemas":{"Thing":{"x-openregister-notifications":{"r":{"channel":"nc","recipient":"@self.owner"}}}}}}
+JSON
+cat > "${_pyapp}/openspec/specs/thing/spec.md" <<'MD'
+# Thing
+
+## Purpose
+
+Thing.
+
+### Requirement: The system SHALL thing
+
+#### Scenario: A thing happens
+
+- **GIVEN** a thing
+- **WHEN** it happens
+- **THEN** it happened
+MD
+(
+    cd "${_pyapp}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_pylogs="${_tmp}/pylogs"
+mkdir -p "${_pylogs}"
+_pyout="${_tmp}/pyrun.txt"
+(
+    cd "${_pyapp}" || exit 1
+    PATH="${_fakebin}:${PATH}" HYDRA_GATE_LOG_DIR="${_pylogs}" \
+        bash "${_runner}" . > "${_pyout}" 2>&1
+)
+
+# A control first: the stub really is in play. If python3 still works, every
+# assertion below would pass for the wrong reason — the exact "a check that did
+# not run looks like one that passed" shape this file is about.
+if grep -q 'simulated interpreter failure' "${_pyout}" \
+    || grep -rq 'simulated interpreter failure' "${_pylogs}" 2>/dev/null; then
+    _ok "control: the python3 stub was actually used (its traceback reached the run)"
+else
+    _bad "control FAILED: no evidence the python3 stub ran — the assertions below prove nothing"
+fi
+
+for _g in 12:nc-input-labels 15:dashboard-antipattern 16:spec-coverage \
+          17:redundant-controller 18:notification-dialect 19:e2e-coverage; do
+    _num="${_g%%:*}"
+    _name="${_g#*:}"
+    _v=$(grep -oE "^\[gate-${_num}\] [^:]+: [A-Z]+( \([a-z]+\))?" "${_pyout}" | head -1 | sed 's/^[^:]*: //')
+    case "${_v}" in
+        "SKIPPED (wiring)")
+            _ok "gate-${_num} ${_name}: SKIPPED (wiring) when python3 cannot run"
+            ;;
+        PASS)
+            _bad "gate-${_num} ${_name}: PASS — its checker never executed and it reported the code clean anyway"
+            ;;
+        FAIL)
+            _bad "gate-${_num} ${_name}: FAIL — an environment failure rendered as findings about the source"
+            ;;
+        "")
+            # A gate whose SUBJECT is absent may legitimately emit nothing;
+            # this fixture gives all six a subject, so silence is a defect.
+            _bad "gate-${_num} ${_name}: emitted NO verdict line at all, though this fixture gives it a subject"
+            ;;
+        *)
+            _bad "gate-${_num} ${_name}: verdict is '${_v}' — expected SKIPPED (wiring)"
+            ;;
+    esac
+done
+
+# Each skip must say WHAT went unchecked — a bare "skipped" is unactionable and
+# is how a wiring failure gets filed under "known noise".
+for _num in 15 16 18; do
+    if grep -qE "^\[gate-${_num}\][^:]*: SKIPPED \(wiring\) — .*(UNVERIFIED|did not complete|exited)" "${_pyout}"; then
+        _ok "gate-${_num}'s skip names what it left unverified"
+    else
+        _bad "gate-${_num}'s skip does not say what went unchecked"
+    fi
+done
+
+# THE ANTI-WIDENING CONTROL. With a WORKING python3 the same fixture must
+# produce real verdicts — this must not become "skip whenever anything looks
+# odd". The fixture's register file carries the legacy dialect, so gate-18 has
+# something to find and MUST find it.
+_oklogs="${_tmp}/oklogs"
+mkdir -p "${_oklogs}"
+_okout="${_tmp}/pyrun-ok.txt"
+(
+    cd "${_pyapp}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_oklogs}" bash "${_runner}" . > "${_okout}" 2>&1
+)
+if grep -qE '^\[gate-18\][^:]*: FAIL' "${_okout}"; then
+    _ok "control: with a working python3, gate-18 still FAILS on the planted legacy dialect"
+else
+    _v=$(grep -oE '^\[gate-18\] [^:]+: [A-Z]+( \([a-z]+\))?' "${_okout}" | head -1 | sed 's/^[^:]*: //')
+    _bad "control FAILED: gate-18 returned '${_v}' on a register file carrying channel/recipient/@self. — the skip logic is suppressing a real finding"
+fi
+for _num in 15 16; do
+    _v=$(grep -oE "^\[gate-${_num}\] [^:]+: [A-Z]+( \([a-z]+\))?" "${_okout}" | head -1 | sed 's/^[^:]*: //')
+    if [ "${_v}" = "SKIPPED (wiring)" ]; then
+        _bad "control FAILED: gate-${_num} still reports SKIPPED (wiring) with a working python3 — the marker check is broken, not the interpreter"
+    else
+        _ok "control: gate-${_num} produces a real verdict (${_v:-none}) with a working python3"
+    fi
+done
+
 echo
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_crashed_checker_is_not_a_finding.sh: ALL PASS"

--- a/hydra-gates/scripts/lib/test_gate_empty_scope_never_passes.sh
+++ b/hydra-gates/scripts/lib/test_gate_empty_scope_never_passes.sh
@@ -309,6 +309,101 @@ else
     _bad "the run exited ${_violation_rc} with a planted ADR-079 violation in scope — a finding must fail the run on its own merits"
 fi
 
+# ---------------------------------------------------------------------------
+# GATES 12 AND 13: `src/` EXISTS, AND HOLDS NOT ONE .vue (.github#274, #271)
+#
+# The same defect one layer down from #272. Those four a11y gates declared
+# themselves NOT APPLICABLE on a templates-only repo; gates 12 and 13 did the
+# opposite on an nldesign-shaped one — `[ -d src ]` passed, `find src -name
+# '*.vue'` matched nothing, the findings log was empty, and both printed PASS.
+#
+# MEASURED at package sha fef032b (origin/main, post-#272) against a repo whose
+# `src/` holds a single `manifest.json` and whose `templates/` holds real
+# markup:
+#
+#     [gate-12] nc-input-labels: PASS
+#     [gate-13] modal-isolation: PASS
+#
+# That is nldesign's exact shape — the shape that let twelve gates certify it in
+# #225 — and it is not one `rm` away, it is current. `na` is the honest verdict:
+# NcSelect / NcModal / NcDialog are Vue SFC components, a PHP template cannot
+# instantiate one, so nothing in such a repo is unverified. But PASS says the
+# gate looked and found nothing, and it did not look.
+# ---------------------------------------------------------------------------
+_novue="${_tmp}/novue"
+mkdir -p "${_novue}/src" "${_novue}/templates"
+printf '{"name":"nl","pages":[]}\n' > "${_novue}/src/manifest.json"
+printf '<div><select name="x"></select></div>\n' > "${_novue}/templates/admin.php"
+(
+    cd "${_novue}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_novue_out="${_tmp}/novue.txt"
+_novue_logs="${_tmp}/novue-logs"
+mkdir -p "${_novue_logs}"
+(
+    cd "${_novue}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_novue_logs}" bash "${_runner}" . > "${_novue_out}" 2>&1
+)
+for _g in 12 13; do
+    _v="$(_verdict "${_novue_out}" "${_g}")"
+    case "${_v}" in
+        "NOT APPLICABLE")
+            _ok "gate-${_g}: NOT APPLICABLE when src/ holds no .vue — it says it looked at nothing"
+            ;;
+        PASS)
+            _bad "gate-${_g}: PASS over a src/ containing zero .vue files — the nldesign shape, green over nothing (#225/#274)"
+            ;;
+        *)
+            _bad "gate-${_g}: returned '${_v:-none emitted}' on a src/ with no .vue — expected NOT APPLICABLE"
+            ;;
+    esac
+done
+# The reason must say WHY it cannot apply, not merely that it does not. The old
+# shared reason claimed these gates inspect ".vue/.js/.ts source", which is
+# false — they are .vue-only, and that is the judgement #274 asked to be made
+# explicit.
+if grep -qE '^\[gate-12\][^:]*: NOT APPLICABLE — .*(Vue SFC|no \.vue)' "${_novue_out}"; then
+    _ok "gate-12's na reason states the .vue-only judgement rather than a generic 'no frontend'"
+else
+    _bad "gate-12's na reason does not state why a template repo cannot contain its subject"
+fi
+
+# THE ANTI-WIDENING CONTROL. Add ONE .vue carrying the defect and both gates
+# must go back to judging — this is not "skip whenever src/ looks thin".
+mkdir -p "${_novue}/src/views"
+cat > "${_novue}/src/views/Probe.vue" <<'VUE'
+<template>
+  <div>
+    <NcSelect v-model="v" :options="o" :reduce="(option) => option.value" />
+    <NcModal v-if="open" @close="open = false"><p>inline</p></NcModal>
+  </div>
+</template>
+VUE
+(
+    cd "${_novue}" || exit 1
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm probe
+) >/dev/null 2>&1
+_novue_out2="${_tmp}/novue2.txt"
+_novue_logs2="${_tmp}/novue-logs2"
+mkdir -p "${_novue_logs2}"
+(
+    cd "${_novue}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_novue_logs2}" bash "${_runner}" . > "${_novue_out2}" 2>&1
+)
+for _g in 12 13; do
+    _v="$(_verdict "${_novue_out2}" "${_g}")"
+    if [ "${_v}" = "FAIL" ]; then
+        _ok "control: gate-${_g} FAILS on the planted defect once ONE .vue exists — the na is about absence, not about skipping"
+    else
+        _bad "control FAILED: gate-${_g} returned '${_v:-none}' with a planted unnamed NcSelect / inline NcModal in src/views/Probe.vue"
+    fi
+done
+
 echo
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_empty_scope_never_passes.sh: ALL PASS"

--- a/hydra-gates/scripts/lib/test_gate_or_objectservice_surface.sh
+++ b/hydra-gates/scripts/lib/test_gate_or_objectservice_surface.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_or_objectservice_surface.sh — gate-20 (or-objectservice-api) and
+# gate-17 (redundant-controller) both reason about OpenRegister's ObjectService.
+# Both were wrong about it, in opposite directions, and both reported PASS.
+#
+# WHAT THIS GUARDS (.github#271)
+# ------------------------------
+# gate-20 HAD NEVER FIRED. Not rarely — never, in any repo, since it was
+# written. Its search was
+#
+#     grep -nE "->${_pat//(/\\(}" "${_file}"
+#
+# and the expanded pattern is `->findObjects\(`, which begins with `-`. grep
+# reads that as OPTIONS:
+#
+#     $ grep -nE "->findObjects\(" file.php
+#     grep: invalid option -- '>'      (exit 2)
+#
+# `2>/dev/null || true` swallowed the message and the status, every file came
+# back with zero hits, and the gate printed PASS. Proven 2026-08-08 by planting
+# `$this->objectService->findObjects(['limit' => 1])` in openregister's
+# ActionsController: gate-20 reported PASS over it.
+#
+# Repairing the grep ALONE is not the fix. The old receiver test was "the FILE
+# mentions ObjectService somewhere", which is not a claim about the call. With
+# the grep repaired and that heuristic left alone the fleet measurement is 14
+# findings on openregister and 5 on shillinq, ALL FALSE — `createFromArray()`
+# is a real method on OpenRegister's *Mappers*
+# (`$this->schemaMapper->createFromArray(...)`), and those files mention
+# ObjectService elsewhere. A gate that cries wolf gets switched off, so the
+# receiver is now part of the pattern.
+#
+# gate-17 was wrong the other way. Four of the six names in its
+# OBJECT_SERVICE_CRUD tuple — findObjects / createFromArray / updateFromArray /
+# deleteFromId — DO NOT EXIST on ObjectService; they are precisely what gate-20
+# exists to flag as fabricated. The real surface (openregister
+# lib/Service/ObjectService.php) is find / findAll / saveObject / createObject /
+# updateObject / deleteObject, and only `find` and `saveObject` were listed. So
+# a textbook ADR-022 pass-through written against the REAL API was not
+# recognised as an ObjectService call at all, fell through to RESCUE_PATTERNS,
+# and was matched by `\$this->\w+Service->\w+\(` ("any non-objectService call →
+# escape"). The gate did not merely miss the modern shape — it rescued it.
+#
+# Every arm below has an anti-widening sibling: the thing that MUST still be
+# silent, differing from the finding by the one property the rule keys on.
+#
+# Run: bash scripts/lib/test_gate_or_objectservice_surface.sh   (exit 0 = green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${HYDRA_GATES_RUNNER_UNDER_TEST:-${PKG_ROOT}/scripts/run-hydra-gates.sh}"
+
+_fail_n=0
+_ok()  { printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-or-surface.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+echo "== gate-20 / gate-17: the OpenRegister ObjectService surface =="
+echo
+
+# ---------------------------------------------------------------------------
+# THE MECHANISM ITSELF. Asserted directly, because the whole gate-20 defect is
+# this one fact and it is invisible in a log that discards stderr.
+# ---------------------------------------------------------------------------
+printf 'x->findObjects(1);\n' > "${_tmp}/probe.txt"
+grep -nE "->findObjects\(" "${_tmp}/probe.txt" >/dev/null 2>&1
+_grep_rc=$?
+if [ "${_grep_rc}" -ge 2 ]; then
+    _ok "a grep pattern beginning with '-' is parsed as OPTIONS (rc=${_grep_rc}) — the defect is real on this platform"
+else
+    echo "  note — this grep tolerates a leading '-' in the pattern (rc=${_grep_rc});"
+    echo "         the defect cannot be provoked here, but the '--' guard is asserted below."
+fi
+if grep -nE -- "->findObjects\(" "${_tmp}/probe.txt" >/dev/null 2>&1; then
+    _ok "the same pattern after '--' matches — '--' is the whole difference between dead and alive"
+else
+    _bad "'--' did not make the pattern usable; the gate-20 repair rests on this"
+fi
+
+# ---------------------------------------------------------------------------
+# The fixture app. One TRUE positive per gate, each with its silent sibling.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/app"
+mkdir -p "${_app}/lib/Controller" "${_app}/lib/Service"
+
+# gate-20 TRUE POSITIVE: a fabricated method, called on the ObjectService.
+cat > "${_app}/lib/Service/SeedService.php" <<'PHP'
+<?php
+namespace OCA\Fx\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+
+class SeedService
+{
+    public function __construct(private ObjectService $objectService) {}
+
+    public function seed(): array
+    {
+        // `findObjects` does not exist on ObjectService. Real API: findAll().
+        return $this->objectService->findObjects(['limit' => 1]);
+    }
+}
+PHP
+
+# gate-20 ANTI-WIDENING SIBLING: `createFromArray` IS a real method — on the
+# mappers. The file mentions ObjectService, which is exactly what the old
+# file-level heuristic keyed on, so this is the false positive that repairing
+# the grep alone produces.
+cat > "${_app}/lib/Service/ImportService.php" <<'PHP'
+<?php
+namespace OCA\Fx\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+
+class ImportService
+{
+    public function __construct(
+        private ObjectService $objectService,
+        private $schemaMapper,
+    ) {}
+
+    public function import(array $data): mixed
+    {
+        // A REAL method on a DIFFERENT class. Must never be reported.
+        return $this->schemaMapper->createFromArray($data);
+    }
+}
+PHP
+
+# gate-17 TRUE POSITIVE: CRUD-named, body is one call to the REAL ObjectService
+# API. This is the shape the old fabricated-name tuple could not see.
+cat > "${_app}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+
+class ThingController
+{
+    public function fetchAll(): JSONResponse
+    {
+        return new JSONResponse($this->objectService->findAll([]));
+    }
+
+    // ANTI-WIDENING SIBLING: identical body, DOMAIN name. The name is the
+    // signal ADR-022 keys on, and it must still exempt this.
+    public function publishThing(): JSONResponse
+    {
+        return new JSONResponse($this->objectService->findAll([]));
+    }
+}
+PHP
+
+(
+    cd "${_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_logs="${_tmp}/logs"
+mkdir -p "${_logs}"
+_out="${_tmp}/run.txt"
+(
+    cd "${_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_logs}" bash "${RUNNER}" . > "${_out}" 2>&1
+)
+
+_verdict() { grep -oE "^\[gate-$1\] [^:]+: [A-Z]+( \([a-z]+\))?" "${_out}" | head -1 | sed 's/^[^:]*: //'; }
+
+# ---- gate-20 ---------------------------------------------------------------
+_v20="$(_verdict 20)"
+_log20="${_logs}/hydra-gate-or-objectservice-api.log"
+if [ "${_v20}" = "FAIL" ]; then
+    _ok "gate-20 FAILS on a fabricated ObjectService method (was PASS for the gate's entire life)"
+else
+    _bad "gate-20 returned '${_v20:-none}' over \$this->objectService->findObjects( — the gate is still dead"
+fi
+if grep -q 'SeedService.php' "${_log20}" 2>/dev/null; then
+    _ok "gate-20 NAMES the offending file"
+else
+    _bad "gate-20 did not name SeedService.php — a verdict that does not say where is not actionable"
+fi
+if grep -q 'ImportService.php' "${_log20}" 2>/dev/null; then
+    _bad "gate-20 flagged \$this->schemaMapper->createFromArray() — a REAL method on a different class. This is the 14-finding openregister false positive."
+else
+    _ok "gate-20 does NOT flag a mapper's real createFromArray() in a file that merely mentions ObjectService"
+fi
+if [ "$(grep -c . "${_log20}" 2>/dev/null || echo 0)" -eq 1 ]; then
+    _ok "exactly ONE gate-20 finding — the receiver is part of the pattern, not the file"
+else
+    _bad "expected exactly 1 gate-20 finding, got: $(tr '\n' '|' < "${_log20}" 2>/dev/null)"
+fi
+
+# ---- gate-17 ---------------------------------------------------------------
+_v17="$(_verdict 17)"
+_log17="${_logs}/hydra-gate-redundant-controller.log"
+if [ "${_v17}" = "FAIL" ]; then
+    _ok "gate-17 FAILS on a CRUD-named pass-through written against the REAL ObjectService API"
+else
+    _bad "gate-17 returned '${_v17:-none}' over fetchAll() { return new JSONResponse(\$this->objectService->findAll([])); }"
+fi
+if grep -q 'method=fetchAll' "${_log17}" 2>/dev/null; then
+    _ok "gate-17 NAMES fetchAll"
+else
+    _bad "gate-17 did not name fetchAll"
+fi
+if grep -q 'method=publishThing' "${_log17}" 2>/dev/null; then
+    _bad "gate-17 flagged publishThing — a domain-named method. The CRUD-name filter is the whole false-positive defence."
+else
+    _ok "gate-17 does NOT flag the identically-bodied domain-named sibling"
+fi
+
+# The checker must have finished — its terminal marker is the evidence.
+if grep -q '^# count=' "${_log17}" 2>/dev/null; then
+    _ok "gate-17's checker printed its terminal '# count=' marker (it reached its own summary)"
+else
+    _bad "no '# count=' marker in gate-17's log — the checker did not complete and any verdict is unmeasured"
+fi
+
+echo
+if [ "${_fail_n}" -eq 0 ]; then
+    echo "ALL gate-20 / gate-17 ObjectService-surface assertions PASSED"
+    exit 0
+fi
+echo "${_fail_n} assertion(s) FAILED"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_route_registration.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_registration.sh
@@ -35,6 +35,10 @@
 #
 #   routes-standard/            5 canonical routes exempt   -> gate-14 PASS on them
 #                               `gadget#run` has no route   -> gate-14 FAILS
+#   routes-standard-missing-update/
+#                               the SAME app minus SettingsController::update()
+#                               -> settings#update MUST be reported (#265)
+#                               the other nine canonical names MUST NOT be
 #   delegated-registrar/        AppHost call in a registrar -> 3 generics exempt
 #                               `gadget#run` bound nowhere  -> gate-14 FAILS
 #   delegated-registrar-absent/ the SAME app minus that one file -> all 4 FAIL
@@ -103,7 +107,8 @@ _expect_lines()   { local _n; _n=$(printf '%s' "$1" | grep -c . ); if [ "${_n}" 
 echo "== gate-5 / gate-14 / gate-30 route + registration detection =="
 echo
 
-for _f in routes-standard delegated-registrar delegated-registrar-absent \
+for _f in routes-standard routes-standard-missing-update \
+          delegated-registrar delegated-registrar-absent \
           monitoring-capitalised monitoring-per-object monitoring-per-object-only \
           monitoring-none; do
     [ -d "${FIXTURES}/${_f}" ] || _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
@@ -122,6 +127,41 @@ if _run "${FIXTURES}/routes-standard"; then
         "routes-standard: settings#index / #create / #load likewise"
     _expect_lines "${_RRLOG}" 1 \
         "routes-standard: exactly ONE finding — the exemption is ten names, not a blanket"
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. #265 — the ten Routes::standard() names must be JUDGED, not just exempted
+#
+# THE ANTI-WIDENING SIBLING OF 1, INVERTED. #223 taught invariant 1 that those
+# ten names exist so it would stop reporting working endpoints as unroutable.
+# Invariant 2 asks the opposite question — "does the method the route names
+# actually exist?" — and it never asked it about those ten, because it read
+# route names as LITERALS out of the leaf's appinfo/routes.php and they are not
+# there.
+#
+# `aliasControllerUnlessLeafDefinesIt()` makes that gap reachable: the moment a
+# leaf ships its own SettingsController it owes every method the canonical table
+# routes to `settings#`, and a missing one is a ReflectionException 500, not a
+# 404. Reproduced on shillinq 2026-08-08 by deleting `update()` — gate-14's
+# findings log came back EMPTY and the gate said PASS.
+#
+# The two fixtures differ by exactly that one method.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/routes-standard-missing-update"; then
+    _expect_gate 14 "FAIL" "routes-standard-missing-update: a canonical AppHost route whose method is gone IS a finding"
+    _expect_log "${_RRLOG}" "SettingsController\.php route='settings#update' rule=method-not-found-on-target-controller" \
+        "routes-standard-missing-update: settings#update is named, and named as method-not-found (a 500, not a 404)"
+    # THE CONTROL: the OTHER nine canonical names still resolve here, so this is
+    # not "an AppHost adopter now fails on all ten".
+    _expect_not_log "${_RRLOG}" "settings#index\|settings#create\|settings#load" \
+        "routes-standard-missing-update: index / create / load still resolve and are NOT reported"
+    _expect_not_log "${_RRLOG}" "DashboardController" \
+        "routes-standard-missing-update: dashboard#page / #catchAll are served by AppHost and stay exempt"
+    # Exactly two: the sibling's pre-existing `gadget#run`, plus the one method
+    # this fixture deletes. Anything more means the ten names stopped being
+    # exempt for the CLASS-ABSENT case and the widening went too far.
+    _expect_lines "${_RRLOG}" 2 \
+        "routes-standard-missing-update: exactly TWO findings — gadget#run and settings#update, nothing else"
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_gate_route_registration.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_registration.sh
@@ -39,6 +39,15 @@
 #                               the SAME app minus SettingsController::update()
 #                               -> settings#update MUST be reported (#265)
 #                               the other nine canonical names MUST NOT be
+#   psr4-namespaced-controller/ `AppHost\Controller\GenericHealth#index` resolves
+#                               to lib/AppHost/Controller/, the app root, NOT to
+#                               lib/Controller/ -> gate-14 PASS (#271)
+#                               a conventional `ping#index` in the same repo is
+#                               unaffected
+#   psr4-namespaced-controller-missing-method/
+#                               the SAME app with that method renamed
+#                               -> MUST be reported, and as
+#                               method-not-found (a 500), not class-not-found
 #   delegated-registrar/        AppHost call in a registrar -> 3 generics exempt
 #                               `gadget#run` bound nowhere  -> gate-14 FAILS
 #   delegated-registrar-absent/ the SAME app minus that one file -> all 4 FAIL
@@ -53,7 +62,13 @@
 set -uo pipefail
 
 PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
-RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+# THE RUNNER MUST BE OVERRIDABLE, OR THIS SUITE CANNOT BE MUTATION-CHECKED
+# (.github#271). This was hardcoded, so pointing HYDRA_GATES_RUNNER_UNDER_TEST at
+# a pre-fix tree — the way every other suite in this package is proved
+# non-vacuous — silently kept running the FIXED runner and reported all-green.
+# A mutation check that cannot fail is the same defect as a gate that cannot
+# fail, one level up, and it is what this whole suite exists to catch.
+RUNNER="${HYDRA_GATES_RUNNER_UNDER_TEST:-${PKG_ROOT}/scripts/run-hydra-gates.sh}"
 FIXTURES="${PKG_ROOT}/scripts/test-fixtures/route-registration"
 
 _fail_n=0
@@ -108,6 +123,7 @@ echo "== gate-5 / gate-14 / gate-30 route + registration detection =="
 echo
 
 for _f in routes-standard routes-standard-missing-update \
+          psr4-namespaced-controller psr4-namespaced-controller-missing-method \
           delegated-registrar delegated-registrar-absent \
           monitoring-capitalised monitoring-per-object monitoring-per-object-only \
           monitoring-none; do
@@ -162,6 +178,49 @@ if _run "${FIXTURES}/routes-standard-missing-update"; then
     # exempt for the CLASS-ABSENT case and the widening went too far.
     _expect_lines "${_RRLOG}" 2 \
         "routes-standard-missing-update: exactly TWO findings — gadget#run and settings#update, nothing else"
+fi
+
+# ---------------------------------------------------------------------------
+# 1c. #271 — a NAMESPACED route name resolves relative to the APP ROOT
+#
+# NC's RouteParser::buildControllerName() does not prefix the app namespace when
+# the route name already contains a backslash, so
+# `AppHost\Controller\GenericHealth#index` is looked up as the bare class
+# `AppHost\Controller\GenericHealthController`. PSR-4 maps `OCA\<App>\` onto
+# `lib/`, so that class lives at lib/AppHost/Controller/ — NOT under
+# lib/Controller/, which is the only place the resolver looked.
+#
+# Reproduced 2026-08-08 against this package's own gates-23-33/planted fixture:
+#
+#   lib/Controller/AppHost/Controller/GenericHealthController.php
+#     route='AppHost\Controller\GenericHealth#index'
+#     rule=controller-class-not-found
+#
+# — a path that cannot exist, reported as a missing class, INSIDE the repository
+# that ships the file. Same shape as the gate-30 finding: the path the gate
+# derives is not the path the app uses.
+#
+# The false FAIL was only half. Where a DI binding rescued the absence the loop
+# `continue`d, so the method-existence check never ran at all — #265's defect at
+# a different address. The two fixtures differ by exactly that method.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/psr4-namespaced-controller"; then
+    _expect_gate 14 "PASS" "psr4-namespaced-controller: a namespaced route whose PSR-4 file EXISTS is not a finding"
+    _expect_not_log "${_RRLOG}" "controller-class-not-found" \
+        "psr4-namespaced-controller: no 'class not found' for a class sitting in lib/AppHost/Controller/"
+    _expect_not_log "${_RRLOG}" "lib/Controller/AppHost" \
+        "psr4-namespaced-controller: the impossible lib/Controller/AppHost/... path is never derived"
+fi
+
+if _run "${FIXTURES}/psr4-namespaced-controller-missing-method"; then
+    _expect_gate 14 "FAIL" "psr4-namespaced-controller-missing-method: the method-existence check now RUNS on a namespaced route"
+    _expect_log "${_RRLOG}" "lib/AppHost/Controller/GenericHealthController\.php route='AppHost.Controller.GenericHealth#index' rule=method-not-found-on-target-controller" \
+        "…and names the REAL path plus the real rule (a 500, not a missing class)"
+    # THE CONTROL: the conventional sibling in the same repo still resolves.
+    _expect_not_log "${_RRLOG}" "PingController" \
+        "psr4-namespaced-controller-missing-method: the conventional ping#index route is unaffected"
+    _expect_lines "${_RRLOG}" 1 \
+        "psr4-namespaced-controller-missing-method: exactly ONE finding"
 fi
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2123,15 +2123,39 @@ if [ -d src ]; then
     _il_ran=1
     _il_helper="${SCRIPT_DIR}/lib/check_nc_select_labels.py"
     _il_files=()
+    # Counted separately from the in-scope list so "this repo has no Vue
+    # component at all" can be told apart from "the diff touched none of them".
+    _il_present=0
     while IFS= read -r vue; do
         [ -f "${vue}" ] || continue
+        _il_present=$((_il_present + 1))
         _in_scope "${vue}" || continue
         _il_files+=("${vue}")
         # .vue only: <NcSelect> is a Vue component. Gate 40 covers the
         # language-agnostic <input>/<select> label rule for PHP templates.
     done < <(find src -name '*.vue' 2>/dev/null)
     if [ "${#_il_files[@]}" -eq 0 ]; then
-        : # nothing in scope — ordinary diff scoping.
+        # ZERO FILES IS NOT A PASS (.github#274, and #225 one layer down).
+        #
+        # `[ -d src ]` was the whole guard, and `src/` existing is not the same
+        # as `src/` containing a Vue component. nldesign's `src/` holds ONE
+        # file — `manifest.json` — and this gate printed PASS there, over an
+        # empty glob. That is the exact shape that let twelve a11y gates certify
+        # nldesign in #225; gates 12 and 13 were not in that band and kept it.
+        #
+        # `na`, not `structural`: nothing in the repository is missing. An app
+        # that renders from PHP templates has no `<NcSelect>` to name, because
+        # `NcSelect` is a Vue SFC component — a PHP template cannot instantiate
+        # one, which is why this gate stays `.vue`-only while gate-40 owns the
+        # language-agnostic `<input>`/`<select>` label rule for templates. That
+        # is the judgement #274 asked for, and it is stated in the reason so a
+        # reader can disagree with it.
+        _il_ran=0
+        if [ "${_il_present}" -eq 0 ]; then
+            _skip 12 "nc-input-labels" na "src/ exists but contains NO .vue component, so there is no <NcSelect> to name. This gate is deliberately .vue-only: NcSelect is a Vue SFC component and a PHP/HTML template cannot instantiate one — gate-40 owns the language-agnostic <input>/<select> label rule for templates/. Reported instead of PASS because an empty glob under an existing src/ is what let twelve gates certify nldesign in #225."
+        else
+            _skip 12 "nc-input-labels" na "${_il_present} .vue component(s) exist here and the diff against '${BASE_REF}' touched none of them, so no <NcSelect> was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass."
+        fi
     elif [ ! -f "${_il_helper}" ]; then
         # A MISSING HELPER MUST NOT REPORT PASS (#147).
         _il_ran=0
@@ -2165,18 +2189,32 @@ fi
 if [ -d src ]; then
     _mi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-modal-isolation.log
     : > "${_mi_log}"
+    # See gate-12 above: `src/` existing is not the same as `src/` containing a
+    # Vue component, and this gate printed PASS over an empty glob on nldesign
+    # (whose src/ holds one manifest.json). Counted so the two cases can be told
+    # apart in the reason (.github#274).
+    _mi_present=0
+    _mi_scoped=0
     while IFS= read -r vue; do
         case "${vue}" in
             src/modals/*|src/dialogs/*) continue ;;
         esac
+        _mi_present=$((_mi_present + 1))
         _in_scope "${vue}" || continue
+        _mi_scoped=$((_mi_scoped + 1))
         if grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]' "${vue}" 2>/dev/null; then
             echo "${vue}: inline NcModal/NcDialog — extract to src/modals/ or src/dialogs/" >> "${_mi_log}"
         fi
         # .vue only: NcModal/NcDialog are Vue components with a .vue-file rule.
     done < <(find src -name '*.vue' 2>/dev/null)
     _mi_fail=$(wc -l < "${_mi_log}" 2>/dev/null || echo 0)
-    if [ "${_mi_fail}" -eq 0 ]; then
+    if [ "${_mi_scoped}" -eq 0 ]; then
+        if [ "${_mi_present}" -eq 0 ]; then
+            _skip 13 "modal-isolation" na "src/ exists but contains NO .vue component outside src/modals/ and src/dialogs/, so there is no parent component that could inline a modal. NcModal/NcDialog are Vue SFC components; a PHP/HTML template cannot instantiate one. Reported instead of PASS because an empty glob under an existing src/ is what let twelve gates certify nldesign in #225."
+        else
+            _skip 13 "modal-isolation" na "${_mi_present} .vue component(s) exist here and the diff against '${BASE_REF}' touched none of them, so no component was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass."
+        fi
+    elif [ "${_mi_fail}" -eq 0 ]; then
         _pass 13 "modal-isolation"
     else
         _fail 13 "modal-isolation" "${_mi_fail} file(s) with inline modal/dialog — see ${_mi_log}"
@@ -2304,8 +2342,39 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     done < <(_enum_tracked 'Controller\.php$' lib/Controller)
 
     # ---- Invariant 2: every routed entry resolves to a method that exists.
-    grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
-        | grep -oE "${_ROUTE_PAIR_RX}" | sort -u \
+    #
+    # THE ROUTES AN APPHOST ADOPTER NEVER SPELLS OUT ARE STILL ITS ROUTES
+    # (.github#265, closed here).
+    #
+    # This loop reads route names as LITERALS out of appinfo/routes.php. An
+    # ADR-040 adopter returns `\OCA\OpenRegister\AppHost\Routes::standard($extra)`
+    # and receives ten canonical entries whose names appear nowhere in its own
+    # file — so invariant 2 has never judged a single one of them. Invariant 1
+    # was taught about that table in #223 (`_apphost_supplies_route`); invariant
+    # 2 was not, and the two invariants ask opposite questions, so the fix to
+    # one does nothing for the other.
+    #
+    # What that costs is not hypothetical. `Bootstrap::aliasControllerUnlessLeaf-
+    # DefinesIt()` deliberately lets a leaf keep its OWN SettingsController — and
+    # the moment it does, it owes every method the canonical table routes to
+    # `settings#`. Delete `update()` and `PUT /api/settings` does not 404: the
+    # router matches, `ControllerMethodReflector` reflects, and the request dies
+    # with a ReflectionException 500. Reproduced 2026-08-08 on shillinq by
+    # deleting exactly that method — gate-14's findings log came back EMPTY and
+    # the gate reported PASS. shillinq's own docblock on `update()` spells the
+    # hazard out; the gate was the only thing not reading it.
+    #
+    # The ten names are appended only when this repo's routes.php actually
+    # defers to `Routes::standard()`. `_apphost_serves` / `_di_binds_controller`
+    # still exempt the legitimate absences below, so an adopter that does NOT
+    # ship its own controller is unaffected — the file is missing by design and
+    # those helpers say so.
+    {
+        grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php | grep -oE "${_ROUTE_PAIR_RX}"
+        if [ "${_HYDRA_APPHOST_ROUTE_TABLE}" -eq 1 ]; then
+            printf '%s\n' ${_HYDRA_APPHOST_ROUTE_NAMES}
+        fi
+    } | sort -u \
         | while IFS='#' read -r _ctrl _method; do
             # `read -r` for the reason spelled out in gate-5's loop: plain
             # `read` strips the backslashes out of a namespaced route name, and
@@ -2380,10 +2449,29 @@ if [ -f src/manifest.json ]; then
         _da_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_da_lib_dir}/check_dashboard_antipattern.py" ]; then
-        # The helper exits with the number of violations and prints one
-        # "<file>:<line> ..." per finding; capture both into the log.
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271).
+        #
+        # This used to be `>> log 2>/dev/null || true` followed by `wc -l`. A
+        # helper that never started, or died on a traceback, wrote nothing —
+        # so the log was empty, the count was 0, and the gate printed PASS
+        # over a check that did not run. Proven 2026-08-08 by running the
+        # whole suite with a python3 stub that exits 1: gate-12 and gate-17
+        # said SKIPPED (wiring), gate-15 said PASS.
+        #
+        # stderr goes to a .err file (not /dev/null) so the reason is
+        # readable, and the helper's terminal `# count=` marker is what proves
+        # it reached its own summary.
+        _da_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-dashboard-antipattern.err"
+        : > "${_da_err}"
         python3 "${_da_lib_dir}/check_dashboard_antipattern.py" . \
-            >> "${_da_log}" 2>/dev/null || true
+            >> "${_da_log}" 2>"${_da_err}" || true
+        if ! grep -qE '^# count=[0-9]+$' "${_da_log}" 2>/dev/null; then
+            _da_ran=0
+            _da_why=$(head -3 "${_da_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _skip 15 "dashboard-antipattern" wiring "check_dashboard_antipattern.py did not complete — it never printed its terminal '# count=' marker, so src/manifest.json and the .vue tree were NOT inspected and nested dashboard-in-dashboard patterns are UNVERIFIED by this run. Checker output: ${_da_why:-<empty>}. See ${_da_err}."
+        fi
+        # Drop the marker from the findings log so it is never counted as one.
+        sed -i '/^# count=[0-9]*$/d' "${_da_log}" 2>/dev/null || true
         # Filter to scope when --scope-to-diff is set — the helper reports
         # absolute paths, so strip the app-dir prefix before comparing.
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
@@ -2436,9 +2524,21 @@ if [ -d lib ] || [ -d src ]; then
         # non-default mainline (e.g. --base main) is honoured. Always diff-
         # scoped — a full-repo @spec sweep would flag the entire legacy
         # surface, which is the wrong contract (ADR-020).
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271) — same repair as
+        # gate-15 above. `2>/dev/null || true` + `wc -l` reported PASS for a
+        # helper that never ran; verified 2026-08-08 with a python3 stub that
+        # exits 1. The terminal `# count=` marker is the evidence it finished.
+        _sc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-coverage.err"
+        : > "${_sc_err}"
         HYDRA_GATE_BASE_REF="${BASE_REF}" \
             python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
-            >> "${_sc_log}" 2>/dev/null || true
+            >> "${_sc_log}" 2>"${_sc_err}" || true
+        if ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
+            _sc_ran=0
+            _sc_why=$(head -3 "${_sc_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _skip 16 "spec-coverage" wiring "check_spec_coverage.py did not complete — it never printed its terminal '# count=' marker, so NO changed method was inspected and @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run. Checker output: ${_sc_why:-<empty>}. See ${_sc_err}."
+        fi
+        sed -i '/^# count=[0-9]*$/d' "${_sc_log}" 2>/dev/null || true
         _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)
     else
         _sc_ran=0
@@ -2601,11 +2701,35 @@ _nd_ran=1
 if [ -n "${_nd_register_files}" ]; then
     _nd_lib_dir="${SCRIPT_DIR}/lib"
     if [ -f "${_nd_lib_dir}/check_notification_dialect.py" ]; then
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271).
+        #
+        # This helper's own contract is "exit 0 always; the printed lines are
+        # the findings" — so ANY non-zero exit means it did not run, and the
+        # old `2>/dev/null || true` turned that into an empty log and a PASS.
+        # Verified 2026-08-08 with a python3 stub that exits 1: gate-18 said
+        # PASS while not one register file had been opened.
+        #
+        # The failure count is written to a file, not a variable: the loop runs
+        # in a pipeline subshell, so a variable assigned inside it does not
+        # survive (the classic `while read` + pipe trap).
+        _nd_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect.err"
+        _nd_crash_marker="${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect.crashed"
+        : > "${_nd_err}"; rm -f "${_nd_crash_marker}"
         # shellcheck disable=SC2086
         echo "${_nd_register_files}" | while IFS= read -r _rf; do
             [ -n "${_rf}" ] || continue
-            python3 "${_nd_lib_dir}/check_notification_dialect.py" "${_rf}" >> "${_nd_log}" 2>/dev/null || true
+            python3 "${_nd_lib_dir}/check_notification_dialect.py" "${_rf}" >> "${_nd_log}" 2>>"${_nd_err}"
+            _nd_rc=$?
+            if [ "${_nd_rc}" -ne 0 ]; then
+                echo "${_rf} (exit ${_nd_rc})" >> "${_nd_crash_marker}"
+            fi
         done
+        if [ -s "${_nd_crash_marker}" ]; then
+            _nd_ran=0
+            _nd_why=$(head -3 "${_nd_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _nd_crashed_n=$(wc -l < "${_nd_crash_marker}" 2>/dev/null || echo '?')
+            _skip 18 "notification-dialect" wiring "check_notification_dialect.py exited non-zero on ${_nd_crashed_n} register file(s) — its contract is 'always exit 0, findings on stdout', so a non-zero exit means it did not judge the file. The obsolete legacy notification dialect (ADR-031) is UNVERIFIED for those files by this run. Checker output: ${_nd_why:-<empty>}. See ${_nd_err} and ${_nd_crash_marker}."
+        fi
     else
         _nd_ran=0
         _skip 18 "notification-dialect" wiring "check_notification_dialect.py not found at ${_nd_lib_dir} — register file(s) were in scope and NONE were inspected; the obsolete legacy notification dialect (ADR-031) is UNVERIFIED by this run. The imperative-dispatch advisory below is unaffected and still ran."
@@ -2713,8 +2837,22 @@ if [ -d openspec/specs ] || [ -d tests/e2e ]; then
         # It is a status now, and the honest number is the printed one.
         _e2e_count=$(grep -oE 'FAIL — [0-9]+ scenario' "${_e2e_log}" 2>/dev/null \
             | tail -1 | grep -oE '[0-9]+' || true)
+        # NO VERDICT LINE MEANS NO VERDICT (.github#271). Exit 1 is EXIT_FAIL,
+        # but a helper that died before printing anything cannot honour its own
+        # status contract — with a python3 that exits 1 for every invocation
+        # this gate reported "FAIL — an unreported number of scenario(s)". That
+        # is a finding count nobody measured, wearing a blocking verdict. If the
+        # helper never printed its own `FAIL — N scenario(s)` summary, it did
+        # not finish: wiring, not a fail.
+        _e2e_no_verdict=0
+        if [ "${_e2e_fail}" -eq 1 ] && [ -z "${_e2e_count}" ]; then
+            _e2e_no_verdict=1
+        fi
         [ -z "${_e2e_count}" ] && _e2e_count="an unreported number of"
-        if [ "${_e2e_fail}" -eq 0 ]; then
+        if [ "${_e2e_no_verdict}" -eq 1 ]; then
+            _e2e_ran=0
+            _skip 19 "e2e-coverage" wiring "check_e2e_coverage.py exited 1 (EXIT_FAIL) but never printed its own 'FAIL — N scenario(s)' summary, so it did not reach the end of its run — there is no finding count and no verdict. Reporting this as a failure would block a PR on a number nobody measured. @e2e traceability (ADR-020) is UNVERIFIED by this run. See ${_e2e_log}."
+        elif [ "${_e2e_fail}" -eq 0 ]; then
             _pass 19 "e2e-coverage"
         elif [ "${_e2e_fail}" -eq 3 ]; then
             # EMPTY SCOPE. Specs exist; the diff selected none of them. Not a
@@ -2756,35 +2894,91 @@ fi
 # named like an OR call is fabricated.
 #
 # Scoped to PHP files under lib/, diff-aware when --scope-to-diff is on.
+#
+# ---------------------------------------------------------------------------
+# A PATTERN THAT STARTS WITH `-` IS AN OPTION, NOT A PATTERN (.github#271)
+# ---------------------------------------------------------------------------
+# This gate has never fired. Not "rarely" — never, in any repo, since it was
+# written. The search was
+#
+#     grep -nE "->${_pat//(/\\(}" "${_file}"
+#
+# and the expanded pattern is `->findObjects\(`. grep parses that as OPTIONS
+# because it begins with `-`:
+#
+#     $ grep -nE "->findObjects\(" lib/Controller/ActionsController.php
+#     grep: invalid option -- '>'
+#     exit 2
+#
+# `2>/dev/null || true` swallowed both the message and the status, so `_hits`
+# came back empty for every pattern on every file, `_or_hits` stayed 0, and the
+# gate printed PASS. Measured 2026-08-08 by planting a textbook
+# `$this->objectService->findObjects(...)` in openregister: the gate reported
+# PASS over it.
+#
+# Two changes, and the second matters as much as the first:
+#
+#  1. `--` before the pattern, so grep stops option parsing. Without this the
+#     gate cannot fire at all.
+#
+#  2. THE RECEIVER IS NOW PART OF THE PATTERN. The old heuristic was "the FILE
+#     mentions ObjectService somewhere", which is not a statement about the
+#     call. Turning on (1) alone produces 14 findings on openregister and 5 on
+#     shillinq that are all FALSE: `createFromArray()` is a real method on
+#     OpenRegister's *Mappers* (`$this->registerMapper->createFromArray(...)`,
+#     `$this->schemaMapper->createFromArray(...)`), and those files mention
+#     ObjectService elsewhere. Repairing the grep without tightening the
+#     receiver would swap a dead gate for a noisy one, and a noisy gate gets
+#     switched off. The receiver must itself be named `*[Oo]bjectService`.
+#
+# With both, the fleet measurement across openregister + pipelinq + shillinq is
+# exactly ONE finding, and it is real: shillinq
+# lib/Controller/BookingNotificationController.php resolves
+# `OCA\OpenRegister\Service\ObjectService` from the container inside its
+# non-admin authorisation guard and calls `findObject(...)`, which does not
+# exist on it (verified against openregister lib/Service/ObjectService.php:
+# find / findAll / saveObject / deleteObject / createObject / updateObject).
+#
+# A grep that ERRORS (rc >= 2) is now a wiring skip, never a pass — the same
+# rule the helper-backed gates in this suite follow.
 # ---------------------------------------------------------------------------
 if [ -d lib ]; then
     _or_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-or-objectservice-api.log
     : > "${_or_log}"
     _or_hits=0
-    # Method-call style only — `->findObjects(` etc — to avoid matching
-    # legitimately-named methods on other services (notably $context->
-    # findObject in plugin code, which doesn't use OR's ObjectService).
-    # The leading `->` requires the call to be on an object, which the
-    # ObjectService usage always is.
-    for _pat in 'findObjects(' 'findObject(' 'createFromArray(' 'deleteFromId('; do
-        while IFS= read -r _file; do
-            [ -z "${_file}" ] && continue
-            _in_scope "${_file}" || continue
-            _hits=$(grep -nE "->${_pat//(/\\(}" "${_file}" 2>/dev/null || true)
-            [ -z "${_hits}" ] && continue
-            # Only flag when the call appears to be on an ObjectService
-            # instance — heuristic: the same file references
-            # ObjectService\>|objectService\> somewhere. If not, the
-            # method name is presumably legitimate on a different class.
-            if grep -qE 'ObjectService|objectService' "${_file}" 2>/dev/null; then
-                while IFS= read -r _line; do
-                    echo "${_file}:${_line}  rule=or-objectservice-fabricated-method (${_pat})" >> "${_or_log}"
-                    _or_hits=$((_or_hits + 1))
-                done <<< "${_hits}"
-            fi
-        done < <(_enum_tracked '\.php$' lib)
-    done
-    if [ "${_or_hits}" -eq 0 ]; then
+    _or_ran=1
+    _or_broken=""
+    # Receiver-anchored: the call must be made ON something named
+    # `*[Oo]bjectService` — `$this->objectService->`, `$objectService->`,
+    # `$this->orObjectService?->`. `$this->schemaMapper->createFromArray()` is
+    # a different class's real method and is deliberately not matched.
+    _OR_FABRICATED_RX='(\$this->[A-Za-z_]*[Oo]bjectService|\$[A-Za-z_]*[Oo]bjectService)\??->(findObjects|findObject|createFromArray|updateFromArray|deleteFromId)[[:space:]]*\('
+    while IFS= read -r _file; do
+        [ -z "${_file}" ] && continue
+        [ -f "${_file}" ] || continue
+        _in_scope "${_file}" || continue
+        # `--` terminates option parsing. The pattern is anchored on `$`, not
+        # `-`, since #271, but the guard stays: it is the whole defect.
+        _hits=$(grep -nE -- "${_OR_FABRICATED_RX}" "${_file}" 2>/dev/null)
+        _or_rc=$?
+        if [ "${_or_rc}" -ge 2 ]; then
+            # grep could not run (bad pattern, unreadable file, option-parse
+            # error). It has no verdict about this file; say so rather than
+            # counting its silence as clean.
+            _or_ran=0
+            _or_broken="${_file}"
+            break
+        fi
+        [ -z "${_hits}" ] && continue
+        while IFS= read -r _line; do
+            [ -z "${_line}" ] && continue
+            echo "${_file}:${_line}  rule=or-objectservice-fabricated-method" >> "${_or_log}"
+            _or_hits=$((_or_hits + 1))
+        done <<< "${_hits}"
+    done < <(_enum_tracked '\.php$' lib)
+    if [ "${_or_ran}" -eq 0 ]; then
+        _skip 20 "or-objectservice-api" wiring "grep exited >= 2 on ${_or_broken} — the fabricated-ObjectService-method search did NOT complete, so no call site was judged. Calls to methods that do not exist on OpenRegister's ObjectService are UNVERIFIED by this run."
+    elif [ "${_or_hits}" -eq 0 ]; then
         _pass 20 "or-objectservice-api"
     else
         _fail 20 "or-objectservice-api" "${_or_hits} call(s) to fabricated OR ObjectService methods (use find / findAll / saveObject / createObject / updateObject / deleteObject) — see ${_or_log}"
@@ -6360,9 +6554,25 @@ _declare_na() {
     done
 }
 
-# `if [ -d src ]` — gates 10 12 13 26 45
+# `if [ -d src ]` — gates 10 26 45
 [ -d src ] || _declare_na "no src/ directory — this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect." \
-    10 12 13 26 45
+    10 26 45
+# `if [ -d src ]` — gates 12 13, with the reason that is actually true of them
+# (.github#274).
+#
+# The line above claimed these two inspect ".vue/.js/.ts source". They inspect
+# `.vue` and ONLY `.vue`, because their subjects — `<NcSelect>`, `<NcModal>`,
+# `<NcDialog>` — are Vue SFC components. A PHP or HTML template cannot
+# instantiate one, so widening them the way #272 widened the a11y family would
+# be widening toward markup that cannot contain the defect. gate-40 owns the
+# language-agnostic `<input>`/`<select>` label rule for `templates/`.
+#
+# That is the judgement #274 asked for, written down where a reader can
+# disagree with it rather than left implicit in a shared reason string. Note
+# these two now ALSO report `na` when `src/` exists but holds no `.vue` — see
+# the gates themselves; this declaration only covers `src/` being absent.
+[ -d src ] || _declare_na "no src/ directory — this repo ships no .vue component, and <NcSelect>/<NcModal>/<NcDialog> are Vue SFC components that a PHP or HTML template cannot instantiate. gate-40 owns the language-agnostic <input>/<select> label rule for templates/." \
+    12 13
 # `if _a11y_has_markup_dir` — gates 31 32 34 35 36 37 39 40 42 43 44
 #
 # THE TABLE HAD DRIFTED FROM THE GUARDS IT CLAIMS TO MIRROR.

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1003,7 +1003,51 @@ _ctrl_path_from_name() {
             # which cannot exist on disk and so always resolved to "missing".
             # Invisible until 2026-08-08 because plain `read` had been deleting
             # the backslashes before this branch could ever see two of them.
-            echo "lib/Controller/${_ns//\\//}/${_last_cap}Controller.php"
+            #
+            # A NAMESPACED ROUTE NAME IS RELATIVE TO THE APP ROOT, NOT TO
+            # lib/Controller/ (.github#271).
+            #
+            # NC's RouteParser::buildControllerName() does NOT prefix the app
+            # namespace when the route name already contains a backslash — the
+            # class is looked up under the bare string
+            # `AppHost\Controller\GenericHealthController`. PSR-4 for an NC app
+            # maps `OCA\<App>\` onto `lib/`, so that class lives at
+            #
+            #     lib/AppHost/Controller/GenericHealthController.php
+            #
+            # and NOT under lib/Controller/. Deriving only the lib/Controller/
+            # spelling produced a path that cannot exist, and gate-14 reported
+            #
+            #   lib/Controller/AppHost/Controller/GenericHealthController.php
+            #     route='AppHost\Controller\GenericHealth#index'
+            #     rule=controller-class-not-found
+            #
+            # INSIDE the repository that ships the file — reproduced 2026-08-08
+            # against this package's own gates-23-33/planted fixture. Same shape
+            # as the gate-30 finding: a path the gate derives is not the path
+            # the app uses.
+            #
+            # The false FAIL is only half of it. When a DI binding rescued the
+            # absence (`_di_binds_fq_controller`), the loop `continue`d — so the
+            # method-existence check never ran, and a route pointing at a
+            # method that does not exist on a controller sitting right there in
+            # the tree was never judged. That is #265's defect at a different
+            # address.
+            #
+            # Both candidates are probed and the one that EXISTS wins. When
+            # neither does, the lib/Controller/ spelling is reported, exactly as
+            # before, so a genuinely missing controller reads the same as it
+            # always has.
+            local _ctrl_under _ctrl_psr4
+            _ctrl_under="lib/Controller/${_ns//\\//}/${_last_cap}Controller.php"
+            _ctrl_psr4="lib/${_ns//\\//}/${_last_cap}Controller.php"
+            if [ -f "${_ctrl_under}" ]; then
+                echo "${_ctrl_under}"
+            elif [ -f "${_ctrl_psr4}" ]; then
+                echo "${_ctrl_psr4}"
+            else
+                echo "${_ctrl_under}"
+            fi
             ;;
         *_*)
             local _camel

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2123,15 +2123,39 @@ if [ -d src ]; then
     _il_ran=1
     _il_helper="${SCRIPT_DIR}/lib/check_nc_select_labels.py"
     _il_files=()
+    # Counted separately from the in-scope list so "this repo has no Vue
+    # component at all" can be told apart from "the diff touched none of them".
+    _il_present=0
     while IFS= read -r vue; do
         [ -f "${vue}" ] || continue
+        _il_present=$((_il_present + 1))
         _in_scope "${vue}" || continue
         _il_files+=("${vue}")
         # .vue only: <NcSelect> is a Vue component. Gate 40 covers the
         # language-agnostic <input>/<select> label rule for PHP templates.
     done < <(find src -name '*.vue' 2>/dev/null)
     if [ "${#_il_files[@]}" -eq 0 ]; then
-        : # nothing in scope — ordinary diff scoping.
+        # ZERO FILES IS NOT A PASS (.github#274, and #225 one layer down).
+        #
+        # `[ -d src ]` was the whole guard, and `src/` existing is not the same
+        # as `src/` containing a Vue component. nldesign's `src/` holds ONE
+        # file — `manifest.json` — and this gate printed PASS there, over an
+        # empty glob. That is the exact shape that let twelve a11y gates certify
+        # nldesign in #225; gates 12 and 13 were not in that band and kept it.
+        #
+        # `na`, not `structural`: nothing in the repository is missing. An app
+        # that renders from PHP templates has no `<NcSelect>` to name, because
+        # `NcSelect` is a Vue SFC component — a PHP template cannot instantiate
+        # one, which is why this gate stays `.vue`-only while gate-40 owns the
+        # language-agnostic `<input>`/`<select>` label rule for templates. That
+        # is the judgement #274 asked for, and it is stated in the reason so a
+        # reader can disagree with it.
+        _il_ran=0
+        if [ "${_il_present}" -eq 0 ]; then
+            _skip 12 "nc-input-labels" na "src/ exists but contains NO .vue component, so there is no <NcSelect> to name. This gate is deliberately .vue-only: NcSelect is a Vue SFC component and a PHP/HTML template cannot instantiate one — gate-40 owns the language-agnostic <input>/<select> label rule for templates/. Reported instead of PASS because an empty glob under an existing src/ is what let twelve gates certify nldesign in #225."
+        else
+            _skip 12 "nc-input-labels" na "${_il_present} .vue component(s) exist here and the diff against '${BASE_REF}' touched none of them, so no <NcSelect> was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass."
+        fi
     elif [ ! -f "${_il_helper}" ]; then
         # A MISSING HELPER MUST NOT REPORT PASS (#147).
         _il_ran=0
@@ -2165,18 +2189,32 @@ fi
 if [ -d src ]; then
     _mi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-modal-isolation.log
     : > "${_mi_log}"
+    # See gate-12 above: `src/` existing is not the same as `src/` containing a
+    # Vue component, and this gate printed PASS over an empty glob on nldesign
+    # (whose src/ holds one manifest.json). Counted so the two cases can be told
+    # apart in the reason (.github#274).
+    _mi_present=0
+    _mi_scoped=0
     while IFS= read -r vue; do
         case "${vue}" in
             src/modals/*|src/dialogs/*) continue ;;
         esac
+        _mi_present=$((_mi_present + 1))
         _in_scope "${vue}" || continue
+        _mi_scoped=$((_mi_scoped + 1))
         if grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]' "${vue}" 2>/dev/null; then
             echo "${vue}: inline NcModal/NcDialog — extract to src/modals/ or src/dialogs/" >> "${_mi_log}"
         fi
         # .vue only: NcModal/NcDialog are Vue components with a .vue-file rule.
     done < <(find src -name '*.vue' 2>/dev/null)
     _mi_fail=$(wc -l < "${_mi_log}" 2>/dev/null || echo 0)
-    if [ "${_mi_fail}" -eq 0 ]; then
+    if [ "${_mi_scoped}" -eq 0 ]; then
+        if [ "${_mi_present}" -eq 0 ]; then
+            _skip 13 "modal-isolation" na "src/ exists but contains NO .vue component outside src/modals/ and src/dialogs/, so there is no parent component that could inline a modal. NcModal/NcDialog are Vue SFC components; a PHP/HTML template cannot instantiate one. Reported instead of PASS because an empty glob under an existing src/ is what let twelve gates certify nldesign in #225."
+        else
+            _skip 13 "modal-isolation" na "${_mi_present} .vue component(s) exist here and the diff against '${BASE_REF}' touched none of them, so no component was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass."
+        fi
+    elif [ "${_mi_fail}" -eq 0 ]; then
         _pass 13 "modal-isolation"
     else
         _fail 13 "modal-isolation" "${_mi_fail} file(s) with inline modal/dialog — see ${_mi_log}"
@@ -2304,8 +2342,39 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     done < <(_enum_tracked 'Controller\.php$' lib/Controller)
 
     # ---- Invariant 2: every routed entry resolves to a method that exists.
-    grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php \
-        | grep -oE "${_ROUTE_PAIR_RX}" | sort -u \
+    #
+    # THE ROUTES AN APPHOST ADOPTER NEVER SPELLS OUT ARE STILL ITS ROUTES
+    # (.github#265, closed here).
+    #
+    # This loop reads route names as LITERALS out of appinfo/routes.php. An
+    # ADR-040 adopter returns `\OCA\OpenRegister\AppHost\Routes::standard($extra)`
+    # and receives ten canonical entries whose names appear nowhere in its own
+    # file — so invariant 2 has never judged a single one of them. Invariant 1
+    # was taught about that table in #223 (`_apphost_supplies_route`); invariant
+    # 2 was not, and the two invariants ask opposite questions, so the fix to
+    # one does nothing for the other.
+    #
+    # What that costs is not hypothetical. `Bootstrap::aliasControllerUnlessLeaf-
+    # DefinesIt()` deliberately lets a leaf keep its OWN SettingsController — and
+    # the moment it does, it owes every method the canonical table routes to
+    # `settings#`. Delete `update()` and `PUT /api/settings` does not 404: the
+    # router matches, `ControllerMethodReflector` reflects, and the request dies
+    # with a ReflectionException 500. Reproduced 2026-08-08 on shillinq by
+    # deleting exactly that method — gate-14's findings log came back EMPTY and
+    # the gate reported PASS. shillinq's own docblock on `update()` spells the
+    # hazard out; the gate was the only thing not reading it.
+    #
+    # The ten names are appended only when this repo's routes.php actually
+    # defers to `Routes::standard()`. `_apphost_serves` / `_di_binds_controller`
+    # still exempt the legitimate absences below, so an adopter that does NOT
+    # ship its own controller is unaffected — the file is missing by design and
+    # those helpers say so.
+    {
+        grep -oE "${_ROUTE_NAME_RX}" appinfo/routes.php | grep -oE "${_ROUTE_PAIR_RX}"
+        if [ "${_HYDRA_APPHOST_ROUTE_TABLE}" -eq 1 ]; then
+            printf '%s\n' ${_HYDRA_APPHOST_ROUTE_NAMES}
+        fi
+    } | sort -u \
         | while IFS='#' read -r _ctrl _method; do
             # `read -r` for the reason spelled out in gate-5's loop: plain
             # `read` strips the backslashes out of a namespaced route name, and
@@ -2380,10 +2449,29 @@ if [ -f src/manifest.json ]; then
         _da_lib_dir="${SCRIPT_DIR}/lib"
     fi
     if [ -f "${_da_lib_dir}/check_dashboard_antipattern.py" ]; then
-        # The helper exits with the number of violations and prints one
-        # "<file>:<line> ..." per finding; capture both into the log.
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271).
+        #
+        # This used to be `>> log 2>/dev/null || true` followed by `wc -l`. A
+        # helper that never started, or died on a traceback, wrote nothing —
+        # so the log was empty, the count was 0, and the gate printed PASS
+        # over a check that did not run. Proven 2026-08-08 by running the
+        # whole suite with a python3 stub that exits 1: gate-12 and gate-17
+        # said SKIPPED (wiring), gate-15 said PASS.
+        #
+        # stderr goes to a .err file (not /dev/null) so the reason is
+        # readable, and the helper's terminal `# count=` marker is what proves
+        # it reached its own summary.
+        _da_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-dashboard-antipattern.err"
+        : > "${_da_err}"
         python3 "${_da_lib_dir}/check_dashboard_antipattern.py" . \
-            >> "${_da_log}" 2>/dev/null || true
+            >> "${_da_log}" 2>"${_da_err}" || true
+        if ! grep -qE '^# count=[0-9]+$' "${_da_log}" 2>/dev/null; then
+            _da_ran=0
+            _da_why=$(head -3 "${_da_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _skip 15 "dashboard-antipattern" wiring "check_dashboard_antipattern.py did not complete — it never printed its terminal '# count=' marker, so src/manifest.json and the .vue tree were NOT inspected and nested dashboard-in-dashboard patterns are UNVERIFIED by this run. Checker output: ${_da_why:-<empty>}. See ${_da_err}."
+        fi
+        # Drop the marker from the findings log so it is never counted as one.
+        sed -i '/^# count=[0-9]*$/d' "${_da_log}" 2>/dev/null || true
         # Filter to scope when --scope-to-diff is set — the helper reports
         # absolute paths, so strip the app-dir prefix before comparing.
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
@@ -2436,9 +2524,21 @@ if [ -d lib ] || [ -d src ]; then
         # non-default mainline (e.g. --base main) is honoured. Always diff-
         # scoped — a full-repo @spec sweep would flag the entire legacy
         # surface, which is the wrong contract (ADR-020).
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271) — same repair as
+        # gate-15 above. `2>/dev/null || true` + `wc -l` reported PASS for a
+        # helper that never ran; verified 2026-08-08 with a python3 stub that
+        # exits 1. The terminal `# count=` marker is the evidence it finished.
+        _sc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-coverage.err"
+        : > "${_sc_err}"
         HYDRA_GATE_BASE_REF="${BASE_REF}" \
             python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
-            >> "${_sc_log}" 2>/dev/null || true
+            >> "${_sc_log}" 2>"${_sc_err}" || true
+        if ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
+            _sc_ran=0
+            _sc_why=$(head -3 "${_sc_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _skip 16 "spec-coverage" wiring "check_spec_coverage.py did not complete — it never printed its terminal '# count=' marker, so NO changed method was inspected and @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run. Checker output: ${_sc_why:-<empty>}. See ${_sc_err}."
+        fi
+        sed -i '/^# count=[0-9]*$/d' "${_sc_log}" 2>/dev/null || true
         _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)
     else
         _sc_ran=0
@@ -2601,11 +2701,35 @@ _nd_ran=1
 if [ -n "${_nd_register_files}" ]; then
     _nd_lib_dir="${SCRIPT_DIR}/lib"
     if [ -f "${_nd_lib_dir}/check_notification_dialect.py" ]; then
+        # A CRASHED CHECKER IS NOT A CLEAN ONE (.github#271).
+        #
+        # This helper's own contract is "exit 0 always; the printed lines are
+        # the findings" — so ANY non-zero exit means it did not run, and the
+        # old `2>/dev/null || true` turned that into an empty log and a PASS.
+        # Verified 2026-08-08 with a python3 stub that exits 1: gate-18 said
+        # PASS while not one register file had been opened.
+        #
+        # The failure count is written to a file, not a variable: the loop runs
+        # in a pipeline subshell, so a variable assigned inside it does not
+        # survive (the classic `while read` + pipe trap).
+        _nd_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect.err"
+        _nd_crash_marker="${HYDRA_GATE_LOG_DIR}/hydra-gate-notification-dialect.crashed"
+        : > "${_nd_err}"; rm -f "${_nd_crash_marker}"
         # shellcheck disable=SC2086
         echo "${_nd_register_files}" | while IFS= read -r _rf; do
             [ -n "${_rf}" ] || continue
-            python3 "${_nd_lib_dir}/check_notification_dialect.py" "${_rf}" >> "${_nd_log}" 2>/dev/null || true
+            python3 "${_nd_lib_dir}/check_notification_dialect.py" "${_rf}" >> "${_nd_log}" 2>>"${_nd_err}"
+            _nd_rc=$?
+            if [ "${_nd_rc}" -ne 0 ]; then
+                echo "${_rf} (exit ${_nd_rc})" >> "${_nd_crash_marker}"
+            fi
         done
+        if [ -s "${_nd_crash_marker}" ]; then
+            _nd_ran=0
+            _nd_why=$(head -3 "${_nd_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+            _nd_crashed_n=$(wc -l < "${_nd_crash_marker}" 2>/dev/null || echo '?')
+            _skip 18 "notification-dialect" wiring "check_notification_dialect.py exited non-zero on ${_nd_crashed_n} register file(s) — its contract is 'always exit 0, findings on stdout', so a non-zero exit means it did not judge the file. The obsolete legacy notification dialect (ADR-031) is UNVERIFIED for those files by this run. Checker output: ${_nd_why:-<empty>}. See ${_nd_err} and ${_nd_crash_marker}."
+        fi
     else
         _nd_ran=0
         _skip 18 "notification-dialect" wiring "check_notification_dialect.py not found at ${_nd_lib_dir} — register file(s) were in scope and NONE were inspected; the obsolete legacy notification dialect (ADR-031) is UNVERIFIED by this run. The imperative-dispatch advisory below is unaffected and still ran."
@@ -2713,8 +2837,22 @@ if [ -d openspec/specs ] || [ -d tests/e2e ]; then
         # It is a status now, and the honest number is the printed one.
         _e2e_count=$(grep -oE 'FAIL — [0-9]+ scenario' "${_e2e_log}" 2>/dev/null \
             | tail -1 | grep -oE '[0-9]+' || true)
+        # NO VERDICT LINE MEANS NO VERDICT (.github#271). Exit 1 is EXIT_FAIL,
+        # but a helper that died before printing anything cannot honour its own
+        # status contract — with a python3 that exits 1 for every invocation
+        # this gate reported "FAIL — an unreported number of scenario(s)". That
+        # is a finding count nobody measured, wearing a blocking verdict. If the
+        # helper never printed its own `FAIL — N scenario(s)` summary, it did
+        # not finish: wiring, not a fail.
+        _e2e_no_verdict=0
+        if [ "${_e2e_fail}" -eq 1 ] && [ -z "${_e2e_count}" ]; then
+            _e2e_no_verdict=1
+        fi
         [ -z "${_e2e_count}" ] && _e2e_count="an unreported number of"
-        if [ "${_e2e_fail}" -eq 0 ]; then
+        if [ "${_e2e_no_verdict}" -eq 1 ]; then
+            _e2e_ran=0
+            _skip 19 "e2e-coverage" wiring "check_e2e_coverage.py exited 1 (EXIT_FAIL) but never printed its own 'FAIL — N scenario(s)' summary, so it did not reach the end of its run — there is no finding count and no verdict. Reporting this as a failure would block a PR on a number nobody measured. @e2e traceability (ADR-020) is UNVERIFIED by this run. See ${_e2e_log}."
+        elif [ "${_e2e_fail}" -eq 0 ]; then
             _pass 19 "e2e-coverage"
         elif [ "${_e2e_fail}" -eq 3 ]; then
             # EMPTY SCOPE. Specs exist; the diff selected none of them. Not a
@@ -2756,35 +2894,91 @@ fi
 # named like an OR call is fabricated.
 #
 # Scoped to PHP files under lib/, diff-aware when --scope-to-diff is on.
+#
+# ---------------------------------------------------------------------------
+# A PATTERN THAT STARTS WITH `-` IS AN OPTION, NOT A PATTERN (.github#271)
+# ---------------------------------------------------------------------------
+# This gate has never fired. Not "rarely" — never, in any repo, since it was
+# written. The search was
+#
+#     grep -nE "->${_pat//(/\\(}" "${_file}"
+#
+# and the expanded pattern is `->findObjects\(`. grep parses that as OPTIONS
+# because it begins with `-`:
+#
+#     $ grep -nE "->findObjects\(" lib/Controller/ActionsController.php
+#     grep: invalid option -- '>'
+#     exit 2
+#
+# `2>/dev/null || true` swallowed both the message and the status, so `_hits`
+# came back empty for every pattern on every file, `_or_hits` stayed 0, and the
+# gate printed PASS. Measured 2026-08-08 by planting a textbook
+# `$this->objectService->findObjects(...)` in openregister: the gate reported
+# PASS over it.
+#
+# Two changes, and the second matters as much as the first:
+#
+#  1. `--` before the pattern, so grep stops option parsing. Without this the
+#     gate cannot fire at all.
+#
+#  2. THE RECEIVER IS NOW PART OF THE PATTERN. The old heuristic was "the FILE
+#     mentions ObjectService somewhere", which is not a statement about the
+#     call. Turning on (1) alone produces 14 findings on openregister and 5 on
+#     shillinq that are all FALSE: `createFromArray()` is a real method on
+#     OpenRegister's *Mappers* (`$this->registerMapper->createFromArray(...)`,
+#     `$this->schemaMapper->createFromArray(...)`), and those files mention
+#     ObjectService elsewhere. Repairing the grep without tightening the
+#     receiver would swap a dead gate for a noisy one, and a noisy gate gets
+#     switched off. The receiver must itself be named `*[Oo]bjectService`.
+#
+# With both, the fleet measurement across openregister + pipelinq + shillinq is
+# exactly ONE finding, and it is real: shillinq
+# lib/Controller/BookingNotificationController.php resolves
+# `OCA\OpenRegister\Service\ObjectService` from the container inside its
+# non-admin authorisation guard and calls `findObject(...)`, which does not
+# exist on it (verified against openregister lib/Service/ObjectService.php:
+# find / findAll / saveObject / deleteObject / createObject / updateObject).
+#
+# A grep that ERRORS (rc >= 2) is now a wiring skip, never a pass — the same
+# rule the helper-backed gates in this suite follow.
 # ---------------------------------------------------------------------------
 if [ -d lib ]; then
     _or_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-or-objectservice-api.log
     : > "${_or_log}"
     _or_hits=0
-    # Method-call style only — `->findObjects(` etc — to avoid matching
-    # legitimately-named methods on other services (notably $context->
-    # findObject in plugin code, which doesn't use OR's ObjectService).
-    # The leading `->` requires the call to be on an object, which the
-    # ObjectService usage always is.
-    for _pat in 'findObjects(' 'findObject(' 'createFromArray(' 'deleteFromId('; do
-        while IFS= read -r _file; do
-            [ -z "${_file}" ] && continue
-            _in_scope "${_file}" || continue
-            _hits=$(grep -nE "->${_pat//(/\\(}" "${_file}" 2>/dev/null || true)
-            [ -z "${_hits}" ] && continue
-            # Only flag when the call appears to be on an ObjectService
-            # instance — heuristic: the same file references
-            # ObjectService\>|objectService\> somewhere. If not, the
-            # method name is presumably legitimate on a different class.
-            if grep -qE 'ObjectService|objectService' "${_file}" 2>/dev/null; then
-                while IFS= read -r _line; do
-                    echo "${_file}:${_line}  rule=or-objectservice-fabricated-method (${_pat})" >> "${_or_log}"
-                    _or_hits=$((_or_hits + 1))
-                done <<< "${_hits}"
-            fi
-        done < <(_enum_tracked '\.php$' lib)
-    done
-    if [ "${_or_hits}" -eq 0 ]; then
+    _or_ran=1
+    _or_broken=""
+    # Receiver-anchored: the call must be made ON something named
+    # `*[Oo]bjectService` — `$this->objectService->`, `$objectService->`,
+    # `$this->orObjectService?->`. `$this->schemaMapper->createFromArray()` is
+    # a different class's real method and is deliberately not matched.
+    _OR_FABRICATED_RX='(\$this->[A-Za-z_]*[Oo]bjectService|\$[A-Za-z_]*[Oo]bjectService)\??->(findObjects|findObject|createFromArray|updateFromArray|deleteFromId)[[:space:]]*\('
+    while IFS= read -r _file; do
+        [ -z "${_file}" ] && continue
+        [ -f "${_file}" ] || continue
+        _in_scope "${_file}" || continue
+        # `--` terminates option parsing. The pattern is anchored on `$`, not
+        # `-`, since #271, but the guard stays: it is the whole defect.
+        _hits=$(grep -nE -- "${_OR_FABRICATED_RX}" "${_file}" 2>/dev/null)
+        _or_rc=$?
+        if [ "${_or_rc}" -ge 2 ]; then
+            # grep could not run (bad pattern, unreadable file, option-parse
+            # error). It has no verdict about this file; say so rather than
+            # counting its silence as clean.
+            _or_ran=0
+            _or_broken="${_file}"
+            break
+        fi
+        [ -z "${_hits}" ] && continue
+        while IFS= read -r _line; do
+            [ -z "${_line}" ] && continue
+            echo "${_file}:${_line}  rule=or-objectservice-fabricated-method" >> "${_or_log}"
+            _or_hits=$((_or_hits + 1))
+        done <<< "${_hits}"
+    done < <(_enum_tracked '\.php$' lib)
+    if [ "${_or_ran}" -eq 0 ]; then
+        _skip 20 "or-objectservice-api" wiring "grep exited >= 2 on ${_or_broken} — the fabricated-ObjectService-method search did NOT complete, so no call site was judged. Calls to methods that do not exist on OpenRegister's ObjectService are UNVERIFIED by this run."
+    elif [ "${_or_hits}" -eq 0 ]; then
         _pass 20 "or-objectservice-api"
     else
         _fail 20 "or-objectservice-api" "${_or_hits} call(s) to fabricated OR ObjectService methods (use find / findAll / saveObject / createObject / updateObject / deleteObject) — see ${_or_log}"
@@ -6585,9 +6779,25 @@ _declare_na() {
     done
 }
 
-# `if [ -d src ]` — gates 10 12 13 26 45
+# `if [ -d src ]` — gates 10 26 45
 [ -d src ] || _declare_na "no src/ directory — this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect." \
-    10 12 13 26 45
+    10 26 45
+# `if [ -d src ]` — gates 12 13, with the reason that is actually true of them
+# (.github#274).
+#
+# The line above claimed these two inspect ".vue/.js/.ts source". They inspect
+# `.vue` and ONLY `.vue`, because their subjects — `<NcSelect>`, `<NcModal>`,
+# `<NcDialog>` — are Vue SFC components. A PHP or HTML template cannot
+# instantiate one, so widening them the way #272 widened the a11y family would
+# be widening toward markup that cannot contain the defect. gate-40 owns the
+# language-agnostic `<input>`/`<select>` label rule for `templates/`.
+#
+# That is the judgement #274 asked for, written down where a reader can
+# disagree with it rather than left implicit in a shared reason string. Note
+# these two now ALSO report `na` when `src/` exists but holds no `.vue` — see
+# the gates themselves; this declaration only covers `src/` being absent.
+[ -d src ] || _declare_na "no src/ directory — this repo ships no .vue component, and <NcSelect>/<NcModal>/<NcDialog> are Vue SFC components that a PHP or HTML template cannot instantiate. gate-40 owns the language-agnostic <input>/<select> label rule for templates/." \
+    12 13
 # `if _a11y_has_markup_dir` — gates 31 32 34 35 36 37 39 40 42 43 44
 #
 # THE TABLE HAD DRIFTED FROM THE GUARDS IT CLAIMS TO MIRROR.

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/appinfo/routes.php
@@ -1,0 +1,13 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// A NAMESPACED route name. NC's RouteParser::buildControllerName() does NOT
+// prefix the app namespace when the name already contains a backslash, so this
+// resolves to the bare class `AppHost\Controller\GenericHealthController`,
+// which PSR-4 places at lib/AppHost/Controller/ — NOT under lib/Controller/.
+return [
+    'routes' => [
+        ['name' => 'AppHost\Controller\GenericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
+        ['name' => 'ping#index', 'url' => '/api/ping', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/AppHost/Controller/GenericHealthController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/AppHost/Controller/GenericHealthController.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppHost\Controller;
+
+class GenericHealthController extends Controller
+{
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function indexRenamed(): JSONResponse
+    {
+        return new JSONResponse(['status' => 'ok']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/AppInfo/Application.php
@@ -1,0 +1,16 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+class Application
+{
+    public function register($context): void
+    {
+        $context->registerService(
+            'AppHost\\Controller\\GenericHealthController',
+            static fn ($c) => new \OCA\Fixture\AppHost\Controller\GenericHealthController()
+        );
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/Controller/PingController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller-missing-method/lib/Controller/PingController.php
@@ -1,0 +1,17 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+// The CONVENTIONAL spelling, in the same repo. Its route name has no backslash,
+// so it resolves under lib/Controller/ — the anti-widening control for the
+// namespaced case next door.
+class PingController extends Controller
+{
+    #[PublicPage]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['pong' => true]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/appinfo/routes.php
@@ -1,0 +1,13 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// A NAMESPACED route name. NC's RouteParser::buildControllerName() does NOT
+// prefix the app namespace when the name already contains a backslash, so this
+// resolves to the bare class `AppHost\Controller\GenericHealthController`,
+// which PSR-4 places at lib/AppHost/Controller/ — NOT under lib/Controller/.
+return [
+    'routes' => [
+        ['name' => 'AppHost\Controller\GenericHealth#index', 'url' => '/api/health', 'verb' => 'GET'],
+        ['name' => 'ping#index', 'url' => '/api/ping', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/AppHost/Controller/GenericHealthController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/AppHost/Controller/GenericHealthController.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppHost\Controller;
+
+class GenericHealthController extends Controller
+{
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['status' => 'ok']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/AppInfo/Application.php
@@ -1,0 +1,16 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+class Application
+{
+    public function register($context): void
+    {
+        $context->registerService(
+            'AppHost\\Controller\\GenericHealthController',
+            static fn ($c) => new \OCA\Fixture\AppHost\Controller\GenericHealthController()
+        );
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/Controller/PingController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/psr4-namespaced-controller/lib/Controller/PingController.php
@@ -1,0 +1,17 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+// The CONVENTIONAL spelling, in the same repo. Its route name has no backslash,
+// so it resolves under lib/Controller/ — the anti-widening control for the
+// namespaced case next door.
+class PingController extends Controller
+{
+    #[PublicPage]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse(['pong' => true]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/appinfo/routes.php
@@ -1,0 +1,12 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// ADR-040 route table. The ten canonical entries — dashboard#page,
+// dashboard#catchAll, settings#index/create/update/load,
+// preferences#getPreference/setPreference, metrics#index, health#index —
+// are PREPENDED by Routes::standard() and appear nowhere in this file.
+// That is the whole point of #223: gate-14 invariant 1 was grepping here
+// for names that live in openregister.
+return \OCA\OpenRegister\AppHost\Routes::standard([
+    ['name' => 'widget#show', 'url' => '/api/widget', 'verb' => 'GET'],
+]);

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/AppInfo/Application.php
@@ -1,0 +1,15 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+
+class Application
+{
+    public function register($context): void
+    {
+        Bootstrap::register($context, 'fixture', ['namespace' => 'OCA\\Fixture']);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/DashboardController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/DashboardController.php
@@ -1,0 +1,28 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * The leaf ships its OWN dashboard controller — the supported shape;
+ * Bootstrap::aliasControllerUnlessLeafDefinesIt() exists precisely to allow
+ * it. Its two routes are supplied by Routes::standard(), so neither name
+ * appears in appinfo/routes.php.
+ */
+class DashboardController extends Controller
+{
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function page(): TemplateResponse
+    {
+        return new TemplateResponse('fixture', 'index');
+    }
+
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function catchAll(): TemplateResponse
+    {
+        return new TemplateResponse('fixture', 'index');
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/GadgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/GadgetController.php
@@ -1,0 +1,24 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE ANTI-WIDENING HALF of this fixture.
+ *
+ * `gadget#run` is not one of the ten names Routes::standard() supplies and
+ * it is not in appinfo/routes.php either — so it is a genuine 404 and
+ * gate-14 invariant 1 MUST still report it. If the #223 fix had been
+ * written as "an AppHost adopter is exempt from invariant 1" rather than as
+ * "these ten names are declared elsewhere", this method would go quiet and
+ * the gate would be retired for every ADR-040 app in the fleet.
+ */
+class GadgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function run(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/SettingsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/SettingsController.php
@@ -1,0 +1,42 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// .github#265 FIXTURE — the leaf keeps its OWN SettingsController (which
+// `Bootstrap::aliasControllerUnlessLeafDefinesIt()` explicitly allows) but does
+// NOT define `update()`.
+//
+// `Routes::standard()` prepends `['name' => 'settings#update', 'url' =>
+// '/api/settings', 'verb' => 'PUT']`, and that name appears NOWHERE in this
+// app's appinfo/routes.php. Gate-14 invariant 2 used to read route names as
+// literals out of that file only, so it never asked the question — and
+// `PUT /api/settings` here is not a 404: the router matches,
+// ControllerMethodReflector reflects, and the request dies with a
+// ReflectionException 500.
+//
+// This file is byte-identical to routes-standard/lib/Controller/
+// SettingsController.php with `update()` removed. That sibling MUST stay clean;
+// this one MUST be reported.
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class SettingsController extends Controller
+{
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function create(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function load(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/WidgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard-missing-update/lib/Controller/WidgetController.php
@@ -1,0 +1,14 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+class WidgetController extends Controller
+{
+    #[NoAdminRequired]
+    public function show(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/SettingsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/routes-standard/lib/Controller/SettingsController.php
@@ -18,6 +18,17 @@ class SettingsController extends Controller
         return new JSONResponse([]);
     }
 
+    // `settings#update` (PUT /api/settings) is one of the ten entries
+    // Routes::standard() prepends. A leaf that keeps its OWN SettingsController
+    // owes every one of those methods — see the sibling fixture
+    // routes-standard-missing-update/, which deletes exactly this method and
+    // MUST be reported (.github#265).
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function update(): JSONResponse
+    {
+        return new JSONResponse([]);
+    }
+
     #[AuthorizedAdminSetting(Application::APP_ID)]
     public function load(): JSONResponse
     {

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -414,8 +414,21 @@ fi
 # gates guarded by `[ -d src ]` must genuinely RUN. If the declaration table
 # ever drifts away from the guards it mirrors, it would keep calling them
 # not-applicable here — which is the one way this change could hide a live gate.
+#
+# GATES 12 AND 13 ARE ASSERTED SEPARATELY, AND MORE STRICTLY (.github#271/#274).
+#
+# This loop's premise is "src/ exists, therefore the gate has a subject". For
+# gate-12 (<NcSelect>) and gate-13 (<NcModal>/<NcDialog>) that does not follow:
+# their subjects are Vue SFC components, and THIS FIXTURE'S src/ contains one
+# .js file and no .vue at all. Until now both gates printed PASS here — a green
+# over an empty glob, which is nldesign's exact shape and the reason twelve
+# gates certified it in #225. Keeping them in this loop would have encoded that
+# belief as an assertion.
+#
+# So they move out, and what replaces the loop entry is stronger than what it
+# asserted: not merely "did not say na", but "said na FOR THE RIGHT REASON".
 _still_na=""
-for _g in 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45; do
+for _g in 10 26 31 32 34 35 36 37 39 40 42 43 44 45; do
     printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE" && _still_na="${_still_na}${_g} "
 done
 if [ -z "${_still_na}" ]; then
@@ -423,6 +436,17 @@ if [ -z "${_still_na}" ]; then
 else
     _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists — the table has drifted from the guards it mirrors"
 fi
+
+for _g in 12 13; do
+    if printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE — src/ exists but contains NO \.vue"; then
+        _ok "gate-${_g} reports na and NAMES the empty .vue glob — src/ exists here but holds no Vue component"
+    elif printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: PASS"; then
+        _bad "gate-${_g} reported PASS over a src/ with zero .vue files — green over nothing (#225/#274)"
+    else
+        _v=$(printf '%s' "${OUT_STRUCT}" | grep -oE "^\[gate-${_g}\] [^:]+: [A-Z]+( [A-Z]+)*( \([a-z]+\))?" | head -1 | sed 's/^[^:]*: //')
+        _bad "gate-${_g} returned '${_v:-none emitted}' on a src/ with no .vue — expected na naming the empty glob"
+    fi
+done
 
 echo "[test] an unrecognised skip category is a hard failure, never a silent 'na'"
 # A typo'd category that defaulted to `na` would be a lever for making any

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -415,38 +415,40 @@ fi
 # ever drifts away from the guards it mirrors, it would keep calling them
 # not-applicable here — which is the one way this change could hide a live gate.
 #
-# GATES 12 AND 13 ARE ASSERTED SEPARATELY, AND MORE STRICTLY (.github#271/#274).
+# ASSERT THE FIXTURE'S PREMISE BEFORE ASSERTING THE VERDICT (.github#271).
 #
-# This loop's premise is "src/ exists, therefore the gate has a subject". For
-# gate-12 (<NcSelect>) and gate-13 (<NcModal>/<NcDialog>) that does not follow:
-# their subjects are Vue SFC components, and THIS FIXTURE'S src/ contains one
-# .js file and no .vue at all. Until now both gates printed PASS here — a green
-# over an empty glob, which is nldesign's exact shape and the reason twelve
-# gates certified it in #225. Keeping them in this loop would have encoded that
-# belief as an assertion.
+# This loop's claim is "src/ exists, therefore these gates have a subject", and
+# that stopped following once gates started distinguishing "src/ exists" from
+# "src/ contains what I read". #276 hit it for gates 26/31/32 and answered it
+# the right way — by giving the fixture two real .vue files so the positive
+# control supplies their subject matter instead of just a directory.
 #
-# So they move out, and what replaces the loop entry is stronger than what it
-# asserted: not merely "did not say na", but "said na FOR THE RIGHT REASON".
+# Gates 12 and 13 read `.vue` for the same reason (<NcSelect>, <NcModal> and
+# <NcDialog> are Vue SFC components; a PHP template cannot instantiate one), so
+# they belong in the loop — but only for as long as those .vue files are there.
+# If a later change removes them, this loop would go on asserting "the gates
+# ran" while every one of them iterated an empty glob, which is the nldesign
+# shape it exists to prevent. So the premise is checked, not assumed.
+#
+# The zero-.vue case is asserted where its premise actually holds:
+# test_gate_empty_scope_never_passes.sh builds an nldesign-shaped repo (src/
+# holding one manifest.json) and requires `na` there, with a one-.vue control.
+_fix_vue_n=$(find "${FIX}/src" -name '*.vue' 2>/dev/null | grep -c . || true)
+if [ "${_fix_vue_n}" -ge 1 ]; then
+    _ok "fixture premise holds: ${FIX}/src supplies ${_fix_vue_n} .vue file(s), so the .vue-reading gates below have a subject"
+else
+    _bad "fixture premise BROKEN: ${FIX}/src has no .vue file, so gates 12/13/26/31/32 have nothing to open and 'they ran' below would assert nothing"
+fi
+
 _still_na=""
-for _g in 10 26 31 32 34 35 36 37 39 40 42 43 44 45; do
+for _g in 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45; do
     printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE" && _still_na="${_still_na}${_g} "
 done
 if [ -z "${_still_na}" ]; then
-    _ok "with src/ present, every src-guarded gate really runs (applicability table tracks its guards)"
+    _ok "with src/ present AND holding markup, every src-guarded gate really runs (applicability table tracks its guards)"
 else
-    _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists — the table has drifted from the guards it mirrors"
+    _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists and holds ${_fix_vue_n} .vue file(s) — the table has drifted from the guards it mirrors"
 fi
-
-for _g in 12 13; do
-    if printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE — src/ exists but contains NO \.vue"; then
-        _ok "gate-${_g} reports na and NAMES the empty .vue glob — src/ exists here but holds no Vue component"
-    elif printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: PASS"; then
-        _bad "gate-${_g} reported PASS over a src/ with zero .vue files — green over nothing (#225/#274)"
-    else
-        _v=$(printf '%s' "${OUT_STRUCT}" | grep -oE "^\[gate-${_g}\] [^:]+: [A-Z]+( [A-Z]+)*( \([a-z]+\))?" | head -1 | sed 's/^[^:]*: //')
-        _bad "gate-${_g} returned '${_v:-none emitted}' on a src/ with no .vue — expected na naming the empty glob"
-    fi
-done
 
 echo "[test] an unrecognised skip category is a hard failure, never a silent 'na'"
 # A typo'd category that defaulted to `na` would be a lever for making any

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -377,8 +377,21 @@ fi
 # gates guarded by `[ -d src ]` must genuinely RUN. If the declaration table
 # ever drifts away from the guards it mirrors, it would keep calling them
 # not-applicable here — which is the one way this change could hide a live gate.
+#
+# GATES 12 AND 13 ARE ASSERTED SEPARATELY, AND MORE STRICTLY (.github#271/#274).
+#
+# This loop's premise is "src/ exists, therefore the gate has a subject". For
+# gate-12 (<NcSelect>) and gate-13 (<NcModal>/<NcDialog>) that does not follow:
+# their subjects are Vue SFC components, and THIS FIXTURE'S src/ contains one
+# .js file and no .vue at all. Until now both gates printed PASS here — a green
+# over an empty glob, which is nldesign's exact shape and the reason twelve
+# gates certified it in #225. Keeping them in this loop would have encoded that
+# belief as an assertion.
+#
+# So they move out, and what replaces the loop entry is stronger than what it
+# asserted: not merely "did not say na", but "said na FOR THE RIGHT REASON".
 _still_na=""
-for _g in 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45; do
+for _g in 10 26 31 32 34 35 36 37 39 40 42 43 44 45; do
     printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE" && _still_na="${_still_na}${_g} "
 done
 if [ -z "${_still_na}" ]; then
@@ -386,6 +399,17 @@ if [ -z "${_still_na}" ]; then
 else
     _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists — the table has drifted from the guards it mirrors"
 fi
+
+for _g in 12 13; do
+    if printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE — src/ exists but contains NO \.vue"; then
+        _ok "gate-${_g} reports na and NAMES the empty .vue glob — src/ exists here but holds no Vue component"
+    elif printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: PASS"; then
+        _bad "gate-${_g} reported PASS over a src/ with zero .vue files — green over nothing (#225/#274)"
+    else
+        _v=$(printf '%s' "${OUT_STRUCT}" | grep -oE "^\[gate-${_g}\] [^:]+: [A-Z]+( [A-Z]+)*( \([a-z]+\))?" | head -1 | sed 's/^[^:]*: //')
+        _bad "gate-${_g} returned '${_v:-none emitted}' on a src/ with no .vue — expected na naming the empty glob"
+    fi
+done
 
 echo "[test] an unrecognised skip category is a hard failure, never a silent 'na'"
 # A typo'd category that defaulted to `na` would be a lever for making any


### PR DESCRIPTION
## What was measured

Every gate in the **12–22** band was given **one textbook true positive** of exactly what it exists to catch, in a real fleet repo whose shape suits it; then the plant was removed and the gate had to return to its exact prior verdict, and a clean repo had to stay clean. Three further arms were added after the earlier bands showed a plant cannot see them: **break the interpreter**, **run against a repo whose subject the gate cannot see**, and **read the exit byte on a many-finding run**.

Final measurement at `[hydra-gates] gate package: ff8869d17ed38fbc52b746f99c6ca89abaf841d0` (this branch, merged with `48c88ba`). Earlier arms measured at `cdfbd7a`, `fef032b` and `34370f6`; each defect below is quoted with the sha it was measured at.

**Repo shapes — two per gate where behaviour can differ by shape:**

| Repo | Shape | Why it matters here |
|---|---|---|
| **openregister** | hand-declared `appinfo/routes.php`, 207 `.vue`, 794 spec scenarios, register JSONs | the conventional shape |
| **shillinq** | **ADR-040 AppHost adopter — `Routes::standard()`**, keeps its own `SettingsController` | decisive for gate-14/#265 |
| **pipelinq** | hand-declared routes, six `type:"dashboard"` pages | gate-15's subject |
| **nldesign-shaped fixture** | `src/` holding one `manifest.json` | gates 12/13 zero-`.vue` |
| **gates-23-33/planted** (this package) | DI-bound `AppHost\Controller\GenericHealth` | gate-14 path derivation |

| Gate | Planted true positive | Fired? | Repaired |
|---|---|---|---|
| 12 nc-input-labels | `<NcSelect :reduce="(o) => o.value" />`, no `input-label` | ✅ | ➕ `na` not PASS on zero-`.vue` `src/` |
| 13 modal-isolation | inline `<NcModal>` in `src/views/` | ✅ | ➕ same |
| 14 route-reachability | (a) unrouted method (b) route→missing method (c) **`settings#update` deleted from an AppHost adopter** (d) **DI-bound `AppHost\Controller\GenericHealth`** | ✅ ✅ **❌** **❌** | ✅ **#265 closed** + PSR-4 path |
| 15 dashboard-antipattern | `<CnDashboardPage>` in a `#widget-<id>` slot | ✅ | ✅ crashed checker; attribute-order |
| 16 spec-coverage | changed method with no `@spec`; **deleting an existing `@spec`** | ✅ **❌** | ✅ crashed checker; tag-deletion |
| 17 redundant-controller | `fetchAll() { return new JSONResponse($this->objectService->findAll([])); }` | **❌ PASS** | ✅ two causes |
| 18 notification-dialect | legacy dialect in a register JSON | ✅ (7 tokens) | ✅ crashed checker |
| 19 e2e-coverage | new `#### Scenario:` with no `@e2e` | ✅ | ✅ crashed checker |
| 20 or-objectservice-api | `$this->objectService->findObjects(...)` | **❌ — had never fired anywhere, ever** | ✅ |
| 21 conflict-markers | real markers in `lib/*.php` | ✅ — and **not** on a `.md` documenting them | — |
| 22 manifest-validation | invalid page `type` + additional property | ✅ | ✅ verdict depended on checkout layout |

## Seven defects

**1. gate-20 had never fired. Not rarely — never.** Its pattern expands to `->findObjects\(`, which begins with `-`, so grep parses it as options (`grep: invalid option -- '>'`, exit 2). `2>/dev/null || true` discarded the message *and* the status, so every file returned zero hits and the gate printed PASS fleet-wide.

Repairing the grep alone is **not** the fix: the receiver test was *"the file mentions ObjectService somewhere"*, which with a working grep yields **14 false findings on openregister and 5 on shillinq** — `createFromArray()` is a real method on OpenRegister's *Mappers*. The receiver is now part of the pattern. Measurement across all three repos afterwards: **one finding, and it is real** — shillinq's `BookingNotificationController` resolves `OCA\OpenRegister\Service\ObjectService` from the container *inside its non-admin authorisation guard* and calls `findObject()`, which does not exist on it. A `BadMethodCallException` in an auth guard, shipped.

**2. gate-17 was wrong about the same API, in the other direction.** Four of six names in `OBJECT_SERVICE_CRUD` do not exist on ObjectService — they are what gate-20 flags as fabricated — and `findAll`/`createObject`/`updateObject`/`deleteObject` were absent. Separately, `^\s*return\s+new\s+JSONResponse` sits in `WRAPPER_NOISE_PATTERNS` and was tested *before* the ObjectService check, so the commonest pass-through spelling was discarded as "response wrapping" with the call still inside it — then matched by `RESCUE_PATTERNS` and returned `False`. The gate rescued its own subject. Blast radius of both fixes across the three repos: **0 new findings**.

**3. gate-14 never judged the ten routes AppHost supplies (#265).** #223 taught *invariant 1* about `Routes::standard()`; *invariant 2* asks the opposite question and still read route names as literals out of the leaf's own `routes.php`, where those ten never appear. Deleting `SettingsController::update()` from **shillinq** leaves `PUT /api/settings` resolving to nothing — not a 404: the router matches, `ControllerMethodReflector` reflects, the request dies 500. shillinq's own docblock spells the hazard out. **Gate-14's findings log came back empty.**

**4. gate-14 derived a path the app does not use.** `AppHost\Controller\GenericHealth#index` resolved to `lib/Controller/AppHost/Controller/…` while PSR-4 puts it at `lib/AppHost/Controller/…`, so the gate reported `controller-class-not-found` **inside the repository that ships the file**. And where a DI binding rescued the absence the loop `continue`d — so the *method-existence* check never ran: two fixtures differing by one renamed method **both reported PASS**. #275 found the same root independently from gate-5's side and landed the two-root probe; **this branch's resolver is now byte-identical to `main`'s**, and adds the gate-14 invariant-2 fixtures that assert it from the other direction.

**5. Three gates reported PASS over a crashed checker.** With `python3` exiting 1 — nothing inspected by any python-backed gate:

```
gate-12 SKIPPED (wiring)     gate-15 PASS
gate-17 SKIPPED (wiring)     gate-16 PASS
                             gate-18 PASS
                             gate-19 FAIL — "an unreported number of scenario(s)"
```

15/16/18 wrote `2>/dev/null || true` and counted lines in an empty log; 19 read exit 1 as `EXIT_FAIL` from a helper that never printed its summary — a blocking verdict carrying a count nobody measured.

**6. gates 12 and 13 passed over a `src/` with zero `.vue` (#274).** `[ -d src ]` is not "`src/` contains a Vue component". At `fef032b` both printed **PASS** on the nldesign shape. Now `na`, with the judgement #274 asked for written down: `NcSelect`/`NcModal`/`NcDialog` are Vue SFC components, a PHP template cannot instantiate one, so these two stay `.vue`-only and gate-40 keeps the language-agnostic rule for `templates/`. (#280 closed the gate-45 half; this is the gate-12 half.)

**7. gate-16 could not see the deletion of its own tag.** `_overlaps` walks *forward* from the declaration; the docblock is above it, and the docblock is the only place `@spec` lives. Delete the tag, leave the body byte-identical → `# count=0`, exit 0. **Every `@spec` tag in a repository could be stripped and gate-16 stayed green.** `run_gate` also skipped any file with an empty `added` set, which a pure deletion produces, so the file was never opened. Same family as `filter_preexisting_methods.py` filing an auth-attribute removal as pre-existing — gate-16 does **not** route through that helper (its four call sites are gates 6/7/8/30, and `check_spec_coverage.py` references it zero times); it reached the same blind spot by its own path.

**Plus** gate-22's verdict depended on where the gates were checked out (`ajv` resolved relative to `check_manifest.js`, never to the repo under test — run from openregister's root *with `node_modules/ajv` present there* it printed "not resolvable … no node_modules", which was false), and gate-15's slot matcher had gate-44's attribute-order blind spot (`<template #widget-x class="wide">` did not match).

## Exit is a status, count on stdout — swept, empirically

| Helper | Findings | Exit |
|---|---|---|
| `check_e2e_coverage.py` | 794 | `1` |
| `check_spec_coverage.py` | 239 | `1` |
| `detect-redundant-controllers.py` | 1 + `# count=` marker | `1` |
| `check_dashboard_antipattern.py` | 0 + marker | `0` |
| `check_manifest.js` | `failed` already clamped to 0/1 | `0`/`1`/`2`/`3` |

`check_spec_coverage.py` and `check_dashboard_antipattern.py` **used to return the count**; both are now a status plus a terminal `# count=` marker, which is also what lets the runner tell "clean" from "did not execute".

## Anti-widening

- gate-20: a mapper's **real** `createFromArray()` in a file mentioning ObjectService → not flagged.
- gate-17: a **domain-named** method with a byte-identical body → not flagged.
- gate-14: the other nine canonical AppHost names still resolve; the conventional `ping#index` sibling is unaffected; `routes-standard/` still yields exactly one finding.
- gate-16: a typo fix in a **legacy untagged** method's docblock → clean, no inherited debt surfaced.
- gates 12/13: add **one** `.vue` carrying the defect and both go straight back to FAIL.
- gate-18: a working `python3` on the same fixture still FAILs the planted dialect.
- gate-21: a `.md` documenting conflict markers is not flagged.
- **pipelinq and openregister, clean, whole repo**: verdicts unchanged before and after across all eleven gates.

## Tests — all mutation-checked against the pre-fix tree

| Suite | Red before |
|---|---|
| `test_gate_or_objectservice_surface.sh` (new) | gate-20 + gate-17, each with its silent sibling, plus a direct assertion that a `-`-leading grep pattern is parsed as options |
| `test_gate_crashed_checker_is_not_a_finding.sh` | **7 failures** — all six python-backed gates under a broken interpreter, asserted generically so a future gate inherits it |
| `test_gate_empty_scope_never_passes.sh` | **3 failures** — gates 12/13 on the nldesign shape, with the one-`.vue` control |
| `test_gate_route_registration.sh` | **5 failures** — `routes-standard-missing-update/` (#265) and `psr4-namespaced-controller{,-missing-method}/`. ⚠️ This suite **hardcoded its runner**, so `HYDRA_GATES_RUNNER_UNDER_TEST` silently kept running the fixed one and reported all-green — a mutation check that could not fail. Fixed here too. |
| `test_check_spec_coverage.py` | tag-deletion caught; unrelated docblock edit clean |
| `test_check_manifest.sh` | ajv anchor red before |
| `test_check_dashboard_antipattern.py` | **4 subtests** — slot-tag spellings that were silent misses |

`59` helper suites pass (2 quarantined, unchanged), `61` bin-level assertions pass.

## Verdicts will move

gate-20 and gate-17 can now produce findings in repos that were green — starting with the shillinq auth-guard call above. Gates 12/13/15/16/18/19 can now report `SKIPPED (wiring)` or `NOT APPLICABLE`; neither is a pass.

Closes #265. Closes the gate-12 half of #274.
