### PR TITLE
fix(gates 56-64): six gates passed over an unopened scope, and three could not see the defect they exist to catch

### DIFF
--- a/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
@@ -116,12 +116,67 @@ LOAD_APP = re.compile(r"""loadApp\s*\(\s*['"]openregister['"]\s*\)""")
 # and the escaped string form 'OCA\\OpenRegister\\AppHost\\Bootstrap'.
 BOOTSTRAP_REF = re.compile(r"OpenRegister\\{1,2}AppHost\\{1,2}Bootstrap")
 
-# Rule 2 — class_exists() on a literal AppHost name. This is the probe that
-# answers FALSE on a healthy instance.
-CLASS_EXISTS_APPHOST = re.compile(
-    r"class_exists\s*\(\s*['\"][^'\"]*OpenRegister\\{1,2}AppHost\\{1,2}[^'\"]*['\"]",
-    re.S,
+# Rule 2 — class_exists() on an AppHost name. This is the probe that answers
+# FALSE on a healthy instance.
+#
+# ⚠️ IT ONLY SAW A QUOTED STRING (.github#276). PHP has three ways to name a
+# class and this pattern recognised one of them:
+#
+#     class_exists('OCA\OpenRegister\AppHost\Controller\GenericHealthController')
+#     class_exists(\OCA\OpenRegister\AppHost\Controller\GenericHealthController::class)
+#     use OCA\OpenRegister\AppHost\Controller\GenericHealthController;
+#       … class_exists(GenericHealthController::class)
+#     private const AH = 'OCA\OpenRegister\AppHost\…';  class_exists(self::AH)
+#
+# Only the first failed. The other three were injected into larpingapp's
+# register() and the gate reported OK for all of them — an ADR-040 adoption
+# that is invisible because of the way its author spells a class name. This is
+# #184's lesson in the same file it was learned in: a checker that greps a
+# STRING LITERAL misses every constant.
+#
+# `Foo::class` itself does NOT autoload — it is resolved at compile time. It is
+# `class_exists()` that triggers the autoloader, which is why the CALL is what
+# is matched, in every spelling of its argument, and why a bare
+# `use OCA\OpenRegister\AppHost\…;` on its own is deliberately NOT a finding.
+CLASS_EXISTS_ARG = re.compile(r"class_exists\s*\(\s*([^,)]+)", re.S)
+_APPHOST_FQCN = re.compile(r"OpenRegister\\{1,2}AppHost\\{1,2}")
+QUOTED = re.compile(r"""^(['"])\\{0,2}([^'"]*)\1""")
+# `use A\B\C;` / `use A\B\C as Alias;` — how a short name is bound in this file.
+USE_IMPORT = re.compile(
+    r"use\s+\\?([A-Za-z_][A-Za-z0-9_\\]*)(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;"
 )
+# `const AH = 'OCA\OpenRegister\AppHost\…';` — a constant holding an FQCN.
+CONST_STR = re.compile(
+    r"""const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]\\{0,2}([A-Za-z_][A-Za-z0-9_\\]*)['"]"""
+)
+
+# A class_exists() probe on ANY OCA\OpenRegister class, not just AppHost. The
+# autoloader mechanism is identical — during register() the OCA\OpenRegister\
+# PSR-4 prefix does not exist for any app whose id sorts earlier — so the guard
+# answers FALSE and everything inside it silently never happens.
+#
+# REPORTED AS A NON-BLOCKING NOTE, NOT A FAILURE, and the reason is measured:
+# gate-64 is not diff-scoped, so promoting this to a FAIL turns every PR in
+# six repos permanently red for pre-existing code the PR did not touch. That
+# is the trap this package already documented in check_store_and_settings_
+# surface.py ("blocked EVERY manifest-touching PR in that repo, permanently").
+#
+# Measured 2026-08-08 across apps-extra, lib/AppInfo/, comment-stripped, no
+# prelude present:
+#     larpingapp  3   'OCA\OpenRegister\Event\{DeepLinkRegistration,
+#                      ObjectCreating,ObjectUpdating}Event'  — LIVE-EXPOSED,
+#                      and ObjectCreating/ObjectUpdating carry larpingapp's
+#                      server-authoritative skill-requirement / XP-budget
+#                      enforcement on character writes.
+#     hermiq      2   flow-node + shareable-config registration
+#     nldesign    1   shareable-config registration
+# openconnector independently recorded `class_exists at register(): false` for
+# the same mechanism, and removing its guard took the flow-node registry from
+# 10 nodes to 12.
+#
+# The NOTE exists so a green gate-64 stops being read as evidence about this.
+_OPENREGISTER_FQCN = re.compile(r"(?:^|\\)OCA\\{1,2}OpenRegister\\{1,2}")
+REGISTER_FN = re.compile(r"function\s+register\s*\(")
 
 # OpenRegister owns AppHost; it cannot need a prelude for its own namespace.
 OWN_NAMESPACE = re.compile(r"namespace\s+OCA\\OpenRegister\b")
@@ -233,6 +288,101 @@ def has_prelude(text: str) -> bool:
     return False
 
 
+def class_exists_targets(text: str) -> list[str]:
+    """Every class name reached by a class_exists() call in *text*.
+
+    *text* must be comment-stripped. PHP offers three ways to write the same
+    class name and all three reach the autoloader through class_exists(), so
+    all three are resolved to a comparable FQCN string:
+
+      quoted FQCN     class_exists('OCA\\OpenRegister\\AppHost\\X')
+      ::class         class_exists(\\OCA\\OpenRegister\\AppHost\\X::class)
+                      class_exists(X::class)  with `use …AppHost\\X;` above
+      class constant  const AH = 'OCA\\OpenRegister\\AppHost\\X';
+                      class_exists(self::AH)
+
+    Reading only the first is what let an injected AppHost probe pass. Every
+    caller below asks its question of this ONE resolver, so a spelling that
+    escapes it escapes both the hard rule and the note — rather than escaping
+    whichever of them happened to be written second.
+    """
+    imports: dict[str, str] = {}
+    for m in USE_IMPORT.finditer(text):
+        fqcn = m.group(1)
+        alias = m.group(2) or fqcn.rsplit("\\", 1)[-1].rsplit("\\\\", 1)[-1]
+        imports[alias] = fqcn
+    constants = dict(CONST_STR.findall(text))
+
+    out: list[str] = []
+    for m in CLASS_EXISTS_ARG.finditer(text):
+        arg = m.group(1).strip()
+        q = QUOTED.match(arg)
+        if q:
+            out.append(q.group(2))
+            continue
+        if "::" not in arg:
+            continue
+        left, right = arg.split("::", 1)
+        left, right = left.strip().lstrip("\\"), right.strip()
+        if right.startswith("class"):
+            # `Foo\Bar::class` — an FQCN written inline, or an imported alias.
+            out.append(imports.get(left, left))
+        elif right in constants:
+            out.append(constants[right])
+    return out
+
+
+def apphost_class_exists(text: str) -> bool:
+    """True when *text* calls class_exists() on an AppHost class, any spelling."""
+    return any(_APPHOST_FQCN.search(t) for t in class_exists_targets(text))
+
+
+def register_body(text: str) -> str:
+    """The balanced body of `function register(...)`, or '' when absent.
+
+    Only register() matters for the OCA\\OpenRegister\\ note: boot() runs after
+    every app has registered, so a probe there resolves correctly and is not a
+    defect. Reporting it would be the false positive that gets a note ignored.
+    """
+    m = REGISTER_FN.search(text)
+    if m is None:
+        return ""
+    i = text.find("{", m.end())
+    if i < 0:
+        return ""
+    depth, j, n = 0, i, len(text)
+    while j < n:
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[i:j + 1]
+        j += 1
+    return text[i:]
+
+
+def openregister_probes(text: str) -> list[str]:
+    """Non-AppHost OCA\\OpenRegister\\ class_exists() probes inside register().
+
+    Resolves imports and constants against the WHOLE file (that is where `use`
+    and `const` live) but only reports probes whose call site is in register().
+    """
+    body = register_body(text)
+    if not body:
+        return []
+    header = text[:text.find(body)] if body in text else text
+    in_body = set(class_exists_targets(header + body)) - set(class_exists_targets(header))
+    out = []
+    for target in sorted(in_body):
+        if not _OPENREGISTER_FQCN.search("\\" + target.lstrip("\\")):
+            continue
+        if _APPHOST_FQCN.search(target):
+            continue  # already a hard failure above
+        out.append(target)
+    return out
+
+
 def suppression_reason(text: str) -> str | None:
     """Return the reason of a reason-bearing suppression, else None.
 
@@ -279,7 +429,7 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
             findings.append(
                 (path, "references OCA\\OpenRegister\\AppHost\\Bootstrap")
             )
-        elif CLASS_EXISTS_APPHOST.search(text):
+        elif apphost_class_exists(text):
             findings.append(
                 (path, "calls class_exists() on an OCA\\OpenRegister\\AppHost\\ class")
             )
@@ -295,6 +445,30 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
         )
 
     return findings
+
+
+def scan_notes(app_dir: str) -> list[tuple[str, list[str]]]:
+    """[(path, [probed FQCN, ...])] for non-AppHost register()-time probes.
+
+    Non-blocking. Same mechanism as the hard rules, different blast radius —
+    see CLASS_EXISTS_OR_LITERAL for why this is a note and what it measured.
+    """
+    sources = _sources(app_dir)
+    if not sources:
+        return []
+    code = {path: strip_comments(text) for path, text in sources.items()}
+    if any(OWN_NAMESPACE.search(text) for text in code.values()):
+        return []
+    if has_prelude("\n".join(code.values())):
+        return []
+    if suppression_reason("\n".join(sources.values())):
+        return []
+    out = []
+    for path, text in sorted(code.items()):
+        probes = openregister_probes(text)
+        if probes:
+            out.append((path, probes))
+    return out
 
 
 APP_ID = re.compile(r"<id>\s*([a-z0-9_\-]+)\s*</id>", re.I)
@@ -356,6 +530,20 @@ def main(argv: list[str] | None = None) -> int:
                 f"comment 'apphost-prelude exclude <reason>'."
             )
             failures += 1
+
+        for path, probes in scan_notes(target):
+            rel = os.path.relpath(path, target)
+            print(
+                f"NOTE {app}: {rel} calls class_exists() inside register() on "
+                f"{len(probes)} non-AppHost OpenRegister class(es) "
+                f"({', '.join(probes)}) with no ADR-040 prelude. Same mechanism, "
+                f"outside this gate's hard rule: the OCA\\OpenRegister\\ prefix is "
+                f"not on the autoloader yet, so each guard answers FALSE and "
+                f"everything inside it silently never happens. {severity}. NOT a "
+                f"failure — this gate is not diff-scoped, so failing it would "
+                f"block every PR in this repo on code the PR did not touch. "
+                f"Add the prelude, or move the probe into boot()."
+            )
 
     if failures:
         print(f"\n{failures} AppHost adoption(s) without the autoload prelude.")

--- a/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
@@ -337,6 +337,92 @@ def apphost_class_exists(text: str) -> bool:
     return any(_APPHOST_FQCN.search(t) for t in class_exists_targets(text))
 
 
+_CLOSURE_START = re.compile(r"(?<![A-Za-z0-9_$])(?:static\s+)?(?:function\s*\(|fn\s*\()")
+
+
+def blank_closure_bodies(text: str) -> str:
+    """*text* with the bodies of ANONYMOUS functions blanked, offsets kept.
+
+    THE EXEMPTION WAS DOCUMENTED AND NEVER IMPLEMENTED (.github#276).
+
+    This module's header has always said:
+
+        Lazy service closures that merely MENTION an AppHost class are
+        deliberately NOT flagged: their bodies run at resolution time, long
+        after every app has registered. Only register()-time resolution is
+        the defect.
+
+    Both rules ran over the whole file, so they did not. Measured on
+    launchpad — whose entire composition root is built on resolving
+    OpenRegister lazily inside closures, which is the documented leaf
+    pattern and the reason launchpad is green today:
+
+        $context->registerService('Lazy', function ($c) {
+            return new \\OCA\\OpenRegister\\AppHost\\Bootstrap($c);
+        });
+
+    reported byte-identically to an eager `Bootstrap::register($context, …)`
+    at the top of register(). The gate would have failed the one repo doing
+    it correctly, for doing it correctly, and the only remedy available is to
+    stop writing the lazy form — i.e. to introduce the defect.
+
+    NAMED methods are NOT blanked: `public function register(` has an
+    identifier between `function` and `(`, so the pattern cannot match it.
+    An eager reference AFTER a closure is still seen (asserted).
+    """
+    out = list(text)
+    n = len(text)
+
+    def blank(a: int, b: int) -> None:
+        for k in range(max(a, 0), min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    for m in _CLOSURE_START.finditer(text):
+        i, depth = m.end() - 1, 0
+        while i < n:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        j = i + 1
+        if m.group(0).lstrip().startswith("fn"):
+            # `fn (...) => <expr>` — blank to the first `,`/`;` or the
+            # enclosing closing bracket, at the expression's own depth.
+            d = 0
+            while j < n:
+                c = text[j]
+                if c in "([{":
+                    d += 1
+                elif c in ")]}":
+                    if d == 0:
+                        break
+                    d -= 1
+                elif c in ",;" and d == 0:
+                    break
+                j += 1
+            blank(i + 1, j)
+            continue
+        while j < n and text[j] not in "{;":
+            j += 1
+        if j >= n or text[j] == ";":
+            continue  # a signature with no body
+        d, k = 0, j
+        while k < n:
+            if text[k] == "{":
+                d += 1
+            elif text[k] == "}":
+                d -= 1
+                if d == 0:
+                    break
+            k += 1
+        blank(j + 1, k)
+    return "".join(out)
+
+
 def register_body(text: str) -> str:
     """The balanced body of `function register(...)`, or '' when absent.
 
@@ -425,6 +511,12 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
 
     findings: list[tuple[str, str]] = []
     for path, text in sorted(code.items()):
+        # Only EAGER references are the defect. A mention inside an anonymous
+        # function or arrow function resolves when that closure is CALLED,
+        # long after every app has registered — this module's header has said
+        # so since it was written and nothing implemented it (.github#276).
+        # See blank_closure_bodies() for what launchpad measured.
+        text = blank_closure_bodies(text)
         if BOOTSTRAP_REF.search(text):
             findings.append(
                 (path, "references OCA\\OpenRegister\\AppHost\\Bootstrap")
@@ -465,7 +557,8 @@ def scan_notes(app_dir: str) -> list[tuple[str, list[str]]]:
         return []
     out = []
     for path, text in sorted(code.items()):
-        probes = openregister_probes(text)
+        # Eager only, for the same reason as the hard rules above.
+        probes = openregister_probes(blank_closure_bodies(text))
         if probes:
             out.append((path, probes))
     return out

--- a/hydra-gates/scripts/lib/check_listener_placement.py
+++ b/hydra-gates/scripts/lib/check_listener_placement.py
@@ -85,6 +85,11 @@ GATE_NUM = 61
 
 # The three POST events. A listener on one of these cannot influence the write,
 # so its work does not belong on the request path.
+# Status codes, same contract as check_store_and_settings_surface.py so the
+# runner can tell "clean" from "I inspected nothing" (.github#240/#242/#276).
+EXIT_EMPTY_SCOPE = 3      # scope resolved, selected nothing -> runner _skip na
+EXIT_NOT_APPLICABLE = 4   # no post-event registration exists -> runner _skip na
+
 POST_EVENTS = {
     'ObjectCreatedEvent',
     'ObjectUpdatedEvent',
@@ -555,8 +560,8 @@ def main() -> int:
     repo = Path(args.repo).resolve()
     infos = appinfo_files(repo)
     if not infos:
-        print('checked 0 registration(s): 0 failure(s) — no lib/AppInfo')
-        return 0
+        print('checked 0 registration(s) — no lib/AppInfo, nothing to place.')
+        return EXIT_NOT_APPLICABLE
 
     if args.all:
         touched: dict[str, set[int]] = {}
@@ -675,7 +680,21 @@ def main() -> int:
     scope = 'all' if args.all else f'diff vs {args.base}'
     print(f'\nchecked {checked} post-event registration(s) [{scope}], '
           f'{skipped_out_of_scope} out of scope: {total} failure(s)')
-    return 1 if total else 0
+    if total:
+        return 1
+    # AN EXIT CODE IS A STATUS (.github#276, borrowing #240/#242's convention
+    # from check_store_and_settings_surface.py verbatim).
+    #
+    # "I checked N registrations and they were fine" and "the diff put all N
+    # out of scope, so I checked none" were the same 0, and the runner printed
+    # PASS for both. This gate is ALWAYS diff-scoped by design, so the second
+    # is the common case on any PR that does not touch a listener — a PASS
+    # asserted about work placement no run inspected.
+    if checked == 0 and skipped_out_of_scope > 0:
+        return EXIT_EMPTY_SCOPE
+    if checked == 0:
+        return EXIT_NOT_APPLICABLE
+    return 0
 
 
 if __name__ == '__main__':

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -134,10 +134,27 @@ _MCP_SCANNABLE_INTERFACE = "IMcpScannableServices"
 # `registerServiceAlias('OCA\OpenRegister\Mcp\IMcpScannableServices::<app>', Impl::class)`
 # On disk the namespace separators are double-backslashed inside the PHP
 # string literal, so the pattern must accept either spelling.
+#
+# ⚠️ THE LEADING BACKSLASH (.github#276). The implementation argument's
+# namespace prefix was `(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*` — every segment
+# had to START with a letter. So the FULLY-QUALIFIED spelling
+#
+#     registerServiceAlias('…IMcpScannableServices::app', \OCA\App\Mcp\Impl::class)
+#
+# did not match, and it is the ordinary way to write an FQCN inside a
+# namespaced Application.php with no `use` for it. When it does not match,
+# `bound_impls` is empty, `_build_mcp_attribute_seam` short-circuits to the
+# empty set, and EVERY `#[McpTool]` write method in the app is reported dead —
+# which is #200 exactly: the finding whose remedy is deleting a live, curated
+# MCP write tool. Reproduced on shillinq with the two spellings side by side:
+# leading `\` -> the seam vanished; no leading `\` -> the seam held.
+#
+# The seam's three-part evidence is unchanged. This only stops the alias being
+# invisible because of how its author spelled a namespace.
 _MCP_ALIAS_RE = re.compile(
     r"registerServiceAlias\s*\(\s*"
     r"(['\"])[^'\"]*" + _MCP_SCANNABLE_INTERFACE + r"::[A-Za-z0-9_-]+\1"
-    r"\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*"
+    r"\s*,\s*\\*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*"
     r"([A-Za-z_][A-Za-z0-9_]*)\s*::\s*class",
     re.DOTALL,
 )
@@ -146,8 +163,22 @@ _CLASS_CONST_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*::\s*class")
 # `#[McpTool(...)]` — optionally namespace-qualified. NOT a comment: `#` opens
 # a line comment in PHP but `#[` opens an attribute, which is exactly why the
 # comment blanker below has to know the difference.
+#
+# ⚠️ SAME LEADING-BACKSLASH BLIND SPOT AS _MCP_ALIAS_RE ABOVE (.github#276),
+# and this is why the honest regression mutant is BOTH sites at once: the seam
+# needs the alias AND the attribute, so reverting either one alone still
+# reproduces the false positive, and reverting one while testing the other
+# looks like the fix did nothing.
+#
+#     #[McpTool(name: 'x')]                         matched before
+#     #[OCA\OpenRegister\Mcp\McpTool(name: 'x')]    matched before
+#     #[\OCA\OpenRegister\Mcp\McpTool(name: 'x')]   did NOT match
+#
+# The third is how the attribute is written with no `use` import for it — a
+# style choice that silently removed the method's only proof of reachability
+# and put a live MCP write tool back on the deletion list (#200).
 _MCP_TOOL_ATTR_RE = re.compile(
-    r"#\[\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*McpTool\b"
+    r"#\[\s*\\*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*McpTool\b"
 )
 # Lines that cannot belong to the attribute block of the method below them.
 # ONLY the statement/block terminators. A word-based boundary (`\bclass\b`)

--- a/hydra-gates/scripts/lib/check_register_handler_resolution.py
+++ b/hydra-gates/scripts/lib/check_register_handler_resolution.py
@@ -76,11 +76,39 @@ def _class_def_re(short_name: str) -> re.Pattern:
     whitespace, never with the bare word `class`. Without this anchor the
     fallback search could silently treat a merely-MENTIONED class as
     "found", masking the exact fleet defect this gate exists to catch.
+
+    ⚠️ IT ONLY MATCHED `class`, AND ONLY ONE MODIFIER (.github#276).
+
+    The PSR-4 path guess above handles the conventional layout. This fallback
+    walk is what finds a type living where PSR-4 does not predict — a
+    DI-bound registration, a type not named after its file. That is exactly
+    the shape gate-30 was caught mis-resolving: `AppHost\\Controller\\
+    GenericHealth` PSR-4-maps to `lib/Controller/AppHost/Controller/…` while
+    openregister DI-binds it to `lib/AppHost/Controller/`. So every
+    declaration form the walk cannot match is a FALSE POSITIVE on a type that
+    genuinely exists — and the action `guard-class-not-found` invites is to
+    write the class a second time.
+
+    Measured, each against a real declaration at a non-conventional path:
+
+        enum ProbeState: string { … }        -> guard-class-not-found
+        interface ProbeContract { … }        -> guard-class-not-found
+        final readonly class ReadonlyProbe   -> guard-class-not-found
+
+    The third is not exotic: `final readonly` is ordinary PHP 8.2, and the
+    pattern allowed `final ` OR `abstract `, never two modifiers. Enums and
+    interfaces belong here too — a `handler` may name an enum-backed strategy
+    or an interface the container resolves to an implementation.
+
+    Only the DECLARATION FORMS widen. The line anchor — the thing that keeps
+    docblock prose out, and the reason this walk is trustworthy at all — is
+    unchanged, and asserted in both directions by the test suite.
     """
     pat = _CLASS_DEF_RE_CACHE.get(short_name)
     if pat is None:
         pat = re.compile(
-            r"^\s*(?:final\s+|abstract\s+)?class\s+" + re.escape(short_name) + r"\b",
+            r"^\s*(?:(?:final|abstract|readonly)\s+)*"
+            r"(?:class|interface|trait|enum)\s+" + re.escape(short_name) + r"\b",
             re.MULTILINE,
         )
         _CLASS_DEF_RE_CACHE[short_name] = pat

--- a/hydra-gates/scripts/lib/check_unclosable_gate.py
+++ b/hydra-gates/scripts/lib/check_unclosable_gate.py
@@ -21,9 +21,10 @@ This is a static fact and therefore cheap to check: a read with no matching
 write, in the same app.
 
 Exit 0 when clean, 1 when a gate cannot close.
-Suppress a deliberate case with a comment containing:
-    unclosable-gate exclude <reason>
-on the reading line or the line above it.
+Suppress a deliberate case with a comment that NAMES THE KEY, in quotes, on
+the same line as the marker:
+    // unclosable-gate exclude 'configuration_version' is written by the
+    //   OpenRegister importer, not by this app
 
 SPDX-License-Identifier: EUPL-1.2
 SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
@@ -32,6 +33,9 @@ SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
 import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
 
 # Config accessors. NC exposes both the modern IAppConfig typed getters and the
 # legacy IConfig app-value pair; apps in this fleet use both.
@@ -45,7 +49,36 @@ GATE_SHAPE = re.compile(r'(version|bootstrapped|provisioned|initialized|imported
 # Keys Nextcloud itself maintains; apps legitimately only read these.
 NC_MANAGED = {'installed_version', 'app_version', 'core_version', 'types', 'enabled'}
 
-KEY = re.compile(r"'([a-z][a-z0-9_]{3,})'")
+# THE KEY, IN EVERY WAY PHP LETS YOU SPELL IT (.github#276).
+#
+# This pattern was `r"'([a-z][a-z0-9_]{3,})'"` — a SINGLE-quoted literal only.
+# PHP treats `'k'` and `"k"` identically, so the gate was wrong in BOTH
+# directions at once, which is #184's signature:
+#
+#   false GREEN     read "k" / write "k"   — neither side is seen, so the key
+#                   never enters `read`, and an unclosable gate reports OK.
+#   false POSITIVE  read 'k' / write "k"   — the read is seen and the write is
+#                   not, so code that closes its gate correctly is reported as
+#                   never closing it. Measured: the only remedy available to
+#                   the app is to change its quote style.
+#
+# Both were reproduced against docudesk before this line changed.
+KEY = re.compile(r"""['"]([a-z][a-z0-9_]{3,})['"]""")
+
+# `private const CONFIG_KEY = 'configuration_version';` then
+# `getValueString($app, self::CONFIG_KEY, '')`.
+#
+# A constant is the IDIOMATIC way to write a key used in two places — which is
+# precisely the shape a closable gate has, since the read and the write must
+# agree. Reading only quoted literals made the constant form invisible on BOTH
+# sides, so the most correctly-written apps were the ones this gate could say
+# nothing about. Resolving the constant to its literal keeps read and write
+# symmetric: if both spell it `self::CONFIG_KEY` they cancel exactly as they
+# would if both spelled it `'configuration_version'`.
+CONST_DEF = re.compile(
+    r"""const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]([a-z][a-z0-9_]{3,})['"]"""
+)
+CONST_REF = re.compile(r"""(?:self|static|parent|[A-Za-z_][A-Za-z0-9_\\]*)\s*::\s*([A-Z][A-Z0-9_]*)\b""")
 
 
 def call_args(src: str, fname: str):
@@ -65,13 +98,41 @@ def call_args(src: str, fname: str):
 
 
 def suppressed(src: str, key: str) -> bool:
-    """True when a suppression comment names this key's gate."""
-    for line_no, line in enumerate(src.split('\n')):
-        if 'unclosable-gate exclude' in line:
-            window = '\n'.join(src.split('\n')[max(0, line_no - 1):line_no + 3])
-            if f"'{key}'" in window:
-                return True
+    """True when a suppression comment names this key's gate.
+
+    Reads RAW source on purpose — the marker is a comment, which is exactly
+    what the mask in scan_app() removes.
+
+    THE KEY MUST BE QUOTED ON THE MARKER'S OWN LINE (.github#276), in either
+    quote style.
+
+    It used to be looked for in a FOUR-LINE WINDOW around the marker — and the
+    read this suppression is attached to lives inside that window, carrying its
+    own key literal. So a suppression naming `'some_other_version'` matched
+    `'configuration_version'` two lines below it: the marker suppressed
+    whatever happened to be near it rather than what it named. That is the
+    same shape as gate-64's `SUPPRESS` bug, where `\\s` let a bare annotation
+    swallow the next line of source as its "reason".
+
+    Nothing in the fleet uses this marker yet (measured: 0 files), so tightening
+    it costs nothing and closes the hole before the first user arrives.
+    """
+    for line in src.split('\n'):
+        if 'unclosable-gate exclude' not in line:
+            continue
+        if f"'{key}'" in line or f'"{key}"' in line:
+            return True
     return False
+
+
+def keys_in(arg: str, constants: dict) -> set:
+    """Every config key named by *arg*, literal or via a resolved constant."""
+    found = set(KEY.findall(arg))
+    for name in CONST_REF.findall(arg):
+        value = constants.get(name)
+        if value is not None:
+            found.add(value)
+    return found
 
 
 def scan_app(app_dir: str):
@@ -91,20 +152,42 @@ def scan_app(app_dir: str):
     if not sources:
         return []
 
-    blob = '\n'.join(sources.values())
+    raw = '\n'.join(sources.values())
+
+    # A COMMENT IS NOT A WRITE (.github#276, the #184 shape).
+    #
+    # This scan ran on raw source, so a commented-out or not-yet-written setter
+    #
+    #     // TODO: $this->cfg->setValueString('app', 'configuration_version', $v);
+    #
+    # put the key into `written` and CLOSED the finding. That is the false
+    # GREEN — and it is the single most likely comment to sit beside a key
+    # nobody writes, because it is what someone types when they notice the gap
+    # and defer it. A gate whose whole subject is "this guard never closes" was
+    # itself closed by a comment saying the guard would be closed later.
+    #
+    # `php_mask` blanks comment REGIONS and preserves offsets and newlines;
+    # string CONTENTS are kept, because the key literal is the evidence.
+    #
+    # The SUPPRESSION is the one thing that must keep reading raw text — it is
+    # authored as a comment, which is exactly what this mask removes.
+    blob = php_mask(raw)
+
+    constants = dict(CONST_DEF.findall(blob))
+
     read, written = set(), set()
     for fname in GETTERS:
         for arg in call_args(blob, fname):
-            read |= set(KEY.findall(arg))
+            read |= keys_in(arg, constants)
     for fname in SETTERS:
         for arg in call_args(blob, fname):
-            written |= set(KEY.findall(arg))
+            written |= keys_in(arg, constants)
 
     out = []
     for key in sorted(read - written):
         if key in NC_MANAGED or not GATE_SHAPE.search(key):
             continue
-        if suppressed(blob, key):
+        if suppressed(raw, key):
             continue
         out.append((key, sum(1 for _ in re.finditer(re.escape(key), blob))))
     return out

--- a/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
@@ -588,5 +588,94 @@ class Application {
         self.assertNotIn("NOTE", out)
 
 
+class LazyClosureTest(GateCase):
+    """THE EXEMPTION WAS DOCUMENTED AND NEVER IMPLEMENTED (.github#276).
+
+    This module's header has always said lazy service closures that merely
+    MENTION an AppHost class are deliberately NOT flagged, because their
+    bodies run at resolution time, long after every app has registered. Both
+    rules ran over the whole file, so they did not.
+
+    Measured on launchpad — a DIFFERENT repo shape from larpingapp, and the
+    one that matters here: launchpad's whole composition root resolves
+    OpenRegister lazily inside closures (it already does this for
+    `AppHost\\Observability\\ManifestLoader`), which is the documented leaf
+    pattern and the reason launchpad is green today. A closure body naming
+    Bootstrap reported byte-identically to an eager
+    `Bootstrap::register($context, …)`. The gate would have failed the one
+    repo doing it correctly, for doing it correctly, and the only remedy is
+    to stop writing the lazy form — i.e. to introduce the defect.
+    """
+
+    def _app(self, body: str) -> None:
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+class Application {
+    public function register($context): void {
+%s
+    }
+}
+""" % body)
+
+    def test_a_closure_body_naming_bootstrap_is_not_a_finding(self):
+        self._app('        $context->registerService("L", function ($c) {\n'
+                  '            return new \\OCA\\OpenRegister\\AppHost\\Bootstrap($c);\n'
+                  '        });')
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_an_arrow_function_naming_bootstrap_is_not_a_finding(self):
+        self._app('        $context->registerService("L", '
+                  'fn ($c) => new \\OCA\\OpenRegister\\AppHost\\Bootstrap($c));')
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_a_closure_body_probing_an_apphost_class_is_not_a_finding(self):
+        self._app('        $context->registerService("L", function ($c) {\n'
+                  '            return class_exists(\\OCA\\OpenRegister\\AppHost'
+                  '\\Controller\\GenericHealthController::class);\n'
+                  '        });')
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_a_static_closure_is_also_lazy(self):
+        self._app('        $context->registerService("L", static function ($c) {\n'
+                  '            return new \\OCA\\OpenRegister\\AppHost\\Bootstrap($c);\n'
+                  '        });')
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    # --- ANTI-WIDENING. The mask must not swallow eager code. ------------
+    def test_an_eager_reference_is_still_a_finding(self):
+        self._app('        \\OCA\\OpenRegister\\AppHost\\Bootstrap::register($context, "leaf", []);')
+        self.assertEqual(_run(self.dir)[0], 1)
+
+    def test_an_eager_reference_AFTER_a_closure_is_still_a_finding(self):
+        """The blanker walks every closure; a badly-bounded one would eat the
+        rest of register(). This is the arm that catches that."""
+        self._app('        $context->registerService("L", function ($c) { return 1; });\n'
+                  '        \\OCA\\OpenRegister\\AppHost\\Bootstrap::register($context, "leaf", []);')
+        self.assertEqual(_run(self.dir)[0], 1)
+
+    def test_an_eager_reference_BETWEEN_two_closures_is_still_a_finding(self):
+        self._app('        $context->registerService("A", function ($c) { return 1; });\n'
+                  '        \\OCA\\OpenRegister\\AppHost\\Bootstrap::register($context, "leaf", []);\n'
+                  '        $context->registerService("B", fn ($c) => 2);')
+        self.assertEqual(_run(self.dir)[0], 1)
+
+    def test_the_named_register_method_is_not_blanked(self):
+        """`public function register(` must never be treated as a closure —
+        blanking it would empty the gate entirely, which is the failure mode
+        that looks exactly like a fix."""
+        code = gate.blank_closure_bodies(
+            "<?php class A { public function register($c): void {"
+            " \\OCA\\OpenRegister\\AppHost\\Bootstrap::x(); } }")
+        self.assertIn("Bootstrap", code)
+
+    def test_a_probe_inside_a_closure_is_not_NOTEd_either(self):
+        self._app('        $context->registerService("L", function ($c) {\n'
+                  "            return class_exists('OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent');\n"
+                  '        });')
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("NOTE", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
@@ -372,5 +372,221 @@ class Application {
         )
 
 
+_CLASS_EXISTS_APP = """<?php
+namespace OCA\\Leaf\\AppInfo;
+%(use)s
+class Application
+{
+%(const)s
+    public function register($context): void
+    {
+        if (class_exists(%(arg)s) === true) {
+            $context->registerEventListener(SomeEvent::class, SomeListener::class);
+        }
+    }
+}
+"""
+
+_AH = "OCA\\\\OpenRegister\\\\AppHost\\\\Controller\\\\GenericHealthController"
+
+
+class ClassNameSpellingTest(GateCase):
+    """RULE 2 SAW ONE OF PHP'S THREE WAYS TO NAME A CLASS (.github#276).
+
+    `CLASS_EXISTS_APPHOST` required a QUOTED literal, so only the first of
+    these was a finding — the other three were injected into larpingapp's
+    register() and the gate reported OK for every one:
+
+        class_exists('OCA\\OpenRegister\\AppHost\\…\\GenericHealthController')
+        class_exists(\\OCA\\OpenRegister\\AppHost\\…\\GenericHealthController::class)
+        use …\\GenericHealthController;  class_exists(GenericHealthController::class)
+        const AH = 'OCA\\OpenRegister\\AppHost\\…';  class_exists(self::AH)
+
+    That is #184's lesson in the file where it was learned: a checker that
+    greps a STRING LITERAL misses every constant. The class name is the
+    SUBJECT of this gate, so missing three of its four spellings is missing
+    the gate.
+
+    `Foo::class` does not itself autoload — it is compile-time. It is
+    `class_exists()` that reaches the autoloader, which is why the CALL is
+    what is matched and why a bare `use` import is deliberately NOT a finding
+    (asserted below, so the fix cannot drift into flagging imports).
+    """
+
+    def _app(self, *, arg: str, use: str = "", const: str = "") -> None:
+        self.app(
+            "Application.php",
+            _CLASS_EXISTS_APP % {"arg": arg, "use": use, "const": const},
+        )
+
+    def test_quoted_fqcn(self):
+        self._app(arg=f"'{_AH}'")
+        self.assertEqual(_run(self.dir)[0], 1)
+
+    def test_fully_qualified_class_constant(self):
+        self._app(arg="\\OCA\\OpenRegister\\AppHost\\Controller\\GenericHealthController::class")
+        self.assertEqual(_run(self.dir)[0], 1, "the ::class form is the same probe")
+
+    def test_imported_short_name_class_constant(self):
+        self._app(
+            arg="GenericHealthController::class",
+            use="use OCA\\OpenRegister\\AppHost\\Controller\\GenericHealthController;",
+        )
+        self.assertEqual(_run(self.dir)[0], 1, "a `use` import must be resolved")
+
+    def test_php_class_constant_holding_the_fqcn(self):
+        self._app(arg="self::AH_HEALTH", const=f"    private const AH_HEALTH = '{_AH}';")
+        self.assertEqual(_run(self.dir)[0], 1, "a constant is not a different defect")
+
+    def test_the_prelude_still_clears_every_spelling(self):
+        for arg, use, const in (
+            (f"'{_AH}'", "", ""),
+            ("\\OCA\\OpenRegister\\AppHost\\Controller\\GenericHealthController::class", "", ""),
+            ("self::AH_HEALTH", "", f"    private const AH_HEALTH = '{_AH}';"),
+        ):
+            with self.subTest(arg=arg):
+                self.app(
+                    "Application.php",
+                    _CLASS_EXISTS_APP % {"arg": arg, "use": use, "const": const}
+                    + "\nclass Prelude { function p() {" + PRELUDE + "} }\n",
+                )
+                self.assertEqual(_run(self.dir)[0], 0)
+
+    # --- ANTI-WIDENING -------------------------------------------------
+    def test_a_bare_use_import_is_not_a_finding(self):
+        """`use` is a compile-time alias. It does not autoload, so it is not
+        this defect — and treating it as one would newly redden four repos
+        (docudesk, opencatalogi, openconnector, openbuild) for code that
+        works. Measured before this fix landed."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Controller\\GenericHealthController;
+class Application { public function register($c): void { $c->x(); } }
+""")
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_class_exists_on_an_unrelated_class_is_not_a_finding(self):
+        self._app(arg="\\OCA\\Talk\\Manager::class")
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_a_comment_naming_the_probe_is_not_the_probe(self):
+        """#184's other direction, re-asserted on the new spellings."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+class Application {
+    public function register($c): void {
+        // Deliberately NOT class_exists(\\OCA\\OpenRegister\\AppHost\\Bootstrap::class):
+        // ADR-040 says register the autoloader instead.
+        $c->x();
+    }
+}
+""")
+        self.assertEqual(_run(self.dir)[0], 0)
+
+
+_OR_EVENT_APP = """<?php
+namespace OCA\\Leaf\\AppInfo;
+%(use)s
+class Application
+{
+    public function register($context): void
+    {
+        if (class_exists(%(arg)s) === true) {
+            $context->registerEventListener(X::class, Y::class);
+        }
+    }
+
+    public function boot($context): void
+    {
+        if (class_exists('OCA\\\\OpenRegister\\\\Event\\\\BootTimeEvent') === true) {
+            $context->x();
+        }
+    }
+}
+"""
+
+
+class OpenRegisterProbeNoteTest(GateCase):
+    """A GREEN GATE-64 WAS NOT EVIDENCE ABOUT THIS (.github#276).
+
+    The gate's hard rule is scoped to `OCA\\OpenRegister\\AppHost\\`, but the
+    autoloader mechanism has nothing to do with AppHost: during register() the
+    whole `OCA\\OpenRegister\\` PSR-4 prefix is absent for any app sorting
+    earlier, so ANY class_exists() on it answers FALSE and everything it
+    guards silently never happens.
+
+    Measured 2026-08-08 across apps-extra with no prelude present:
+      larpingapp  3 — Event\\{DeepLinkRegistration,ObjectCreating,ObjectUpdating}
+                      and the last two carry larpingapp's server-authoritative
+                      skill-requirement / XP-budget enforcement on character
+                      writes, which therefore never registers.
+      hermiq      3 — flow-node, leaf-provider and shareable-config registration
+      nldesign    1 — shareable-config registration
+
+    Reported as a NOTE, not a FAIL, and deliberately: this gate is not
+    diff-scoped, so failing it turns every PR in three repos permanently red
+    for code the PR did not touch — the trap
+    check_store_and_settings_surface.py already records ("blocked EVERY
+    manifest-touching PR in that repo, permanently").
+    """
+
+    def _app(self, *, arg: str, use: str = "") -> None:
+        self.app("Application.php", _OR_EVENT_APP % {"arg": arg, "use": use})
+
+    def test_quoted_probe_is_noted_but_does_not_fail(self):
+        self._app(arg="'OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent'")
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0, "a NOTE must not fail the gate")
+        self.assertIn("NOTE", out)
+        self.assertIn("ObjectCreatingEvent", out)
+
+    def test_class_constant_probe_is_noted(self):
+        """The note must not repeat the string-literal blind spot it exists to
+        report. hermiq and nldesign write theirs as `::class`; a note that
+        could not see them would have measured 1 repo instead of 3."""
+        self._app(arg="\\OCA\\OpenRegister\\Service\\Flow\\RegisterFlowNodesEvent::class")
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0)
+        self.assertIn("RegisterFlowNodesEvent", out)
+
+    def test_imported_probe_is_noted(self):
+        self._app(
+            arg="RegisterLeafProvidersEvent::class",
+            use="use OCA\\OpenRegister\\Event\\RegisterLeafProvidersEvent;",
+        )
+        self.assertIn("RegisterLeafProvidersEvent", _run(self.dir)[1])
+
+    def test_a_probe_in_boot_is_NOT_noted(self):
+        """boot() runs after every app has registered, so the prefix is on the
+        autoloader and the probe resolves. Noting it would be a false positive
+        — the reason a note gets ignored. The fixture's boot() carries
+        `BootTimeEvent` in every case above and it must never appear."""
+        self._app(arg="'OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent'")
+        self.assertNotIn("BootTimeEvent", _run(self.dir)[1])
+
+    def test_the_prelude_silences_the_note(self):
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+class Application {
+    public function register($context): void {
+%s
+        if (class_exists('OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent') === true) {
+            $context->x();
+        }
+    }
+}
+""" % PRELUDE)
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("NOTE", out)
+
+    def test_an_apphost_probe_is_a_FAIL_not_a_note(self):
+        """The two rules must not double-report one defect."""
+        self._app(arg=f"'{_AH}'")
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 1)
+        self.assertNotIn("NOTE", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_listener_placement.py
+++ b/hydra-gates/scripts/lib/test_check_listener_placement.py
@@ -538,7 +538,18 @@ class DiffScopeTest(unittest.TestCase):
             _write(root, 'README.md', 'unrelated\n')
             self._git(root, 'add', 'README.md')
             self._git(root, 'commit', '-qm', 'unrelated change')
-            self.assertEqual(self._run(root, 'base'), 0)
+            # EXIT_EMPTY_SCOPE (3), not 0 (.github#276).
+            #
+            # Both are non-blocking, and this test's intent — "the legacy
+            # backlog must not fail a PR that did not touch it" — is unchanged:
+            # the runner maps 3 to `_skip … na`, which does not count against
+            # --require-full-coverage. What changed is that 0 no longer has to
+            # mean two different things. It used to mean BOTH "I inspected the
+            # registrations and they were clean" and "the diff put all of them
+            # out of scope, so I inspected none", and the runner printed PASS
+            # for both — a verdict about work placement over a scope no run
+            # opened.
+            self.assertEqual(self._run(root, 'base'), clp.EXIT_EMPTY_SCOPE)
 
     def test_touching_the_listener_file_pulls_it_into_scope(self):
         """...and the same violation then fails. Same repo, same listener —

--- a/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -961,6 +962,117 @@ class ExitContractTest(unittest.TestCase):
             self.assertGreater(
                 len([ln for ln in buf.getvalue().splitlines() if ln.strip()]), 0
             )
+
+
+class McpSeamSpellingTest(unittest.TestCase):
+    """A LEADING BACKSLASH MUST NOT DISSOLVE THE SEAM (.github#276).
+
+    Both halves of the attribute seam matched a namespace prefix as
+    `(?:[A-Za-z_]\\w*\\s*\\\\+\\s*)*` — every segment had to START with a
+    letter. So the fully-qualified spelling, which is the ordinary way to
+    write a name with no `use` import for it, matched neither:
+
+        registerServiceAlias('…::demoapp', \\OCA\\DemoApp\\Mcp\\Impl::class)
+        #[\\OCA\\OpenRegister\\Mcp\\Attribute\\McpTool(name: 'createLead')]
+
+    Either miss alone empties the seam and puts `createLead` — pipelinq's
+    curated, spec'd MCP write tool — back on the finding list, which is
+    .github#200 verbatim: a finding whose only remedy is deleting a live
+    write tool.
+
+    THE MUTANT IS BOTH SITES AT ONCE. The seam needs the alias AND the
+    attribute, so reverting one regex while the other is fixed still
+    reproduces the false positive — and reverting one while testing the other
+    reads as "the fix changed nothing". `test_pre_fix_regexes_reproduce_the_
+    false_positive` therefore restores the pre-fix pair together and asserts
+    the finding comes BACK.
+    """
+
+    _FQ_ALIAS = """        $context->registerServiceAlias(
+            'OCA\\\\OpenRegister\\\\Mcp\\\\IMcpScannableServices::demoapp',
+            \\OCA\\DemoApp\\Mcp\\DemoScannableServices::class
+        );"""
+
+    _FQ_ATTRIBUTE = """    #[\\OCA\\OpenRegister\\Mcp\\Attribute\\McpTool(
+        name: 'createLead',
+        scope: 'create'
+    )]"""
+
+    # The two patterns exactly as they read before the fix.
+    _PRE_FIX_ALIAS = re.compile(
+        r"registerServiceAlias\s*\(\s*"
+        r"(['\"])[^'\"]*IMcpScannableServices::[A-Za-z0-9_-]+\1"
+        r"\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*"
+        r"([A-Za-z_][A-Za-z0-9_]*)\s*::\s*class",
+        re.DOTALL,
+    )
+    _PRE_FIX_ATTR = re.compile(r"#\[\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*\\+\s*)*McpTool\b")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "demoapp")
+        os.makedirs(self.root)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _fully_qualified(self):
+        return _McpFixture(
+            self.root, alias=self._FQ_ALIAS, attribute=self._FQ_ATTRIBUTE
+        )
+
+    def test_fully_qualified_alias_and_attribute_still_form_the_seam(self):
+        self.assertNotIn("createLead", self._fully_qualified().methods())
+
+    def test_fully_qualified_alias_with_short_attribute(self):
+        f = _McpFixture(self.root, alias=self._FQ_ALIAS, attribute=_MCP_ATTRIBUTE)
+        self.assertNotIn("createLead", f.methods())
+
+    def test_short_alias_with_fully_qualified_attribute(self):
+        f = _McpFixture(
+            self.root, alias=_MCP_ALIAS_CALL, attribute=self._FQ_ATTRIBUTE
+        )
+        self.assertNotIn("createLead", f.methods())
+
+    def test_pre_fix_regexes_reproduce_the_false_positive(self):
+        """THE MUTANT. Restore BOTH pre-fix patterns; the finding must return.
+
+        Without this the two assertions above could be green because the seam
+        never depended on those regexes at all.
+        """
+        old_alias, old_attr = owc._MCP_ALIAS_RE, owc._MCP_TOOL_ATTR_RE
+        self.assertIsNot(old_alias, self._PRE_FIX_ALIAS)
+        self.assertIsNot(old_attr, self._PRE_FIX_ATTR)
+        try:
+            owc._MCP_ALIAS_RE = self._PRE_FIX_ALIAS
+            owc._MCP_TOOL_ATTR_RE = self._PRE_FIX_ATTR
+            self.assertIn(
+                "createLead",
+                self._fully_qualified().methods(),
+                "the pre-fix patterns must reproduce the #200 false positive — "
+                "if they do not, this test is measuring nothing",
+            )
+        finally:
+            owc._MCP_ALIAS_RE, owc._MCP_TOOL_ATTR_RE = old_alias, old_attr
+
+    def test_the_controls_survive_the_widening(self):
+        """ANTI-WIDENING. Accepting a leading `\\` must not accept everything."""
+        # A DIFFERENT interface in the alias grants nothing.
+        f = _McpFixture(
+            self.root,
+            alias=self._FQ_ALIAS.replace("IMcpScannableServices", "ISomethingElse"),
+            attribute=self._FQ_ATTRIBUTE,
+        )
+        self.assertIn("createLead", f.methods())
+        # An attribute that is not McpTool grants nothing.
+        f = _McpFixture(
+            self.root,
+            alias=self._FQ_ALIAS,
+            attribute="    #[\\OCA\\Other\\Attribute\\NotAnMcpTool(name: 'x')]",
+        )
+        self.assertIn("createLead", f.methods())
+        # And a write method with no attribute on the same class is still dead.
+        self.assertIn("createInvoice", self._fully_qualified().methods())
 
 
 if __name__ == "__main__":

--- a/hydra-gates/scripts/lib/test_check_register_handler_resolution.py
+++ b/hydra-gates/scripts/lib/test_check_register_handler_resolution.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -155,6 +156,118 @@ class ResolvedTest(unittest.TestCase):
                 json.dump({"class": "OCA\\Fixture\\Guard\\RealGuard"}, fh)
             out = _run_main(reg)
             self.assertEqual(out, [])
+
+
+class DeclarationFormTest(unittest.TestCase):
+    """THE FALLBACK WALK ONLY RECOGNISED `class` (.github#276).
+
+    The PSR-4 path guess handles the conventional layout. This fallback walk
+    over lib/ is what finds a type living where PSR-4 does NOT predict — a
+    DI-bound registration, a type not named after its file. That is the shape
+    gate-30 was caught mis-resolving: `AppHost\\Controller\\GenericHealth`
+    PSR-4-maps to `lib/Controller/AppHost/Controller/…` while openregister
+    DI-binds it to `lib/AppHost/Controller/`.
+
+    So every declaration form the walk cannot match is a FALSE POSITIVE on a
+    type that genuinely exists — and the action `guard-class-not-found`
+    invites is to write the class a second time. Measured, each against a
+    real declaration at a non-conventional path (file `bundle.php`, class
+    names unrelated to it):
+
+        enum ProbeState: string { … }        -> guard-class-not-found
+        interface ProbeContract { … }        -> guard-class-not-found
+        trait ProbeTrait { … }               -> guard-class-not-found
+        final readonly class ReadonlyProbe   -> guard-class-not-found
+
+    `final readonly` is ordinary PHP 8.2; the pattern allowed `final ` OR
+    `abstract `, never two modifiers.
+    """
+
+    BUNDLE = (
+        "<?php\nnamespace OCA\\Fixture\\Health;\n"
+        "enum ProbeState: string { case Ok = 'ok';"
+        " public function check(): bool { return true; } }\n"
+        "interface ProbeContract { public function check(): bool; }\n"
+        "trait ProbeTrait { public function check(): bool { return true; } }\n"
+        "final readonly class ReadonlyProbe"
+        " { public function check(): bool { return true; } }\n"
+    )
+
+    def _probe(self, fqcn: str) -> list[str]:
+        with _AppFixture() as root:
+            os.makedirs(os.path.join(root, "lib", "Health"), exist_ok=True)
+            # NOTE the filename: PSR-4 would look for <ClassName>.php, so
+            # every resolution below can only come from the fallback walk.
+            with open(os.path.join(root, "lib", "Health", "bundle.php"),
+                      "w", encoding="utf-8") as fh:
+                fh.write(self.BUNDLE)
+            os.makedirs(os.path.join(root, "lib", "Docs"), exist_ok=True)
+            with open(os.path.join(root, "lib", "Docs", "notes.php"),
+                      "w", encoding="utf-8") as fh:
+                fh.write(
+                    "<?php\nnamespace OCA\\Fixture\\Docs;\n"
+                    "/**\n * See the MentionedGuard class for details;\n"
+                    " * interface MentionedGuard is planned.\n */\n"
+                    "class Notes {}\n"
+                )
+            reg = os.path.join(root, "register.json")
+            with open(reg, "w", encoding="utf-8") as fh:
+                json.dump({"transitions": {"s": {"guard": fqcn}}}, fh)
+            return _run_main(reg)
+
+    def test_enum_at_an_unconventional_path_resolves(self):
+        self.assertEqual(self._probe("OCA\\Fixture\\Health\\ProbeState::check"), [])
+
+    def test_interface_at_an_unconventional_path_resolves(self):
+        self.assertEqual(self._probe("OCA\\Fixture\\Health\\ProbeContract::check"), [])
+
+    def test_trait_at_an_unconventional_path_resolves(self):
+        self.assertEqual(self._probe("OCA\\Fixture\\Health\\ProbeTrait::check"), [])
+
+    def test_final_readonly_class_resolves(self):
+        self.assertEqual(self._probe("OCA\\Fixture\\Health\\ReadonlyProbe::check"), [])
+
+    # --- ANTI-WIDENING. The gate must still be able to fail. --------------
+    def test_a_genuinely_absent_class_is_still_not_found(self):
+        out = self._probe("OCA\\Fixture\\Health\\NotARealGuard::may")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("guard-class-not-found", out[0])
+
+    def test_a_docblock_mention_is_still_not_a_declaration(self):
+        """The line anchor is why this walk is trustworthy at all: a
+        merely-MENTIONED class counted as found would mask the exact fleet
+        defect the gate exists for (17 nonexistent guards on shillinq). The
+        fixture's docblock says both "MentionedGuard class" and "interface
+        MentionedGuard", so it exercises the widened alternation too."""
+        out = self._probe("OCA\\Fixture\\Docs\\MentionedGuard::may")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("guard-class-not-found", out[0])
+
+    def test_a_missing_method_on_a_real_enum_is_still_reported(self):
+        out = self._probe("OCA\\Fixture\\Health\\ProbeState::nosuchmethod")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("guard-method-not-found", out[0])
+
+    def test_the_mutant_the_widened_forms_are_load_bearing(self):
+        """Restore the pre-fix pattern; all four must go back to not-found.
+        Without this, the four assertions above could be green because the
+        types were resolving by some other route."""
+        original = rhr._class_def_re
+        try:
+            def pre_fix(short_name):
+                return re.compile(
+                    r"^\s*(?:final\s+|abstract\s+)?class\s+"
+                    + re.escape(short_name) + r"\b", re.MULTILINE)
+            rhr._class_def_re = pre_fix
+            for fqcn in ("ProbeState", "ProbeContract", "ProbeTrait", "ReadonlyProbe"):
+                out = self._probe(f"OCA\\Fixture\\Health\\{fqcn}::check")
+                self.assertEqual(
+                    len(out), 1,
+                    f"the pre-fix pattern must reproduce the false positive on "
+                    f"{fqcn} — if it does not, this suite is measuring nothing",
+                )
+        finally:
+            rhr._class_def_re = original
 
 
 class ExcludeAnnotationTest(unittest.TestCase):

--- a/hydra-gates/scripts/lib/test_check_unclosable_gate.py
+++ b/hydra-gates/scripts/lib/test_check_unclosable_gate.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+# SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+"""Tests for check_unclosable_gate (gate 59). Run with:
+
+    python3 scripts/lib/test_check_unclosable_gate.py
+
+WHY THIS FILE DID NOT EXIST UNTIL NOW, AND WHAT WRITING IT FOUND (.github#276)
+-----------------------------------------------------------------------------
+Gate 59 shipped with no helper suite at all. Measured against docudesk with a
+planted true positive, it caught the textbook case — and then failed in BOTH
+directions on the very next mutation, which is #184's signature:
+
+  false GREEN     a COMMENTED-OUT setter counted as a write.
+
+                      // TODO: $c->setValueString('app','configuration_version',$v);
+
+                  and the finding vanished. That is the single most likely
+                  comment to sit beside a key nobody writes, because it is
+                  what someone types when they notice the gap and defer it.
+                  The gate whose whole subject is "this guard never closes"
+                  was itself closed by a comment promising to close a guard.
+
+  false GREEN     `"key"` — the key in double quotes — was invisible on both
+                  sides, so the whole gate silently stopped existing for any
+                  app using that quote style.
+
+  false POSITIVE  read `'key'`, write `"key"` — code that closes its gate
+                  correctly was reported as never closing it, and the only
+                  remedy available to the app was to change its quote style.
+
+  false GREEN     `private const CONFIG_KEY = '…'` + `self::CONFIG_KEY` was
+                  invisible — and a constant is the IDIOMATIC way to write a
+                  key used in two places, which is exactly the shape a
+                  CLOSABLE gate has. The best-written apps were the ones this
+                  gate could say nothing about.
+
+Every case below is an arm of that matrix, each with its control, plus the
+mutant that proves the mask is load-bearing.
+"""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_unclosable_gate as gate  # noqa: E402
+
+KEY = "configuration_version"
+
+READ = "$seen = $this->cfg->getValueString(%s, %s, '');"
+WRITE = "$this->cfg->setValueString(%s, %s, '1.0.0');"
+
+
+def _app(root: Path, body: str, *, head: str = "") -> None:
+    path = root / "lib" / "Service" / "Initializer.php"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "<?php\nnamespace OCA\\Leaf\\Service;\n"
+        "class Initializer {\n" + head + "\n"
+        "    public function initialize(): void {\n"
+        "        " + body + "\n"
+        "        $this->importEverything();\n"
+        "    }\n"
+        "    private function importEverything(): void {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+def _run(root: Path) -> tuple[int, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        argv, sys.argv = sys.argv, ["check_unclosable_gate.py", str(root)]
+        try:
+            rc = gate.main()
+        finally:
+            sys.argv = argv
+    return rc, buf.getvalue()
+
+
+class GateCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dir = Path(tempfile.mkdtemp(prefix="unclosable-gate-"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def assertFinding(self, msg: str = "") -> None:
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 1, msg or out)
+        self.assertIn(KEY, out)
+
+    def assertClean(self, msg: str = "") -> None:
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0, msg or out)
+
+
+class TruePositiveTest(GateCase):
+    """The gate must be able to fail before anything else is worth asserting."""
+
+    def test_read_with_no_write_anywhere(self):
+        _app(self.dir, READ % ("'leaf'", f"'{KEY}'"))
+        self.assertFinding()
+
+    def test_a_real_write_closes_it(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'") + "\n        " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertClean()
+
+    def test_an_ordinary_setting_is_not_a_gate(self):
+        """A read-only config key is normal — it is a setting with a default.
+        Only keys SHAPED like a done-marker are gates (GATE_SHAPE)."""
+        _app(self.dir, READ % ("'leaf'", "'default_page_size'"))
+        self.assertClean()
+
+    def test_nextcloud_managed_keys_are_not_gates(self):
+        _app(self.dir, READ % ("'leaf'", "'installed_version'"))
+        self.assertClean()
+
+
+class CommentIsNotAWriteTest(GateCase):
+    """A COMMENT IS NOT A WRITE — the false GREEN, and the dangerous one."""
+
+    def test_commented_out_setter_does_not_close_the_gate(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        // TODO: " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertFinding("a `// TODO:` setter is a promise, not a write")
+
+    def test_docblock_setter_does_not_close_the_gate(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'"),
+            head="    /**\n     * Callers should " + WRITE % ("'leaf'", f"'{KEY}'")
+                 + "\n     */",
+        )
+        self.assertFinding("prose describing a write is not a write")
+
+    def test_hash_comment_setter_does_not_close_the_gate(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        # " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertFinding()
+
+    def test_a_php8_attribute_is_not_a_comment(self):
+        """`#[` opens an attribute. Blanking it as a `#` comment would eat the
+        rest of the line — the distinction php_mask exists to keep."""
+        _app(self.dir, READ % ("'leaf'", f"'{KEY}'"), head="    #[SomeAttribute]")
+        self.assertFinding()
+
+    def test_a_real_write_with_a_trailing_comment_still_counts(self):
+        """The control for the mask: blanking comment REGIONS must not eat the
+        code in front of them."""
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        " + WRITE % ("'leaf'", f"'{KEY}'") + " // close the gate",
+        )
+        self.assertClean()
+
+    def test_the_mutant_the_mask_is_load_bearing(self):
+        """Remove the mask; the commented-out setter must silence the gate
+        again. Without this the arms above could be green for another reason.
+        """
+        original = gate.php_mask
+        self.assertTrue(callable(original))
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        // TODO: " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        try:
+            gate.php_mask = lambda text: text  # the pre-fix behaviour
+            rc, _ = _run(self.dir)
+            self.assertEqual(
+                rc, 0,
+                "without the comment mask the commented-out setter must close "
+                "the finding — if it does not, this suite proves nothing",
+            )
+        finally:
+            gate.php_mask = original
+        self.assertFinding("and with the mask restored the finding returns")
+
+
+class QuoteStyleTest(GateCase):
+    """PHP treats 'k' and "k" identically. The gate must too — and it was
+    wrong in BOTH directions at once, which is why both arms are here."""
+
+    def test_double_quoted_read_with_no_write_is_still_a_finding(self):
+        _app(self.dir, READ % ('"leaf"', f'"{KEY}"'))
+        self.assertFinding("a double-quoted key is the same key")
+
+    def test_single_quoted_read_closed_by_a_double_quoted_write(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'") + "\n        " + WRITE % ('"leaf"', f'"{KEY}"'),
+        )
+        self.assertClean("quote style is not a defect — this was a FALSE POSITIVE")
+
+    def test_double_quoted_read_closed_by_a_single_quoted_write(self):
+        _app(
+            self.dir,
+            READ % ('"leaf"', f'"{KEY}"') + "\n        " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertClean()
+
+
+class ClassConstantKeyTest(GateCase):
+    """A constant is how a key used twice is normally written."""
+
+    CONST = f"    private const CONFIG_KEY = '{KEY}';"
+
+    def test_constant_read_with_no_write_is_a_finding(self):
+        _app(self.dir, READ % ("'leaf'", "self::CONFIG_KEY"), head=self.CONST)
+        self.assertFinding()
+
+    def test_constant_on_both_sides_closes_it(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", "self::CONFIG_KEY")
+            + "\n        " + WRITE % ("'leaf'", "self::CONFIG_KEY"),
+            head=self.CONST,
+        )
+        self.assertClean("read and write must resolve to the SAME key")
+
+    def test_constant_read_closed_by_a_literal_write(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", "self::CONFIG_KEY")
+            + "\n        " + WRITE % ("'leaf'", f"'{KEY}'"),
+            head=self.CONST,
+        )
+        self.assertClean()
+
+    def test_literal_read_closed_by_a_constant_write(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        " + WRITE % ("'leaf'", "self::CONFIG_KEY"),
+            head=self.CONST,
+        )
+        self.assertClean()
+
+    def test_an_unresolvable_constant_is_not_invented(self):
+        """ANTI-WIDENING. A `self::` reference to a constant this app does not
+        define must not be turned into a key — a resolver that guesses would
+        manufacture findings nobody can act on."""
+        _app(self.dir, READ % ("'leaf'", "self::SOME_OTHER_CONST"))
+        self.assertClean()
+
+    def test_a_constant_defined_in_a_comment_is_not_a_definition(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", "self::CONFIG_KEY"),
+            head=f"    // private const CONFIG_KEY = '{KEY}';",
+        )
+        self.assertClean("a commented-out const defines nothing")
+
+
+class SuppressionTest(GateCase):
+    """The suppression is authored AS a comment, so it is the one thing that
+    must keep reading raw text — the mask would otherwise delete it."""
+
+    def test_reason_bearing_suppression_is_honoured(self):
+        _app(
+            self.dir,
+            f"// unclosable-gate exclude '{KEY}' is written by the OpenRegister "
+            "importer, not by this app\n        " + READ % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertClean("the marker lives in a comment and must survive the mask")
+
+    def test_suppression_naming_a_different_key_does_not_apply(self):
+        _app(
+            self.dir,
+            "// unclosable-gate exclude 'some_other_version' is externally set\n"
+            "        " + READ % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertFinding("a suppression is per-key, not per-file")
+
+
+class NoSubjectTest(GateCase):
+    def test_an_app_with_no_lib_is_clean(self):
+        self.assertClean()
+
+    def test_an_app_with_lib_but_no_config_access_is_clean(self):
+        path = self.dir / "lib" / "Service" / "Plain.php"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("<?php\nclass Plain { public function x(): void {} }\n")
+        self.assertClean()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_gate_5661_empty_scope_is_not_a_pass.sh
+++ b/hydra-gates/scripts/lib/test_gate_5661_empty_scope_is_not_a_pass.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_5661_empty_scope_is_not_a_pass.sh — gates 56-61 must not report
+# PASS over a scope they never opened.
+#
+# WHAT THIS GUARDS (.github#276)
+# ------------------------------
+# #242/#240 established that an unopened diff scope is not a PASS, and #268
+# established that it is `na` rather than `structural`. Both were applied to
+# gates 19, 25, 62 and 63 — and to nothing else.
+#
+# Measured 2026-08-08 on shillinq, one docs-only commit, `--scope-to-diff`:
+#
+#   [gate-56] register-handler-resolution: PASS      <- 153 registers, 0 opened
+#   [gate-57] orphaned-write-capability:   PASS      <- 316 services,  0 opened
+#   [gate-58] e2e-networkidle:             PASS      <-  60 e2e files, 0 opened
+#   [gate-59] unclosable-gate:             PASS      <- lib/ untouched
+#   [gate-60] icon-vocabulary:             PASS      <- no manifest in the diff
+#   [gate-61] listener-work-placement:     PASS      <- all 15 out of scope
+#   [gate-62] store-plane:                 NOT APPLICABLE   (fixed by #268)
+#   [gate-63] settings-surface:            NOT APPLICABLE   (fixed by #268)
+#
+# Six gates asserting a verdict about code the run had not looked at, sitting
+# next to two that had already learned not to. `--require-full-coverage` cannot
+# see a PASS, so nothing anywhere reported that six gates had gone quiet.
+#
+# FOUR ARMS, and the order matters:
+#   ARM 1  each gate PASSes over a genuinely clean, genuinely OPENED full tree.
+#          Without this, every other arm is satisfiable by a permanent skip.
+#   ARM 2  a docs-only diff yields NOT APPLICABLE, with a reason naming
+#          ADR-020, and does NOT fail --require-full-coverage.
+#   ARM 3  ANTI-WIDENING / the inverse invariant. The SAME repo with a real
+#          violation planted in each subject, in a diff that touches it, must
+#          FAIL every one of the six. A gate that had been skipped into
+#          uselessness passes ARM 2 perfectly and dies here.
+#   ARM 4  the `na` verdicts must not be counted as a coverage gap.
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_5661_empty_scope_is_not_a_pass.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-5661.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_app="${_tmp}/app"
+mkdir -p "${_app}/src" "${_app}/appinfo" "${_app}/tests/e2e" \
+         "${_app}/lib/AppInfo" "${_app}/lib/Service" "${_app}/lib/Listener" \
+         "${_app}/lib/Lifecycle" "${_app}/lib/Settings/register.d" \
+         "${_app}/node_modules/vue-material-design-icons"
+
+# gate-60 needs the icon package present, or it reports SKIPPED (wiring) —
+# a real coverage gap that would mask ARM 2's exit-code assertion.
+for _icon in ViewDashboardOutline CogOutline StoreOutline Bookshelf \
+             FileReplaceOutline ViewGridOutline BookOpenPageVariantOutline \
+             MapMarkerPathOutline; do
+    printf '<template></template>\n' \
+        > "${_app}/node_modules/vue-material-design-icons/${_icon}.vue"
+done
+
+printf '<?xml version="1.0"?>\n<info>\n <id>leaf</id>\n</info>\n' \
+    > "${_app}/appinfo/info.xml"
+printf '{"name":"leaf","menu":[{"label":"Dashboard","icon":"ViewDashboardOutline","route":"home"}]}\n' \
+    > "${_app}/src/manifest.json"
+
+# gate-56 — a handler reference that RESOLVES.
+cat > "${_app}/lib/Settings/register.d/10-thing.json" <<'JSON'
+{
+  "components": {
+    "schemas": {
+      "Thing": {
+        "slug": "Thing",
+        "x-openregister-lifecycle": {
+          "states": {
+            "closed": { "guard": "OCA\\Leaf\\Lifecycle\\ThingGuard::mayClose" }
+          }
+        }
+      }
+    }
+  }
+}
+JSON
+cat > "${_app}/lib/Lifecycle/ThingGuard.php" <<'PHP'
+<?php
+namespace OCA\Leaf\Lifecycle;
+class ThingGuard { public function mayClose(array $o): bool { return true; } }
+PHP
+
+# gate-57 — a write capability that HAS a production caller.
+cat > "${_app}/lib/Service/ThingService.php" <<'PHP'
+<?php
+namespace OCA\Leaf\Service;
+class ThingService { public function publishThing(string $id): void {} }
+PHP
+cat > "${_app}/lib/Service/ThingCoordinator.php" <<'PHP'
+<?php
+namespace OCA\Leaf\Service;
+class ThingCoordinator {
+    public function __construct(private ThingService $svc) {}
+    public function run(string $id): void { $this->svc->publishThing($id); }
+}
+PHP
+
+# gate-58 — an e2e file using the ADR-074 rule 4 remedy.
+cat > "${_app}/tests/e2e/thing.spec.ts" <<'TS'
+test('thing', async ({ page }) => {
+  await page.goto('/apps/leaf/', { waitUntil: 'domcontentloaded' });
+});
+TS
+
+# gate-59 — a config gate that CLOSES. gate-61 — a post-event listener that
+# does no request-path work.
+cat > "${_app}/lib/AppInfo/Application.php" <<'PHP'
+<?php
+namespace OCA\Leaf\AppInfo;
+class Application {
+    public function register($context): void {
+        $context->registerEventListener(
+            \OCA\OpenRegister\Event\ObjectCreatedEvent::class,
+            \OCA\Leaf\Listener\ThingListener::class
+        );
+    }
+    public function seed($cfg): void {
+        $seen = $cfg->getValueString('leaf', 'configuration_version', '');
+        if ($seen === '1.0.0') { return; }
+        $cfg->setValueString('leaf', 'configuration_version', '1.0.0');
+    }
+}
+PHP
+cat > "${_app}/lib/Listener/ThingListener.php" <<'PHP'
+<?php
+namespace OCA\Leaf\Listener;
+class ThingListener {
+    public function handle($event): void { $this->counter++; }
+}
+PHP
+
+(
+    cd "${_app}" || exit 1
+    git init -q .
+    printf 'node_modules/\n' > .gitignore
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+
+_run() {  # _run <outfile> [runner args...]
+    local out="$1"; shift
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    (
+        cd "${_app}" || exit 1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" "$@" . > "${out}" 2>&1
+    )
+    return $?
+}
+_verdict() { grep -oE "^\[gate-$2\] [^:]+: [A-Z]+( [A-Z]+)*( \([a-z]+\))?" "$1" | head -1 | sed 's/^[^:]*: //'; }
+
+_GATES="56 57 58 59 60 61"
+
+# ---------------------------------------------------------------------------
+# ARM 1 — a genuinely clean subject, genuinely IN SCOPE, PASSes.
+#
+# Scoped rather than full-tree, because gate-61 is always diff-scoped BY
+# DESIGN (it is about new debt; the fleet's 149-registration backlog is a
+# work-list, not a reason to redden every repo). Asserting a full-tree PASS
+# for it would be asserting a behaviour the gate deliberately does not have.
+#
+# This arm has to come first: every later assertion here is satisfiable by a
+# gate that has been skipped into uselessness, and this is the one that is not.
+# ---------------------------------------------------------------------------
+(
+    cd "${_app}" || exit 1
+    # Touch every subject, changing nothing that any gate objects to.
+    printf '\n' >> lib/Settings/register.d/10-thing.json
+    printf '\n' >> lib/Service/ThingService.php
+    printf '\n' >> tests/e2e/thing.spec.ts
+    printf '\n' >> lib/AppInfo/Application.php
+    printf '\n' >> lib/Listener/ThingListener.php
+    printf '{"name":"leaf","menu":[{"label":"Dashboard","icon":"ViewDashboardOutline","route":"home"}],"version":"1.0.1"}\n' \
+        > src/manifest.json
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm "touch every subject, cleanly"
+) >/dev/null 2>&1
+
+_clean="${_tmp}/clean.txt"
+_run "${_clean}" --scope-to-diff --base HEAD~1
+for _g in ${_GATES}; do
+    _v="$(_verdict "${_clean}" "${_g}")"
+    if [ "${_v}" = "PASS" ]; then
+        _ok "gate-${_g} opened its in-scope subject and PASSed"
+    else
+        _bad "gate-${_g} verdict is '${_v}' for a clean subject THE DIFF TOUCHED — expected PASS (a SKIP here means the fixture gives this gate no subject, and every later arm is measuring nothing)"
+    fi
+done
+
+# gate-59's own extra property: it must also run on an UNSCOPED audit.
+# CHANGED_FILES is populated only under --scope-to-diff, so the condition
+# `grep '^lib/.*\.php$'` was false for every full-tree run and the gate
+# reported PASS having walked no PHP (.github#276). A full-tree audit was the
+# one mode it could not reach — #240's sentence, in a gate #240 did not visit.
+_full="${_tmp}/full.txt"
+_run "${_full}"
+_v="$(_verdict "${_full}" 59)"
+if [ "${_v}" = "PASS" ]; then
+    _ok "gate-59 runs on an UNSCOPED full-tree audit (PASS over a clean tree)"
+else
+    _bad "gate-59 full-tree verdict is '${_v}' — an unscoped run must audit lib/, not diff-scope itself to nothing"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — a docs-only diff is NOT APPLICABLE, never PASS, and never fatal.
+#
+# The commit is made HERE, after ARM 1's, so `--base HEAD~1` names exactly the
+# docs-only change. (Written the other way round first, ARM 1's commit became
+# HEAD~1 and ARM 2 measured an empty diff against HEAD itself — which the
+# runner resolves through the push-before fallback and is a different test.)
+# ---------------------------------------------------------------------------
+(
+    cd "${_app}" || exit 1
+    printf 'docs only\n' > README.md
+    git add README.md
+    git -c user.email=t@t -c user.name=t commit -qm docs
+) >/dev/null 2>&1
+
+_scoped="${_tmp}/scoped.txt"
+_run "${_scoped}" --scope-to-diff --base HEAD~1 --require-full-coverage
+_scoped_rc=$?
+
+for _g in ${_GATES}; do
+    _v="$(_verdict "${_scoped}" "${_g}")"
+    case "${_v}" in
+        "NOT APPLICABLE")
+            _ok "gate-${_g} reports NOT APPLICABLE over an empty diff scope"
+            ;;
+        PASS)
+            _bad "gate-${_g} reported PASS over a scope it never opened — this is the #242 defect, unfixed in this gate"
+            ;;
+        "SKIPPED (structural)"|"SKIPPED (wiring)")
+            _bad "gate-${_g} reported '${_v}' over an empty diff scope — #268: an empty ADR-020 scope must not count against coverage"
+            ;;
+        *)
+            _bad "gate-${_g} empty-scope verdict is '${_v}' — expected NOT APPLICABLE"
+            ;;
+    esac
+done
+
+for _g in ${_GATES}; do
+    if grep -qE "^\[gate-${_g}\][^:]*: NOT APPLICABLE — .+(ADR-020|no lib/|no tests/e2e|no lib/AppInfo)" "${_scoped}"; then
+        _ok "gate-${_g} states WHY it was not applicable"
+    else
+        _bad "gate-${_g}'s NOT APPLICABLE line carries no reason — a bare declaration is how a gate disappears quietly"
+    fi
+done
+
+if [ "${_scoped_rc}" -eq 98 ]; then
+    _bad "--require-full-coverage exited 98 over an empty diff scope — the #268 regression"
+elif [ "${_scoped_rc}" -eq 0 ]; then
+    _ok "--require-full-coverage let an empty diff scope through (exit 0)"
+else
+    _bad "empty-scope run exited ${_scoped_rc}, expected 0 — see ${_scoped}"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 4 — and the `na` verdicts are not counted as a coverage gap.
+# ---------------------------------------------------------------------------
+if grep -q 'GATES THAT DID NOT RUN' "${_scoped}"; then
+    _bad "the empty-scope run reported a coverage gap: $(sed -n '/GATES THAT DID NOT RUN/,$p' "${_scoped}" | grep -oE 'gate-[0-9]+' | tr '\n' ' ')"
+else
+    _ok "the empty-scope run reports NO coverage gap at all"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 3 — ANTI-WIDENING. One violation per gate, in a diff that touches it.
+#
+# This is the arm that a gate skipped into uselessness cannot survive. ARM 2
+# alone is satisfied by making every gate permanently `na`.
+# ---------------------------------------------------------------------------
+(
+    cd "${_app}" || exit 1
+    # 56 — a guard class that does not exist.
+    sed -i 's#ThingGuard::mayClose#MissingGuard::mayClose#' \
+        lib/Settings/register.d/10-thing.json
+    # 57 — a NEW write capability on the service, with no caller anywhere.
+    #      Deleting ThingCoordinator.php instead does NOT work and the reason
+    #      is ADR-020 working correctly: the service file itself would be
+    #      unchanged, so it stays out of scope. The defect a PR introduces is
+    #      the one this gate answers for.
+    cat > lib/Service/ThingService.php <<'PHP'
+<?php
+namespace OCA\Leaf\Service;
+class ThingService {
+    public function publishThing(string $id): void {}
+    public function publishScore(string $id, float $score): void {}
+}
+PHP
+    # 58 — a wait that never settles.
+    printf "test('b', async ({ page }) => { await page.waitForLoadState('networkidle'); });\n" \
+        >> tests/e2e/thing.spec.ts
+    # 59 — the write that closed the gate, removed.
+    sed -i "/setValueString('leaf', 'configuration_version'/d" lib/AppInfo/Application.php
+    # 60 — an MDI name that exists nowhere.
+    printf '{"name":"leaf","menu":[{"label":"Dashboard","icon":"LedgerOutline","route":"home"}]}\n' \
+        > src/manifest.json
+    # 61 — outbound I/O on the write path, no deferral, no annotation.
+    cat > lib/Listener/ThingListener.php <<'PHP'
+<?php
+namespace OCA\Leaf\Listener;
+use OCP\Http\Client\IClientService;
+class ThingListener {
+    public function __construct(private IClientService $clientService) {}
+    public function handle($event): void {
+        $this->clientService->newClient()->post('https://example.invalid/hook');
+    }
+}
+PHP
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm "plant one violation per gate"
+) >/dev/null 2>&1
+
+_planted="${_tmp}/planted.txt"
+_run "${_planted}" --scope-to-diff --base HEAD~1
+for _g in ${_GATES}; do
+    _v="$(_verdict "${_planted}" "${_g}")"
+    if [ "${_v}" = "FAIL" ]; then
+        _ok "gate-${_g} FAILs its planted true positive when the diff touches it"
+    else
+        _bad "gate-${_g} returned '${_v}' for a planted true positive IN SCOPE — the gate has been skipped into uselessness"
+    fi
+done
+
+# gate-59, UNSCOPED, with the violation present. This is the arm that
+# discriminates: on the pre-fix runner an unscoped run left CHANGED_FILES empty,
+# the `grep '^lib/.*\.php$'` guard was false, and the gate printed PASS over an
+# unclosable config gate sitting in the tree. A clean-tree PASS cannot tell the
+# two apart, because PASS is what the broken version prints either way.
+_full_planted="${_tmp}/full-planted.txt"
+_run "${_full_planted}"
+_v="$(_verdict "${_full_planted}" 59)"
+if [ "${_v}" = "FAIL" ]; then
+    _ok "gate-59 CATCHES the violation on an unscoped full-tree audit"
+else
+    _bad "gate-59 returned '${_v}' on an unscoped run over a tree containing an unclosable gate — the full-tree audit is the one mode this gate could not reach (.github#276)"
+fi
+
+echo
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_5661_empty_scope_is_not_a_pass.sh: ALL PASS"
+    exit 0
+fi
+echo "test_gate_5661_empty_scope_is_not_a_pass.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
+++ b/hydra-gates/scripts/lib/test_gate_crashed_checker_is_not_a_finding.sh
@@ -212,6 +212,130 @@ else
     _bad "gate-60 returned '${_v}' for a real violation it can detect offline — the missing dependency is now suppressing rules that DO work"
 fi
 
+# ---------------------------------------------------------------------------
+# gates 56 + 57 — a DEAD INTERPRETER must not read as a clean tree (.github#276)
+#
+# Both invoked their helper as `>> log 2>/dev/null || true` and then derived
+# the verdict from `wc -l` on the log. Stderr discarded, exit status
+# discarded, empty log — so a checker that never started reported PASS.
+#
+# Measured on shillinq against gate package 48c88ba, with a python3 shim that
+# exits 1 for exactly these two helpers:
+#
+#     [gate-56] register-handler-resolution: PASS      <- 153 registers
+#     [gate-57] orphaned-write-capability:   PASS      <- 316 services
+#
+# and gate-57 had reported 20 real findings over that same tree on the
+# previous run. That is gate-40's defect verbatim.
+#
+# Both helpers ALWAYS exit 0 when they run, by design (#209 — the count goes
+# to stdout, never into the exit byte), so a non-zero exit here can only be a
+# crash and never a finding count. TWO ARMS: the crash must be visible, and
+# the same tree with a working interpreter must still produce real verdicts —
+# otherwise "always skip" would pass this test.
+# ---------------------------------------------------------------------------
+_crash_app="${_tmp}/crash-5657"
+mkdir -p "${_crash_app}/lib/Settings/register.d" "${_crash_app}/lib/Service" \
+         "${_crash_app}/appinfo"
+printf '<?xml version="1.0"?>\n<info>\n <id>leaf</id>\n</info>\n' \
+    > "${_crash_app}/appinfo/info.xml"
+# The SECOND commit has to carry the subjects, or ADR-020 scopes them out and
+# both gates answer `na` — which would satisfy the crash arm for the wrong
+# reason. (Measured while writing this: with the plants in commit 1 and a
+# docs-only commit 2, all four assertions read NOT APPLICABLE.)
+(
+    cd "${_crash_app}" || exit 1
+    git init -q .
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm init
+) >/dev/null 2>&1
+# One unresolvable guard (gate-56) and one caller-less write method (gate-57).
+cat > "${_crash_app}/lib/Settings/register.d/10-thing.json" <<'JSON'
+{"components":{"schemas":{"T":{"x-openregister-lifecycle":{"states":{
+  "s":{"guard":"OCA\\Leaf\\Lifecycle\\NoSuchGuard::may"}}}}}}}
+JSON
+# The body has to DO something: an empty `{}` is a stub, and gate-57
+# deliberately does not call a stub an orphaned write capability.
+cat > "${_crash_app}/lib/Service/ThingService.php" <<'PHP'
+<?php
+namespace OCA\Leaf\Service;
+class ThingService {
+    public function publishScore(string $id, float $score): void {
+        file_put_contents('/dev/null', $id . $score);
+    }
+}
+PHP
+(
+    cd "${_crash_app}" || exit 1
+    git add -A
+    git -c user.email=t@t -c user.name=t commit -qm "plant one TP per gate"
+) >/dev/null 2>&1
+_croot=$(cd "${_crash_app}" && git rev-parse HEAD~1)
+
+# ARM A — with a working interpreter, both gates must FAIL on the plants.
+_clogs_ok="${_tmp}/clogs-ok"; mkdir -p "${_clogs_ok}"
+_cout_ok="${_tmp}/crash-5657-ok.txt"
+(
+    cd "${_crash_app}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_clogs_ok}" bash "${_runner}" \
+        --scope-to-diff --base "${_croot}" . > "${_cout_ok}" 2>&1
+)
+for _g in 56 57; do
+    if grep -qE "^\[gate-${_g}\][^:]*: FAIL" "${_cout_ok}"; then
+        _ok "gate-${_g} FAILs its planted true positive with a working interpreter"
+    else
+        _v=$(grep -oE "^\[gate-${_g}\] [^:]+: [A-Z]+( [A-Z]+)?( \([a-z]+\))?" "${_cout_ok}" | head -1 | sed 's/^[^:]*: //')
+        _bad "gate-${_g} returned '${_v:-none}' for a planted true positive — the crash arm below would then prove nothing"
+    fi
+done
+
+# ARM B — the same tree with a python3 that dies for these two helpers only.
+_shim="${_tmp}/shim"; mkdir -p "${_shim}"
+cat > "${_shim}/python3" <<'SHIM'
+#!/bin/bash
+for a in "$@"; do
+  case "$a" in
+    *check_register_handler_resolution.py|*check_orphaned_write_capability.py)
+      echo "Traceback (most recent call last): ModuleNotFoundError" >&2
+      exit 1 ;;
+  esac
+done
+exec /usr/bin/python3 "$@"
+SHIM
+chmod +x "${_shim}/python3"
+_clogs="${_tmp}/clogs"; mkdir -p "${_clogs}"
+_cout="${_tmp}/crash-5657.txt"
+(
+    cd "${_crash_app}" || exit 1
+    PATH="${_shim}:${PATH}" HYDRA_GATE_LOG_DIR="${_clogs}" bash "${_runner}" \
+        --scope-to-diff --base "${_croot}" . > "${_cout}" 2>&1
+)
+for _g in 56 57; do
+    _v=$(grep -oE "^\[gate-${_g}\] [^:]+: [A-Z]+( [A-Z]+)?( \([a-z]+\))?" "${_cout}" | head -1 | sed 's/^[^:]*: //')
+    case "${_v}" in
+        "SKIPPED (wiring)")
+            _ok "gate-${_g} reports SKIPPED (wiring) when its checker cannot run"
+            ;;
+        PASS)
+            _bad "gate-${_g} reported PASS over a checker that exited 1 — this is gate-40's defect: it FAILED the same tree one run earlier"
+            ;;
+        FAIL)
+            _bad "gate-${_g} reported FAIL from a crashed checker — a crash wearing a finding count (#209/#245)"
+            ;;
+        *)
+            _bad "gate-${_g} verdict is '${_v:-none emitted}' — expected SKIPPED (wiring)"
+            ;;
+    esac
+done
+
+# ...and the crash must be RECOVERABLE, not silently discarded to /dev/null.
+if [ -s "${_clogs}/hydra-gate-register-handler-resolution.err" ] \
+   && [ -s "${_clogs}/hydra-gate-orphaned-write-capability.err" ]; then
+    _ok "both crashes left their stderr on disk for the reader"
+else
+    _bad "a crashed checker's stderr was discarded — the reason it died is unrecoverable"
+fi
+
 echo
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_crashed_checker_is_not_a_finding.sh: ALL PASS"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -6629,15 +6629,29 @@ fi
 _rhr_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-register-handler-resolution.log
 : > "${_rhr_log}"
 _rhr_files=()
+_rhr_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _rhr_present=$((_rhr_present + 1))
     _in_scope "$f" || continue
     _rhr_files+=("$f")
 done < <(find lib/Settings -name '*register*.json' \
     -not -path '*/vendor/*' -not -path '*/node_modules/*' 2>/dev/null; \
     find lib/Settings/register.d -name '*.json' 2>/dev/null)
 _rhr_ran=1
-if [ "${#_rhr_files[@]}" -gt 0 ]; then
+# AN UNOPENED SCOPE IS NOT A PASS (.github#276 — the #242/#268 fix, applied to
+# the gates it was never applied to). Measured on shillinq with a docs-only
+# commit: gates 56, 57, 58, 59, 60 and 61 all printed PASS while 62 and 63 —
+# the two that had been fixed — correctly printed NOT APPLICABLE. Six gates
+# asserting a verdict about code no run had opened.
+if [ "${#_rhr_files[@]}" -eq 0 ]; then
+    _rhr_ran=0
+    if [ "${_rhr_present}" -eq 0 ]; then
+        _skip 56 "register-handler-resolution" na "no lib/Settings register JSON in this repo — this app declares no OpenRegister lifecycle guards or handlers for a class/method reference to dangle from."
+    else
+        _skip 56 "register-handler-resolution" na "${_rhr_present} register JSON(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a register."
+    fi
+elif [ "${#_rhr_files[@]}" -gt 0 ]; then
     _rhr_helper="${SCRIPT_DIR}/lib/check_register_handler_resolution.py"
     if [ -f "${_rhr_helper}" ]; then
         python3 "${_rhr_helper}" "${_rhr_files[@]}" >> "${_rhr_log}" 2>/dev/null || true
@@ -6685,13 +6699,23 @@ fi
 _owc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-orphaned-write-capability.log
 : > "${_owc_log}"
 _owc_files=()
+_owc_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _owc_present=$((_owc_present + 1))
     _in_scope "$f" || continue
     _owc_files+=("$f")
 done < <(_enum_tracked '\.php$' lib/Service | grep -v '/tests/')
 _owc_ran=1
-if [ "${#_owc_files[@]}" -gt 0 ]; then
+# An unopened scope is not a PASS — see gate 56 above (.github#276).
+if [ "${#_owc_files[@]}" -eq 0 ]; then
+    _owc_ran=0
+    if [ "${_owc_present}" -eq 0 ]; then
+        _skip 57 "orphaned-write-capability" na "no lib/Service PHP in this repo — there is no service layer for a write capability to be orphaned in."
+    else
+        _skip 57 "orphaned-write-capability" na "${_owc_present} lib/Service file(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a service."
+    fi
+elif [ "${#_owc_files[@]}" -gt 0 ]; then
     _owc_helper="${SCRIPT_DIR}/lib/check_orphaned_write_capability.py"
     if [ -f "${_owc_helper}" ]; then
         python3 "${_owc_helper}" "${_owc_files[@]}" >> "${_owc_log}" 2>/dev/null || true
@@ -6769,13 +6793,23 @@ _nwi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-networkidle.log
 _nwi_ran=1
 _nwi_helper="${SCRIPT_DIR}/lib/check_js_call_sites.py"
 _nwi_files=()
+_nwi_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _nwi_present=$((_nwi_present + 1))
     _in_scope "$f" || continue
     _nwi_files+=("$f")
 done < <(find tests/e2e -type f \( -name '*.ts' -o -name '*.js' \) 2>/dev/null)
 if [ "${#_nwi_files[@]}" -eq 0 ]; then
-    : # nothing in scope; ADR-020 diff scoping working as designed.
+    # WAS `: # nothing in scope`, which fell through to _pass — an unopened
+    # scope reported as a clean one (.github#276). ADR-020 scoping IS working
+    # as designed; the bug was calling its result PASS.
+    _nwi_ran=0
+    if [ "${_nwi_present}" -eq 0 ]; then
+        _skip 58 "e2e-networkidle" na "no tests/e2e/ files in this repo — there is no Playwright suite in which a wait could fail to settle."
+    else
+        _skip 58 "e2e-networkidle" na "${_nwi_present} tests/e2e file(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 (the fleet carries a 278-site legacy backlog this gate deliberately does not block on) — it runs on the next PR that touches an e2e file."
+    fi
 elif [ ! -f "${_nwi_helper}" ]; then
     _nwi_ran=0
     _skip 58 "e2e-networkidle" wiring "check_js_call_sites.py not found at ${_nwi_helper} — ${#_nwi_files[@]} e2e file(s) were in scope and NONE were inspected; a wait that never settles is UNVERIFIED by this run."
@@ -6821,7 +6855,17 @@ fi
 # ---------------------------------------------------------------------------
 _ucg_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-unclosable-gate.log
 : > "${_ucg_log}"
-if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; then
+# DIFF-SCOPE ONLY WHEN THE CALLER ASKED TO (.github#276 — #240's defect, in a
+# gate #240 did not reach). `CHANGED_FILES` is populated ONLY under
+# --scope-to-diff; on an unscoped run it is the empty string. So the condition
+# `grep -qE '^lib/.*\.php$'` was false for EVERY full-tree audit, and this gate
+# printed PASS having walked no PHP at all. A full-tree audit was the one mode
+# it could never reach — the same sentence #240 wrote about gates 62/63.
+_ucg_scoped_out=0
+if [ "${SCOPE_TO_DIFF}" = "1" ] && ! printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; then
+    _ucg_scoped_out=1
+fi
+if [ -d lib ] && [ "${_ucg_scoped_out}" -eq 0 ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_unclosable_gate.py" . > "${_ucg_log}" 2>&1
     _ucg_rc=$?
@@ -6831,8 +6875,12 @@ if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; th
     else
         _fail 59 "unclosable-gate" "config gate(s) read but never written — guarded setup runs on every request (ADR-076 rule 3); see ${_ucg_log}"
     fi
+elif [ ! -d lib ]; then
+    _skip 59 "unclosable-gate" na "no lib/ in this repo — there is no PHP composition root in which a config gate could be read."
 else
-    _pass 59 "unclosable-gate"
+    # WAS `_pass 59`. lib/ exists and the diff touched none of it, so nothing
+    # was read and nothing was judged — that is `na`, not a pass (.github#276).
+    _skip 59 "unclosable-gate" na "lib/ exists here and the diff against '${BASE_REF}' touched no lib/**.php, so NO PHP was inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches lib/."
 fi
 
 # ---------------------------------------------------------------------------
@@ -6870,7 +6918,10 @@ if [ -f src/manifest.json ]; then
             _iv_changed="__none__"
         fi
         if [ "${_iv_changed}" = "__none__" ]; then
-            _pass 60 "icon-vocabulary"
+            # WAS `_pass 60`. No manifest in the diff means no icon was read
+            # — the same unopened scope gates 62/63 already report as `na`
+            # (.github#276).
+            _skip 60 "icon-vocabulary" na "src/manifest.json exists here and the diff against '${BASE_REF}' touched no manifest, so NO icon was inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a manifest."
             _iv_args="__skip__"
         else
             for _f in ${_iv_changed}; do
@@ -6943,18 +6994,33 @@ _lwp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-listener-work-placement.log
 : > "${_lwp_log}"
 if [ -d lib/AppInfo ]; then
     set +e
+    # `--base` UNCONDITIONALLY, and unlike gates 62/63 that is DELIBERATE:
+    # this gate is always diff-scoped in both modes because it is about NEW
+    # debt, and the fleet's 149-registration backlog is a work-list rather
+    # than a reason to redden every repo (see the header). Switching an
+    # unscoped run to `--all` was tried and reverted here: the builder runs
+    # unscoped, so it would have surfaced the whole backlog as blocking
+    # findings on every build. The helper still fails CLOSED when the base
+    # does not resolve, so an unscopable run is never reported as a clean one.
     python3 "${SCRIPT_DIR}/lib/check_listener_placement.py" . --base "${BASE_REF}" > "${_lwp_log}" 2>&1
     _lwp_rc=$?
     set +e
     if [ "${_lwp_rc}" -eq 0 ]; then
         _pass 61 "listener-work-placement"
+    elif [ "${_lwp_rc}" -eq 3 ]; then
+        # EMPTY SCOPE. This gate is always diff-scoped (ADR-020), so on any PR
+        # that touches no listener EVERY registration falls out of scope. That
+        # used to print PASS (.github#276).
+        _skip 61 "listener-work-placement" na "the diff against '${BASE_REF}' put every post-event registration out of scope, so NONE were inspected. Diff-scoped out under ADR-020 — the fleet's 149-registration backlog is a work-list, not a reason to block an unrelated PR. This gate runs on the next PR that touches a listener registration. See ${_lwp_log}."
+    elif [ "${_lwp_rc}" -eq 4 ]; then
+        _skip 61 "listener-work-placement" na "this repo registers no post-object-event listener, so there is no work to place on or off the write path (ADR-078). See ${_lwp_log}."
     else
         _lwp_n=$(_count '^FAIL' "${_lwp_log}")
         [ "${_lwp_n}" -eq 0 ] && _lwp_n=1
         _fail 61 "listener-work-placement" "${_lwp_n} post-event listener(s) doing synchronous work with no deferral and no justification (ADR-078); see ${_lwp_log}"
     fi
 else
-    _pass 61 "listener-work-placement"
+    _skip 61 "listener-work-placement" na "no lib/AppInfo/ — this repo has no Nextcloud composition root, so it registers no object-event listener."
 fi
 
 # ---------------------------------------------------------------------------
@@ -7057,13 +7123,24 @@ fi
 #
 # Spec: openspec/architecture/adr-040-apphost-adoption.md
 # ---------------------------------------------------------------------------
-_aap_log=/tmp/hydra-gate-apphost-autoload-prelude.log
+# PRIVATE PER-INVOCATION LOG, like every other gate. This was a hardcoded
+# `/tmp/hydra-gate-apphost-autoload-prelude.log` — the exact shared-path
+# non-determinism the HYDRA_GATE_LOG_DIR block at the top of this file was
+# introduced to remove, left behind in one gate (.github#276).
+_aap_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-apphost-autoload-prelude.log
 : > "${_aap_log}"
 if [ -d lib/AppInfo ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_apphost_autoload_prelude.py" . > "${_aap_log}" 2>&1
     _aap_rc=$?
     set +e
+    # Surface the non-blocking NOTE lines. A register()-time class_exists() on a
+    # non-AppHost OCA\OpenRegister\ class is the SAME autoloader mechanism as
+    # the hard rule and silently skips everything it guards, but this gate is
+    # not diff-scoped, so failing it would block every PR in the repo on
+    # pre-existing code. Printing it is what stops a green gate-64 being read
+    # as evidence about it (.github#276).
+    grep -E '^NOTE' "${_aap_log}" || true
     if [ "${_aap_rc}" -eq 0 ]; then
         _pass 64 "apphost-autoload-prelude"
     else

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5842,15 +5842,29 @@ fi
 _rhr_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-register-handler-resolution.log
 : > "${_rhr_log}"
 _rhr_files=()
+_rhr_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _rhr_present=$((_rhr_present + 1))
     _in_scope "$f" || continue
     _rhr_files+=("$f")
 done < <(find lib/Settings -name '*register*.json' \
     -not -path '*/vendor/*' -not -path '*/node_modules/*' 2>/dev/null; \
     find lib/Settings/register.d -name '*.json' 2>/dev/null)
 _rhr_ran=1
-if [ "${#_rhr_files[@]}" -gt 0 ]; then
+# AN UNOPENED SCOPE IS NOT A PASS (.github#276 — the #242/#268 fix, applied to
+# the gates it was never applied to). Measured on shillinq with a docs-only
+# commit: gates 56, 57, 58, 59, 60 and 61 all printed PASS while 62 and 63 —
+# the two that had been fixed — correctly printed NOT APPLICABLE. Six gates
+# asserting a verdict about code no run had opened.
+if [ "${#_rhr_files[@]}" -eq 0 ]; then
+    _rhr_ran=0
+    if [ "${_rhr_present}" -eq 0 ]; then
+        _skip 56 "register-handler-resolution" na "no lib/Settings register JSON in this repo — this app declares no OpenRegister lifecycle guards or handlers for a class/method reference to dangle from."
+    else
+        _skip 56 "register-handler-resolution" na "${_rhr_present} register JSON(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a register."
+    fi
+elif [ "${#_rhr_files[@]}" -gt 0 ]; then
     _rhr_helper="${SCRIPT_DIR}/lib/check_register_handler_resolution.py"
     if [ -f "${_rhr_helper}" ]; then
         python3 "${_rhr_helper}" "${_rhr_files[@]}" >> "${_rhr_log}" 2>/dev/null || true
@@ -5898,13 +5912,23 @@ fi
 _owc_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-orphaned-write-capability.log
 : > "${_owc_log}"
 _owc_files=()
+_owc_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _owc_present=$((_owc_present + 1))
     _in_scope "$f" || continue
     _owc_files+=("$f")
 done < <(_enum_tracked '\.php$' lib/Service | grep -v '/tests/')
 _owc_ran=1
-if [ "${#_owc_files[@]}" -gt 0 ]; then
+# An unopened scope is not a PASS — see gate 56 above (.github#276).
+if [ "${#_owc_files[@]}" -eq 0 ]; then
+    _owc_ran=0
+    if [ "${_owc_present}" -eq 0 ]; then
+        _skip 57 "orphaned-write-capability" na "no lib/Service PHP in this repo — there is no service layer for a write capability to be orphaned in."
+    else
+        _skip 57 "orphaned-write-capability" na "${_owc_present} lib/Service file(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a service."
+    fi
+elif [ "${#_owc_files[@]}" -gt 0 ]; then
     _owc_helper="${SCRIPT_DIR}/lib/check_orphaned_write_capability.py"
     if [ -f "${_owc_helper}" ]; then
         python3 "${_owc_helper}" "${_owc_files[@]}" >> "${_owc_log}" 2>/dev/null || true
@@ -5982,13 +6006,23 @@ _nwi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-e2e-networkidle.log
 _nwi_ran=1
 _nwi_helper="${SCRIPT_DIR}/lib/check_js_call_sites.py"
 _nwi_files=()
+_nwi_present=0
 while IFS= read -r f; do
     [ -f "$f" ] || continue
+    _nwi_present=$((_nwi_present + 1))
     _in_scope "$f" || continue
     _nwi_files+=("$f")
 done < <(find tests/e2e -type f \( -name '*.ts' -o -name '*.js' \) 2>/dev/null)
 if [ "${#_nwi_files[@]}" -eq 0 ]; then
-    : # nothing in scope; ADR-020 diff scoping working as designed.
+    # WAS `: # nothing in scope`, which fell through to _pass — an unopened
+    # scope reported as a clean one (.github#276). ADR-020 scoping IS working
+    # as designed; the bug was calling its result PASS.
+    _nwi_ran=0
+    if [ "${_nwi_present}" -eq 0 ]; then
+        _skip 58 "e2e-networkidle" na "no tests/e2e/ files in this repo — there is no Playwright suite in which a wait could fail to settle."
+    else
+        _skip 58 "e2e-networkidle" na "${_nwi_present} tests/e2e file(s) exist here and the diff against '${BASE_REF}' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 (the fleet carries a 278-site legacy backlog this gate deliberately does not block on) — it runs on the next PR that touches an e2e file."
+    fi
 elif [ ! -f "${_nwi_helper}" ]; then
     _nwi_ran=0
     _skip 58 "e2e-networkidle" wiring "check_js_call_sites.py not found at ${_nwi_helper} — ${#_nwi_files[@]} e2e file(s) were in scope and NONE were inspected; a wait that never settles is UNVERIFIED by this run."
@@ -6034,7 +6068,17 @@ fi
 # ---------------------------------------------------------------------------
 _ucg_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-unclosable-gate.log
 : > "${_ucg_log}"
-if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; then
+# DIFF-SCOPE ONLY WHEN THE CALLER ASKED TO (.github#276 — #240's defect, in a
+# gate #240 did not reach). `CHANGED_FILES` is populated ONLY under
+# --scope-to-diff; on an unscoped run it is the empty string. So the condition
+# `grep -qE '^lib/.*\.php$'` was false for EVERY full-tree audit, and this gate
+# printed PASS having walked no PHP at all. A full-tree audit was the one mode
+# it could never reach — the same sentence #240 wrote about gates 62/63.
+_ucg_scoped_out=0
+if [ "${SCOPE_TO_DIFF}" = "1" ] && ! printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; then
+    _ucg_scoped_out=1
+fi
+if [ -d lib ] && [ "${_ucg_scoped_out}" -eq 0 ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_unclosable_gate.py" . > "${_ucg_log}" 2>&1
     _ucg_rc=$?
@@ -6044,8 +6088,12 @@ if [ -d lib ] && printf '%s\n' "${CHANGED_FILES}" | grep -qE '^lib/.*\.php$'; th
     else
         _fail 59 "unclosable-gate" "config gate(s) read but never written — guarded setup runs on every request (ADR-076 rule 3); see ${_ucg_log}"
     fi
+elif [ ! -d lib ]; then
+    _skip 59 "unclosable-gate" na "no lib/ in this repo — there is no PHP composition root in which a config gate could be read."
 else
-    _pass 59 "unclosable-gate"
+    # WAS `_pass 59`. lib/ exists and the diff touched none of it, so nothing
+    # was read and nothing was judged — that is `na`, not a pass (.github#276).
+    _skip 59 "unclosable-gate" na "lib/ exists here and the diff against '${BASE_REF}' touched no lib/**.php, so NO PHP was inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches lib/."
 fi
 
 # ---------------------------------------------------------------------------
@@ -6083,7 +6131,10 @@ if [ -f src/manifest.json ]; then
             _iv_changed="__none__"
         fi
         if [ "${_iv_changed}" = "__none__" ]; then
-            _pass 60 "icon-vocabulary"
+            # WAS `_pass 60`. No manifest in the diff means no icon was read
+            # — the same unopened scope gates 62/63 already report as `na`
+            # (.github#276).
+            _skip 60 "icon-vocabulary" na "src/manifest.json exists here and the diff against '${BASE_REF}' touched no manifest, so NO icon was inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a manifest."
             _iv_args="__skip__"
         else
             for _f in ${_iv_changed}; do
@@ -6156,18 +6207,33 @@ _lwp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-listener-work-placement.log
 : > "${_lwp_log}"
 if [ -d lib/AppInfo ]; then
     set +e
+    # `--base` UNCONDITIONALLY, and unlike gates 62/63 that is DELIBERATE:
+    # this gate is always diff-scoped in both modes because it is about NEW
+    # debt, and the fleet's 149-registration backlog is a work-list rather
+    # than a reason to redden every repo (see the header). Switching an
+    # unscoped run to `--all` was tried and reverted here: the builder runs
+    # unscoped, so it would have surfaced the whole backlog as blocking
+    # findings on every build. The helper still fails CLOSED when the base
+    # does not resolve, so an unscopable run is never reported as a clean one.
     python3 "${SCRIPT_DIR}/lib/check_listener_placement.py" . --base "${BASE_REF}" > "${_lwp_log}" 2>&1
     _lwp_rc=$?
     set +e
     if [ "${_lwp_rc}" -eq 0 ]; then
         _pass 61 "listener-work-placement"
+    elif [ "${_lwp_rc}" -eq 3 ]; then
+        # EMPTY SCOPE. This gate is always diff-scoped (ADR-020), so on any PR
+        # that touches no listener EVERY registration falls out of scope. That
+        # used to print PASS (.github#276).
+        _skip 61 "listener-work-placement" na "the diff against '${BASE_REF}' put every post-event registration out of scope, so NONE were inspected. Diff-scoped out under ADR-020 — the fleet's 149-registration backlog is a work-list, not a reason to block an unrelated PR. This gate runs on the next PR that touches a listener registration. See ${_lwp_log}."
+    elif [ "${_lwp_rc}" -eq 4 ]; then
+        _skip 61 "listener-work-placement" na "this repo registers no post-object-event listener, so there is no work to place on or off the write path (ADR-078). See ${_lwp_log}."
     else
         _lwp_n=$(_count '^FAIL' "${_lwp_log}")
         [ "${_lwp_n}" -eq 0 ] && _lwp_n=1
         _fail 61 "listener-work-placement" "${_lwp_n} post-event listener(s) doing synchronous work with no deferral and no justification (ADR-078); see ${_lwp_log}"
     fi
 else
-    _pass 61 "listener-work-placement"
+    _skip 61 "listener-work-placement" na "no lib/AppInfo/ — this repo has no Nextcloud composition root, so it registers no object-event listener."
 fi
 
 # ---------------------------------------------------------------------------
@@ -6270,13 +6336,24 @@ fi
 #
 # Spec: openspec/architecture/adr-040-apphost-adoption.md
 # ---------------------------------------------------------------------------
-_aap_log=/tmp/hydra-gate-apphost-autoload-prelude.log
+# PRIVATE PER-INVOCATION LOG, like every other gate. This was a hardcoded
+# `/tmp/hydra-gate-apphost-autoload-prelude.log` — the exact shared-path
+# non-determinism the HYDRA_GATE_LOG_DIR block at the top of this file was
+# introduced to remove, left behind in one gate (.github#276).
+_aap_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-apphost-autoload-prelude.log
 : > "${_aap_log}"
 if [ -d lib/AppInfo ]; then
     set +e
     python3 "${SCRIPT_DIR}/lib/check_apphost_autoload_prelude.py" . > "${_aap_log}" 2>&1
     _aap_rc=$?
     set +e
+    # Surface the non-blocking NOTE lines. A register()-time class_exists() on a
+    # non-AppHost OCA\OpenRegister\ class is the SAME autoloader mechanism as
+    # the hard rule and silently skips everything it guards, but this gate is
+    # not diff-scoped, so failing it would block every PR in the repo on
+    # pre-existing code. Printing it is what stops a green gate-64 being read
+    # as evidence about it (.github#276).
+    grep -E '^NOTE' "${_aap_log}" || true
     if [ "${_aap_rc}" -eq 0 ]; then
         _pass 64 "apphost-autoload-prelude"
     else

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -6654,7 +6654,26 @@ if [ "${#_rhr_files[@]}" -eq 0 ]; then
 elif [ "${#_rhr_files[@]}" -gt 0 ]; then
     _rhr_helper="${SCRIPT_DIR}/lib/check_register_handler_resolution.py"
     if [ -f "${_rhr_helper}" ]; then
-        python3 "${_rhr_helper}" "${_rhr_files[@]}" >> "${_rhr_log}" 2>/dev/null || true
+        # A CHECKER THAT COULD NOT RUN MUST NOT JUDGE THE CODE (.github#276 —
+        # the #245/#233 rule, applied to the two gates it had not reached).
+        #
+        # This was `>> log 2>/dev/null || true`: stderr discarded, exit status
+        # discarded, and the verdict then taken from `wc -l` on an empty log,
+        # i.e. PASS. Measured on shillinq with a python3 that exits 1:
+        # `[gate-56] PASS` and `[gate-57] PASS` — and gate-57 had reported 20
+        # real findings over the same 316 services one run earlier. That is
+        # gate-40's defect verbatim.
+        #
+        # The helper ALWAYS returns 0 when it runs, by design (#209 — the
+        # count goes to stdout, never into the exit byte). So a non-zero exit
+        # here is unambiguously a crash and can never be a finding count.
+        _rhr_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-register-handler-resolution.err"
+        python3 "${_rhr_helper}" "${_rhr_files[@]}" >> "${_rhr_log}" 2>"${_rhr_err}"
+        _rhr_rc=$?
+        if [ "${_rhr_rc}" -ne 0 ]; then
+            _rhr_ran=0
+            _skip 56 "register-handler-resolution" wiring "check_register_handler_resolution.py exited ${_rhr_rc} — ${#_rhr_files[@]} register file(s) were in scope and NONE were judged; whether every referenced handler class/method resolves is UNVERIFIED by this run. This helper always exits 0 when it runs, so this is a crash, not a finding count. See ${_rhr_err}."
+        fi
     else
         _rhr_ran=0
         _skip 56 "register-handler-resolution" wiring "check_register_handler_resolution.py not found at ${_rhr_helper} — ${#_rhr_files[@]} register file(s) were in scope and NONE were inspected; whether every referenced handler class/method actually resolves is UNVERIFIED by this run."
@@ -6718,7 +6737,17 @@ if [ "${#_owc_files[@]}" -eq 0 ]; then
 elif [ "${#_owc_files[@]}" -gt 0 ]; then
     _owc_helper="${SCRIPT_DIR}/lib/check_orphaned_write_capability.py"
     if [ -f "${_owc_helper}" ]; then
-        python3 "${_owc_helper}" "${_owc_files[@]}" >> "${_owc_log}" 2>/dev/null || true
+        # A crashed checker is not a finding — see gate 56 above (.github#276).
+        # Measured on shillinq: with python3 exiting 1 this gate printed PASS
+        # over the same 316 services it had reported 20 findings in one run
+        # earlier. The helper always returns 0 when it runs (#209).
+        _owc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-orphaned-write-capability.err"
+        python3 "${_owc_helper}" "${_owc_files[@]}" >> "${_owc_log}" 2>"${_owc_err}"
+        _owc_rc=$?
+        if [ "${_owc_rc}" -ne 0 ]; then
+            _owc_ran=0
+            _skip 57 "orphaned-write-capability" wiring "check_orphaned_write_capability.py exited ${_owc_rc} — ${#_owc_files[@]} service file(s) were in scope and NONE were judged; orphaned (mintable-but-unreachable) write capabilities are UNVERIFIED by this run. This helper always exits 0 when it runs, so this is a crash, not a finding count. See ${_owc_err}."
+        fi
     else
         _owc_ran=0
         _skip 57 "orphaned-write-capability" wiring "check_orphaned_write_capability.py not found at ${_owc_helper} — ${#_owc_files[@]} service file(s) were in scope and NONE were inspected; orphaned (mintable-but-unreachable) write capabilities are UNVERIFIED by this run."
@@ -7077,7 +7106,32 @@ elif [ "${_ss_rc}" -eq 3 ]; then
     # The log used to say "gate skipped" while the verdict beside it said PASS.
     # Those cannot both be true, and PASS is the one every consumer counted.
     # It is not PASS any more (#242) — and it is `na`, not structural (#268).
-    _skip 63 "settings-surface" na "the diff against '${BASE_REF}' touched no manifest and no menu-layout, so NO manifest was inspected. Diff-scoped out under ADR-020 — not a gap: the manifests in this repo are unchanged from the base branch, so this PR introduces no settings placement (ADR-079) to judge. This gate runs on the next PR that touches a manifest. See ${_ss_log}."
+    #
+    # THE CONTROLLER-ONLY DIFF (.github#276).
+    #
+    # This gate's rules read src/manifest.json + src/manifest.d/ +
+    # src/menu-layout.json. A PR that changes a settings CONTROLLER, or adds
+    # or deletes a lib/Settings/*Admin.php section, therefore lands here — and
+    # the old reason read "this PR introduces no settings placement (ADR-079)
+    # to judge", which on such a diff is an OVERCLAIM. The author changed the
+    # settings surface; this gate simply does not adjudicate that half of it.
+    #
+    # WIDENING IT TO READ THE CONTROLLER WAS TRIED AND REVERTED, and the note
+    # is in check_store_and_settings_surface.py: a gate that only RUNS when a
+    # manifest changed and then judges code the PR never touched "blocked
+    # EVERY manifest-touching PR in that repo, permanently". So the verdict
+    # stays `na` and the rules stay manifest-only. What changes is that the
+    # line now says WHICH HALF it looked at, and names the PHP half when the
+    # diff contains it, so `na` cannot be read as a clearance for the change
+    # the author actually made.
+    _ss_php=$(printf '%s\n' "${CHANGED_FILES}" | grep -cE '^lib/(Settings/.*\.php|Controller/.*[Ss]ettings.*\.php)$' || true)
+    [ -z "${_ss_php}" ] && _ss_php=0
+    if [ "${_ss_php}" -gt 0 ]; then
+        _ss_extra="⚠️ This diff DOES touch the settings surface in PHP (${_ss_php} lib/Settings or settings-controller file(s)), and this gate did not look at any of it: ADR-079's placement rules are expressed in the manifest, and widening this gate to read controllers was tried and reverted because it blocked every manifest-touching PR in the repo permanently. Read this NOT APPLICABLE as 'no manifest placement decision to judge', never as 'the settings change was checked'."
+    else
+        _ss_extra="The manifests in this repo are unchanged from the base branch, so this PR introduces no manifest placement decision to judge."
+    fi
+    _skip 63 "settings-surface" na "the diff against '${BASE_REF}' touched no manifest and no menu-layout, so NO manifest was inspected. Diff-scoped out under ADR-020 — not a gap. This gate adjudicates ADR-079 placement as declared in src/manifest.json, src/manifest.d/ and src/menu-layout.json, and nothing else. ${_ss_extra} It runs on the next PR that touches one of those. See ${_ss_log}."
 elif [ "${_ss_rc}" -eq 4 ]; then
     _skip 63 "settings-surface" na "no src/manifest.json — a Tier-0 app declares no settings surface for ADR-079 to place."
 else


### PR DESCRIPTION
## What this is

The acceptance test applied to all nine gates in the **56–64** band: plant one textbook true positive in a **real fleet repo**, require the gate to FAIL and **name** it, remove the plant, require the prior verdict back, and require a clean fixture to still pass. Then three further arms a planted TP cannot reach: a **crashed checker**, an **`na` over a repo full of the subject**, and a **count returned as an exit status**.

Measured against gate package **`48c88ba`**; this branch is **`298f975`**.

| gate | planted true positive | repos (two shapes) | fired? | repaired? |
|---|---|---|---|---|
| 56 register-handler-resolution | missing guard class + real class/missing method; enum/interface/trait/`final readonly` at a DI-bound path | shillinq (153 registers) + fixture | ⚠️ **4 false positives** | ✅ + crash + scope |
| 57 orphaned-write-capability | `publishScore()` with zero callers | shillinq (316 services) + fixture | ✅ | ✅ MCP seam + crash + scope |
| 58 e2e-networkidle | live `waitForLoadState` + `goto(waitUntil:)`, comment on the line above | shillinq (60 e2e files) + fleet glob audit | ✅ 2 calls, comment ignored | scope verdict only |
| 59 unclosable-gate | config key read, never written | docudesk + fixture | ✅ | ✅ **wrong in both directions** |
| 60 icon-vocabulary | invented MDI · Tier A on wrong glyph · unbridged `icon-*` | shillinq (233 manifests) + fixture | ✅ all three states | scope verdict only |
| 61 listener-work-placement | post-`ObjectCreatedEvent` listener doing HTTP I/O | shillinq (15 registrations) | ✅ | scope verdict only |
| 62 store-plane | `Store` menu entry on `ViewGridOutline` | shillinq | ✅ | scope verdict only |
| 63 settings-surface | `adminSettings[]` in the manifest | shillinq + controller-only fixture | ✅ | ✅ reason was an overclaim |
| 64 apphost-autoload-prelude | `class_exists()` on AppHost — **all four spellings** | **larpingapp** (eager) + **launchpad** (lazy) | ⚠️ **1 of 4**, and a **false positive** | ✅ |

## Seven defects

**1. An unopened scope is not a PASS — gates 56, 57, 58, 59, 60, 61.** #242/#240/#268 reached gates 19, 25, 62, 63 and nothing else. On shillinq with one docs-only commit, all six printed `PASS` over scopes they never opened, beside 62/63 correctly printing `NOT APPLICABLE`. `--require-full-coverage` cannot see a PASS.

**2. Gate 59 could not run a full-tree audit at all.** `CHANGED_FILES` is populated only under `--scope-to-diff`; the guard grepped it unconditionally, so every unscoped run printed PASS having walked no PHP.

**3. Gate 59 was wrong in both directions at once (#184's shape).** A commented-out `// TODO: setValueString(…)` counted as a write; a double-quoted key was invisible; read `'k'` + write `"k"` was a **false positive** with no remedy but changing quote style; a key in a class constant was invisible.

**4. Gate 57's MCP seam dissolved on a leading backslash.** Both halves of the #200/#215 seam required every namespace segment to start with a letter, so `\OCA\App\Mcp\Impl::class` and `#[\OCA\OpenRegister\Mcp\Attribute\McpTool(…)]` matched neither — reinstating the finding whose only remedy is **deleting a live MCP write tool**.

**5. A crashed checker reported PASS — gates 56 and 57.** Both ran `>> log 2>/dev/null || true` and read the verdict from `wc -l`. With a `python3` shim exiting 1: `[gate-56] PASS`, `[gate-57] PASS` — and gate-57 had reported **20 real findings over the same tree one run earlier**. Now `SKIPPED (wiring)`, stderr kept on disk.

**6. Gate 56 called a real class absent.** The fallback walk — the thing that finds a type where PSR-4 does not predict, i.e. gate-30's DI-bound shape — matched `class` only, with at most one modifier. `enum`, `interface`, `trait` and `final readonly class` all reported `guard-class-not-found`, and the action that invites is to write the class twice.

**7. Gate 64 saw one of PHP's three ways to name a class, and flagged the lazy form.** `::class` (FQ or imported) and a class constant read as compliant. Separately, a **lazy service closure** naming Bootstrap reported identically to an eager reference — the exemption this module's header has always documented and never implemented. Measured on **launchpad**, whose entire composition root is built on that pattern: the gate would have failed the one repo doing it correctly.

## The one thing this does NOT fix, deliberately

Gate 64's hard rule is scoped to `AppHost\`, but the mechanism is not: during `register()` the whole `OCA\OpenRegister\` prefix is absent for any app sorting earlier. Measured, no prelude:

- **larpingapp 3** — the last two carry its **server-authoritative skill-requirement / XP-budget enforcement on character writes**, which therefore never registers.
- **hermiq 3** — flow-node, leaf-provider, shareable-config registration. **nldesign 1**.

A **non-blocking NOTE**, printed by the runner. Not a FAIL: gate 64 is not diff-scoped, so failing it blocks every PR in three repos on untouched code — the trap `check_store_and_settings_surface.py` already records. A probe in `boot()` is not noted.

## Gate 63 on a controller-only diff — the recommendation

Every **blocking** rule reads the manifest or `menu-layout.json`; the two rules touching `lib/Settings` are WARNs and never fail it. So a controller-only diff lands in the empty-scope branch and the old line read *"this PR introduces no settings placement (ADR-079) to judge"* — false when the author just changed a settings controller.

**Not widened.** Reading the controller was tried and reverted; `check_store()` records that it *"blocked EVERY manifest-touching PR in that repo, permanently"*. `na` stays — no change the author could make puts a manifest into a diff that does not touch one. What changes: the line now names which half it inspected and, when the diff contains `lib/Settings` or a settings controller, says so explicitly, so `na` cannot be read as a clearance.

## Evidence

- **Count-as-exit-status** (19/26/52's defect): checked all nine — none has it. 56/57 put the count on stdout; the rest return status codes.
- **`na` over a repo full of subject**: audited gate-58's `tests/e2e/` glob fleet-wide — **193 live `networkidle` calls inside, 0 outside**. No blind spot.
- **Fleet sweeps, 21 repos, old vs new**: gate-56 **0** verdict changes · gate-57 **0** · gate-59 **0** · gate-64 **0** (3 new NOTEs; the 3 pre-existing FAILs survive).
- **Both #270 arms**: empty scope → `NOT APPLICABLE`, exit 0 under `--require-full-coverage`; genuine structural gap → `SKIPPED (structural)`, exit **98**.
- **Gate-60 three states**: real finding · `SKIPPED (wiring)` naming the dependency · clean pass.

## Tests

- `test_check_unclosable_gate.py` — **NEW**; gate 59 had no suite at all. 23 cases + the mutant proving the comment mask is load-bearing.
- `test_gate_5661_empty_scope_is_not_a_pass.sh` — **NEW**; 28 assertions over 56–61. Against `48c88ba` it reports **13 failures**, naming the six PASSes.
- `test_gate_crashed_checker_is_not_a_finding.sh` — +2 gates, 5 assertions, two arms so "always skip" cannot pass. Against `48c88ba` it reports the two PASSes.
- `test_check_register_handler_resolution.py` +8 · `test_check_apphost_autoload_prelude.py` +23 · `test_check_orphaned_write_capability.py` +5 (mutant restores **both** pre-fix regexes together).

**59 of 60 discovered helper suites green**, 2 quarantined.

## Not mine, reported not fixed

`test_gate_45_to_55_acceptance.sh` fails 4 **gate-53** assertions **identically on pristine `48c88ba`** and on this branch — the suite expects blocking behaviour for pre-existing orphans that #250/#260/#280 deliberately made advisory. Out of this band; flagged, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
