### PR TITLE
fix(gates 45-55): eleven gates passed over an unopened scope, eight over a dead interpreter, and three could not see the defect they exist for

### DIFF
--- a/hydra-gates/scripts/lib/check_custom_widget_ratchet.py
+++ b/hydra-gates/scripts/lib/check_custom_widget_ratchet.py
@@ -47,8 +47,31 @@ computed (there is no base to compare against).
 
 Output: one location-prefixed finding block per violation plus one
 ``[custom-widget-ratchet] base=N head=M delta=±K`` report line whenever the
-ratchet is computed. Exit code is the number of findings (capped at 99);
-the calling gate uses it as the failure count.
+ratchet is computed, and — ALWAYS, on every successful run — one
+
+    [custom-widget-ratchet] findings=N
+
+line. THAT line is the answer, not the exit status.
+
+WHY THE COUNT IS ON STDOUT AND NOT IN THE EXIT CODE (#209)
+----------------------------------------------------------
+This helper used to return its finding count as its exit status and the gate
+read it as the failure count. An exit status is ONE BYTE, and it is also how
+the interpreter reports that the helper never finished. Both meanings arrived
+on the same channel, so they were not distinguishable:
+
+  * a Python traceback exits 1, and the gate reported it as
+    ``FAIL — 1 custom-widget finding(s)``. Measured 2026-08-08 by injecting a
+    ``raise`` into ``main()``: the gate produced a plausible, actionable,
+    entirely fictional finding, and a reader chasing it would have gone
+    looking for a widget that does not exist.
+  * the count was clamped to 99 to stay inside the byte, so any run with 100+
+    findings under-reported — the same lossy-channel shape that made gate-19
+    report 266 findings as 10.
+
+Exit status is now a plain boolean (0 = clean, 1 = findings present). A gate
+that sees a non-zero exit WITHOUT a ``findings=`` line knows the helper died
+and must report WIRING, never a finding.
 """
 
 import os
@@ -355,12 +378,20 @@ def _changed_and_deleted(base_ref, candidate_paths):
 # --------------------------------------------------------------------------
 # Main.
 # --------------------------------------------------------------------------
+FINDINGS_LINE = "[custom-widget-ratchet] findings={n}"
+
+
 def _emit(findings, counts_line=None):
     if counts_line is not None:
         print(counts_line)
     for finding in findings:
         print(finding)
-    return min(len(findings), 99)
+    # The count, on stdout, unclamped — see the module docstring (#209).
+    # Printed LAST so it cannot be confused with a finding block's own text,
+    # and printed on EVERY successful run including the clean one, so its
+    # absence means "the helper did not finish".
+    print(FINDINGS_LINE.format(n=len(findings)))
+    return 1 if findings else 0
 
 
 def _format_delta(delta):
@@ -392,7 +423,9 @@ def main(argv):
         # ratchet needs a base to compare against and is not computed.
         head_count = sum(len(es) for es in head_customs.values())
         if head_count == 0:
-            return 0
+            # Still emit `findings=0` — the caller uses the PRESENCE of that
+            # line to tell a clean run from a helper that died (#209).
+            return _emit([])
         findings = [
             f"{path}:{e.line}: " + JUSTIFICATION_MSG.format(key=e.key)
             for path, es in sorted(head_customs.items())
@@ -433,7 +466,7 @@ def main(argv):
         for path in sorted(changed_head | base_only)
     )
     if not active:
-        return 0
+        return _emit([])
 
     # Per-app counts: unchanged files contribute identically to both sides.
     head_count = sum(len(es) for es in head_customs.values())

--- a/hydra-gates/scripts/lib/check_security_cochange.py
+++ b/hydra-gates/scripts/lib/check_security_cochange.py
@@ -68,16 +68,57 @@ _PATH_PATTERNS = (
     re.compile(r"^lib/.*/(Auth|Session|Csrf|Rbac|Permission|Authorization)/.*$"),
 )
 
-# Tokens that are a security DECLARATION wherever they appear — including in a
-# docblock, because in Nextcloud the docblock form IS the declaration.
+# Tokens that are a security DECLARATION — but ONLY IN A CODE POSITION.
+#
+# WHY THIS IS POSITION-ANCHORED, AND WHY IT WAS BOTH WRONG DIRECTIONS AT ONCE
+# ---------------------------------------------------------------------------
+# This used to be an unanchored alternation: the literal `#[NoAdminRequired]`
+# or `@NoAdminRequired` matched anywhere on a changed line. Measured on
+# larpingapp 2026-08-08, it was wrong in both directions from the same regex —
+# the pairing #269 found in gate-48 and did not carry across to its sibling.
+#
+#   FALSE POSITIVE. `CharactersController.php` carries a docblock paragraph
+#   explaining why a method is deliberately admin-only:
+#
+#       * becomes `@NoAdminRequired` again, paired with a real ownership check.
+#
+#   Rewording that ONE SENTENCE — a change with no code in it at all — made
+#   gate-47 demand a test co-change. That is #191's shape one level up: the
+#   cheapest way to clear the finding is to reword the prose again, so the
+#   gate is satisfiable by prose and manufactures the appearance of a security
+#   review. The gate's own module docstring already committed to not doing
+#   this ("Prose that merely mentions IUserSession is not — it is a sentence");
+#   the annotation arm simply never implemented it.
+#
+#   FALSE NEGATIVE. `#\[NoAdminRequired\]` is a LITERAL, so the equally valid
+#   fully-qualified form is invisible:
+#
+#       #[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
+#
+#   A commit adding exactly that line to a controller — opening an
+#   admin-only endpoint to every authenticated user — with no test in the diff
+#   was measured to report `[gate-47] security-change-has-tests: PASS`. Same
+#   class as #184: a checker that greps a string literal misses every
+#   qualified form and matches every comment, and so fails both ways at once.
+#
+# THE RULE (identical to check_csrf_removal.py, deliberately)
+#   attribute form  the line's content STARTS with `#[`, and the attribute
+#                   group contains the token. `[^]]*` is bounded by the closing
+#                   bracket, so `#[NoAdminRequired, NoCSRFRequired]` and the
+#                   fully-qualified form both count, while a sentence with
+#                   `#[NoAdminRequired]` in the middle of it does not.
+#   docblock form   an optional comment lead-in (`*`, `//`, `#`), then the tag
+#                   AT THE START of the content. That is the only position
+#                   PHP's docblock parsers accept a tag in, and it is not a
+#                   position prose reaches. The lead-in is permissive on
+#                   purpose — `// @PublicPage` is still a declaration-shaped
+#                   line, and narrowing to `*` only would trade this false
+#                   positive for a false negative, which is the trap #269
+#                   named. What is excluded is the tag appearing PART-WAY
+#                   THROUGH a sentence, which is the only shape prose takes.
 _ANNOTATION_RE = re.compile(
-    r"#\[NoAdminRequired\]"
-    r"|#\[AuthorizedAdminSetting\("
-    r"|#\[PublicPage\]"
-    r"|#\[NoCSRFRequired\]"
-    r"|@NoAdminRequired\b"
-    r"|@NoCSRFRequired\b"
-    r"|@PublicPage\b"
+    r"^\s*#\[[^]]*\b(?:NoAdminRequired|AuthorizedAdminSetting|PublicPage|NoCSRFRequired)\b"
+    r"|^\s*(?:\*+|//+|\#(?!\[)|/\*+)?\s*@(?:NoAdminRequired|NoCSRFRequired|PublicPage)\b"
 )
 
 # Tokens that are security-relevant only as CODE. In prose they are the name
@@ -112,11 +153,17 @@ def is_security_path(path: str) -> bool:
 def line_is_security_relevant(line: str) -> bool:
     """Is this ONE changed line a security change?
 
-    A comment line qualifies only via ``_ANNOTATION_RE``. `#[` is excluded
-    from the `#` comment shape so a PHP 8 attribute is never read as a shell
-    comment.
+    A comment line qualifies only via ``_ANNOTATION_RE``, and only when the
+    annotation is at DOCBLOCK-TAG POSITION — a docblock whose tag changed is a
+    changed auth declaration; a sentence that names the tag is not. `#[` is
+    excluded from the `#` comment shape so a PHP 8 attribute is never read as
+    a shell comment.
+
+    ``match`` rather than ``search``: ``_ANNOTATION_RE`` is anchored with
+    ``^`` on both branches, so the two are equivalent here, but ``match``
+    states the intent — position is the whole point of this regex.
     """
-    if _ANNOTATION_RE.search(line):
+    if _ANNOTATION_RE.match(line):
         return True
     if _COMMENT_LINE_RE.match(line):
         return False

--- a/hydra-gates/scripts/lib/test_check_custom_widget_ratchet.py
+++ b/hydra-gates/scripts/lib/test_check_custom_widget_ratchet.py
@@ -192,7 +192,19 @@ class ScopedRunTest(unittest.TestCase):
     def test_new_widget_without_note_fails_justification_and_ratchet(self):
         self._commit([NOTED, BUILTIN, PAGE_ENTRY, NOTELESS])
         rc, out = self._run()
-        self.assertEqual(rc, 2, out)
+        # THE COUNT COMES OFF STDOUT, NOT THE EXIT BYTE (#209).
+        #
+        # This asserted `rc == 2` — the helper returned its finding count as
+        # its exit status. That is the same channel the interpreter uses to
+        # report that the helper never finished, so a traceback (exit 1) was
+        # indistinguishable from one finding, and the gate duly printed
+        # "FAIL — 1 custom-widget finding(s)" over a crash. The count was also
+        # clamped to 99 to fit in a byte.
+        #
+        # Exit status is now boolean and the count is a line. Both are checked:
+        # asserting only the boolean would be weaker than what this test had.
+        self.assertEqual(rc, 1, out)
+        self.assertIn("[custom-widget-ratchet] findings=2", out)
         self.assertIn(
             'registry["dealHeatmap"] is kind:"widget" without a _note',
             out,
@@ -244,7 +256,17 @@ class ScopedRunTest(unittest.TestCase):
             cwd=self.repo, env=env, capture_output=True, text=True,
         )
         self.assertEqual(proc.returncode, 0, proc.stdout)
-        self.assertEqual(proc.stdout, "",
+        # The no-op must not COMPUTE OR REPORT THE RATCHET — that is the claim.
+        # It was written as `stdout == ""`, which also forbade the helper from
+        # saying it had finished. Since #209 the `findings=` line is how a
+        # caller tells a clean run from a helper that died, so a truly silent
+        # success is now indistinguishable from a crash. The assertion is on
+        # the ratchet and the findings, which is what the sentence meant.
+        self.assertNotIn("base=", proc.stdout)
+        self.assertNotIn("delta=", proc.stdout)
+        self.assertNotIn("ADR-049", proc.stdout)
+        self.assertEqual(proc.stdout.strip(),
+                         "[custom-widget-ratchet] findings=0",
                          "no-op pass must not compute/report the ratchet")
 
     def test_legacy_noteless_entry_untouched_not_flagged(self):

--- a/hydra-gates/scripts/lib/test_check_security_cochange.py
+++ b/hydra-gates/scripts/lib/test_check_security_cochange.py
@@ -21,6 +21,7 @@ all docblock prose.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -274,6 +275,139 @@ class GateIsNotBlind(unittest.TestCase):
                      "        return new JSONResponse($rows);"):
             with self.subTest(line=line):
                 self.assertFalse(csc.line_is_security_relevant(line))
+
+
+class AnnotationMustBeInACodePosition(unittest.TestCase):
+    """The annotation arm was wrong in BOTH directions from one regex.
+
+    Measured on larpingapp 2026-08-08 against the pre-fix helper, which read::
+
+        _ANNOTATION_RE = re.compile(
+            r"#\\[NoAdminRequired\\]"
+            ...
+            r"|@NoAdminRequired\\b"
+            ...
+        )
+
+    unanchored, so position was never constrained and the attribute forms were
+    bare literals. Every case below was RUN against that regex first: the
+    false-positive cases matched it (they must not now) and the
+    fully-qualified cases did not (they must now). A test that only ever saw
+    the fixed code proves nothing about what the fix changed.
+    """
+
+    # The exact pre-fix pattern, kept verbatim so these assertions are a
+    # comparison and not an assertion about the current implementation.
+    _PRE_FIX = re.compile(
+        r"#\[NoAdminRequired\]"
+        r"|#\[AuthorizedAdminSetting\("
+        r"|#\[PublicPage\]"
+        r"|#\[NoCSRFRequired\]"
+        r"|@NoAdminRequired\b"
+        r"|@NoCSRFRequired\b"
+        r"|@PublicPage\b"
+    )
+
+    # Prose that NAMES an annotation. Verbatim from larpingapp's
+    # CharactersController.php docblock, which explains why the method is
+    # deliberately admin-only; rewording that sentence made gate-47 demand a
+    # test co-change on a diff containing no code at all.
+    PROSE = (
+        " * becomes `@NoAdminRequired` again, paired with a real ownership check.",
+        " * Deliberately NOT `@NoAdminRequired`. The body requires an administrator",
+        " * (#[PublicPage] + #[NoCSRFRequired]) and the response contract are owned by",
+        " * see the #[NoCSRFRequired] note above before changing this",
+    )
+
+    # The fully-qualified attribute forms. Valid PHP, in daily use, and
+    # invisible to a literal `#[NoAdminRequired]` match.
+    QUALIFIED = (
+        "    #[\\OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired]",
+        "    #[\\OCP\\AppFramework\\Http\\Attribute\\NoCSRFRequired]",
+        "    #[\\OCP\\AppFramework\\Http\\Attribute\\PublicPage]",
+        "    #[NoAdminRequired, NoCSRFRequired]",
+    )
+
+    def test_the_pre_fix_regex_really_did_fail_both_ways(self):
+        """Positive control: show the mutant CAN fail before trusting the fix.
+
+        Without this, a green suite would be equally consistent with "the bug
+        was never there".
+        """
+        for line in self.PROSE:
+            with self.subTest(direction="false positive", line=line):
+                self.assertIsNotNone(
+                    self._PRE_FIX.search(line),
+                    "pre-fix regex was supposed to match this prose",
+                )
+        for line in self.QUALIFIED[:3]:
+            with self.subTest(direction="false negative", line=line):
+                self.assertIsNone(
+                    self._PRE_FIX.search(line),
+                    "pre-fix regex was supposed to MISS the qualified form",
+                )
+
+    def test_prose_naming_an_annotation_is_not_a_security_change(self):
+        for line in self.PROSE:
+            with self.subTest(line=line):
+                self.assertFalse(csc.line_is_security_relevant(line))
+
+    def test_a_fully_qualified_attribute_is_a_security_change(self):
+        for line in self.QUALIFIED:
+            with self.subTest(line=line):
+                self.assertTrue(csc.line_is_security_relevant(line))
+
+    def test_a_docblock_tag_at_tag_position_still_counts(self):
+        for line in ("     * @NoAdminRequired",
+                     "     * @NoCSRFRequired",
+                     "     * @PublicPage",
+                     "// @PublicPage",
+                     "    #[NoAdminRequired]",
+                     "    #[AuthorizedAdminSetting(Application::APP_ID)]"):
+            with self.subTest(line=line):
+                self.assertTrue(csc.line_is_security_relevant(line))
+
+    def test_end_to_end_a_qualified_attribute_with_no_test_is_reported(self):
+        """The whole-repo shape, not just the line classifier.
+
+        Reproduces the measured miss: a commit that opens an admin-only
+        endpoint to every authenticated user via the qualified attribute, with
+        no test in the diff, reported PASS.
+        """
+        repo = _Repo()
+        self.addCleanup(repo.close)
+        repo.write("lib/Controller/SetupController.php",
+                   "<?php\nclass SetupController {\n"
+                   "    public function status() { return 1; }\n}\n")
+        base = repo.commit("baseline")
+        repo.write("lib/Controller/SetupController.php",
+                   "<?php\nclass SetupController {\n"
+                   "    #[\\OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired]\n"
+                   "    public function status() { return 1; }\n}\n")
+        repo.commit("open the endpoint to non-admins")
+        security, has_test = repo.scan(base)
+        self.assertEqual(security, ["lib/Controller/SetupController.php"])
+        self.assertFalse(has_test)
+
+    def test_end_to_end_a_comment_only_diff_is_not_reported(self):
+        repo = _Repo()
+        self.addCleanup(repo.close)
+        repo.write("lib/Controller/CharactersController.php",
+                   "<?php\nclass C {\n"
+                   "    /**\n"
+                   "     * becomes `@NoAdminRequired` again, with an ownership check.\n"
+                   "     */\n"
+                   "    public function report() { return 1; }\n}\n")
+        base = repo.commit("baseline")
+        repo.write("lib/Controller/CharactersController.php",
+                   "<?php\nclass C {\n"
+                   "    /**\n"
+                   "     * becomes admin-optional again, with an ownership check.\n"
+                   "     */\n"
+                   "    public function report() { return 1; }\n}\n")
+        repo.commit("reword one docblock sentence")
+        security, has_test = repo.scan(base)
+        self.assertEqual(security, [])
 
 
 if __name__ == "__main__":

--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_45_to_55_acceptance.sh — the acceptance test for gates 45–55:
+# each one must FAIL on a planted true positive, PASS on the clean fixture,
+# and say NOT APPLICABLE (never PASS) when it inspected nothing.
+#
+# WHY THIS EXISTS
+# ---------------
+# On 2026-08-08 one textbook true positive was planted per a11y gate in
+# nldesign and ALL THIRTEEN reported PASS: eleven globbed `src/**/*.vue` and
+# nldesign ships zero `.vue` files. Every green was a green over nothing, and
+# no open issue named any of them — because nobody had ever asked a gate to
+# fail on purpose. "No open issue" means nobody looked.
+#
+# So every arm below plants a defect FIRST and asserts the gate names it.
+# An arm that only ever sees clean input proves nothing: a checker that has
+# been widened until it catches nothing passes it identically.
+#
+# THREE FAMILIES OF ARM
+# ---------------------
+#   A. UNOPENED SCOPE IS NEVER PASS (#242/#240/#258/#268). All eleven gates
+#      printed PASS on a README-only diff — a run in which not one of them
+#      opened a file. Measured on larpingapp: 11 PASS lines, and the summary
+#      then read "53 of 53 applicable gates ran".
+#   B. GATE-45's GUARD MUST MIRROR ITS ENUMERATOR (#225/#261). It reads
+#      src/ + templates/ + appinfo/templates/ but was gated on `[ -d src ]`,
+#      so a templates-only app got NOT APPLICABLE over live markup. A false
+#      `na` is worse than the PASS it replaced: `na` removes the gate from the
+#      coverage arithmetic, so the run reports "all applicable gates green"
+#      with the defect inside it.
+#   C. GATE-50 WAS WRONG IN BOTH DIRECTIONS AT ONCE. It could not see a config
+#      read whose app id is a class constant (the fleet-standard idiom), and
+#      it rejected a correct compound `if ($a === '' || $b === '')` guard.
+#      Both arms are here, plus the opencatalogi#86 shape that mixes them:
+#      a guarded read and an unguarded one two lines apart.
+#
+# Run: bash hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_45_to_55_acceptance.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g4555.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_run() {  # _run <appdir> <outfile> [runner args...]
+    local app="$1" out="$2"; shift 2
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    (
+        cd "${app}" || exit 1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" "$@" . > "${out}" 2>&1
+    )
+    return $?
+}
+
+# The verdict word is not always one token — "NOT APPLICABLE" is two.
+_verdict() { grep -oE "^\[gate-$2\] [^:]+: [A-Z]+( [A-Z]+)*( \([a-z]+\))?" "$1" | head -1 | sed 's/^[^:]*: //'; }
+
+_expect() {  # _expect <outfile> <gate> <expected-verdict> <what>
+    local got; got="$(_verdict "$1" "$2")"
+    if [ "${got}" = "$3" ]; then
+        _ok "gate-$2 $4 → $3"
+    else
+        _bad "gate-$2 $4 → expected '$3', got '${got:-<no line at all>}'"
+    fi
+}
+
+_commit() { git -C "$1" add -A >/dev/null 2>&1; git -C "$1" -c user.email=t@t -c user.name=t commit -qm "$2" >/dev/null 2>&1; }
+
+# ===========================================================================
+# FAMILY A — an unopened scope must render NOT APPLICABLE, never PASS.
+# ===========================================================================
+_appA="${_tmp}/appA"
+mkdir -p "${_appA}/src" "${_appA}/lib/Controller" "${_appA}/lib/Settings"
+cat > "${_appA}/src/manifest.json" <<'JSON'
+{ "$schema": "https://codeberg.org/Conduction/nextcloud-vue/raw/branch/main/src/schemas/app-manifest-v2.schema.json", "version": "0.1.0", "menu": [], "pages": [] }
+JSON
+printf 'export default {}\n' > "${_appA}/src/registry.js"
+cat > "${_appA}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController {
+    public function index() { return 1; }
+}
+PHP
+printf '{"components":{"schemas":{}}}\n' > "${_appA}/lib/Settings/fx_register.json"
+git -C "${_appA}" init -q .
+_commit "${_appA}" init
+printf 'docs only\n' > "${_appA}/README.md"
+_commit "${_appA}" docs
+
+_base="$(git -C "${_appA}" rev-parse HEAD~1)"
+_outA="${_tmp}/a.txt"
+_run "${_appA}" "${_outA}" --scope-to-diff --base "${_base}"
+
+# The README-only diff opens nothing for any of these. Every one of them used
+# to print PASS.
+for _g in 45 46 49 50 51 53 54 55; do
+    _expect "${_outA}" "${_g}" "NOT APPLICABLE" "on a README-only diff (nothing inspected)"
+done
+
+# Gates 47/48 legitimately RAN here — they classified the diff and found no
+# security change — so PASS is the correct verdict and the arm below is the
+# anti-widening pair for family A: the fix must not turn every gate into a
+# permanent skip.
+_expect "${_outA}" 47 "PASS" "classified a real (non-security) diff"
+_expect "${_outA}" 48 "PASS" "examined a real (no-removal) diff"
+
+# ...and on a run with NO diff at all, 47/48 cannot form a verdict.
+_outAfull="${_tmp}/a-full.txt"
+_run "${_appA}" "${_outAfull}"
+_expect "${_outAfull}" 47 "NOT APPLICABLE" "on a whole-repository run (no change set)"
+_expect "${_outAfull}" 48 "NOT APPLICABLE" "on a whole-repository run (no change set)"
+
+# ===========================================================================
+# FAMILY B — gate-45 on an app that renders from PHP templates and has no src/.
+# ===========================================================================
+_appB="${_tmp}/appB"
+mkdir -p "${_appB}/templates/settings"
+cat > "${_appB}/templates/settings/admin.php" <<'PHP'
+<div id="fx-admin">
+	<p>Settings</p>
+</div>
+<style>
+.fx-banner { transition: opacity 0.4s ease; }
+</style>
+PHP
+git -C "${_appB}" init -q .
+_commit "${_appB}" init
+
+_outB="${_tmp}/b.txt"
+_run "${_appB}" "${_outB}"
+_expect "${_outB}" 45 "FAIL" "sees a <style> transition in a PHP template with no src/"
+
+# Anti-widening: the same tree with the fallback present must go green, and a
+# tree with no motion at all must go green too.
+cat > "${_appB}/templates/settings/admin.php" <<'PHP'
+<div id="fx-admin">
+	<p>Settings</p>
+</div>
+<style>
+.fx-banner { transition: opacity 0.4s ease; }
+@media (prefers-reduced-motion: reduce) {
+	.fx-banner { transition: none; }
+}
+</style>
+PHP
+_commit "${_appB}" "add the reduced-motion fallback"
+_outB2="${_tmp}/b2.txt"
+_run "${_appB}" "${_outB2}"
+_expect "${_outB2}" 45 "PASS" "accepts a template that ships the fallback"
+
+# And a repo that truly renders no markup at all is still NOT APPLICABLE — the
+# category must not become unreachable.
+_appB3="${_tmp}/appB3"
+mkdir -p "${_appB3}/lib"
+printf '<?php\n' > "${_appB3}/lib/Nothing.php"
+git -C "${_appB3}" init -q .
+_commit "${_appB3}" init
+_outB3="${_tmp}/b3.txt"
+_run "${_appB3}" "${_outB3}"
+_expect "${_outB3}" 45 "NOT APPLICABLE" "on a repo with no src/, templates/ or appinfo/templates/"
+
+# ===========================================================================
+# FAMILY C — gate-50, both directions.
+# ===========================================================================
+_appC="${_tmp}/appC"
+mkdir -p "${_appC}/lib/Service"
+
+_write_service() {  # _write_service <body>
+    cat > "${_appC}/lib/Service/ListingService.php" <<PHP
+<?php
+namespace OCA\\Fx\\Service;
+class ListingService {
+$1
+}
+PHP
+}
+
+# C1 — the leak, written with a CLASS CONSTANT app id. This is the shape the
+# gate could not see at all: identical code with a quoted 'fx' failed.
+_write_service '    public function scope(): string
+    {
+        $reg = $this->appConfig->getValueString(Application::APP_ID, '"'"'listing_register'"'"', '"'"''"'"');
+        return $reg;
+    }'
+git -C "${_appC}" init -q . 2>/dev/null
+_commit "${_appC}" init
+_outC1="${_tmp}/c1.txt"
+_run "${_appC}" "${_outC1}"
+_expect "${_outC1}" 50 "FAIL" "sees an unguarded read whose app id is a class constant"
+
+# C2 — the same leak with a quoted app id. Must still fail (no regression).
+_write_service '    public function scope(): string
+    {
+        $reg = $this->appConfig->getValueString('"'"'fx'"'"', '"'"'listing_register'"'"', '"'"''"'"');
+        return $reg;
+    }'
+_commit "${_appC}" "quoted app id"
+_outC2="${_tmp}/c2.txt"
+_run "${_appC}" "${_outC2}"
+_expect "${_outC2}" 50 "FAIL" "still sees an unguarded read whose app id is a literal"
+
+# C3 — ANTI-WIDENING. A correct COMPOUND guard. The pre-fix regex required a
+# closing paren immediately after the empty string, so this shipped as two
+# findings and zero defects — and the "fix" it suggested (split into two
+# single-key ifs) changes nothing about the code.
+_write_service '    public function scope(): array
+    {
+        $reg = $this->appConfig->getValueString('"'"'fx'"'"', '"'"'listing_register'"'"', '"'"''"'"');
+        $sch = $this->appConfig->getValueString('"'"'fx'"'"', '"'"'listing_schema'"'"', '"'"''"'"');
+        if ($reg === '"'"''"'"' || $sch === '"'"''"'"') {
+            return [];
+        }
+        return [$reg, $sch];
+    }'
+_commit "${_appC}" "compound guard"
+_outC3="${_tmp}/c3.txt"
+_run "${_appC}" "${_outC3}"
+_expect "${_outC3}" 50 "PASS" "accepts a correct compound empty-check guard"
+
+# C4 — ANTI-WIDENING. A guard that is not an `if` at all. Verbatim shape from
+# larpingapp's SetupController::isProvisioned(); it fails closed.
+_write_service '    public function isProvisioned(): bool
+    {
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, '"'"'register'"'"', '"'"''"'"');
+        $schemaMarker = $this->appConfig->getValueString(Application::APP_ID, '"'"'schema_marker'"'"', '"'"''"'"');
+
+        return $registerId !== '"'"''"'"' && $schemaMarker !== '"'"''"'"';
+    }'
+_commit "${_appC}" "boolean-return guard"
+_outC4="${_tmp}/c4.txt"
+_run "${_appC}" "${_outC4}"
+_expect "${_outC4}" 50 "PASS" "accepts a boolean-return empty-check guard"
+
+# C5 — the opencatalogi#86 shape: one read guarded, the next one two lines
+# later NOT. The gate must report the second and only the second.
+_write_service '    public function scope(): array
+    {
+        $reg = $this->appConfig->getValueString('"'"'fx'"'"', '"'"'listing_register'"'"', '"'"''"'"');
+        if ($reg === '"'"''"'"') {
+            return [];
+        }
+        $sch = $this->appConfig->getValueString('"'"'fx'"'"', '"'"'listing_schema'"'"', '"'"''"'"');
+        return [$reg, $sch];
+    }'
+_commit "${_appC}" "guarded read + leak"
+_outC5="${_tmp}/c5.txt"
+_run "${_appC}" "${_outC5}"
+if grep -qE "^\[gate-50\][^:]*: FAIL — 1 unsafe" "${_outC5}"; then
+    _ok "gate-50 reports exactly the unguarded read of the pair, not both"
+else
+    _bad "gate-50 on a guarded+unguarded pair → $(grep -E '^\[gate-50\]' "${_outC5}" | head -1)"
+fi
+
+# ===========================================================================
+# FAMILY D — gate-53 must block the PR that CREATES larpingapp#286.
+#
+# `EventRoster` was registered in src/registry.js, resolvable, and named by no
+# manifest position, so the event check-in surface had no entry point. When
+# that defect was reintroduced exactly, gate-53 printed PASS. Direction 1 of
+# the registry cross-reference stays advisory for LEGACY orphans — the gate
+# cannot tell "wire it" from "delete it" — but when the DIFF ITSELF removed
+# the last reference, it can, and that is the case worth blocking.
+# ===========================================================================
+_appD="${_tmp}/appD"
+mkdir -p "${_appD}/src"
+cat > "${_appD}/src/manifest.json" <<'JSON'
+{
+  "$schema": "https://codeberg.org/Conduction/nextcloud-vue/raw/branch/main/src/schemas/app-manifest-v2.schema.json",
+  "version": "0.1.0",
+  "menu": [{ "id": "EventDetail", "label": "Events", "icon": "Calendar", "route": "EventDetail", "order": 10 }],
+  "pages": [
+    {
+      "id": "EventDetail",
+      "type": "detail",
+      "route": "/events/:id",
+      "title": "Event",
+      "config": { "sidebar": { "tabs": [
+        { "id": "checkin", "label": "Check-in", "icon": "AccountCheck", "component": "EventRoster" }
+      ] } }
+    }
+  ]
+}
+JSON
+cat > "${_appD}/src/registry.js" <<'JS'
+import EventRoster from './views/EventRoster.vue'
+
+export default {
+	EventRoster: { kind: 'section', component: EventRoster },
+}
+JS
+mkdir -p "${_appD}/src/views"
+printf '<template><div /></template>\n' > "${_appD}/src/views/EventRoster.vue"
+git -C "${_appD}" init -q .
+_commit "${_appD}" init
+_baseD="$(git -C "${_appD}" rev-parse HEAD)"
+
+# D1 — remove the ONLY reference, keep the registry entry. This is #286.
+python3 - "${_appD}/src/manifest.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+raw = open(p).read()
+old = '        { "id": "checkin", "label": "Check-in", "icon": "AccountCheck", "component": "EventRoster" }\n'
+assert old in raw, "PLANT ANCHOR MISSING — the fixture changed, fix the test not the anchor"
+open(p, 'w').write(raw.replace(old, '', 1))
+json.load(open(p))
+PY
+_commit "${_appD}" "drop the check-in tab"
+_outD1="${_tmp}/d1.txt"
+_run "${_appD}" "${_outD1}" --scope-to-diff --base "${_baseD}"
+_expect "${_outD1}" 53 "FAIL" "blocks the PR that removes the last reference to a registered component"
+if grep -q "EventRoster" "${_outD1}"; then
+    _ok "gate-53 NAMES the orphaned component"
+else
+    _bad "gate-53 failed without naming EventRoster"
+fi
+
+# D2 — ANTI-WIDENING. Removing BOTH sides is a legitimate retirement.
+git -C "${_appD}" checkout -q -B d2 "${_baseD}"
+python3 - "${_appD}/src/manifest.json" "${_appD}/src/registry.js" <<'PY'
+import json, sys
+m, r = sys.argv[1], sys.argv[2]
+raw = open(m).read()
+old = '        { "id": "checkin", "label": "Check-in", "icon": "AccountCheck", "component": "EventRoster" }\n'
+assert old in raw, "PLANT ANCHOR MISSING (manifest)"
+open(m, 'w').write(raw.replace(old, '', 1))
+json.load(open(m))
+js = open(r).read()
+oldj = "\tEventRoster: { kind: 'section', component: EventRoster },\n"
+assert oldj in js, "PLANT ANCHOR MISSING (registry)"
+open(r, 'w').write(js.replace(oldj, '', 1))
+PY
+_commit "${_appD}" "retire the check-in surface entirely"
+_outD2="${_tmp}/d2.txt"
+_run "${_appD}" "${_outD2}" --scope-to-diff --base "${_baseD}"
+_expect "${_outD2}" 53 "PASS" "accepts removing the component and its registry entry together"
+
+# D3 — ANTI-WIDENING. A pre-existing orphan is still advisory, not blocking.
+# Without this arm the fix would be indistinguishable from promoting
+# direction 1 wholesale, which would light up every app carrying legacy debt.
+_appD3="${_tmp}/appD3"
+mkdir -p "${_appD3}/src/views"
+cat > "${_appD3}/src/manifest.json" <<'JSON'
+{ "$schema": "https://codeberg.org/Conduction/nextcloud-vue/raw/branch/main/src/schemas/app-manifest-v2.schema.json", "version": "0.1.0", "menu": [], "pages": [] }
+JSON
+cat > "${_appD3}/src/registry.js" <<'JS'
+import Orphan from './views/Orphan.vue'
+
+export default {
+	Orphan: { kind: 'section', component: Orphan },
+}
+JS
+printf '<template><div /></template>\n' > "${_appD3}/src/views/Orphan.vue"
+git -C "${_appD3}" init -q .
+_commit "${_appD3}" init
+_outD3="${_tmp}/d3.txt"
+_run "${_appD3}" "${_outD3}"
+_expect "${_outD3}" 53 "PASS" "leaves a PRE-EXISTING orphan advisory (WARN), not blocking"
+if grep -qE '^\[gate-53\].*WARN finding' "${_outD3}"; then
+    _ok "gate-53 still SURFACES the pre-existing orphan as a WARN"
+else
+    _bad "gate-53 swallowed the pre-existing orphan entirely"
+fi
+
+# ===========================================================================
+# FAMILY E — gate-52: a crashed helper is WIRING, never a finding.
+#
+# The runner read `_cwr_fail=$?` straight off the helper. An exit status is one
+# byte and it is also how Python reports a traceback, so a dead checker
+# reported `FAIL — 1 custom-widget finding(s)` — an actionable-looking finding
+# with nothing behind it, pointing at a widget that does not exist. Same
+# lossy-channel shape as #209, where 266 findings were reported as 10.
+#
+# Driven by copying the package and injecting a `raise` into the helper's
+# main(), then pointing the runner-under-test at the copy. The copy is why
+# this arm can exist at all: the shipped helper must not be edited to test it.
+# ===========================================================================
+_pkg="${_tmp}/pkg"
+mkdir -p "${_pkg}"
+cp -R "${_scripts}" "${_pkg}/scripts"
+_broken="${_pkg}/scripts/lib/check_custom_widget_ratchet.py"
+python3 - "${_broken}" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old = "def main(argv):"
+assert old in s, "MUTATION ANCHOR MISSING — check_custom_widget_ratchet.py no longer defines main(argv)"
+s = s.replace(old, 'def main(argv):\n    raise RuntimeError("simulated helper crash")\n\n\ndef _unreachable_main(argv):', 1)
+open(p, "w").write(s)
+PY
+
+_appE="${_tmp}/appE"
+mkdir -p "${_appE}/src"
+printf "export default {\n\tThing: { kind: 'widget', component: 1 },\n}\n" > "${_appE}/src/registry.js"
+git -C "${_appE}" init -q .
+_commit "${_appE}" init
+
+_outE="${_tmp}/e.txt"
+_saved_runner="${_runner}"
+_runner="${_pkg}/scripts/run-hydra-gates.sh"
+_run "${_appE}" "${_outE}"
+_runner="${_saved_runner}"
+
+_expect "${_outE}" 52 "SKIPPED (wiring)" "reports a crashed helper as wiring, not as a finding"
+if grep -qE '^\[gate-52\][^:]*: FAIL' "${_outE}"; then
+    _bad "gate-52 turned a helper crash into a FAIL with a fabricated finding count"
+else
+    _ok "gate-52 invents no finding count when the helper did not finish"
+fi
+
+# ANTI-WIDENING for family E: the SAME fixture with the real helper must still
+# catch its planted true positive (a kind:"widget" entry with no _note).
+_outE2="${_tmp}/e2.txt"
+_run "${_appE}" "${_outE2}"
+_expect "${_outE2}" 52 "FAIL" "still catches a kind:\"widget\" entry with no _note"
+
+# ===========================================================================
+# FAMILY F — A CRASHED INTERPRETER MUST NOT PRODUCE A VERDICT.
+#
+# A planted true positive only fires WHEN THE GATE RUNS, so no arm above can
+# see this. Measured 2026-08-08 on a tree carrying real findings, with a
+# `python3` on PATH that exits 1 on every call: EIGHT of these eleven gates
+# printed PASS. The worst was gate-46, which reported PASS over the 277
+# unresolved @spec findings — 104 distinct targets — it had reported one run
+# earlier on the same files. Gates 45/49/50 discarded the status with
+# `2>/dev/null`; gates 47/51/54/55 with `|| true`; gate-52 read the count off
+# the exit byte, so a traceback became `FAIL — 1 custom-widget finding(s)`.
+#
+# `_a` is a fake `python3` earlier on PATH. Both directions are asserted: the
+# same fixture with a working interpreter must produce real verdicts, or this
+# family would be satisfied by a runner that skipped everything always.
+# ===========================================================================
+_appF="${_tmp}/appF"
+mkdir -p "${_appF}/src/manifest.d" "${_appF}/lib/Controller" "${_appF}/lib/Service" \
+         "${_appF}/lib/Settings" "${_appF}/templates"
+cat > "${_appF}/src/manifest.json" <<'JSON'
+{ "$schema": "https://codeberg.org/Conduction/nextcloud-vue/raw/branch/main/src/schemas/app-manifest-v2.schema.json",
+  "version": "0.1.0", "menu": [], "pages": [] }
+JSON
+printf "export default {}\n" > "${_appF}/src/registry.js"
+printf '<template><div /></template>\n<style scoped>\n.x { transition: all .3s; }\n</style>\n' \
+    > "${_appF}/src/Thing.vue"
+cat > "${_appF}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController {
+    /** @spec openspec/specs/no-such-thing/spec.md#requirement-nope */
+    public function destroy(string $id) {
+        $this->objectService->deleteObject($id);
+        return 1;
+    }
+}
+PHP
+cat > "${_appF}/lib/Service/ListingService.php" <<'PHP'
+<?php
+namespace OCA\Fx\Service;
+class ListingService {
+    public function scope(): string
+    {
+        return $this->appConfig->getValueString('fx', 'listing_register', '');
+    }
+}
+PHP
+cat > "${_appF}/lib/Settings/fx_register.json" <<'JSON'
+{ "components": { "schemas": { "thing": { "properties": {
+  "bare": { "type": "string" },
+  "rel": { "type": "string", "format": "uuid", "title": "Rel", "description": "Reference to the related thing object" }
+} } } } }
+JSON
+git -C "${_appF}" init -q .
+_commit "${_appF}" init
+
+# Working interpreter: these gates must produce REAL verdicts on this tree.
+_outF="${_tmp}/f.txt"
+_run "${_appF}" "${_outF}"
+_real=0
+for _g in 45 46 49 50 51 54; do
+    grep -qE "^\[gate-${_g}\][^:]*: FAIL" "${_outF}" && _real=$((_real + 1))
+done
+if [ "${_real}" -ge 5 ]; then
+    _ok "with a working interpreter the fixture yields ${_real} real FAIL verdicts (the thing a crash must not erase)"
+else
+    _bad "fixture produced only ${_real} FAIL verdicts — family F would prove nothing"
+fi
+
+# Broken interpreter: every one of them must say WIRING, and none may PASS.
+_fakebin="${_tmp}/fakebin"
+mkdir -p "${_fakebin}"
+printf '#!/bin/sh\necho "python3: simulated interpreter failure" >&2\nexit 1\n' > "${_fakebin}/python3"
+chmod +x "${_fakebin}/python3"
+_outF2="${_tmp}/f2.txt"
+(
+    cd "${_appF}" || exit 1
+    _l="${_tmp}/logs.crash"; mkdir -p "${_l}"
+    PATH="${_fakebin}:${PATH}" HYDRA_GATE_LOG_DIR="${_l}" bash "${_runner}" . > "${_outF2}" 2>&1
+)
+_green_over_crash=""
+for _g in 45 46 47 48 49 50 51 52 54 55; do
+    if grep -qE "^\[gate-${_g}\][^:]*: (PASS|FAIL)" "${_outF2}"; then
+        _green_over_crash="${_green_over_crash} ${_g}"
+    fi
+done
+if [ -z "${_green_over_crash}" ]; then
+    _ok "with python3 exiting 1, no gate in the band produced a verdict — all reported wiring or na"
+else
+    _bad "gate(s)${_green_over_crash} produced a PASS/FAIL verdict although their checker never ran"
+fi
+if grep -qE "^\[gate-46\][^:]*: SKIPPED \(wiring\)" "${_outF2}"; then
+    _ok "gate-46 says SKIPPED (wiring) rather than PASS over findings it cannot see"
+else
+    _bad "gate-46 on a dead interpreter → $(grep -E '^\[gate-46\]' "${_outF2}" | head -1)"
+fi
+
+echo ""
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_45_to_55_acceptance.sh: ALL GREEN"
+    exit 0
+fi
+echo "test_gate_45_to_55_acceptance.sh: ${_failures} failure(s)"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -36,6 +36,14 @@
 #      a guarded read and an unguarded one two lines apart.
 #
 # Run: bash hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+#
+# ShellCheck: SC2016 is suppressed for this file only. The PHP and JS fixtures
+# below are written as single-quoted heredocs on purpose — `$reg`, `$sch`,
+# `$this->appConfig` are PHP variables that must reach the fixture VERBATIM.
+# Letting the shell expand them would write `  = ->appConfig->...` into the
+# file and silently turn every arm into a test of an empty fixture, which is
+# the exact "green over nothing" failure this suite exists to catch.
+# shellcheck disable=SC2016
 
 set -u
 
@@ -262,6 +270,66 @@ if grep -qE "^\[gate-50\][^:]*: FAIL — 1 unsafe" "${_outC5}"; then
 else
     _bad "gate-50 on a guarded+unguarded pair → $(grep -E '^\[gate-50\]' "${_outC5}" | head -1)"
 fi
+
+# C6 — ANTI-WIDENING. A PHPCS-FORMATTED MULTI-LINE READ.
+#
+# Verbatim shape from procest lib/Service/AiService.php:580 and :967. Two
+# five-line calls plus a blank line put the guard on the ELEVENTH line, one
+# outside a window that counted from where the call BEGAN. The constant-app-id
+# fix (C1) is what made these reads visible at all, so the window bug arrived
+# with it: 3 findings on procest, all three textbook `empty()` guards.
+_write_service '    public function writeAudit(): void
+    {
+        $registerId = $this->appConfig->getValueString(
+            Application::APP_ID,
+            '"'"'register'"'"',
+            '"'"''"'"'
+        );
+        $schemaId   = $this->appConfig->getValueString(
+            Application::APP_ID,
+            '"'"'ai_audit_entry_schema'"'"',
+            '"'"''"'"'
+        );
+
+        if (empty($registerId) === true || empty($schemaId) === true) {
+            $this->logger->warning('"'"'AI audit: register or schema ID not configured'"'"');
+            return;
+        }
+    }'
+_commit "${_appC}" "multi-line reads with a guard below them"
+_outC6="${_tmp}/c6.txt"
+_run "${_appC}" "${_outC6}"
+_expect "${_outC6}" 50 "PASS" "accepts a PHPCS-formatted multi-line read whose guard follows it"
+
+# C7 — ANTI-WIDENING. The guard on the SAME LINE as the read (procest:710).
+_write_service '    public function settings(): array
+    {
+        return [
+            '"'"'ai_api_key_set'"'"' => $this->appConfig->getValueString(Application::APP_ID, '"'"'ai_api_key'"'"', '"'"''"'"') !== '"'"''"'"',
+        ];
+    }'
+_commit "${_appC}" "same-line emptiness check"
+_outC7="${_tmp}/c7.txt"
+_run "${_appC}" "${_outC7}"
+_expect "${_outC7}" 50 "PASS" "accepts an emptiness check written on the read's own line"
+
+# C8 — the reverse control for C6/C7: the SAME multi-line shape with the guard
+# DELETED must still fail. Without this, C6 and C7 could be satisfied by a
+# window so wide the gate can no longer find anything.
+_write_service '    public function writeAudit(): void
+    {
+        $registerId = $this->appConfig->getValueString(
+            Application::APP_ID,
+            '"'"'register'"'"',
+            '"'"''"'"'
+        );
+
+        $this->objectService->saveObject($registerId, []);
+    }'
+_commit "${_appC}" "multi-line read with no guard at all"
+_outC8="${_tmp}/c8.txt"
+_run "${_appC}" "${_outC8}"
+_expect "${_outC8}" 50 "FAIL" "still fails a multi-line read with no guard anywhere"
 
 # ===========================================================================
 # FAMILY D — gate-53 must block the PR that CREATES larpingapp#286.

--- a/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_a11y_markup_scope.sh
@@ -230,7 +230,7 @@ _run "${_nosrc_app}" "${_nosrc_out}"
 
 _excused=""
 _still=""
-for _g in 31 32 34 35 36 37 39 40 42 43 44; do
+for _g in 31 32 34 35 36 37 39 40 42 43 44 45; do
     if grep -qE "^\[gate-${_g}\][^:]*: NOT APPLICABLE" "${_nosrc_out}"; then
         _excused="${_excused} ${_g}"
     elif ! grep -qE "^\[gate-${_g}\]" "${_nosrc_out}"; then
@@ -251,9 +251,20 @@ _nosrc_caught=0
 _nosrc_total=0
 while IFS=: read -r _g _what; do
     [ -z "${_g}" ] && continue
-    # gate-45 (prefers-reduced-motion) is outside the 34-44 band this arm
-    # repairs and still guards on `[ -d src ]`; gate-38 is not in _expect.
-    case "${_g}" in 38|45) continue ;; esac
+    # gate-38 is not in _expect (it is a whole-document rule, not a per-element
+    # one) so it has nothing to be counted against here.
+    #
+    # gate-45 USED TO BE EXCLUDED HERE TOO, AND THE EXCLUSION WAS THE BUG
+    # (.github#274). #272 migrated 35/40/42/44 off `[ -d src ]` and left the
+    # twelfth member of the family behind — still `[ -d src ]`-guarded, still
+    # listed under `[ -d src ]` in the applicability table — so on this exact
+    # templates-only fixture gate-45 reported NOT APPLICABLE ("this repo ships
+    # no frontend") over a `<style>` block with `transition: all .3s` and no
+    # reduced-motion fallback, sitting in the same file the arm above reads.
+    # The skip carried a comment saying so, which is the shape to distrust: a
+    # test that documents the defect it declines to assert on. Removing the
+    # name from this list IS the regression test.
+    case "${_g}" in 38) continue ;; esac
     _nosrc_total=$((_nosrc_total + 1))
     if grep -qE "^\[gate-${_g}\][^:]*: FAIL" "${_nosrc_out}"; then
         _nosrc_caught=$((_nosrc_caught + 1))

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5175,7 +5175,12 @@ for m in re.finditer(r'<style\b[^>]*>(.*?)</style>', src, re.IGNORECASE | re.DOT
         continue
     print(f'{fname}: <style> rule=motion-without-reduced-motion-fallback')
 PYRM
-        [ $? -ne 0 ] && _rm_rc=1
+        # `$?` immediately after a heredoc-fed command is the command's status;
+        # captured into a named variable rather than tested inline so
+        # ShellCheck's SC2181 ("check the exit code directly") does not fire on
+        # a construct where `if ! cmd <<HEREDOC` is not available.
+        _rm_one=$?
+        [ "${_rm_one}" -ne 0 ] && _rm_rc=1
     done < <(_a11y_markup_files)
     _rm_fail=$(wc -l < "${_rm_log}" 2>/dev/null || echo 0)
     if [ "${_rm_rc}" -ne 0 ]; then
@@ -5695,8 +5700,50 @@ for fp in files:
     for m in SEC_KEY.finditer(src):
         # Find the line number of the match
         lineno = src[:m.start()].count('\n') + 1
-        # Window: 10 lines after the config read
-        window = ''.join(lines[lineno:lineno+10])
+        # WINDOW STARTS WHERE THE CALL ENDS, NOT WHERE IT STARTS.
+        #
+        # It was `lines[lineno:lineno+10]` — ten lines after the line the
+        # match BEGAN on, excluding that line. Two false positives fall out of
+        # that, and both are ordinary code:
+        #
+        #   multi-line call   PHPCS-formatted reads span five lines each:
+        #                         $registerId = $this->appConfig->getValueString(
+        #                             Application::APP_ID,
+        #                             'register',
+        #                             ''
+        #                         );
+        #                     Two of those plus a blank line put the guard on
+        #                     the ELEVENTH line — one outside the window.
+        #                     Measured on procest lib/Service/AiService.php:580
+        #                     and :967, where the guard is a textbook
+        #                     `if (empty($registerId) === true || empty($schemaId)
+        #                     === true) { $this->logger->warning(...); return; }`
+        #                     and the gate called both unguarded.
+        #
+        #   same-line guard   `'ai_api_key_set' => $this->appConfig->getValueString(
+        #                     Application::APP_ID, 'ai_api_key', '') !== ''`
+        #                     handles the empty default ON THE MATCH LINE, which
+        #                     the window started AFTER. procest:710.
+        #
+        # Both are fixed by anchoring the window to the END of the call
+        # expression: balance parentheses forward from the `(`, then take the
+        # remainder of THAT line plus ten more. A single-line read gets the
+        # same ten lines it always did, so nothing is loosened for the shape
+        # this gate was built on — only the shapes it could not see.
+        _open = src.find('(', m.start())
+        _depth, _p = 0, _open
+        while _p < len(src) and _p != -1:
+            if src[_p] == '(':
+                _depth += 1
+            elif src[_p] == ')':
+                _depth -= 1
+                if _depth == 0:
+                    break
+            _p += 1
+        _end_line = src[:_p].count('\n') + 1 if _p < len(src) else lineno
+        # `_end_line - 1` is the 0-based index of the call's closing line, so
+        # the window INCLUDES the rest of that line (the same-line case).
+        window = ''.join(lines[_end_line-1:_end_line+10])
         # Look for fail-mode signals
         #
         # THE EMPTY-COMPARE ARM MUST SURVIVE A COMPOUND CONDITION.

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5126,12 +5126,41 @@ fi
 # References:
 #   - openspec/architecture/wcag-coverage.md SC 2.3.3 (AAA, audit-common)
 # ---------------------------------------------------------------------------
-if [ -d src ]; then
+# THE GUARD MUST MIRROR THE ENUMERATOR (#225 / #261, finished here).
+#
+# This gate reads `_a11y_markup_files` — src/, templates/ and appinfo/templates/
+# — but was still gated on `[ -d src ]`, the guard that enumerator replaced.
+# On an app that renders from PHP templates and has no src/ (nldesign is the
+# fleet's example) the gate emitted nothing, and the central applicability
+# table then declared it NOT APPLICABLE — "this repo ships no frontend" — over
+# a `templates/settings/admin.php` that ships real markup. Measured 2026-08-08:
+# a textbook `transition:` with no reduced-motion fallback was planted in that
+# exact file and this gate reported NOT APPLICABLE while its siblings 31/32/34/
+# 36/37/39/43, which had been migrated, reported on it (43 FAILED on it).
+#
+# `na` over a live defect is worse than the PASS it replaced: PASS at least
+# counts as a claim someone can dispute, whereas `na` removes the gate from the
+# coverage arithmetic entirely — the run then reports "all applicable gates
+# green" with the defect inside it.
+if _a11y_has_markup_dir; then
     _rm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-prefers-reduced-motion.log
     : > "${_rm_log}"
+    : > "${_rm_log}.err"
+    _rm_seen=0
+    _rm_rc=0
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
-        python3 - "$vue" <<'PYRM' >> "${_rm_log}" 2>/dev/null
+        _rm_seen=$((_rm_seen + 1))
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+        #
+        # `2>/dev/null` alone discarded the traceback AND the failure, so a
+        # broken interpreter left an empty log and this gate called it clean.
+        # Measured 2026-08-08 with a `python3` that exits 1 on every call:
+        # every gate in this band that read its checker's return code said
+        # SKIPPED (wiring); this one said PASS. stderr is kept so the reason
+        # is recoverable, and the status is read.
+        set +e
+        python3 - "$vue" <<'PYRM' >> "${_rm_log}" 2>>"${_rm_log}.err"
 import re, sys
 fname = sys.argv[1]
 try:
@@ -5146,9 +5175,15 @@ for m in re.finditer(r'<style\b[^>]*>(.*?)</style>', src, re.IGNORECASE | re.DOT
         continue
     print(f'{fname}: <style> rule=motion-without-reduced-motion-fallback')
 PYRM
+        [ $? -ne 0 ] && _rm_rc=1
     done < <(_a11y_markup_files)
     _rm_fail=$(wc -l < "${_rm_log}" 2>/dev/null || echo 0)
-    if [ "${_rm_fail}" -eq 0 ]; then
+    if [ "${_rm_rc}" -ne 0 ]; then
+        _skip 45 "prefers-reduced-motion" wiring "the inline reduced-motion checker exited non-zero on at least one of ${_rm_seen} markup file(s) — no verdict was produced for them; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run. See ${_rm_log}.err."
+    elif [ "${_rm_seen}" -eq 0 ]; then
+        # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+        _skip 45 "prefers-reduced-motion" na "scope was empty — 0 markup file(s) (src/, templates/, appinfo/templates/) in this diff, so NO <style> block was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run."
+    elif [ "${_rm_fail}" -eq 0 ]; then
         _pass 45 "prefers-reduced-motion"
     else
         _fail 45 "prefers-reduced-motion" "${_rm_fail} <style> block(s) with motion but no reduced-motion fallback — see ${_rm_log}"
@@ -5180,8 +5215,15 @@ done < <(find lib src \( -name '*.php' -o -name '*.vue' -o -name '*.js' -o -name
 _sae_ran=1
 _sae_helper="${SCRIPT_DIR}/lib/check_spec_anchors.py"
 if [ "${#_sae_files[@]}" -eq 0 ]; then
-    : # nothing in scope — ordinary diff scoping, same as before this gate
-      # moved into a helper. See the note on gate-40.
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    #
+    # This branch was a bare `:` and the gate fell through to `_pass 46`. On a
+    # diff that touches no lib/ or src/ file — a README, a workflow, a
+    # composer bump — the gate opened no file at all and printed PASS, exactly
+    # the shape #258 removed from gates 19/25/62/63 and #268 then categorised.
+    # Gates 4/6/7/28 have said `na` for the identical situation since #268.
+    _sae_ran=0
+    _skip 46 "spec-anchor-existence" na "scope was empty — 0 lib/ or src/ file(s) in this diff, so NO @spec target was resolved. Diff-scoped out under ADR-020: nothing in this repository is missing, and no change the author could make would let this gate inspect a file the diff does not contain. It runs on the next PR that touches annotated code."
 elif [ ! -f "${_sae_helper}" ]; then
     # A MISSING HELPER MUST NOT REPORT PASS (#147). The gate previously
     # carried its resolver inline, so "the helper is absent" was not a
@@ -5190,7 +5232,22 @@ elif [ ! -f "${_sae_helper}" ]; then
     _sae_ran=0
     _skip 46 "spec-anchor-existence" wiring "check_spec_anchors.py not found at ${_sae_helper} — ${#_sae_files[@]} file(s) were in scope and NONE had their @spec targets resolved; dangling spec references are UNVERIFIED by this run."
 else
-    python3 "${_sae_helper}" "${_sae_log}" "${_sae_files[@]}" || true
+    # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+    #
+    # `|| true` swallowed the status, so a resolver that died left an empty
+    # log and this gate called the repository clean. Measured 2026-08-08 with
+    # a `python3` that exits 1 on every call: gate-46 printed PASS over the
+    # 277 unresolved @spec findings, across 104 distinct targets, that it had
+    # reported one run earlier on the same tree. This gate has form here —
+    # its helper did not exist at all in packages before #246, which is how
+    # three repos pinned at v1.3.0 ran it and saw nothing.
+    set +e
+    python3 "${_sae_helper}" "${_sae_log}" "${_sae_files[@]}" 2>>"${_sae_log}.err"
+    _sae_rc=$?
+    if [ "${_sae_rc}" -ne 0 ]; then
+        _sae_ran=0
+        _skip 46 "spec-anchor-existence" wiring "check_spec_anchors.py exited ${_sae_rc} — ${#_sae_files[@]} file(s) were in scope and no verdict was produced; dangling @spec targets are UNVERIFIED by this run. See ${_sae_log}.err."
+    fi
 fi
 set +e
 _sae_fail=$(wc -l < "${_sae_log}" 2>/dev/null | tr -d ' ')
@@ -5233,7 +5290,17 @@ _scht_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-security-change-has-tests.log
 : > "${_scht_log}"
 _scht_ran=1
 _scht_helper="${SCRIPT_DIR}/lib/check_security_cochange.py"
-if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
+if [ "${SCOPE_TO_DIFF}" != "1" ] || [ -z "${BASE_REF}" ]; then
+    # NO DIFF, NO VERDICT — and NOT a PASS (#242/#240/#258/#268).
+    #
+    # This gate's whole subject is "what did this change touch, and did it also
+    # touch a test". A builder full-repo run has no base to diff against, so the
+    # `if` above was simply false and the gate fell through to `_pass 47`,
+    # announcing a co-change verdict it had not formed. Every full-repo run in
+    # the fleet — every builder iteration — printed that green.
+    _scht_ran=0
+    _skip 47 "security-change-has-tests" na "this run is not diff-scoped (no --scope-to-diff / no base ref), so there is no change set to classify. This gate compares a PR's hunks against the tests it touched; on a whole-repository run there is no such pair, and no change in this repository could create one."
+elif [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
     if [ ! -f "${_scht_helper}" ]; then
         # A MISSING HELPER MUST NOT REPORT PASS (#147).
         _scht_ran=0
@@ -5252,7 +5319,25 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
         # docblocks) was told to co-change tests. Neither used the opt-out,
         # which is the tell — people do not reach for an opt-out when they
         # believe the finding is wrong.
-        _scht_sec=$(python3 "${_scht_helper}" "${BASE_REF}" "$(pwd)" 2>/dev/null || true)
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+        #
+        # `2>/dev/null || true` threw away the traceback and the status, and
+        # "no output" is exactly what a clean diff produces — so a dead
+        # classifier was indistinguishable from a clean bill of health.
+        # Measured 2026-08-08 on a diff that DROPS #[NoCSRFRequired] from a
+        # controller with no test co-change: this gate reported FAIL with a
+        # working interpreter and PASS with one that exits 1, while gate-48,
+        # which reads its helper's status, said SKIPPED (wiring) on the same
+        # run over the same diff.
+        set +e
+        _scht_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-security-change-has-tests.err"
+        _scht_sec=$(python3 "${_scht_helper}" "${BASE_REF}" "$(pwd)" 2>"${_scht_err}")
+        _scht_rc=$?
+        if [ "${_scht_rc}" -ne 0 ]; then
+            _scht_ran=0
+            _scht_sec=""
+            _skip 47 "security-change-has-tests" wiring "check_security_cochange.py exited ${_scht_rc} — the diff was NOT classified; a security change shipping without a test co-change is UNVERIFIED by this run. See ${_scht_err}."
+        fi
         _scht_has_test=""
         while IFS= read -r f; do
             [ -z "$f" ] && continue
@@ -5294,7 +5379,13 @@ fi
 _csrf_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-cochange.log
 : > "${_csrf_log}"
 _csrf_ran=1
-if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
+if [ "${SCOPE_TO_DIFF}" != "1" ] || [ -z "${BASE_REF}" ]; then
+    # NO DIFF, NO VERDICT — and NOT a PASS (#242/#240/#258/#268). Identical
+    # reasoning to gate-47 above: "was an attribute REMOVED" is a question only
+    # a diff can answer, and a full-repo run printed PASS without asking it.
+    _csrf_ran=0
+    _skip 48 "csrf-cochange" na "this run is not diff-scoped (no --scope-to-diff / no base ref), so there is no removal to detect. Whether a controller DROPPED @NoCSRFRequired is a property of a change set, not of a checkout, and no change in this repository could make a whole-repository run able to answer it."
+elif [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
     # Find removed @NoCSRFRequired lines in changed PHP files.
     #
     # A REMOVED COMMENT IS NOT A REMOVED ATTRIBUTE (#191).
@@ -5388,8 +5479,13 @@ while IFS= read -r f; do
     _in_scope "$f" || continue
     _cxt_files+=("$f")
 done < <(_enum_tracked '\.php$' lib/Controller)
+_cxt_rc=0
 if [ "${#_cxt_files[@]}" -gt 0 ]; then
-    python3 - "${_cxt_log}" "${_cxt_files[@]}" << 'PY'
+    # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262). The status
+    # of this inline python was never read, so a broken interpreter left an
+    # empty log and the gate called every controller clean.
+    set +e
+    python3 - "${_cxt_log}" "${_cxt_files[@]}" 2>>"${_cxt_log}.err" << 'PY'
 import re, sys, os
 log_path = sys.argv[1]
 files = sys.argv[2:]
@@ -5502,6 +5598,7 @@ for fp in files:
                 g.write(f"{fp}:{m['start_line']}: {m['name']}() calls a service method that may throw a tracked exception, "
                         f"but has no matching try/catch and no @throws declaration\n")
 PY
+    _cxt_rc=$?
 fi
 # Opt-out: `[hydra-gate-controller-exception-translation exclude] <reason>` in
 # the PR body or head commit message (≥ 20 chars).
@@ -5515,7 +5612,13 @@ set +e
 _cxt_fail=$(wc -l < "${_cxt_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_cxt_fail}" ] && _cxt_fail=0
-if [ "${_cxt_fail}" -eq 0 ]; then
+if [ "${_cxt_rc}" -ne 0 ]; then
+    _skip 49 "controller-exception-translation" wiring "the inline exception-translation checker exited ${_cxt_rc} — ${#_cxt_files[@]} lib/Controller file(s) were in scope and no verdict was produced; untranslated service exceptions are UNVERIFIED by this run. See ${_cxt_log}.err."
+elif [ "${#_cxt_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268) — same category
+    # gates 6/7 already use for the identical "0 controllers in this diff".
+    _skip 49 "controller-exception-translation" na "scope was empty — 0 lib/Controller PHP file(s) in this repo or this diff, so NO controller method was inspected; untranslated service exceptions (HTTP 500 on a defended path) are UNVERIFIED by this run."
+elif [ "${_cxt_fail}" -eq 0 ]; then
     _pass 49 "controller-exception-translation"
 else
     _fail 49 "controller-exception-translation" "${_cxt_fail} controller method(s) missing try/catch or @throws — see ${_cxt_log}"
@@ -5539,13 +5642,34 @@ while IFS= read -r f; do
     _in_scope "$f" || continue
     _scfm_files+=("$f")
 done < <(_enum_tracked '(Controller|Service)[^/]*\.php$' lib)
+_scfm_rc=0
 if [ "${#_scfm_files[@]}" -gt 0 ]; then
-    python3 - "${_scfm_log}" "${_scfm_files[@]}" << 'PY'
+    # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+    set +e
+    python3 - "${_scfm_log}" "${_scfm_files[@]}" 2>>"${_scfm_log}.err" << 'PY'
 import re, sys
 log_path = sys.argv[1]
 files = sys.argv[2:]
 SEC_KEY = re.compile(
-    r"getValue(?:String|Bool|Int)\s*\(\s*['\"][^'\"]+['\"]\s*,\s*['\"]"
+    # FIRST ARGUMENT: THE APP ID, IN ANY FORM.
+    #
+    # This was `['\"][^'\"]+['\"]` — a QUOTED STRING LITERAL only. The
+    # fleet-standard idiom is a class constant:
+    #
+    #     $this->appConfig->getValueString(Application::APP_ID, 'listing_register', '')
+    #
+    # so every read written that way was invisible to this gate. Measured
+    # 2026-08-08: an unguarded read of `listing_register` — the exact
+    # opencatalogi#86 defect this gate was built for — reported PASS with
+    # `Application::APP_ID`, and FAIL with `'larpingapp'`, one token apart.
+    # 7 real security-relevant reads across 5 fleet repos sit behind a
+    # constant today. Same family as #184: a checker that matches a string
+    # literal misses every constant.
+    #
+    # `[^,()]+` is deliberately shape-agnostic (literal, `self::APP_ID`,
+    # `Application::APP_ID`, `$this->appId`) and stops at the comma, so it
+    # cannot swallow the key argument this regex exists to capture.
+    r"getValue(?:String|Bool|Int)\s*\(\s*[^,()]+\s*,\s*['\"]"
     r"(?P<key>[^'\"]*"
     r"(?:register|schema|allow[_-]?list|allow_?list|whitelist|blocklist|"
     # Quote-or-underscore-anchored short tokens so `author_name`,
@@ -5574,9 +5698,40 @@ for fp in files:
         # Window: 10 lines after the config read
         window = ''.join(lines[lineno:lineno+10])
         # Look for fail-mode signals
+        #
+        # THE EMPTY-COMPARE ARM MUST SURVIVE A COMPOUND CONDITION.
+        #
+        # It was `if\s*\(\s*[\$\w\->]+\s*(===|…)\s*['\"]{2}\s*\)` — a closing
+        # paren required IMMEDIATELY after the empty string. So the correct,
+        # idiomatic two-key guard
+        #
+        #     if ($reg === '' || $sch === '') { return []; }
+        #
+        # did not match, and BOTH reads above it were reported as unguarded.
+        # Measured 2026-08-08 on larpingapp: two findings, zero defects. That
+        # is the worst possible false positive for this gate, because the code
+        # it rejects is the code it is asking for — an author who "fixes" it
+        # by splitting into two single-key ifs has changed nothing and learned
+        # that the gate rewards shape over meaning.
+        #
+        # The trailing `\s*\)` is dropped: the condition continues with `||`,
+        # `&&`, `)` or anything else, and none of those change whether an
+        # empty-string comparison happened.
+        #
+        # The leading `if\s*\(` is dropped for the same reason. A guard does
+        # not have to be an `if` — larpingapp's SetupController::isProvisioned()
+        # fails closed with
+        #
+        #     return $registerId !== '' && $schemaMarker !== '';
+        #
+        # which is a complete empty-default handler and was reported as
+        # unguarded the moment the constant-app-id fix made the read visible.
+        # What this gate actually asks is "did the code compare the value
+        # against empty"; the statement it sits in is not the question.
         has_guard = re.search(
-            r"if\s*\(\s*[\$\w\-\>]+\s*(===|!==|==|!=)\s*['\"]{2}\s*\)"       # empty-string compare
-            r"|if\s*\(\s*empty\s*\("                                          # empty()
+            r"(===|!==|==|!=)\s*['\"]{2}"                                     # empty-string compare
+            r"|['\"]{2}\s*(===|!==|==|!=)"                                    # …written the other way round
+            r"|\bempty\s*\("                                                  # empty()
             r"|->logger->(warning|error|critical|alert)"                      # log-warn
             r"|throw\s+new\s+"                                                # throw
             r"|return\s+new\s+(JSONResponse|Response|DataResponse)",          # early return
@@ -5586,12 +5741,18 @@ for fp in files:
             with open(log_path, 'a', encoding='utf-8') as g:
                 g.write(f"{fp}:{lineno}: security-relevant config read of \"{m.group('key')}\" has no fail-mode guard within 10 lines\n")
 PY
+    _scfm_rc=$?
 fi
 set +e
 _scfm_fail=$(wc -l < "${_scfm_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_scfm_fail}" ] && _scfm_fail=0
-if [ "${_scfm_fail}" -eq 0 ]; then
+if [ "${_scfm_rc}" -ne 0 ]; then
+    _skip 50 "security-config-fail-mode" wiring "the inline security-config checker exited ${_scfm_rc} — ${#_scfm_files[@]} Controller/Service file(s) were in scope and no verdict was produced; a security-relevant config key silently defaulting to empty is UNVERIFIED by this run. See ${_scfm_log}.err."
+elif [ "${#_scfm_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    _skip 50 "security-config-fail-mode" na "scope was empty — 0 lib/**/*Controller.php or *Service.php file(s) in this repo or this diff, so NO config read was inspected; a security-relevant key silently defaulting to empty is UNVERIFIED by this run."
+elif [ "${_scfm_fail}" -eq 0 ]; then
     _pass 50 "security-config-fail-mode"
 else
     _fail 50 "security-config-fail-mode" "${_scfm_fail} unsafe security-config read(s) — see ${_scfm_log}"
@@ -5633,11 +5794,19 @@ if [ "${#_spt_files[@]}" -gt 0 ]; then
         # title debt in a touched register never blocks an unrelated PR —
         # titles are enforced going forward only (mirrors gate-16). Builder
         # full-repo runs leave HYDRA_GATE_BASE_REF unset → ratchet every prop.
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+        # `2>/dev/null || true` discarded both the traceback and the status.
+        set +e
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
             HYDRA_GATE_BASE_REF="${BASE_REF}" \
-                python3 "${_spt_helper}" "${_spt_files[@]}" >> "${_spt_log}" 2>/dev/null || true
+                python3 "${_spt_helper}" "${_spt_files[@]}" >> "${_spt_log}" 2>>"${_spt_log}.err"
         else
-            python3 "${_spt_helper}" "${_spt_files[@]}" >> "${_spt_log}" 2>/dev/null || true
+            python3 "${_spt_helper}" "${_spt_files[@]}" >> "${_spt_log}" 2>>"${_spt_log}.err"
+        fi
+        _spt_rc=$?
+        if [ "${_spt_rc}" -ne 0 ]; then
+            _spt_ran=0
+            _skip 51 "schema-property-titles" wiring "check_schema_property_meta.py exited ${_spt_rc} — ${#_spt_files[@]} register file(s) were in scope and no verdict was produced; schema properties missing a human-friendly title/description are UNVERIFIED by this run. See ${_spt_log}.err."
         fi
     else
         _spt_ran=0
@@ -5648,7 +5817,10 @@ set +e
 _spt_fail=$(wc -l < "${_spt_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_spt_fail}" ] && _spt_fail=0
-if [ "${_spt_ran}" -eq 1 ]; then
+if [ "${#_spt_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    _skip 51 "schema-property-titles" na "scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO schema property was inspected; missing human-friendly titles are UNVERIFIED by this run."
+elif [ "${_spt_ran}" -eq 1 ]; then
     if [ "${_spt_fail}" -eq 0 ]; then
         _pass 51 "schema-property-titles"
     else
@@ -5700,8 +5872,19 @@ _cwr_ran=1
 if [ "${#_cwr_files[@]}" -gt 0 ]; then
     _cwr_helper="${SCRIPT_DIR}/lib/check_custom_widget_ratchet.py"
     if [ -f "${_cwr_helper}" ]; then
-        # Helper exit code = number of findings (capped at 99); stdout gets
-        # the finding blocks + the always-on counts report line.
+        # READ THE COUNT OFF STDOUT, NOT THE EXIT BYTE (#209).
+        #
+        # This was `_cwr_fail=$?` straight after the helper. An exit status
+        # carries two different facts on one channel — "how many findings" and
+        # "I did not finish" — and the gate could not tell them apart.
+        # Measured 2026-08-08 by injecting `raise RuntimeError(...)` into the
+        # helper's main(): Python exited 1 and the gate printed
+        # `FAIL — 1 custom-widget finding(s)`, a fabricated finding with a
+        # plausible message and nothing behind it. The helper's own count was
+        # also clamped to 99 to fit in the byte, so 100+ findings under-reported.
+        #
+        # The helper now prints `[custom-widget-ratchet] findings=N` on every
+        # completed run and exits boolean. No such line ⇒ it died ⇒ WIRING.
         set +e
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
             HYDRA_GATE_BASE_REF="${BASE_REF}" \
@@ -5709,8 +5892,22 @@ if [ "${#_cwr_files[@]}" -gt 0 ]; then
         else
             python3 "${_cwr_helper}" "${_cwr_files[@]}" >> "${_cwr_log}" 2>&1
         fi
-        _cwr_fail=$?
+        _cwr_rc=$?
+        _cwr_reported=$(grep -oE '\[custom-widget-ratchet\] findings=[0-9]+' "${_cwr_log}" 2>/dev/null \
+            | tail -1 | sed 's/.*findings=//')
         set +e
+        case "${_cwr_reported}" in
+            ''|*[!0-9]*)
+                # The helper produced no count line. It crashed, was killed, or
+                # is a version that predates the contract — either way it did
+                # NOT judge this repository, and saying "N findings" here would
+                # invent them.
+                _cwr_ran=0
+                _cwr_fail=0
+                _skip 52 "custom-widget-ratchet" wiring "check_custom_widget_ratchet.py exited ${_cwr_rc} without printing its \`findings=\` count — it did NOT finish, so ${#_cwr_files[@]} frontend file(s) were left uninspected and custom kind:\"widget\" growth (ADR-049) is UNVERIFIED by this run. This is a broken checker, NOT a finding about the code. See ${_cwr_log}."
+                ;;
+            *) _cwr_fail="${_cwr_reported}" ;;
+        esac
     else
         _cwr_ran=0
         _skip 52 "custom-widget-ratchet" wiring "check_custom_widget_ratchet.py not found at ${_cwr_helper} — ${#_cwr_files[@]} frontend file(s) were in scope and NONE were inspected; custom kind:\"widget\" growth (ADR-049) is UNVERIFIED by this run — no base/head/delta counts were produced."
@@ -5720,7 +5917,10 @@ fi
 # reported so migrations can show the number shrinking).
 _cwr_counts=$(grep -m1 -o 'base=[0-9]* head=[0-9]* delta=[+-]*[0-9]*.*' "${_cwr_log}" 2>/dev/null || true)
 [ -n "${_cwr_counts}" ] && echo "[gate-52] custom-widget-ratchet: ${_cwr_counts}"
-if [ "${_cwr_ran}" -eq 1 ]; then
+if [ "${#_cwr_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    _skip 52 "custom-widget-ratchet" na "no src/**/*.{js,ts,vue} file(s) in this repo, so there is no component registry to hold a custom kind:\"widget\" entry and no ratchet to compute."
+elif [ "${_cwr_ran}" -eq 1 ]; then
     if [ "${_cwr_fail}" -eq 0 ]; then
         _pass 52 "custom-widget-ratchet"
     else
@@ -5790,8 +5990,16 @@ if [ -f src/manifest.json ]; then
         _em_touched=1
     fi
     if [ "${_em_touched}" -eq 0 ]; then
-        # PR touches no manifest input — informational pass (ADR-020).
-        _pass 53 "effective-manifest-crossref"
+        # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+        #
+        # "Informational pass" is a contradiction: the line printed is
+        # `[gate-53] effective-manifest-crossref: PASS`, and no consumer of
+        # this runner's stdout — the coverage assertion, the reviewer skill,
+        # a human reading the summary — can tell it apart from a manifest that
+        # was assembled, validated and cross-referenced. Gates 62 and 63 answer
+        # this identical condition ("touched no manifest and no menu-layout")
+        # with `na`, and this gate now agrees with them.
+        _skip 53 "effective-manifest-crossref" na "the diff against '${BASE_REF}' touched no manifest input (src/manifest.json, src/manifest.d/**, src/menu-layout.json, lib/Settings/*register*.json), so NO effective manifest was assembled or cross-referenced. Diff-scoped out under ADR-020 — not a gap: the manifests in this repo are unchanged from the base branch. This gate runs on the next PR that touches a manifest input."
     elif [ ! -f "${_em_builder}" ] || [ ! -f "${_em_crossref}" ] || [ ! -f "${_em_validator}" ]; then
         # Gate misconfiguration — a vendored helper is missing. Fail-closed.
         _fail 53 "effective-manifest-crossref" "vendored helper missing under ${SCRIPT_DIR}/lib (need build_effective_manifest.js + check_manifest_crossref.js + check_manifest.js) — fail-closed"
@@ -5910,6 +6118,56 @@ if [ -f src/manifest.json ]; then
         # green from reading as "the manifest is clean".
         _em_pre=$(_count '^at .*: PRE-EXISTING ' "${_em_log}")
         [ "${_em_pre}" -gt 0 ] && echo "[gate-53] effective-manifest-crossref: ${_em_pre} PRE-EXISTING finding(s) on manifest entries this PR did not touch (ADR-020, not blocking) — see ${_em_log}"
+
+        # -------------------------------------------------------------------
+        # ORPHANING A COMPONENT IN THIS PR IS NOT ADVISORY.
+        #
+        # This gate exists because of larpingapp#286 — `EventRoster` was
+        # registered in src/registry.js, resolvable, and named by no manifest
+        # position, so the event check-in surface had no entry point at all
+        # and a spec task was ticked over unreachable UI. Direction 1 of the
+        # registry cross-reference (registered, unreferenced) is reported as
+        # WARN, deliberately and correctly: for LEGACY debt the gate genuinely
+        # cannot tell "wire it" from "delete it", and forcing a choice
+        # fleet-wide is the widening that would make the check useless.
+        #
+        # But there is one case where it CAN tell, and it is the only case
+        # that matters for prevention: THE DIFF ITSELF REMOVED THE LAST
+        # REFERENCE. Measured 2026-08-08 — larpingapp#286 was reintroduced
+        # exactly (the `checkin` tab deleted from src/manifest.json, the
+        # registry entry left in place) and gate-53 reported
+        # `[gate-53] effective-manifest-crossref: PASS`. The gate built to
+        # catch that defect does not block the commit that creates it.
+        #
+        # So: a WARN whose component name appears on a REMOVED `"component":`
+        # line of this PR's own manifest diff is promoted to blocking. Nothing
+        # pre-existing changes severity — an app carrying legacy orphans (and
+        # larpingapp carries one today, `ObjectDetail`) is unaffected, so this
+        # is prevention rather than a burn-down list nobody can close.
+        # -------------------------------------------------------------------
+        _em_orphaned=""
+        if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ] && [ "${_em_warns}" -gt 0 ]; then
+            set +e
+            _em_removed_refs=$(git diff -U0 "${BASE_REF}...HEAD" -- \
+                'src/manifest.json' 'src/manifest.d/*' 'src/menu-layout.json' 2>/dev/null \
+                | grep -E '^-' | grep -vE '^---' || true)
+            while IFS= read -r _em_wl; do
+                [ -z "${_em_wl}" ] && continue
+                _em_name=$(printf '%s' "${_em_wl}" | sed -n "s/.*exports '\\([^']*\\)'.*/\\1/p")
+                [ -z "${_em_name}" ] && continue
+                # `"component": "<name>"` on a line the PR deleted.
+                if printf '%s\n' "${_em_removed_refs}" \
+                    | grep -qE "\"component\"[[:space:]]*:[[:space:]]*\"${_em_name}\"" 2>/dev/null; then
+                    _em_orphaned="${_em_orphaned}${_em_orphaned:+, }${_em_name}"
+                fi
+            done <<< "$(grep -E '^at .*: WARN .*registry\.js exports ' "${_em_log}" 2>/dev/null || true)"
+            set +e
+        fi
+        if [ -n "${_em_orphaned}" ]; then
+            echo "[gate-53] this PR REMOVED the last manifest reference to: ${_em_orphaned} — promoted from WARN to blocking (larpingapp#286)." >> "${_em_log}"
+            _em_reason="${_em_reason:+${_em_reason}; }this PR removed the last manifest reference to ${_em_orphaned}, which src/registry.js still exports — the surface it renders is now unreachable (larpingapp#286). Delete the registry entry too, or keep an entry point (tabs[]/sections[]/page) that names it."
+        fi
+
         if [ -z "${_em_reason}" ]; then
             _pass 53 "effective-manifest-crossref"
         else
@@ -5958,11 +6216,21 @@ if [ "${#_rd_files[@]}" -gt 0 ]; then
         # Property-level diff-scoping for the relation-shape check when
         # --scope-to-diff is set (mirrors gate-51); other checks scope to the
         # changed file set. Builder full-repo runs leave the env unset.
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+        # `>/dev/null 2>&1 || true` threw away the traceback and the status,
+        # and this gate's advisory WARN half reads the same empty log — so a
+        # dead helper silenced BOTH halves and printed PASS.
+        set +e
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
             HYDRA_GATE_BASE_REF="${BASE_REF}" \
-                python3 "${_rd_helper}" "${_rd_log}" "${_rd_files[@]}" >/dev/null 2>&1 || true
+                python3 "${_rd_helper}" "${_rd_log}" "${_rd_files[@]}" >/dev/null 2>>"${_rd_log}.err"
         else
-            python3 "${_rd_helper}" "${_rd_log}" "${_rd_files[@]}" >/dev/null 2>&1 || true
+            python3 "${_rd_helper}" "${_rd_log}" "${_rd_files[@]}" >/dev/null 2>>"${_rd_log}.err"
+        fi
+        _rd_rc=$?
+        if [ "${_rd_rc}" -ne 0 ]; then
+            _rd_ran=0
+            _skip 54 "relation-dialect" wiring "check_relation_dialect.py exited ${_rd_rc} — ${#_rd_files[@]} register file(s) were in scope and no verdict was produced; non-canonical relation dialects (ADR-062 rules 6/7/10) are UNVERIFIED by this run, and so is its advisory WARN half. See ${_rd_log}.err."
         fi
     else
         _rd_ran=0
@@ -5976,7 +6244,10 @@ set +e
 [ -z "${_rd_fail}" ] && _rd_fail=0
 [ -z "${_rd_warn}" ] && _rd_warn=0
 [ "${_rd_warn}" -gt 0 ] && echo "[gate-54] relation-dialect: ${_rd_warn} WARN finding(s) (non-blocking) — see ${_rd_log}"
-if [ "${_rd_ran}" -eq 1 ]; then
+if [ "${#_rd_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    _skip 54 "relation-dialect" na "scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO relation property was inspected; non-canonical relation dialects (ADR-062 rules 6/7/10) are UNVERIFIED by this run."
+elif [ "${_rd_ran}" -eq 1 ]; then
     if [ "${_rd_fail}" -eq 0 ]; then
         _pass 54 "relation-dialect"
     else
@@ -6018,11 +6289,18 @@ if [ "${#_dpd_files[@]}" -gt 0 ]; then
         # Page-level diff-scoping when --scope-to-diff is set: only detail pages
         # the PR touches are checked. Builder full-repo runs leave the env unset
         # → every detail page in a changed manifest is checked.
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
+        set +e
         if [ "${SCOPE_TO_DIFF}" = "1" ]; then
             HYDRA_GATE_BASE_REF="${BASE_REF}" \
-                python3 "${_dpd_helper}" "${_dpd_log}" "${_dpd_files[@]}" >/dev/null 2>&1 || true
+                python3 "${_dpd_helper}" "${_dpd_log}" "${_dpd_files[@]}" >/dev/null 2>>"${_dpd_log}.err"
         else
-            python3 "${_dpd_helper}" "${_dpd_log}" "${_dpd_files[@]}" >/dev/null 2>&1 || true
+            python3 "${_dpd_helper}" "${_dpd_log}" "${_dpd_files[@]}" >/dev/null 2>>"${_dpd_log}.err"
+        fi
+        _dpd_rc=$?
+        if [ "${_dpd_rc}" -ne 0 ]; then
+            _dpd_ran=0
+            _skip 55 "detail-page-discipline" wiring "check_detail_page_discipline.py exited ${_dpd_rc} — ${#_dpd_files[@]} manifest file(s) were in scope and no verdict was produced; ADR-062 detail-page grid discipline is UNVERIFIED by this run. See ${_dpd_log}.err."
         fi
     else
         _dpd_ran=0
@@ -6033,7 +6311,10 @@ set +e
 _dpd_fail=$(wc -l < "${_dpd_log}" 2>/dev/null | tr -d ' ')
 set +e
 [ -z "${_dpd_fail}" ] && _dpd_fail=0
-if [ "${_dpd_ran}" -eq 1 ]; then
+if [ "${#_dpd_files[@]}" -eq 0 ]; then
+    # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
+    _skip 55 "detail-page-discipline" na "scope was empty — 0 src/manifest.json or src/manifest.d/*.json file(s) in this repo or this diff, so NO type:\"detail\" page was inspected; ADR-062 grid discipline (render-path shadowing, widgets↔layout integrity, widget icons, row/viewAll routes) is UNVERIFIED by this run."
+elif [ "${_dpd_ran}" -eq 1 ]; then
     if [ "${_dpd_fail}" -eq 0 ]; then
         _pass 55 "detail-page-discipline"
     else
@@ -6585,10 +6866,10 @@ _declare_na() {
     done
 }
 
-# `if [ -d src ]` — gates 10 12 13 26 45
+# `if [ -d src ]` — gates 10 12 13 26
 [ -d src ] || _declare_na "no src/ directory — this repo ships no frontend, so there is no .vue/.js/.ts source for this gate to inspect." \
-    10 12 13 26 45
-# `if _a11y_has_markup_dir` — gates 31 32 34 35 36 37 39 40 42 43 44
+    10 12 13 26
+# `if _a11y_has_markup_dir` — gates 31 32 34 35 36 37 39 40 42 43 44 45
 #
 # THE TABLE HAD DRIFTED FROM THE GUARDS IT CLAIMS TO MIRROR.
 #
@@ -6611,10 +6892,21 @@ _declare_na() {
 # is one `rm` away: its `src/` holds a single `manifest.json`, which is the
 # exact shape that made twelve gates pass over nothing in #225.
 #
+# GATE-45 IS THE SAME DEFECT, AND #272 LEFT IT BEHIND (.github#274).
+#
+# It was the twelfth member of the family and stayed in the `[ -d src ]`
+# list above, with its own `[ -d src ]` guard. Measured 2026-08-08 on
+# nldesign, with a `transition:` and no reduced-motion fallback planted in
+# `templates/settings/admin.php`: gate-45 reported NOT APPLICABLE — "this
+# repo ships no frontend" — while gate-43, already migrated, FAILED on the
+# same tree in the same run. A partial fix to a table like this is the worst
+# outcome available: it removes the smell that would have led someone back
+# to the entry still carrying the defect.
+#
 # The condition here is now the SAME FUNCTION the gates call, not a restated
 # copy of it, so the two cannot drift again.
 _a11y_has_markup_dir || _declare_na "no src/, templates/ or appinfo/templates/ — this repo renders no markup, so there is no DOM for this accessibility gate to inspect." \
-    31 32 34 35 36 37 39 40 42 43 44
+    31 32 34 35 36 37 39 40 42 43 44 45
 # `if [ -f appinfo/routes.php ]` — gates 5 25
 [ -f appinfo/routes.php ] || _declare_na "no appinfo/routes.php — this repo registers no HTTP routes, so there is no endpoint for this gate to inspect." \
     5 25

--- a/hydra-gates/tests/test-hydra-gates-bin.sh
+++ b/hydra-gates/tests/test-hydra-gates-bin.sh
@@ -414,14 +414,46 @@ fi
 # gates guarded by `[ -d src ]` must genuinely RUN. If the declaration table
 # ever drifts away from the guards it mirrors, it would keep calling them
 # not-applicable here — which is the one way this change could hide a live gate.
+#
+# WHAT THIS ASSERTS ON, AND WHY IT IS THE REASON AND NOT THE VERDICT
+# -------------------------------------------------------------------
+# It used to assert "no gate in the list says NOT APPLICABLE at all". That
+# conflated two different sentences that happen to share a verdict word:
+#
+#   the TABLE spoke   "no src/ directory — this repo ships no frontend"
+#                     A gate that never reached its own code. Drift. The bug.
+#   the GATE spoke    "scope was empty — 0 markup file(s) in this diff"
+#                     The gate ran, enumerated its subject, found none, and
+#                     said so with a reason only it could produce.
+#
+# The fixture here has `src/leaf.js` and no `.vue`/`.php`/`.html` at all, so the
+# WCAG family legitimately has nothing to inspect — and since 2026-08-08 those
+# gates say `na` with their own reason instead of printing PASS over an
+# unopened scope. Asserting on the verdict alone made the correct behaviour
+# indistinguishable from the drift it was written to catch.
+#
+# So the check is now on the REASON TEXT: the table's phrasings must not
+# appear once their prerequisite is satisfied. The drift this arm exists to
+# catch still fails it, because drift produces exactly those sentences.
 _still_na=""
 for _g in 10 12 13 26 31 32 34 35 36 37 39 40 42 43 44 45; do
-    printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE" && _still_na="${_still_na}${_g} "
+    printf '%s' "${OUT_STRUCT}" \
+        | grep -qE "^\[gate-${_g}\] [a-z-]+: NOT APPLICABLE — no src/(,| directory)" \
+        && _still_na="${_still_na}${_g} "
 done
 if [ -z "${_still_na}" ]; then
-    _ok "with src/ present, every src-guarded gate really runs (applicability table tracks its guards)"
+    _ok "with src/ present, no gate is excused by the applicability table (it tracks its guards)"
 else
-    _bad "gates ${_still_na}were still called NOT APPLICABLE though src/ exists — the table has drifted from the guards it mirrors"
+    _bad "gates ${_still_na}were excused by the applicability table's own reason though src/ exists — the table has drifted from the guards it mirrors"
+fi
+
+# ...and the pairing: a gate that DID reach its own code must say so in its own
+# words. Without this, the reason-based check above could be satisfied by a
+# gate falling silent altogether.
+if printf '%s' "${OUT_STRUCT}" | grep -qE "^\[gate-45\] prefers-reduced-motion: (PASS|FAIL|NOT APPLICABLE — scope was empty)"; then
+    _ok "gate-45 reported from inside its own guard, not from the applicability table"
+else
+    _bad "gate-45 produced neither a verdict nor its own empty-scope reason: $(printf '%s' "${OUT_STRUCT}" | grep -E '^\[gate-45\]' | head -1)"
 fi
 
 echo "[test] an unrecognised skip category is a hard failure, never a silent 'na'"


### PR DESCRIPTION
fix(gates 45-55): eleven gates passed over an unopened scope, eight over a dead interpreter, and three could not see the defect they exist for

Every gate in this band was given ONE textbook true positive of exactly what
it exists to catch, planted in a real fleet repo, then removed again. Where a
gate could not fail, it was repaired; where it could, the plant is now a
regression test. Measured at package sha 34370f6.

## 1. All eleven reported PASS over a scope they never opened (#242/#240/#258/#268)

On a README-only diff against larpingapp, gates 45-55 printed eleven PASS
lines and the summary read "53 of 53 applicable gates ran". Not one of them
had opened a file. Gates 4/6/7/19/25/28/62/63 have answered the identical
situation with NOT APPLICABLE since #268; this band never adopted it.

Gates 47 and 48 are the sharper case: they can only answer a question about a
CHANGE SET, so on every builder full-repo run in the fleet — no base ref at
all — they printed a co-change verdict they had not formed.

## 2. Eight reported PASS over a crashed interpreter (#147/#249/#262)

A planted defect only fires when the gate runs, so no plant can see this. With
a `python3` on PATH that exits 1 on every call, on a tree carrying real
findings:

  gate-46  PASS — over the 277 unresolved @spec findings, across 104 distinct
           targets, it had reported one run earlier on the same files
  gate-47  PASS — on the same diff where it had just reported FAIL
  gate-45/49/50   PASS  (`2>/dev/null` discarded status and traceback)
  gate-51/54/55   PASS  (`|| true` discarded the status)
  gate-52  FAIL — "1 custom-widget finding(s)", a fabricated finding: the
           helper returned its COUNT as its exit status, the same channel
           Python uses for a traceback (#209). The count was also clamped to
           99 to fit in a byte. It now prints `findings=N` on stdout and exits
           boolean; no `findings=` line means the helper died.

gate-54 was the quietest: its advisory WARN half reads the same log, so a dead
helper silenced both halves at once.

## 3. gate-45 was the residue of #272's fix (.github#274)

#272 migrated gates 35/40/42/44 off `[ -d src ]` onto `_a11y_has_markup_dir`
and left the twelfth member of the family behind. On a templates-only app
gate-45 reported NOT APPLICABLE — "this repo ships no frontend" — over a
`<style>` block with `transition:` and no reduced-motion fallback, in the same
file gate-43 FAILED on in the same run. `na` is the one verdict that removes a
gate from coverage accounting.

The regression test was already written and gate-45 was excluded from it by
name, with a comment explaining why. Removing the name from ARM 4's skip list
in test_gate_a11y_markup_scope.sh IS the test; it fails against 34370f6.

## 4. gate-47: prose satisfied it, and a qualified attribute did not

`_ANNOTATION_RE` was an unanchored alternation of string literals, and it was
wrong in both directions from that one regex — the pairing #269 found in
gate-48 and never carried to its sibling.

  FALSE POSITIVE  rewording ONE docblock sentence that merely NAMES the
                  annotation ("becomes `@NoAdminRequired` again, paired with a
                  real ownership check") made the gate demand a test
                  co-change. A gate satisfiable by prose manufactures the
                  appearance of a security review (#191).
  FALSE NEGATIVE  `#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]` was
                  invisible. A commit adding exactly that to a controller —
                  opening an admin-only endpoint to every authenticated user —
                  with no test in the diff reported PASS.

Now position-anchored, by the same rule check_csrf_removal.py already used.

## 5. gate-50: a false positive and a false negative in the same regex

  FALSE NEGATIVE  the app-id argument had to be a QUOTED STRING, so every read
                  written the fleet-standard way — `getValueString(
                  Application::APP_ID, 'listing_register', '')` — was invisible.
                  Identical code with `'larpingapp'` FAILED. Same family as
                  #184. 7 security-relevant reads across 5 repos sit behind a
                  constant today.
  FALSE POSITIVE  the empty-compare guard required a closing paren immediately
                  after the empty string, so the correct compound guard
                  `if ($reg === '' || $sch === '')` was reported as unguarded —
                  twice, on code the gate was asking for. A guard that is a
                  boolean `return` rather than an `if` was rejected too.

Both directions are now asserted, including the opencatalogi#86 shape that
mixes them: one read guarded, the next unguarded two lines later.

## 6. gate-53 did not block the PR that creates larpingapp#286

Reintroducing #286 exactly — the check-in tab deleted from src/manifest.json,
`EventRoster` left registered in src/registry.js — reported PASS. Direction 1
of the registry cross-reference stays advisory for LEGACY orphans, correctly:
the gate cannot tell "wire it" from "delete it". But when the DIFF ITSELF
removed the last reference it can, and that finding now blocks. Pre-existing
orphans are untouched (larpingapp carries one today), so this is prevention,
not a burn-down list nobody can close.

## Verified working, repaired nothing

gate-46 (dangling file, dangling fragment, valid anchor), gate-48 (short and
fully-qualified attribute removal; a comment reword correctly stays green),
gate-49, gate-51 (title, description and nested items.properties independently),
gate-52's ratchet (growth fails, shrink passes), gate-54 (flat, nested and
$ref-carrying), gate-55.

## Deliberately NOT enforced

`title == key` on a schema property is a real gate-51 defect — the renderer
uses `prop.title || key`, so the user sees the raw technical key. Measured
across 10 repos: 148 occurrences, ALL of them in softwarecatalog, where they
are VNG-standardised element names (`identifier`, `type`, `name`) that must
not be renamed. Enforcing it would produce 148 findings with no legitimate end
state in the one repo that has them. Reported rather than gated (#252).

## Divergence to reconcile

gate-45 now answers an empty in-scope set with `na`; gate-40 answers it with
PASS, by a deliberate choice in #272 that cited the invariant test this PR
reworks. The invariant now discriminates on the REASON — the applicability
table's own phrasing must not appear once its prerequisite holds — so both
behaviours are expressible. The family should pick one.

## Testing

New: hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh — 31 arms across
six families, discovered by run-helper-suites.sh. Against the package as
merged on main it fails 20 of 31; the 11 that pass are exactly the
anti-widening and no-regression controls. Every mutation asserts its anchor is
present before it plants.

Repos used, chosen for different shapes: larpingapp (register-owning,
manifest-driven, ships registry.js), nldesign (PHP templates, no .vue, no
register), doriath (ships no phpcs SpecTagSniff — the #246 control, held at
81 findings across 46 targets before and after the plant), openconnector
(41 register files).

Full package suite: 52 discovered suites pass, 2 quarantined as documented;
60/60 entry-point invariants.
