### PR TITLE
test(gates): refuse to run the 45–55 suite when ajv is unresolvable (it reported 4 gate-53 defects that do not exist)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -51,11 +51,54 @@ _here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _scripts="$(cd "${_here}/.." && pwd)"
 _runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
 
+# ---------------------------------------------------------------------------
+# PREFLIGHT — ajv must be resolvable, or this suite reports GATE DEFECTS that
+# are really a WIRING fault, and one of them is a false pass.
+#
+# Measured 2026-08-09 on a fresh clone of main (c51a225, zero drift): with ajv
+# unresolvable, gate-53 fails closed ("ajv not resolvable ... refusing to run
+# fail-open"), and FOUR arms of FAMILY D then read as gate defects —
+#   D2  removing component + registry entry together : expected PASS, got FAIL
+#   D3  a pre-existing orphan stays advisory         : expected PASS, got FAIL
+#   D1b the finding NAMES EventRoster                : name never appears
+#   D3b the pre-existing orphan surfaces as a WARN   : WARN never appears
+# and this was reported upstream as "the suite expects blocking where the gate
+# was deliberately made advisory". It does not. The gate is correct.
+#
+# 🔑 Worse, arm D1 still printed `ok`. It expects FAIL and got FAIL — for a
+# completely unrelated reason. That is a FALSE PASS inside the very suite
+# built to catch false passes, and it is why this preflight aborts instead of
+# letting the run continue with a warning.
+#
+# ⚠️ `node -e "require('ajv')"` is NOT a valid check on its own: Node resolves
+# UPWARD from the cwd, so it can succeed against a node_modules belonging to
+# some ancestor directory rather than to the gates package. Resolve it from
+# the helpers' own directory — the same place the runner resolves it from —
+# and print the ABSOLUTE PATH, because the path is the evidence and the exit
+# code is not.
+# ---------------------------------------------------------------------------
+if ! command -v node >/dev/null 2>&1; then
+    echo "WIRING: node is not on PATH." >&2
+    echo "        Every gate in this band that shells out to a JS helper would fail" >&2
+    echo "        closed, and this suite would report that as a gate defect." >&2
+    exit 2
+fi
+_ajv_at="$(cd "${_scripts}/lib" && node -e "process.stdout.write(require.resolve('ajv'))" 2>/dev/null || true)"
+if [ -z "${_ajv_at}" ]; then
+    echo "WIRING: ajv is not resolvable from ${_scripts}/lib." >&2
+    echo "        gates 22 and 53 fail CLOSED without it, so this suite would report" >&2
+    echo "        four gate-53 defects that do not exist — and arm D1 would print 'ok'" >&2
+    echo "        for the wrong reason. Refusing to run rather than emit a false verdict." >&2
+    echo "        Fix: NODE_PATH=<dir containing ajv> bash ${BASH_SOURCE[0]}" >&2
+    exit 2
+fi
+
 _failures=0
 _ok()  { echo "  ok   — $1"; }
 _bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
 
 echo "test_gate_45_to_55_acceptance.sh"
+echo "  preflight — ajv resolves to ${_ajv_at}"
 
 _tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g4555.XXXXXX")"
 trap 'rm -rf "${_tmp}"' EXIT


### PR DESCRIPTION
## What this fixes

`test_gate_45_to_55_acceptance.sh` reports **four gate-53 defects that do not exist** when `ajv` is not resolvable — and one of its arms passes for the wrong reason while doing so.

## Evidence

Fresh clone of `main` (`c51a225`, `git rev-list --left-right --count origin/main...HEAD` = `0 0`), 0-byte stderr on both runs.

**Without `NODE_PATH`** — 4 failures:

```
FAIL — gate-53 failed without naming EventRoster
FAIL — gate-53 accepts removing the component and its registry entry together → expected 'PASS', got 'FAIL'
FAIL — gate-53 leaves a PRE-EXISTING orphan advisory (WARN), not blocking → expected 'PASS', got 'FAIL'
FAIL — gate-53 swallowed the pre-existing orphan entirely
```

**With `NODE_PATH` set** — `ALL GREEN`, exit 0.

So **gate-53 is correct and the suite is not stale.** Both helpers behave properly in isolation: `check_manifest_crossref.js` on the D3 fixture exits **0** and emits the expected `WARN` for the pre-existing orphan. The gate fails closed on `[gate-53] ... ajv not resolvable from <lib> — refusing to run fail-open`, which is the right behaviour — but it makes every downstream assertion describe a gate that never ran.

This was previously reported upstream as *"the suite expects blocking behaviour for pre-existing orphans that #250/#260/#280 deliberately made advisory"*. That reading is wrong in both halves: the suite expects **advisory**, and the shipped gate **delivers** advisory.

## The part worth keeping

🔑 **Arm D1 still printed `ok`.** It expects `FAIL` and got `FAIL` — because gate-53 failed closed, not because it detected the orphan. **A false pass inside the suite built to catch false passes.**

That is why this **aborts (exit 2, zero verdict lines)** rather than warning and continuing. A wiring fault must not be able to produce a verdict at all.

## The check itself

⚠️ `node -e "require('ajv')"` is **not** a valid check on its own — Node resolves **upward** from the cwd, so it can succeed against a `node_modules` belonging to an ancestor directory rather than to the gates package. (Measured the same day: an agent's ajv check passed for exactly this reason.)

So ajv is resolved **from the helpers' own directory** — the same place the runner resolves it from — and the **absolute path is printed as the evidence**:

```
preflight — ajv resolves to /…/node_modules/ajv/dist/ajv.js
```

The path is the evidence; the exit code cannot tell you *which* ajv answered.

## Proven both directions

| arm | result |
|---|---|
| ajv **absent** | exit **2**, **0** verdict lines emitted, wiring message on stderr naming the fix |
| ajv **present** | exit **0**, `ALL GREEN`, empty stderr |

No gate logic changed. No assertion relaxed. One file touched.
