### PR TITLE
fix(gate-19): a GUARDED test.skip(true, …) is a test that RUNS

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -670,8 +670,73 @@ def _has_own_unconditional_skip(block_body: str) -> bool:
     """
     nested = [(s, e) for s, e, _d in _decl_spans(block_body)]
     for m in _UNCONDITIONAL_SKIP_RE.finditer(block_body):
-        if not any(s < m.start() < e for s, e in nested):
-            return True
+        if any(s < m.start() < e for s, e in nested):
+            continue
+        if _skip_is_guarded(block_body, m.start()):
+            continue
+        return True
+    return False
+
+
+# Openers that make the block they introduce conditional. `try` is here because
+# a `test.skip(true)` in a try-body runs only while no earlier statement in that
+# body threw; `finally` is deliberately absent — it always runs.
+# ANCHORED AT THE END on purpose. A window-scan here matched the `try` in
+# `} finally {` and called a finally-block guarded — the exact inversion this
+# check exists to avoid. Only the token immediately before the `{` opens it.
+_GUARD_OPENER_RE = re.compile(
+    r"(?:^|[;{}\s)])(?:if|else\s+if|else|catch|for|while|switch|try)\s*"
+    r"(?:\((?:[^()]|\([^()]*\))*\)\s*)?$",
+)
+
+
+def _skip_is_guarded(body: str, skip_pos: int) -> bool:
+    """Is the `test.skip(true, …)` at *skip_pos* inside a conditional construct?
+
+    WHY THIS EXISTS
+    ---------------
+    `test.skip(true, 'reason')` is NOT the syntax for "this test is switched
+    off". It is Playwright's *skip from this point* form, and the condition
+    lives at the CALL SITE:
+
+        if (!response) { test.skip(true, 'container not reachable'); return }
+
+    That test runs, and passes, whenever the guard is false. Treating it as
+    permanently skipped is how this check came to report "referenced only by a
+    test that never runs" about a test that ran and passed in the same CI run.
+
+    Measured across 11 repos: **118** `test.skip(true, …)` call sites, of which
+    **114 are guarded** and only **4** are genuinely unconditional. So the rule
+    without this test misfires on ~96% of what it inspects.
+
+    The false positive is worse than a normal one because the gate's prescribed
+    remedy is `@e2e exclude` — so complying DELETES a true coverage claim and
+    marks a tested scenario permanently untestable.
+
+    HOW
+    ---
+    Walk backwards tracking brace depth to find the innermost `{` still open at
+    *skip_pos*, then ask what introduced it. Repeat outward: a skip nested three
+    blocks deep inside an `if` is still guarded. Stops at the enclosing test
+    body, whose opener is the `test(`/`it(` callback — not a guard.
+    """
+    depth = 0
+    i = skip_pos - 1
+    while i >= 0:
+        ch = body[i]
+        if ch == "}":
+            depth += 1
+        elif ch == "{":
+            if depth == 0:
+                # Innermost still-open block. What opened it?
+                head = body[max(0, i - 200):i]
+                if _GUARD_OPENER_RE.search(head):
+                    return True
+                # Not a guard (a function body, an object literal, the test
+                # callback). Keep walking outward — an `if` may enclose it.
+            else:
+                depth -= 1
+        i -= 1
     return False
 
 

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -1104,6 +1104,40 @@ class SkippedAncestorTest(unittest.TestCase):
             "  })\n"
             "})\n"), set())
 
+    # #239: a GUARDED `test.skip(true, …)` is a test that RUNS. Measured across
+    # 11 repos: 118 call sites, 114 guarded, 4 genuinely unconditional.
+    def test_guarded_skip_is_live(self):
+        self.assertEqual(self._refs(
+            "// @e2e demo::guarded\n"
+            "test('syncs when reachable', async ({ page }) => {\n"
+            "  if (!response) { test.skip(true, 'container not reachable'); return }\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"), {"demo::guarded"})
+
+    def test_bare_skip_is_still_dead(self):
+        # Negative control: if this passes, the rule was disabled, not fixed.
+        self.assertEqual(self._refs(
+            "// @e2e demo::bare\n"
+            "test('never runs', async ({ page }) => {\n"
+            "  test.skip(true, 'pending backend work')\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"), set())
+
+    def test_skip_in_finally_is_still_dead(self):
+        # `finally` always runs, so this skip is unconditional. Proves the
+        # check discriminates BETWEEN openers rather than treating any
+        # enclosing brace as a guard.
+        self.assertEqual(self._refs(
+            "// @e2e demo::finally\n"
+            "test('always skipped', async ({ page }) => {\n"
+            "  try {\n"
+            "    await probe()\n"
+            "  } finally {\n"
+            "    test.skip(true, 'always')\n"
+            "  }\n"
+            "  await expect(page).toBeTruthy()\n"
+            "})\n"), set())
+
     def test_the_four_case_fixture_from_the_issue(self):
         # #210's minimal reproduction, whole, in one file — the shape the fix
         # is measured against.


### PR DESCRIPTION
Closes #239.

## The bug

gate-19's liveness check treated **every** `test.skip(true, …)` as permanent. That is not the syntax for "this test is switched off" — it is Playwright's *skip-from-this-point* form, and the condition lives at the **call site**:

```ts
if (!response) { test.skip(true, 'container not reachable'); return }
```

That test runs, and passes, whenever the guard is false. So the gate reported *"referenced only by a test that never runs"* about tests that **ran and passed in the same CI run**.

## Measured blast radius

| | |
|---|---|
| `test.skip(true, …)` call sites across 11 repos | **118** |
| of those, **guarded** | **114** |
| genuinely unconditional | **4** (all in one procest file) |

The rule misfired on **~96%** of the sites it inspected.

On **openregister** alone: of **205** `@e2e` refs across 63 spec files, **16 flip dead → live** under this fix.

## Why this was worse than an ordinary false positive

The gate's prescribed remedy is `@e2e exclude`. So complying with a false finding **deletes a true coverage claim** and marks a tested scenario permanently untestable. The gate would have laundered away real coverage, and the resulting number would have looked like an improvement.

## The fix

`_skip_is_guarded()` walks backwards tracking brace depth to the innermost still-open `{`, asks what introduced it, and repeats outward — so a skip nested several blocks deep inside an `if` is still guarded.

**`finally` is deliberately not a guard opener.** A finally block always runs, so a skip there *is* unconditional. That case is the sharpest control: it proves the check discriminates *between* block openers rather than treating any enclosing brace as a guard.

It also caught a real bug in my first draft — a 120-character look-back window matched the `try` in `} finally {` and called a finally-block guarded, the exact inversion this check exists to prevent. The opener regex is now anchored to the token immediately preceding the brace.

## Verified in both directions

78 tests pass. The controls:

| state | result |
|---|---|
| `_skip_is_guarded` stubbed to pre-fix behaviour | **FAIL** — `test_guarded_skip_is_live`, rc 1 |
| restored | rc 0 |
| bare `test.skip(true)` | still **dead** |
| skip inside `finally` | still **dead** |

A fix that only makes things live is a fix that turned the rule off. The negative controls are what distinguish the two.
