### PR TITLE
fix(gate-50): the app-id widening reached settings read-outs, which have nothing to guard

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -331,6 +331,49 @@ _outC8="${_tmp}/c8.txt"
 _run "${_appC}" "${_outC8}"
 _expect "${_outC8}" 50 "FAIL" "still fails a multi-line read with no guard anywhere"
 
+# C9 — A DELIBERATE, MEASURED BLIND SPOT, PINNED SO IT CANNOT DRIFT SILENTLY.
+#
+# The first draft of the app-id fix accepted ANY expression up to the comma,
+# which also takes `$app` and `$this->appName`. A 12-repo before/after sweep
+# priced that: softwarecatalog went 23 -> 64 findings and 47 of the new ones
+# are entries in an array literal that assembles the admin settings payload —
+#
+#     'sendgridApiKey' => $this->config->getValueString($app, 'email_sendgrid_api_key', ''),
+#
+# There is no defense being deactivated in a settings read-out and nothing to
+# guard, so the finding has no legitimate end state (#252). The accepted app-id
+# shapes are therefore the ones actually measured as blind: a quoted literal
+# and a class constant.
+#
+# This arm asserts the CURRENT boundary rather than an ideal one. If someone
+# later teaches this gate to tell a scope decision from a read-out, this is the
+# arm to change — deliberately, with the number in front of them.
+_write_service '    public function readouts(): array
+    {
+        $app = '"'"'fx'"'"';
+        return [
+            '"'"'sendgridApiKey'"'"' => $this->config->getValueString($app, '"'"'email_sendgrid_api_key'"'"', '"'"''"'"'),
+            '"'"'mailgunApiKey'"'"'  => $this->config->getValueString($this->appName, '"'"'email_mailgun_api_key'"'"', '"'"''"'"'),
+        ];
+    }'
+_commit "${_appC}" "settings read-outs with a variable app id"
+_outC9="${_tmp}/c9.txt"
+_run "${_appC}" "${_outC9}"
+_expect "${_outC9}" 50 "PASS" "does not report settings read-outs whose app id is a plain variable (measured blind spot, not a safe shape)"
+
+# C10 — and the constant form of the SAME read is still caught, so C9 is a
+# boundary and not a hole the gate fell through.
+_write_service '    public function readouts(): array
+    {
+        return [
+            '"'"'sendgridApiKey'"'"' => $this->config->getValueString(Application::APP_ID, '"'"'email_sendgrid_api_key'"'"', '"'"''"'"'),
+        ];
+    }'
+_commit "${_appC}" "same read-out with a class-constant app id"
+_outC10="${_tmp}/c10.txt"
+_run "${_appC}" "${_outC10}"
+_expect "${_outC10}" 50 "FAIL" "still catches the same read written with a class-constant app id"
+
 # ===========================================================================
 # FAMILY D — gate-53 must block the PR that CREATES larpingapp#286.
 #

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5880,10 +5880,35 @@ SEC_KEY = re.compile(
     # constant today. Same family as #184: a checker that matches a string
     # literal misses every constant.
     #
-    # `[^,()]+` is deliberately shape-agnostic (literal, `self::APP_ID`,
-    # `Application::APP_ID`, `$this->appId`) and stops at the comma, so it
-    # cannot swallow the key argument this regex exists to capture.
-    r"getValue(?:String|Bool|Int)\s*\(\s*[^,()]+\s*,\s*['\"]"
+    # LITERAL OR CLASS CONSTANT — AND DELIBERATELY NOT AN ARBITRARY EXPRESSION.
+    #
+    # The first draft of this fix accepted `[^,()]+`, i.e. anything up to the
+    # comma, which also takes `$app` and `$this->appName`. That is a strictly
+    # larger widening than the defect measured, and a before/after sweep of 12
+    # repos caught what it costs: softwarecatalog went 23 -> 64 findings, and
+    # 47 of the new ones are reads inside SETTINGS READ-OUTS —
+    #
+    #     'sendgridApiKey' => $this->config->getValueString($app, 'email_sendgrid_api_key', ''),
+    #
+    # entries in an array literal that assembles the admin settings payload.
+    # There is no defense being deactivated there and nothing to guard: the
+    # finding has no legitimate end state, which is the unclosable-gate shape
+    # (#252). A gate that emits 47 of those in one repo teaches people to stop
+    # reading it.
+    #
+    # So the accepted shapes are the ones the fleet actually writes for an app
+    # id — a quoted literal, or a class constant (`Application::APP_ID`,
+    # `self::APP_ID`, `static::APP_ID`) — which is exactly the blind spot that
+    # was measured: 7 security-relevant reads across 5 repos.
+    #
+    # KNOWN BLIND SPOT, STATED RATHER THAN QUIETLY ENFORCED: a read whose app
+    # id is a plain variable is still invisible to this gate. It is not a safe
+    # shape, it is an unmeasured one — separating the settings read-outs from
+    # the real scope decisions among them needs a data-flow question this
+    # regex cannot ask.
+    r"getValue(?:String|Bool|Int)\s*\(\s*"
+    r"(?:['\"][^'\"]*['\"]|(?:self|static|parent|[A-Z]\w*)(?:\\\w+)*::\w+)"
+    r"\s*,\s*['\"]"
     r"(?P<key>[^'\"]*"
     r"(?:register|schema|allow[_-]?list|allow_?list|whitelist|blocklist|"
     # Quote-or-underscore-anchored short tokens so `author_name`,


### PR DESCRIPTION
fix(gate-50): the app-id widening reached settings read-outs, which have nothing to guard

Follow-up to #280, caught by re-running the 12-repo before/after sweep and
comparing FINDING COUNTS rather than verdicts. The verdict-level diff I ran
first showed 26 changes and missed this entirely, because the verdict did not
move: softwarecatalog was FAIL before and FAIL after — at 23 findings and then
at 64.

## What went wrong

#280 fixed a real blind spot: gate-50's app-id argument had to be a QUOTED
STRING, so every read written the fleet-standard way — `getValueString(
Application::APP_ID, 'listing_register', '')` — was invisible. That was
measured at 7 security-relevant reads across 5 repos.

The regex I wrote to fix it accepted `[^,()]+`, i.e. anything up to the comma.
That is a strictly larger widening than the defect measured, and it takes
`$app` and `$this->appName` as well. 47 of softwarecatalog's 41 new findings
are entries in an array literal that assembles the admin settings payload:

    'sendgridApiKey' => $this->config->getValueString($app, 'email_sendgrid_api_key', ''),

No defense is being deactivated in a settings read-out, and there is nothing
to guard — you cannot add an empty-check to an entry in an array literal. The
finding has no legitimate end state, which is the unclosable-gate shape (#252)
and the thing most likely to make people stop reading this gate.

## What this changes

The accepted app-id shapes are now exactly the ones measured as blind: a
quoted literal, or a class constant (`Application::APP_ID`, `self::APP_ID`,
`static::APP_ID`). Measured after:

    softwarecatalog   23 -> 17   (0 added; the 6 removed are #280's window fix,
                                  verified by hand: ArchiMateService.php:1804-1807
                                  and ArchiMateImportService.php:2050-2052 are all
                                  guarded by `if ($rawRegisterId !== null &&
                                  $rawRegisterId !== '' && ...)` or by a same-line
                                  `if (getValueString(...) !== '')`)
    procest            3 ->  0   (all three were the multi-line-window false
                                  positives #280 fixed)
    larpingapp/decidesk/opencatalogi/openconnector/doriath/nldesign — unchanged

So against the package before #280, this band now reports strictly fewer
gate-50 findings and every removal is a verified false positive, while the 7
constant-app-id reads that were invisible are caught.

## The blind spot is now stated, not silent

A read whose app id is a plain VARIABLE remains invisible to this gate. That
is not a safe shape — it is an unmeasured one, and separating the settings
read-outs from the real scope decisions among them needs a data-flow question
a regex cannot ask. Two arms pin the boundary rather than an ideal:

  C9   settings read-outs with `$app` / `$this->appName` -> PASS, with the
       number and the reason in the test's own comment
  C10  the SAME read written with a class constant -> FAIL, so C9 is a
       boundary and not a hole the gate fell through

## Note on method

Comparing verdicts across a sweep is not enough: FAIL -> FAIL hid a 23 -> 64
change. Count, not verdict, is the comparison that would have caught this
before the merge.
