### PR TITLE
fix(gate-55): add the missing Map key to the icon mirror, and pin its derivation

### DIFF
--- a/hydra-gates/scripts/lib/check_detail_page_discipline.py
+++ b/hydra-gates/scripts/lib/check_detail_page_discipline.py
@@ -56,6 +56,30 @@ import sys
 # This list is a hardcoded mirror — when the registry changes, replace the
 # names below (kept as a single, alphabetically-ordered constant on purpose so
 # the swap is a trivial one-line edit).
+#
+# ⚠️ MIRROR THE OBJECT KEYS, NOT THE IMPORT FILENAMES.
+#
+# `CnIcon` resolves a name with a plain key lookup:
+#
+#     _registry[name] || DASHBOARD_ICONS[name] || ... || HelpCircleOutline
+#
+# so what must appear here is the KEY on the left of each entry in
+# `DASHBOARD_ICONS`. Two keys deliberately differ from the file they import,
+# because the registry name is the concept and the file is just the glyph
+# chosen for it:
+#
+#     ClipboardList: ClipboardListIcon   <- 'vue-material-design-icons/ClipboardListOutline.vue'
+#     Map:           MapIcon             <- 'vue-material-design-icons/MapOutline.vue'
+#
+# Deriving this set by grepping the import statements therefore produces
+# `ClipboardListOutline` / `MapOutline` — names that are NOT registry keys and
+# that render the "?" fallback — while dropping the two that work. That mistake
+# is what .github#304 reported as a registry drift; the mirror was right about
+# `ClipboardList` and the measurement was wrong. Do not "fix" it in that
+# direction.
+#
+# `Map` was the one genuine omission (added by nextcloud-vue's Map dashboard
+# widget); without it the gate REJECTED a valid icon.
 # --------------------------------------------------------------------------
 ICON_REGISTRY = {
     "Account", "AccountBoxOutline", "AccountGroup", "AlertCircleOutline",
@@ -64,7 +88,7 @@ ICON_REGISTRY = {
     "ClipboardList", "Cog", "CurrencyEur", "DatabaseOutline", "Earth", "Email",
     "FileDocument", "FileSign", "FilterVariant", "FolderOutline", "Gauge",
     "Gavel", "HandshakeOutline", "Heart", "History", "Home", "Lightbulb",
-    "LinkVariant", "MapMarker", "MessageTextOutline", "NoteTextOutline",
+    "LinkVariant", "Map", "MapMarker", "MessageTextOutline", "NoteTextOutline",
     "OfficeBuilding", "Package", "Percent", "Phone", "RocketLaunch",
     "ScaleBalance", "School", "ShieldCheckOutline", "Sitemap", "SourceBranch",
     "Star", "TableColumn", "TagOutline", "Timeline", "TrendingDown",

--- a/hydra-gates/scripts/lib/test_check_detail_page_icon_registry.py
+++ b/hydra-gates/scripts/lib/test_check_detail_page_icon_registry.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for gate-55's ICON_REGISTRY mirror in check_detail_page_discipline.py.
+
+The mirror is a hardcoded copy of nextcloud-vue's
+``src/components/CnWidgetGrid/widgetIcons.js``. Nothing enforces the copy, so
+it is a silent expiry date — and when it drifts, the gate is wrong in a
+direction nobody notices: a widget icon is either rejected while it renders
+fine, or accepted while it renders the "?" fallback.
+
+THE DERIVATION IS THE PART THAT GOES WRONG
+------------------------------------------
+``CnIcon`` resolves a name by KEY lookup::
+
+    _registry[name] || DASHBOARD_ICONS[name] || ... || HelpCircleOutline
+
+so the mirror must hold the object KEYS of ``DASHBOARD_ICONS``. Two keys
+deliberately differ from the file they import::
+
+    ClipboardList: ClipboardListIcon  <- '…/ClipboardListOutline.vue'
+    Map:           MapIcon            <- '…/MapOutline.vue'
+
+Deriving the set from the ``import`` statements instead — which is what
+.github#304 did — yields ``ClipboardListOutline`` / ``MapOutline``, names that
+are NOT registry keys and DO render "?", while dropping the two that work. That
+report concluded the mirror had drifted on ``ClipboardList``; the mirror was
+right and the measurement was wrong, and applying its suggested swap would have
+made the gate reject the only working name.
+
+This suite pins both halves so neither can regress:
+
+  1. the working KEYS are present (``Map`` was the one genuine omission —
+     nextcloud-vue added it with the Map dashboard widget, and without it the
+     gate rejected a valid icon);
+  2. the filename-derived spellings are ABSENT, so a future "resync" done by
+     grepping imports fails here instead of silently inverting the gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TARGET = os.path.join(HERE, "check_detail_page_discipline.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_dpd", TARGET)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class IconRegistryMirrorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.registry = _load().ICON_REGISTRY
+
+    def test_keys_whose_import_filename_differs_are_present(self):
+        """The two entries whose key != imported file must be the KEY."""
+        for key in ("ClipboardList", "Map"):
+            self.assertIn(
+                key, self.registry,
+                f"{key!r} is a DASHBOARD_ICONS key; without it the gate rejects "
+                f"an icon that renders correctly",
+            )
+
+    def test_filename_derived_spellings_are_absent(self):
+        """Guards against a resync done by grepping the import statements.
+
+        These names are not registry keys, so an app that used one would render
+        the '?' fallback — accepting them is the failure mode .github#304
+        described, and (by its own suggested fix) would have introduced.
+        """
+        for name in ("ClipboardListOutline", "MapOutline"):
+            self.assertNotIn(
+                name, self.registry,
+                f"{name!r} is an import FILENAME, not a registry key — it "
+                f"renders the '?' fallback",
+            )
+
+    def test_positive_control_unknown_name_is_not_accepted(self):
+        """A name that was never in the registry must not be in the mirror.
+
+        Without this, a mirror that had accidentally become "everything" would
+        satisfy both tests above while checking nothing.
+        """
+        self.assertNotIn("LedgerOutline", self.registry)
+        self.assertNotIn("NotAnIconAtAll", self.registry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #304 — but **not in the direction that issue proposes**. Please read the correction below before merging.

## What #304 got right

The mirror is a hardcoded copy with nothing enforcing it, so it is a silent expiry date. That part stands, and this PR closes it with a test.

## What #304 got wrong

#304 reports:

| | in nc-vue registry | in gate mirror |
|---|---|---|
| `ClipboardList` | ❌ no | ✅ yes |
| `ClipboardListOutline` | ✅ yes | ❌ no |

…and proposes swapping `ClipboardList` → `ClipboardListOutline`.

**That would invert the gate in both directions.** `CnIcon` resolves a name by **key lookup**:

```js
_registry[name] || DASHBOARD_ICONS[name] || ... || HelpCircleOutline
```

so what matters is the **object key** in `DASHBOARD_ICONS`. Two keys deliberately differ from the file they import — the key is the concept, the file is just the glyph chosen for it:

```js
ClipboardList: ClipboardListIcon   // <- 'vue-material-design-icons/ClipboardListOutline.vue'
Map:           MapIcon             // <- 'vue-material-design-icons/MapOutline.vue'
```

#304 extracted the registry "by its import statements", which is where the inversion came from. `ClipboardList` **is** a valid key and renders correctly; `ClipboardListOutline` is **not** a key and renders `?`. Applying the suggested swap would make the gate reject the only working name and accept the broken one.

Measured against the real registry keys on both nc-vue lines (`beta` and `feat/vue-3`, 56 keys each) and against pipelinq's installed `1.0.0-beta.197` — all three carry `ClipboardList:` **and** `Map:` as keys:

```
mirror count: 55 | real KEY count: 56
real NOT in mirror: ['Map']
mirror NOT in real: []
```

## The one genuine drift

`Map`, added upstream with the Map dashboard widget. Without it the gate **rejects a valid icon**. Latent today — no app currently uses it — which is exactly why it would have surfaced as a baffling gate failure on the first one that did.

## The test

`test_check_detail_page_icon_registry.py`, picked up automatically by `run-helper-suites.sh` (no workflow edit). It pins **both** halves:

1. the working **keys** are present;
2. the **filename-derived** spellings are absent — so a future "resync" done by grepping imports fails here loudly instead of silently inverting the gate, which is the specific mistake this PR is correcting;
3. a **positive control**, so a mirror that had accidentally become "everything" cannot satisfy the other two.

Proof it can fail — against `origin/main`:

```
AssertionError: 'Map' not found in {...} : 'Map' is a DASHBOARD_ICONS key;
without it the gate rejects an icon that renders correctly
FAILED (failures=1)
```

With this change: `Ran 3 tests — OK`.

## Also measured while here

The related report that **decidesk has 28 icons rendering the `?` fallback does not reproduce.** decidesk's manifests use **101 distinct icon values across 330 occurrences, and every one resolves** — its own `src/icons.js` registers exactly those 101 (ADR-077, landed in decidesk#363/#364), and `CnIcon` falls back only when a name is in *neither* `registerIcons()` *nor* `DASHBOARD_ICONS`. Both gates confirm it:

```
gate-55 (detail-page-discipline) on decidesk : exit 0, no findings
gate-60 (icon-vocabulary)        on decidesk : checked 49 manifest(s): 0 failure(s), 0 warning(s)
```

So no icons need adding to nc-vue's registry; this one-key mirror correction is the whole of the real defect.

#304's third point still stands and is worth doing separately: a green gate-55 should not be read as "this icon renders", because app-level registration is gate-60's job.