### PR TITLE
fix(gate-48): a net-zero MOVE is not a removal, and 'no co-change in the diff' is not 'no co-change needed'

### DIFF
--- a/hydra-gates/scripts/lib/check_csrf_callers.py
+++ b/hydra-gates/scripts/lib/check_csrf_callers.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Gate-48 companion — which frontend call sites send NO CSRF token?
+
+WHY THIS EXISTS
+---------------
+Gate-48 asks one question of a diff that removes ``@NoCSRFRequired``: *did the
+same diff add a CSRF signal under* ``src/``? For a PR whose callers have
+**always** sent a token there is no such signal to add, and the gate cannot be
+satisfied without a waiver.
+
+Measured on ConductionNL/larpingapp#298, which closes a live CSRF-forgery hole:
+``SettingsController::create()`` and ``reimport()`` carried
+
+    * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
+
+at docblock-tag position, where Nextcloud's ``ControllerMethodReflector`` reads
+it as the annotation being PRESENT — so the sentence announcing the removal was
+what kept CSRF disabled. Removing it is the fix. All three frontend callers
+already sent ``requesttoken``, and the shared ``CnAdminSettingsShell`` uses
+``@nextcloud/axios``, which injects it. The co-change gate-48 wanted did not
+exist to be made, and the cheapest way to go green would have been a cosmetic
+edit containing the word ``requesttoken`` — the prose-satisfaction the gate
+programme exists to stop.
+
+THE QUESTION THIS ASKS INSTEAD
+------------------------------
+Not "did the diff change a caller?" but "**is any mutating caller unprotected
+right now?**". That is sound in the conservative direction:
+
+* if EVERY mutating call site already carries a CSRF-bearing mechanism, then
+  whichever one reaches the endpoint whose annotation was removed is protected,
+  and enforcing CSRF cannot break it;
+* if ANY mutating call site lacks one, we cannot tell that it is not the
+  caller of that endpoint, so the removal still blocks.
+
+opencatalogi#79 — the defect gate-48 was built for, a delete-modal ``fetch()``
+with no CSRF header — is still caught: that call site is reported here, so the
+gate still fails. A fix that stopped catching it would be a gate switched off.
+
+WHAT COUNTS AS PROTECTED
+------------------------
+Within the call expression itself: ``requesttoken`` / ``OCS-APIRequest`` (both
+case-insensitive, HTTP header names are), or ``getRequestToken``. Or the call
+goes through ``@nextcloud/axios``, imported in that file — that client attaches
+the current token itself, which is the canonical Nextcloud mechanism.
+
+Usage::
+
+    check_csrf_callers.py <app-dir>
+
+Prints one ``path:line — reason`` per UNPROTECTED mutating call site.
+Exits 0 always; the OUTPUT is the answer (#209).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+SRC_SUFFIXES = ('.vue', '.js', '.ts', '.mjs', '.cjs')
+SKIP_DIRS = {'node_modules', 'dist', 'build', 'vendor', '.git', 'coverage'}
+
+# `method: 'POST'` / `method: "put"` / `method:\n 'PATCH'` inside a fetch init.
+MUTATING_METHOD = re.compile(
+    r"""method\s*:\s*['"`](?P<verb>POST|PUT|PATCH|DELETE)['"`]""",
+    re.IGNORECASE,
+)
+# axios.post( / axios.put( / this.$axios.delete( ...
+AXIOS_MUTATING = re.compile(
+    r"""\baxios\s*\.\s*(?P<verb>post|put|patch|delete)\s*\(""",
+    re.IGNORECASE,
+)
+FETCH_CALL = re.compile(r"""\bfetch\s*\(""")
+# An import of the Nextcloud axios wrapper, under any local alias.
+NEXTCLOUD_AXIOS_IMPORT = re.compile(
+    r"""from\s+['"]@nextcloud/axios['"]|require\(\s*['"]@nextcloud/axios['"]\s*\)"""
+)
+CSRF_SIGNAL = re.compile(
+    r"""requesttoken|OCS-APIREQUEST|getRequestToken""",
+    re.IGNORECASE,
+)
+
+
+def _call_text(text: str, open_paren: int) -> str:
+    """Text of the call expression starting at the `(` index, paren-balanced.
+
+    Falls back to the rest of the file when the parentheses never balance, so a
+    malformed file reports the call as UNPROTECTED rather than being skipped —
+    an unparseable caller is not evidence of a token.
+    """
+    depth = 0
+    for i in range(open_paren, len(text)):
+        ch = text[i]
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+            if depth == 0:
+                return text[open_paren:i + 1]
+    return text[open_paren:]
+
+
+def unprotected_call_sites(app_dir: str) -> list[str]:
+    """Mutating frontend call sites carrying no CSRF-bearing mechanism."""
+    findings: list[str] = []
+    src_root = os.path.join(app_dir, 'src')
+    if not os.path.isdir(src_root):
+        return findings
+
+    for root, dirs, files in os.walk(src_root):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for name in sorted(files):
+            if not name.endswith(SRC_SUFFIXES):
+                continue
+            path = os.path.join(root, name)
+            try:
+                with open(path, encoding='utf-8', errors='replace') as handle:
+                    text = handle.read()
+            except OSError:
+                continue
+            rel = os.path.relpath(path, app_dir)
+            uses_nc_axios = bool(NEXTCLOUD_AXIOS_IMPORT.search(text))
+
+            # 1. axios.<verb>(...) — protected iff the file imports @nextcloud/axios.
+            for m in AXIOS_MUTATING.finditer(text):
+                if uses_nc_axios:
+                    continue
+                call = _call_text(text, m.end() - 1)
+                if CSRF_SIGNAL.search(call):
+                    continue
+                line = text.count('\n', 0, m.start()) + 1
+                findings.append(
+                    f"{rel}:{line} — axios.{m.group('verb').lower()}() with no CSRF "
+                    f"signal and no @nextcloud/axios import"
+                )
+
+            # 2. fetch(...) — mutating iff its init object names a mutating verb.
+            for m in FETCH_CALL.finditer(text):
+                call = _call_text(text, m.end() - 1)
+                verb = MUTATING_METHOD.search(call)
+                if verb is None:
+                    continue
+                if CSRF_SIGNAL.search(call):
+                    continue
+                line = text.count('\n', 0, m.start()) + 1
+                findings.append(
+                    f"{rel}:{line} — fetch() {verb.group('verb').upper()} with no "
+                    f"CSRF signal"
+                )
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_csrf_callers.py <app-dir>", file=sys.stderr)
+        return 2
+    for finding in unprotected_call_sites(argv[1]):
+        print(finding)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hydra-gates/scripts/lib/check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/check_csrf_removal.py
@@ -67,15 +67,60 @@ DOCBLOCK_TAG_REMOVED = re.compile(r'^-\s*(?:\*\s*)?@NoCSRFRequired\b')
 
 # A diff header line is `---` / `---` shaped; it is not a removed line of code.
 DIFF_HEADER = re.compile(r'^---(\s|$)')
+# `+++ b/lib/Controller/X.php` — starts a new file's hunks. `+++` must be
+# tested before the `+` addition branch, exactly as `---` is before `-`.
+DIFF_FILE_HEADER = re.compile(r'^\+\+\+\s+(?:b/)?(?P<path>\S+)')
 
 
 def removals(diff: str) -> list[str]:
-    out = []
+    """Removed lines that genuinely DROPPED CSRF protection.
+
+    A REMOVAL PAIRED WITH AN IDENTICAL ADDITION IS A MOVE, NOT A REMOVAL.
+
+    Relocating a docblock line inside a file emits a `-` and a `+` carrying the
+    same bytes. Scanning only `^-` reads that as deleting the annotation, and
+    the gate reports a security regression for a diff in which nothing about
+    CSRF changed. Measured on larpingapp: #297 moved one comment line while
+    reordering `SettingsController`'s docblocks —
+
+        -     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
+        +     * instance-wide configuration write needs. `@NoCSRFRequired` was removed
+        +     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
+
+    — and gate-48 kept `Hydra Gates` red on that repo's `development` branch
+    from then on, over a commit that changed no auth posture at all.
+
+    Cancellation is per FILE and by MULTISET. Per file because a line deleted
+    from one controller and added to another is a real change of posture for
+    the first one; by multiset because a diff that removes a tag twice and
+    restores it once has removed it once.
+    """
+    # {path: [raw content of each added line]} and the removals in file order.
+    added: dict[str | None, list[str]] = {}
+    found: list[tuple[str | None, str]] = []
+    path: str | None = None
+
     for line in diff.splitlines():
+        header = DIFF_FILE_HEADER.match(line)
+        if header:
+            path = header.group('path')
+            continue
+        if line.startswith('+'):
+            added.setdefault(path, []).append(line[1:])
+            continue
         if not line.startswith('-') or DIFF_HEADER.match(line):
             continue
         if ATTRIBUTE_REMOVED.match(line) or DOCBLOCK_TAG_REMOVED.match(line):
-            out.append(line)
+            found.append((path, line))
+
+    out: list[str] = []
+    for file_path, line in found:
+        pool = added.get(file_path)
+        if pool is not None and line[1:] in pool:
+            # Consume the pairing so a second identical removal still reports.
+            pool.remove(line[1:])
+            continue
+        out.append(line)
     return out
 
 

--- a/hydra-gates/scripts/lib/test_check_csrf_callers.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_callers.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_csrf_callers (gate-48 companion).
+
+Run with:  python3 scripts/lib/test_check_csrf_callers.py
+
+Both arms, per #191's rule: arm 2 is the one that proves the companion did not
+simply declare every repository compliant. A checker that reports nothing looks
+exactly like a codebase with nothing to report.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_csrf_callers as gate  # noqa: E402
+
+
+def app_with(files: dict[str, str]) -> str:
+    """Materialise a throwaway app dir; returns its path."""
+    root = tempfile.mkdtemp()
+    for rel, content in files.items():
+        path = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(content)
+    return root
+
+
+class TestCompliantCallersReportNothing(unittest.TestCase):
+    """Arm 1 — the larpingapp#298 shape: every caller already sends a token."""
+
+    def test_the_larpingapp_settings_store(self):
+        root = app_with({'src/store/modules/settings.js': """
+export default {
+    async saveSettings(config) {
+        const response = await fetch('/apps/larpingapp/api/settings', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                requesttoken: OC.requestToken,
+            },
+            body: JSON.stringify(config),
+        })
+        return response.json()
+    },
+}
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_an_ocs_apirequest_header_counts(self):
+        root = app_with({'src/x.vue': """
+await fetch(url, { method: 'POST', headers: { 'OCS-APIREQUEST': 'true' } })
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_get_request_token_counts(self):
+        root = app_with({'src/x.js': """
+await fetch(url, { method: 'PUT', headers: { requesttoken: getRequestToken() } })
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_nextcloud_axios_injects_the_token(self):
+        root = app_with({'src/x.js': """
+import axios from '@nextcloud/axios'
+export const save = () => axios.post('/apps/x/api/settings', {})
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_a_plain_GET_fetch_is_not_a_mutating_call(self):
+        root = app_with({'src/x.js': "const r = await fetch('/apps/x/api/settings')\n"})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_an_app_with_no_src_directory(self):
+        self.assertEqual(gate.unprotected_call_sites(app_with({'lib/X.php': '<?php'})), [])
+
+
+class TestUnprotectedCallersAreReported(unittest.TestCase):
+    """Arm 2 — the gate must still catch what it was built for."""
+
+    def test_the_opencatalogi_79_delete_modal(self):
+        """The defect gate-48 exists for: a delete-modal fetch() with no CSRF
+        header. If this stopped being reported the gate would be switched off."""
+        root = app_with({'src/modals/DeleteModal.vue': """
+export default {
+    methods: {
+        async destroy(id) {
+            await fetch(`/apps/opencatalogi/api/publications/${id}`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+            })
+        },
+    },
+}
+"""})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('src/modals/DeleteModal.vue', found[0])
+        self.assertIn('DELETE', found[0])
+
+    def test_a_bare_axios_post_without_the_nextcloud_wrapper(self):
+        root = app_with({'src/x.js': """
+import axios from 'axios'
+export const save = () => axios.post('/apps/x/api/settings', {})
+"""})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('axios.post()', found[0])
+
+    def test_every_mutating_verb_is_covered(self):
+        for verb in ('POST', 'PUT', 'PATCH', 'DELETE'):
+            root = app_with({'src/x.js': f"await fetch(u, {{ method: '{verb}' }})\n"})
+            found = gate.unprotected_call_sites(root)
+            self.assertEqual(len(found), 1, f"{verb}: {found}")
+            self.assertIn(verb, found[0])
+
+    def test_a_token_on_a_DIFFERENT_call_does_not_protect_this_one(self):
+        """Paren-balanced extraction. A file-wide search would let one correct
+        call vouch for every incorrect one beside it."""
+        root = app_with({'src/x.js': """
+await fetch(a, { method: 'POST', headers: { requesttoken: OC.requestToken } })
+await fetch(b, { method: 'POST', headers: { 'Content-Type': 'application/json' } })
+"""})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn(':3', found[0])
+
+    def test_node_modules_is_not_scanned(self):
+        root = app_with({
+            'src/node_modules/dep/index.js': "fetch(u, { method: 'POST' })\n",
+            'src/ok.js': "fetch(u, { method: 'POST', headers: { requesttoken: t } })\n",
+        })
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_the_reported_line_number_is_the_call(self):
+        root = app_with({'src/x.js': "\n\n\nawait fetch(u, { method: 'POST' })\n"})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('src/x.js:4', found[0])
+
+
+class TestCli(unittest.TestCase):
+    def test_missing_argument_is_rejected(self):
+        self.assertEqual(gate.main(["check_csrf_callers.py"]), 2)
+
+    def test_extra_arguments_are_rejected(self):
+        self.assertEqual(gate.main(["check_csrf_callers.py", "a", "b"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_removal.py
@@ -98,6 +98,89 @@ class TestMustGoRed(unittest.TestCase):
         self.assertEqual(gate.removals("-    #[Route('/x')] // NoCSRFRequired"), [])
 
 
+class TestANetZeroMoveIsNotARemoval(unittest.TestCase):
+    """A `-` paired with an identical `+` is a MOVE.
+
+    Measured on larpingapp: #297 relocated one docblock line and gate-48 kept
+    `Hydra Gates` red on that repo's `development` from then on, over a commit
+    that changed no auth posture at all.
+    """
+
+    MOVED = "     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206)."
+
+    def test_the_larpingapp_297_diff(self):
+        diff = "\n".join([
+            "--- a/lib/Controller/SettingsController.php",
+            "+++ b/lib/Controller/SettingsController.php",
+            "@@ -280 +284,16 @@",
+            "-" + self.MOVED,
+            "+     * instance-wide configuration write needs. `@NoCSRFRequired` was removed",
+            "@@ -301,0 +321,32 @@",
+            "+" + self.MOVED,
+        ])
+        self.assertEqual(gate.removals(diff), [])
+
+    def test_a_moved_attribute_line(self):
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+            "+    #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), [])
+
+    def test_removed_twice_restored_once_still_reports_one(self):
+        """Multiset cancellation. Two deletions and one restoration is one
+        net deletion; reporting zero here would be the fix over-applied."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+            "-    #[NoCSRFRequired]",
+            "+    #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_a_move_ACROSS_files_is_still_a_removal(self):
+        """Deleted from one controller, added to another. The first controller
+        genuinely lost the annotation, so cancelling across files would hide a
+        real posture change."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/A.php",
+            "-    #[NoCSRFRequired]",
+            "+++ b/lib/Controller/B.php",
+            "+    #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_a_genuine_removal_alongside_an_unrelated_move_still_reports(self):
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-     * @NoCSRFRequired",
+            "+     * @NoCSRFRequired",
+            "-    #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_whitespace_is_not_normalised_away(self):
+        """A re-indented line is NOT the same line. Treating it as a move would
+        let a reformat swallow a genuine deletion."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+            "+        #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_the_file_header_is_not_read_as_an_addition(self):
+        """`+++ b/...` starts with `+`. If it were pooled as an added line the
+        path would poison the cancellation set."""
+        diff = "\n".join([
+            "--- a/lib/Controller/X.php",
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+
 class TestCli(unittest.TestCase):
     def test_arguments_are_rejected(self):
         self.assertEqual(gate.main(["check_csrf_removal.py", "extra"]), 2)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5862,13 +5862,66 @@ elif [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
         _csrf_fe_signals="${_csrf_fe_signals%%$'\n'*}"
         case "${_csrf_fe_signals}" in ''|*[!0-9]*) _csrf_fe_signals=0 ;; esac
         if [ "${_csrf_fe_signals}" -eq 0 ]; then
+            # -----------------------------------------------------------------
+            # "NO CO-CHANGE IN THE DIFF" IS NOT "NO CO-CHANGE NEEDED".
+            #
+            # The question above is asked of the DIFF. A PR whose callers have
+            # ALWAYS sent a token has no signal to add, and so could not pass —
+            # the only exits were a waiver or staying red.
+            #
+            # Measured on larpingapp#298, which closes a LIVE CSRF-forgery hole:
+            # `SettingsController::create()` and `reimport()` carried
+            #
+            #     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
+            #
+            # at docblock-tag position, where Nextcloud's
+            # ControllerMethodReflector reads it as the annotation being
+            # PRESENT — the sentence announcing the removal was what kept CSRF
+            # disabled. Deleting it is the fix, and all three callers already
+            # sent `requesttoken` while the shared CnAdminSettingsShell uses
+            # @nextcloud/axios. The cheapest way to green would have been a
+            # cosmetic edit under src/ containing the word `requesttoken`:
+            # exactly the prose-satisfaction #191 warns against.
+            #
+            # So ask the state instead of the diff — is any mutating caller
+            # unprotected RIGHT NOW? Conservative in the direction that matters:
+            # every caller protected => the endpoint's caller is protected too;
+            # any caller unprotected => we cannot show it is not this endpoint's,
+            # so the removal still blocks. opencatalogi#79 (a delete-modal
+            # fetch() with no header) is still caught — its own test pins that.
+            # -----------------------------------------------------------------
+            _csrf_callers_helper="${SCRIPT_DIR}/lib/check_csrf_callers.py"
+            _csrf_unprotected=""
+            _csrf_callers_ran=0
+            if [ -f "${_csrf_callers_helper}" ] && [ -d src ]; then
+                set +e
+                _csrf_callers_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-callers.err"
+                _csrf_unprotected=$(python3 "${_csrf_callers_helper}" . 2>"${_csrf_callers_err}")
+                if [ $? -eq 0 ]; then
+                    _csrf_callers_ran=1
+                fi
+                set +e
+            fi
             # Check for opt-out
             _csrf_optout_re='\[hydra-gate-csrf-cochange exclude\][[:space:]]+.{20,}'
             _csrf_optout=""
             _optout_text | grep -qE "${_csrf_optout_re}" && _csrf_optout="1"
-            if [ -z "${_csrf_optout}" ]; then
+            if [ "${_csrf_callers_ran}" -eq 1 ] && [ -z "${_csrf_unprotected}" ]; then
+                # Stated, never silent: a green here is a claim about the
+                # callers, and the reader must be able to see which claim.
+                echo "[gate-48] no CSRF signal was ADDED by this diff, and none was needed:" \
+                    "every mutating call site under src/ already carries one" \
+                    "(requesttoken / OCS-APIRequest / getRequestToken / @nextcloud/axios)." \
+                    "Checked by scripts/lib/check_csrf_callers.py over the working tree."
+            elif [ -z "${_csrf_optout}" ]; then
                 echo "@NoCSRFRequired removed but no frontend CSRF-signal added in diff:" >> "${_csrf_log}"
                 echo "${_csrf_removed}" >> "${_csrf_log}"
+                if [ "${_csrf_callers_ran}" -eq 1 ] && [ -n "${_csrf_unprotected}" ]; then
+                    echo "UNPROTECTED mutating call site(s) — these are why the removal blocks:" >> "${_csrf_log}"
+                    echo "${_csrf_unprotected}" >> "${_csrf_log}"
+                elif [ "${_csrf_callers_ran}" -eq 0 ]; then
+                    echo "(caller state NOT inspected: check_csrf_callers.py missing or no src/ — falling back to the diff-only question)" >> "${_csrf_log}"
+                fi
             fi
         fi
     fi

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5896,9 +5896,14 @@ elif [ "${SCOPE_TO_DIFF}" = "1" ] && [ -n "${BASE_REF}" ]; then
             if [ -f "${_csrf_callers_helper}" ] && [ -d src ]; then
                 set +e
                 _csrf_callers_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-csrf-callers.err"
-                _csrf_unprotected=$(python3 "${_csrf_callers_helper}" . 2>"${_csrf_callers_err}")
-                if [ $? -eq 0 ]; then
+                # Assignment inside the `if` so the helper's own status is
+                # tested directly — a crashed interpreter must NOT be read as
+                # "no unprotected callers found", which is the fail-open shape
+                # this gate has been bitten by before.
+                if _csrf_unprotected=$(python3 "${_csrf_callers_helper}" . 2>"${_csrf_callers_err}"); then
                     _csrf_callers_ran=1
+                else
+                    _csrf_unprotected=""
                 fi
                 set +e
             fi


### PR DESCRIPTION
Closes #303.

Two defects, both measured on larpingapp.

## 1. A net-zero MOVE counted as a removal

`check_csrf_removal.py` scanned only `^-` lines and never asked whether an identical `^+` line existed, so relocating a docblock line inside a file read as *deleting* the annotation.

larpingapp#297 moved one comment line while reordering `SettingsController`'s docblocks:

```
-     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
+     * instance-wide configuration write needs. `@NoCSRFRequired` was removed
+     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
```

Byte-identity check on that diff: `identical line also ADDED: True`. Nothing about CSRF changed, and gate-48 **kept `Hydra Gates` red on that repo's `development` from then on**.

Cancellation is **per file** and **by multiset**:

- per file, because a line deleted from one controller and added to another is a real posture change for the first one;
- by multiset, because a diff that removes a tag twice and restores it once has removed it once;
- and whitespace is **not** normalised — a re-indented line is not the same line, and treating it as a move would let a reformat swallow a genuine deletion.

```
pre-fix   removals() on the #297 diff -> 1
post-fix  removals() on the #297 diff -> 0
```

Seven new tests pin this, including the cross-file arm, the remove-twice-restore-once arm, the re-indent arm, and the `+++ b/...` header (which starts with `+` and must not be pooled as an added line).

## 2. The gate could not see a caller that was already compliant

The co-change question was asked of the **diff**. A PR whose callers have *always* sent a token has no signal to add, so it could not pass — the only exits were a waiver or staying red.

Measured on **larpingapp#298, which closes a live CSRF-forgery hole.** `SettingsController::create()` and `reimport()` carried

```php
     * @NoCSRFRequired removed to close the CSRF-forgery surface (closes #206).
```

at docblock-tag position, where Nextcloud's `ControllerMethodReflector` parses annotations with

```php
preg_match_all('/^\h+\*\h+@(?P<annotation>[A-Z]\w+)((?P<parameter>.*))?$/m', $docs, $matches);
```

— so **the sentence announcing the removal *was* the annotation**, and `SecurityMiddleware::isValidCSRF()` returned early. CSRF was never enforced on either state-mutating admin POST. Deleting that line is the fix.

Every frontend caller already sent a token (`requesttoken` on all three `fetch` calls; `CnAdminSettingsShell` uses `@nextcloud/axios`, which injects it), and `OC.requestToken` is kept current rather than snapshotted — `core/src/OC/index.js` subscribes to `csrf-token-update` and reassigns it. So the co-change did not exist to be made, and the cheapest route to green would have been a cosmetic edit under `src/` containing the word `requesttoken`.

### The question it asks instead

New `scripts/lib/check_csrf_callers.py`: *is any mutating caller unprotected right now?* Conservative in the direction that matters:

- **every** mutating call site protected ⇒ whichever one reaches the endpoint is protected, so enforcing CSRF cannot break it → pass, **stating the claim on stdout** rather than passing silently;
- **any** call site unprotected ⇒ we cannot show it is not this endpoint's caller → the removal still blocks, and the log now **names the call site**.

Protection means, within the call expression itself: `requesttoken` / `OCS-APIRequest` (both case-insensitive — HTTP header names are) or `getRequestToken`; or the call goes through `@nextcloud/axios`, imported in that file. Extraction is paren-balanced, so a correct call cannot vouch for an incorrect one beside it — pinned by a test.

## Both arms, end-to-end through the runner on larpingapp#298

```
arm 1  every caller protected
       [gate-48] no CSRF signal was ADDED by this diff, and none was needed:
                 every mutating call site under src/ already carries one …
       [gate-48] csrf-cochange: PASS

arm 2  one unprotected fetch() DELETE added — the opencatalogi#79 shape
       [gate-48] csrf-cochange: FAIL
       UNPROTECTED mutating call site(s) — these are why the removal blocks:
       src/services/__armtwo_probe.js:3 — fetch() DELETE with no CSRF signal
```

**Arm 2 is the one that proves this did not switch the gate off.** opencatalogi#79 — the delete-modal `fetch()` with no CSRF header that gate-48 was built for — is still caught, and its shape is pinned as a test.

## Suites

`scripts/lib/test_*` files 63 → 64; `test_check_csrf_callers.py` is auto-discovered by `run-helper-suites.sh` and passes. Full run: **passed 62, quarantined 2, failed 0.**

## Fallback behaviour

If `check_csrf_callers.py` is absent or the app has no `src/`, the gate falls back to the previous diff-only question and says so in the log — a missing helper must not report pass (#147).
