### PR TITLE
fix(gates): five gates that reported PASS over real defects — 45, 46, 19, 13, 20

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -1035,6 +1035,255 @@ def _ref_is_live(doc: _TestFile, pos: int) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Playwright config scope — WHICH FILES DOES CI ACTUALLY RUN? (.github#308)
+# ---------------------------------------------------------------------------
+# This gate counted every `*.spec.ts` under `tests/e2e/**` as a running test.
+# Playwright does not. A file excluded by `testIgnore` — or living outside
+# `testDir`, or not matched by any project's `testMatch` — is never executed,
+# and a scenario referenced ONLY from such a file has no automated proof at all.
+#
+# Measured 2026-08-09 by planting an `@e2e` anchor in a CI-ignored directory:
+# the uncovered count dropped 271 → 270 and the scenario was reported COVERED.
+# The gate could see `describe.skip` (#239) but not the config that silently
+# does the same thing to a whole directory.
+#
+# The live shape in the fleet is openregister's
+# `tests/e2e/api-direct/search-views-presentation.spec.ts`, which carries
+# `@e2e openspec/specs/saved-search-views/spec.md` and sits under
+# `**/api-direct/**` — excluded at top level AND repeated in every project's
+# own `testIgnore`, because a project-level `testIgnore` REPLACES the top-level
+# one rather than merging with it. openconnector's config says so in a comment.
+#
+# WHY A PARSER AND NOT A GLOB LIST
+# --------------------------------
+# `**/visual/**` and `**/docs-screenshots.spec.ts` are ignored by the default
+# project and pulled BACK IN by the `visual` / `docs-capture` projects via
+# `testMatch`. Treating "appears in some testIgnore" as dead would kill both,
+# in every repo that has them — the largest false-positive surface here. A file
+# is dead only when NO project would run it.
+#
+# CONSERVATIVE BY CONSTRUCTION. This reads a TypeScript literal with regexes;
+# it is not a TS evaluator. Every uncertainty resolves to LIVE (i.e. to the
+# pre-existing behaviour): no config, an unparsable config, a `testMatch` that
+# is not a plain regex/string literal, a `testDir` that is not a literal. The
+# gate therefore only ever loses coverage credit for an exclusion it could
+# actually read, and a repo whose config it cannot parse behaves exactly as
+# before this change.
+_PW_CONFIGS = ("playwright.config.ts", "playwright.config.js",
+               "playwright.config.mts", "playwright.config.cjs")
+
+_STR_RE = re.compile(r"""['"]([^'"]*)['"]""")
+
+
+def _strip_ts_comments(text: str) -> str:
+    """Blank out `//` and `/* */` comments, preserving offsets and newlines.
+
+    Not cosmetic. These configs explain themselves at length, and the
+    explanations quote the very keys being parsed — openregister and
+    openconnector both carry a `NOTE: a project-level testIgnore REPLACES the
+    top-level testIgnore` comment. Parsing that sentence as configuration is
+    the #294 mistake in a different file.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c in "\"'`":
+            j = i + 1
+            while j < n and text[j] != c:
+                j += 2 if text[j] == "\\" else 1
+            out.append(text[i:min(j + 1, n)])
+            i = j + 1
+        elif text.startswith("//", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+        elif text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            out.append("".join(ch if ch == "\n" else " " for ch in text[i:j]))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _glob_to_re(glob: str) -> re.Pattern[str] | None:
+    """Minimatch-style glob → regex, for the subset Playwright configs use.
+
+    `**/` matches zero or more directories (so `**/api-direct/**` matches
+    `api-direct/x.spec.ts`), `**` matches anything, `*` matches within one
+    segment, `?` matches one character. Anything with brace/extglob syntax
+    returns None — unparsable means LIVE, never a guess.
+    """
+    if any(ch in glob for ch in "{}()[]!+@"):
+        return None
+    out, i, n = [], 0, len(glob)
+    while i < n:
+        if glob.startswith("**/", i):
+            out.append(r"(?:[^/]+/)*")
+            i += 3
+        elif glob.startswith("**", i):
+            out.append(r".*")
+            i += 2
+        elif glob[i] == "*":
+            out.append(r"[^/]*")
+            i += 1
+        elif glob[i] == "?":
+            out.append(r"[^/]")
+            i += 1
+        else:
+            out.append(re.escape(glob[i]))
+            i += 1
+    try:
+        return re.compile("^" + "".join(out) + "$")
+    except re.error:
+        return None
+
+
+def _match_bracket(text: str, start: int, open_ch: str, close_ch: str) -> int | None:
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == open_ch:
+            depth += 1
+        elif text[i] == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def _value_after(region: str, key: str) -> str | None:
+    """The raw source of `<key>: <value>` inside *region*, at any depth."""
+    m = re.search(r"\b" + key + r"\s*:\s*", region)
+    if not m:
+        return None
+    i = m.end()
+    if i >= len(region):
+        return None
+    if region[i] == "[":
+        end = _match_bracket(region, i, "[", "]")
+        return region[i:end + 1] if end is not None else None
+    end = region.find("\n", i)
+    return region[i:end if end >= 0 else len(region)].rstrip().rstrip(",")
+
+
+def _patterns(raw: str | None) -> list[str] | None:
+    """String literals from a `testIgnore`/`testMatch` value, or None."""
+    if raw is None:
+        return None
+    found = _STR_RE.findall(raw)
+    return found if found else None
+
+
+def _regexes(raw: str | None) -> list[re.Pattern[str]] | None:
+    """`testMatch` as compiled regexes. A `/…/` literal is a JS regex; a
+    quoted value is a glob. Returns None when neither shape is recognised —
+    which the caller reads as "no constraint", i.e. LIVE."""
+    if raw is None:
+        return None
+    out: list[re.Pattern[str]] = []
+    for lit in re.findall(r"/((?:[^/\\\n]|\\.)+)/[gimsuy]*", raw):
+        try:
+            out.append(re.compile(lit))
+        except re.error:
+            return None
+    for s in _STR_RE.findall(raw):
+        r = _glob_to_re(s)
+        if r is None:
+            return None
+        out.append(r)
+    return out or None
+
+
+class _PlaywrightScope:
+    """Answers: would ANY project run this test file?"""
+
+    def __init__(self, app_dir: Path) -> None:
+        self.parsed = False
+        self.test_dir = ""
+        self.projects: list[tuple[list[str] | None, list[re.Pattern[str]] | None]] = []
+        for name in _PW_CONFIGS:
+            cfg = app_dir / name
+            if cfg.is_file():
+                try:
+                    self._parse(_strip_ts_comments(cfg.read_text(encoding="utf-8")))
+                except OSError:
+                    return
+                return
+
+    def _parse(self, text: str) -> None:
+        m = re.search(r"\bprojects\s*:\s*\[", text)
+        blocks: list[str] = []
+        if m:
+            end = _match_bracket(text, m.end() - 1, "[", "]")
+            if end is None:
+                return
+            arr, top = text[m.end():end], text[:m.start()] + text[end + 1:]
+            i = 0
+            while i < len(arr):
+                if arr[i] == "{":
+                    close = _match_bracket(arr, i, "{", "}")
+                    if close is None:
+                        return
+                    blocks.append(arr[i:close + 1])
+                    i = close + 1
+                else:
+                    i += 1
+        else:
+            top = text
+
+        td = _value_after(top, "testDir")
+        if td:
+            lit = _STR_RE.findall(td)
+            if lit:
+                self.test_dir = lit[0].lstrip("./").rstrip("/")
+
+        top_ignore = _patterns(_value_after(top, "testIgnore"))
+        top_match = _regexes(_value_after(top, "testMatch"))
+
+        # A project's OWN testIgnore/testMatch REPLACES the top-level one —
+        # Playwright does not merge them. Both openregister and openconnector
+        # carry that fact as a comment because they were bitten by it.
+        for b in blocks or [""]:
+            ign = _patterns(_value_after(b, "testIgnore")) if b else None
+            mat = _regexes(_value_after(b, "testMatch")) if b else None
+            if b and re.search(r"\btestIgnore\s*:\s*\[\s*\]", b):
+                ign = []          # an explicit empty list clears the top-level one
+            self.projects.append((
+                top_ignore if ign is None else ign,
+                top_match if mat is None else mat,
+            ))
+        self.parsed = True
+
+    def runs(self, rel_to_app: str) -> bool:
+        """True unless the config PROVES no project executes this file."""
+        if not self.parsed or not self.projects:
+            return True
+        if self.test_dir and not rel_to_app.startswith(self.test_dir + "/"):
+            return True   # outside a testDir we may have mis-read — never accuse
+        rel_to_dir = (rel_to_app[len(self.test_dir) + 1:]
+                      if self.test_dir and rel_to_app.startswith(self.test_dir + "/")
+                      else rel_to_app)
+        for ignore, match in self.projects:
+            if match is not None and not any(
+                r.search(rel_to_dir) or r.search(rel_to_app) for r in match
+            ):
+                continue
+            if ignore:
+                compiled = [_glob_to_re(g) for g in ignore]
+                if any(c is None for c in compiled):
+                    return True   # an unreadable glob is not evidence
+                if any(c.match(rel_to_dir) or c.match(rel_to_app)
+                       for c in compiled if c is not None):
+                    continue
+            return True
+        return False
+
+
 def collect_covered_refs(app_dir: Path) -> set[str]:
     """Return the set of ``<spec>::<slug>`` refs found in any e2e test file.
 
@@ -1057,6 +1306,7 @@ def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
     e2e_dir = app_dir / "tests" / "e2e"
     if not e2e_dir.is_dir():
         return live, dead
+    scope = _PlaywrightScope(app_dir)
     for p in e2e_dir.rglob("*"):
         if not p.is_file():
             continue
@@ -1069,6 +1319,13 @@ def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
             text = p.read_text(encoding="utf-8")
         except OSError:
             continue
+        # A FILE THE CONFIG NEVER RUNS IS AS DEAD AS `describe.skip` (#308).
+        #
+        # Checked per file rather than per tag: `testIgnore` switches off the
+        # whole file, so every ref in it is unproven for the same reason, and
+        # the reason names the mechanism so the finding is actionable.
+        rel = str(p.relative_to(app_dir))
+        file_runs = scope.runs(rel)
         # Tokenise ONCE per file, then ask it per tag. nldesign's
         # admin-settings.spec.ts carries 17 tags; the old code re-scanned the
         # whole file for each of them.
@@ -1076,13 +1333,16 @@ def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
         for rex in (_E2E_PATH_RE, _E2E_SHORT_RE):
             for m in rex.finditer(text):
                 ref = f"{m.group('spec')}::{m.group('slug')}"
-                if _ref_is_live(doc, m.end()):
+                if file_runs and _ref_is_live(doc, m.end()):
                     live.add(ref)
                     dead.pop(ref, None)
                 elif ref not in live:
                     dead[ref] = (
-                        f"referenced only by a test that never runs "
-                        f"({p.relative_to(app_dir)})"
+                        f"referenced only by a file no Playwright project "
+                        f"runs — excluded by playwright.config testIgnore/"
+                        f"testMatch ({rel})"
+                        if not file_runs else
+                        f"referenced only by a test that never runs ({rel})"
                     )
     return live, dead
 

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -1678,5 +1678,164 @@ class CodeMaskTest(unittest.TestCase):
         self.assertTrue(cec._ref_is_live(doc, src.index("@e2e") + 4))
 
 
+# ---------------------------------------------------------------------------
+# .github#308 — a file the Playwright config never runs is as dead as
+# `describe.skip`, and this gate could not see it.
+#
+# The config below is openregister's real one, reduced: a top-level
+# `testIgnore` carrying `**/api-direct/**`, a default project that REPEATS it
+# (a project-level `testIgnore` REPLACES the top-level one — Playwright does
+# not merge them, which is why every fleet config repeats the entry), and two
+# opt-in projects that pull `visual/**` and `docs-screenshots.spec.ts` BACK IN
+# via `testMatch`.
+#
+# That last part is the whole false-positive surface. `**/visual/**` and
+# `**/docs-screenshots.spec.ts` appear in a `testIgnore` in fourteen of the
+# fleet's configs; treating "named in some testIgnore" as dead would strip
+# coverage credit from every visual and docs spec in the fleet. Validated
+# against all 21 real configs: 0 dead files anywhere except the api-direct
+# trees that are excluded on purpose (openregister 25, openconnector 6).
+_FLEET_CONFIG = """
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+\ttestDir: './tests/e2e',
+\tprojects: [
+\t\t{
+\t\t\tname: 'chromium',
+\t\t\t// NOTE: a project-level testIgnore REPLACES the top-level testIgnore
+\t\t\t// for this project, so the api-direct exclusion must be repeated here.
+\t\t\ttestIgnore: [
+\t\t\t\t'**/docs-screenshots.spec.ts',
+\t\t\t\t'**/api-direct/**',
+\t\t\t\t'**/visual/**',
+\t\t\t],
+\t\t\tuse: { ...devices['Desktop Chrome'] },
+\t\t},
+\t\t{
+\t\t\tname: 'docs-capture',
+\t\t\ttestMatch: /docs-screenshots\\.spec\\.ts$/,
+\t\t},
+\t\t{
+\t\t\tname: 'visual',
+\t\t\ttestMatch: /visual\\/.*\\.visual\\.spec\\.ts$/,
+\t\t\ttestIgnore: [],
+\t\t},
+\t],
+\ttestIgnore: [
+\t\t'**/node_modules/**',
+\t\t// API-direct specs are HTTP-contract assertions covered by Newman,
+\t\t// not UI-driving Playwright tests.
+\t\t'**/api-direct/**',
+\t],
+})
+"""
+
+_SPEC_MD = """# Saved search views
+
+#### Scenario: Presentation of a saved view
+
+- **WHEN** a user opens a saved view
+- **THEN** the columns are rendered in the stored order
+"""
+
+
+class PlaywrightConfigScopeTest(unittest.TestCase):
+    """A scenario proved only by a file no project runs is NOT covered."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, True)
+        _write(self.root, "playwright.config.ts", _FLEET_CONFIG)
+        _write(self.root, "openspec/specs/saved-search-views/spec.md", _SPEC_MD)
+        self.ref = "saved-search-views::presentation-of-a-saved-view"
+        self.tag = ("// @e2e openspec/specs/saved-search-views/spec.md"
+                    "#presentation-of-a-saved-view\n"
+                    "test('renders', async ({ page }) => {\n"
+                    "  await page.goto('/apps/openregister/views')\n"
+                    "})\n")
+
+    def test_a_tag_in_an_IGNORED_directory_does_not_cover_the_scenario(self):
+        # The measured shape: openregister's
+        # tests/e2e/api-direct/search-views-presentation.spec.ts.
+        _write(self.root, "tests/e2e/api-direct/search-views-presentation.spec.ts",
+               self.tag)
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertNotIn(self.ref, live)
+        self.assertIn(self.ref, dead)
+        self.assertIn("no Playwright project runs", dead[self.ref])
+
+    def test_the_SAME_tag_in_a_run_directory_DOES_cover_it(self):
+        # Anti-widening control. Same tag, same file contents, one directory
+        # over. If this ever goes red the gate has stopped counting real tests.
+        _write(self.root, "tests/e2e/search-views-presentation.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_a_VISUAL_spec_still_covers_although_the_default_project_ignores_it(self):
+        # `**/visual/**` is in the chromium project's testIgnore; the `visual`
+        # project's testMatch runs it. Fourteen fleet configs have this shape.
+        _write(self.root, "tests/e2e/visual/views.visual.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_a_DOCS_SCREENSHOT_spec_still_covers_for_the_same_reason(self):
+        _write(self.root, "tests/e2e/docs-screenshots.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_one_live_reference_rescues_a_ref_also_named_in_an_ignored_file(self):
+        # A ref is dead only when NOTHING live references it.
+        _write(self.root, "tests/e2e/api-direct/search-views.spec.ts", self.tag)
+        _write(self.root, "tests/e2e/search-views.spec.ts", self.tag)
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+        self.assertNotIn(self.ref, dead)
+
+    def test_NO_config_means_every_file_runs(self):
+        # Uncertainty resolves to LIVE — a repo whose config cannot be read
+        # behaves exactly as it did before #308.
+        (self.root / "playwright.config.ts").unlink()
+        _write(self.root, "tests/e2e/api-direct/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_an_UNPARSABLE_config_means_every_file_runs(self):
+        _write(self.root, "playwright.config.ts",
+               "export default defineConfig(loadFromSomewhere())\n")
+        _write(self.root, "tests/e2e/api-direct/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_a_testIgnore_quoted_INSIDE_A_COMMENT_is_not_configuration(self):
+        # Every fleet config explains the replace-not-merge rule in prose that
+        # contains the word `testIgnore:`. Parsing the explanation instead of
+        # the setting is #294's mistake in a different file.
+        _write(self.root, "playwright.config.ts",
+               "export default defineConfig({\n"
+               "\ttestDir: './tests/e2e',\n"
+               "\t// testIgnore: ['**/*.spec.ts'],  <- historical, do not use\n"
+               "})\n")
+        _write(self.root, "tests/e2e/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+
+class GlobTranslationTest(unittest.TestCase):
+    def test_double_star_slash_matches_zero_directories(self):
+        r = cec._glob_to_re("**/api-direct/**")
+        self.assertTrue(r.match("api-direct/x.spec.ts"))
+        self.assertTrue(r.match("deep/nest/api-direct/x.spec.ts"))
+
+    def test_single_star_does_not_cross_a_separator(self):
+        r = cec._glob_to_re("*.spec.ts")
+        self.assertTrue(r.match("a.spec.ts"))
+        self.assertFalse(r.match("dir/a.spec.ts"))
+
+    def test_extglob_and_braces_are_refused_rather_than_guessed(self):
+        self.assertIsNone(cec._glob_to_re("**/*.@(spec|test).ts"))
+        self.assertIsNone(cec._glob_to_re("**/{a,b}/**"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_gate_13_multiline_dialog.sh
+++ b/hydra-gates/scripts/lib/test_gate_13_multiline_dialog.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_13_multiline_dialog.sh — gate-13 must see a dialog tag opened
+# across several lines, which is how Vue components are actually written.
+#
+# WHAT THIS GUARDS (.github#321)
+# ------------------------------
+# The test was `grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]'`. `grep` matches
+# line by line, so a tag with its props on following lines —
+#
+#     <NcDialog
+#         :open="showConfirm"
+#         name="Delete lead">
+#
+# has NOTHING after `<NcDialog` on its own line, the character class cannot
+# match end-of-line, and the tag was invisible.
+#
+# Measured 2026-08-09 on pipelinq: 0 of 9 real violations seen, while the gate
+# passed its own planted true positive the entire time — because a plant is
+# written on one line and a real dialog is not. THAT is why the arms below are
+# built from the shapes the repos contain rather than the minimal case: a
+# minimal plant and a real defect can differ in precisely the feature the
+# regex depends on, and here they did.
+#
+# ARMS
+#   1  a multi-line-opened <NcDialog> is caught          (the real shape)
+#   2  a multi-line-opened <NcModal> is caught too
+#   3  the single-line form still caught                 (no displacement)
+#   4  ANTI-WIDENING — <NcDialogHeader> / <NcModalFooter> are NOT dialogs;
+#      the delimiter must still be required, only widened to end-of-line
+#   5  ANTI-WIDENING — a commented-out dialog is not a dialog
+#   6  ANTI-WIDENING — a component with no dialog at all still PASSes
+#   7  a dialog living correctly under src/dialogs/ is not a finding
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_13_multiline_dialog.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g13.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_mkapp() {  # _mkapp <dir>
+    mkdir -p "$1/src/components" "$1/src/dialogs"
+    printf '{"name":"fx","menu":[]}\n' > "$1/src/manifest.json"
+    (
+        cd "$1" || exit 1
+        git init -q .
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -qm init
+    ) >/dev/null 2>&1
+}
+
+_run13() {  # _run13 <appdir> -> echoes the gate-13 verdict line
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    (
+        cd "$1" || exit 1
+        git add -A >/dev/null 2>&1
+        git -c user.email=t@t -c user.name=t commit -qm wip >/dev/null 2>&1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" . 2>/dev/null
+    ) | grep -E '^\[gate-13\]' || true
+}
+
+_assert() {  # _assert <label> <expected-substring> <actual>
+    case "$3" in
+        *"$2"*) _ok "$1" ;;
+        *)      _bad "$1 — got: $3" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# ARM 1 — pipelinq's shape verbatim.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a1"
+_mkapp "${_app}"
+cat > "${_app}/src/components/LeadList.vue" <<'VUE'
+<template>
+	<div class="lead-list">
+		<NcDialog
+			:open="showConfirm"
+			name="Delete lead"
+			@closing="showConfirm = false">
+			<p>Are you sure?</p>
+		</NcDialog>
+	</div>
+</template>
+<script>
+export default { name: 'LeadList' }
+</script>
+VUE
+_assert "a multi-line-opened <NcDialog> in a parent component → FAIL" \
+    "FAIL" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 2 — the NcModal half of the pattern had the identical defect.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a2"
+_mkapp "${_app}"
+cat > "${_app}/src/components/QueueList.vue" <<'VUE'
+<template>
+	<NcModal
+		v-if="open"
+		size="large"
+		@close="open = false">
+		<div>body</div>
+	</NcModal>
+</template>
+<script>
+export default { name: 'QueueList' }
+</script>
+VUE
+_assert "a multi-line-opened <NcModal> → FAIL" "FAIL" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 3 — the single-line form the gate already caught must STILL be caught.
+# This is the plant that passed while all nine real violations were missed;
+# keeping it proves the widening did not displace the original rule.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a3"
+_mkapp "${_app}"
+cat > "${_app}/src/components/Inline.vue" <<'VUE'
+<template>
+	<div><NcDialog :open="x" name="y" /></div>
+</template>
+<script>
+export default { name: 'Inline' }
+</script>
+VUE
+_assert "the single-line form is still caught → FAIL" "FAIL" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 4 — ANTI-WIDENING. The delimiter is widened to include end-of-line, NOT
+# dropped. A component whose NAME merely starts with NcDialog/NcModal is a
+# different component and must not be reported — otherwise the fix trades one
+# blind gate for a noisy one.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a4"
+_mkapp "${_app}"
+cat > "${_app}/src/components/Header.vue" <<'VUE'
+<template>
+	<div>
+		<NcDialogHeader
+			:title="title" />
+		<NcModalFooter>
+			<slot />
+		</NcModalFooter>
+	</div>
+</template>
+<script>
+export default { name: 'Header' }
+</script>
+VUE
+_assert "<NcDialogHeader> / <NcModalFooter> are NOT dialogs → PASS" \
+    "PASS" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 5 — ANTI-WIDENING. A commented-out dialog is not a dialog. Both the HTML
+# comment in the template and the block/line comments in <script>, and a URL
+# containing `//` must survive the line-comment mask.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a5"
+_mkapp "${_app}"
+cat > "${_app}/src/components/Commented.vue" <<'VUE'
+<template>
+	<div>
+		<!-- TODO: bring this back
+		<NcDialog
+			:open="x" />
+		-->
+		<p>nothing here</p>
+	</div>
+</template>
+<script>
+/*
+ * <NcModal> was removed in favour of the shared dialog.
+ */
+// see https://example.test/docs#NcDialog for the migration note
+export default { name: 'Commented' }
+</script>
+VUE
+_assert "a commented-out <NcDialog>/<NcModal>, plus a https:// URL → PASS" \
+    "PASS" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 6 — a plain component with no dialog at all.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a6"
+_mkapp "${_app}"
+cat > "${_app}/src/components/Plain.vue" <<'VUE'
+<template>
+	<div class="plain">
+		<NcButton @click="go">Go</NcButton>
+	</div>
+</template>
+<script>
+export default { name: 'Plain', methods: { go() {} } }
+</script>
+VUE
+_assert "a component with no dialog → PASS" "PASS" "$(_run13 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 7 — a dialog in its correct home is the thing the rule ASKS for.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a7"
+_mkapp "${_app}"
+cat > "${_app}/src/dialogs/ConfirmDelete.vue" <<'VUE'
+<template>
+	<NcDialog
+		:open="open"
+		name="Confirm delete"
+		@closing="$emit('close')">
+		<p>Are you sure?</p>
+	</NcDialog>
+</template>
+<script>
+export default { name: 'ConfirmDelete' }
+</script>
+VUE
+cat > "${_app}/src/components/Uses.vue" <<'VUE'
+<template>
+	<div><ConfirmDelete :open="open" @close="open = false" /></div>
+</template>
+<script>
+import ConfirmDelete from '../dialogs/ConfirmDelete.vue'
+export default { name: 'Uses', components: { ConfirmDelete } }
+</script>
+VUE
+_assert "a dialog under src/dialogs/, used by import → PASS" "PASS" "$(_run13 "${_app}")"
+
+echo ""
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_13_multiline_dialog.sh: ALL GREEN"
+    exit 0
+fi
+echo "test_gate_13_multiline_dialog.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
+++ b/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_20_comment_masking.sh — gate-20 must not count a commented-out
+# call, and must still count a real one.
+#
+# WHAT THIS GUARDS (.github#294, and #271 underneath it)
+# ------------------------------------------------------
+# Gate-20 had NEVER fired in any repo in its entire existence: its pattern
+# began with `->`, grep parsed that as OPTIONS and exited 2, and
+# `2>/dev/null || true` destroyed both the message and the status. #271
+# repaired the grep and anchored the receiver, which took the fleet yield from
+# 19 false findings down to one real one.
+#
+# The very FIRST thing the repaired gate reported was still not a call. It was
+# openconnector `lib/Service/SearchService.php:189`:
+#
+#     // $directory = $this->objectService->findObjects(filters: [...]);
+#
+# grep has no idea what a comment is. A gate whose first live finding is false
+# is a gate people learn to ignore, so this applies the mask gate-5 got in
+# #196 — `source_scope.py --mask php`, which blanks `//`, `#` and `/* */`
+# while preserving offsets so the reported line number still addresses the
+# real file.
+#
+# ARMS
+#   1  the three comment dialects PHP has are all masked      (0 findings)
+#   2  a REAL call is still reported                          (the point)
+#   3  the reported LINE NUMBER survives masking, and the log shows the
+#      original source line, not a row of blanks
+#   4  ANTI-MASKING — `#[` opens a PHP 8 ATTRIBUTE, not a comment. Treating
+#      it as one swallows the rest of the line, and the line after
+#      `#[NoAdminRequired]` is exactly where these calls live.
+#   5  receiver anchoring from #271 still holds: `$this->schemaMapper->
+#      createFromArray()` is a real method on a different class
+#   6  a file with a real call AND a commented-out one reports ONE finding
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_20_comment_masking.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g20.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_mkapp() {  # _mkapp <dir>
+    mkdir -p "$1/lib/Service" "$1/lib/Controller"
+    (
+        cd "$1" || exit 1
+        git init -q .
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -qm init
+    ) >/dev/null 2>&1
+}
+
+_LAST_LOG_PTR="${_tmp}/last-log-path"
+_run20() {  # _run20 <appdir> -> echoes the gate-20 verdict line
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    printf '%s' "${logs}/hydra-gate-or-objectservice-api.log" > "${_LAST_LOG_PTR}"
+    (
+        cd "$1" || exit 1
+        git add -A >/dev/null 2>&1
+        git -c user.email=t@t -c user.name=t commit -qm wip >/dev/null 2>&1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" . 2>/dev/null
+    ) | grep -E '^\[gate-20\]' || true
+}
+
+_assert() {  # _assert <label> <expected-substring> <actual>
+    case "$3" in
+        *"$2"*) _ok "$1" ;;
+        *)      _bad "$1 — got: $3" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# ARM 1 — openconnector's shape, plus the other two comment dialects.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a1"
+_mkapp "${_app}"
+cat > "${_app}/lib/Service/SearchService.php" <<'PHP'
+<?php
+namespace OCA\Demo\Service;
+
+class SearchService
+{
+	public function search(): array
+	{
+		// $directory = $this->objectService->findObjects(filters: ['_schema' => 'directory']);
+		# $legacy = $this->objectService->deleteFromId(1);
+		/*
+		 * $old = $this->objectService->createFromArray([]);
+		 */
+		return $this->objectService->findAll();
+	}
+}
+PHP
+_assert "//, # and /* */ commented-out calls → PASS" "PASS" "$(_run20 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 2 — the true positive. Masking must not have switched the gate off; that
+# is the failure mode #271 spent a whole session on.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a2"
+_mkapp "${_app}"
+cat > "${_app}/lib/Controller/BookingNotificationController.php" <<'PHP'
+<?php
+namespace OCA\Demo\Controller;
+
+class BookingNotificationController
+{
+	public function guard(string $id): bool
+	{
+		$objectService = $this->container->get(\OCA\OpenRegister\Service\ObjectService::class);
+		$booking = $objectService->findObject($id);
+
+		return $booking !== null;
+	}
+}
+PHP
+_out="$(_run20 "${_app}")"
+_assert "a real \$objectService->findObject() call → FAIL" "FAIL" "${_out}"
+
+# ---------------------------------------------------------------------------
+# ARM 3 — the line number must survive masking, and the log must show the
+# ORIGINAL source line. A mask that shifted offsets would send readers to the
+# wrong line, which is its own kind of blind.
+# ---------------------------------------------------------------------------
+if grep -q 'BookingNotificationController.php:9:' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+    _ok "the finding carries the REAL line number (9) despite the mask"
+else
+    _bad "wrong line number: $(cat "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null)"
+fi
+if grep -q 'findObject(\$id)' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+    _ok "the log shows the ORIGINAL source line, not the blanked mask"
+else
+    _bad "the log does not carry the original source line"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 4 — `#[` is a PHP 8 ATTRIBUTE. If the mask treated it as a `#` comment
+# it would blank the rest of that line; this pins that the code AFTER an
+# attribute is still searched. `#[NoAdminRequired]` is the most load-bearing
+# token in this package and these calls sit directly under it.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a4"
+_mkapp "${_app}"
+cat > "${_app}/lib/Controller/AttrController.php" <<'PHP'
+<?php
+namespace OCA\Demo\Controller;
+
+class AttrController
+{
+	#[NoAdminRequired]
+	public function show(string $id): array
+	{
+		return $this->objectService->findObject($id);
+	}
+}
+PHP
+_assert "a call under a #[NoAdminRequired] attribute is still found → FAIL" \
+    "FAIL" "$(_run20 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 5 — #271's receiver anchoring. `createFromArray()` IS a real method on
+# OpenRegister's Mappers. Un-anchoring produced 14 false findings on
+# openregister and 5 on shillinq; masking must not have loosened it.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a5"
+_mkapp "${_app}"
+cat > "${_app}/lib/Service/RegisterService.php" <<'PHP'
+<?php
+namespace OCA\Demo\Service;
+
+/**
+ * Uses the ObjectService elsewhere, which is why the old file-level
+ * heuristic reported this file.
+ */
+class RegisterService
+{
+	public function seed(array $rows): void
+	{
+		$this->registerMapper->createFromArray($rows);
+		$this->schemaMapper->createFromArray($rows);
+		$this->objectService->saveObject($rows);
+	}
+}
+PHP
+_assert "\$this->schemaMapper->createFromArray() is a different class → PASS" \
+    "PASS" "$(_run20 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 6 — one real call next to a commented-out one is exactly ONE finding.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a6"
+_mkapp "${_app}"
+cat > "${_app}/lib/Service/MixedService.php" <<'PHP'
+<?php
+namespace OCA\Demo\Service;
+
+class MixedService
+{
+	public function run(string $id): array
+	{
+		// $old = $this->objectService->findObjects(['id' => $id]);
+		return $this->objectService->findObject($id);
+	}
+}
+PHP
+_out="$(_run20 "${_app}")"
+_assert "one real call beside a commented one → FAIL" "FAIL" "${_out}"
+_n=$(wc -l < "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null | tr -d ' ')
+if [ "${_n}" = "1" ]; then
+    _ok "exactly ONE finding, not two"
+else
+    _bad "expected 1 finding, got ${_n}"
+fi
+
+echo ""
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_20_comment_masking.sh: ALL GREEN"
+    exit 0
+fi
+echo "test_gate_20_comment_masking.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
+++ b/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
@@ -138,7 +138,7 @@ if grep -q 'BookingNotificationController.php:9:' "$(cat "${_LAST_LOG_PTR}")" 2>
 else
     _bad "wrong line number: $(cat "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null)"
 fi
-if grep -q 'findObject(\$id)' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+if grep -qF 'findObject($id)' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
     _ok "the log shows the ORIGINAL source line, not the blanked mask"
 else
     _bad "the log does not carry the original source line"

--- a/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
+++ b/hydra-gates/scripts/lib/test_gate_20_comment_masking.sh
@@ -138,7 +138,10 @@ if grep -q 'BookingNotificationController.php:9:' "$(cat "${_LAST_LOG_PTR}")" 2>
 else
     _bad "wrong line number: $(cat "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null)"
 fi
-if grep -qF 'findObject($id)' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+# Double-quoted with an escaped `$` rather than single-quoted: ShellCheck's
+# SC2016 fires on ANY single-quoted string containing `$`, and it is fatal in
+# this repository. `\$` inside double quotes is a literal dollar.
+if grep -qF "findObject(\$id)" "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
     _ok "the log shows the ORIGINAL source line, not the blanked mask"
 else
     _bad "the log does not carry the original source line"

--- a/hydra-gates/scripts/lib/test_gate_45_stylesheet_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_stylesheet_scope.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_45_stylesheet_scope.sh — gate-45 must read STYLESHEETS, not only
+# `<style>` blocks written inside markup.
+#
+# WHAT THIS GUARDS (.github#287)
+# ------------------------------
+# Gate-45 (prefers-reduced-motion) had never opened a `.css` file in its entire
+# existence. It scanned `<style>` blocks in `.vue`/`.php`/`.html` and nothing
+# else — so every green it ever produced was a statement about markup, not
+# about CSS. In a Nextcloud app the app-wide motion lives in `css/`, because
+# that is what `Util::addStyle()` loads.
+#
+# Measured 2026-08-09, before the fix:
+#   nldesign      3 stylesheets with motion, 0 reduced-motion guards → gate-45 PASS
+#   openregister  css/main.css, 7 motion declarations, 0 guards      → gate-45 PASS
+#
+# BOTH DIRECTIONS, and the second half is the one that matters. Un-blinding a
+# gate fleet-wide is exactly the change that turns it into a noise generator,
+# so the anti-widening arms below encode the shapes the fleet's stylesheets
+# ACTUALLY contain, not the minimal case:
+#
+#   ARM 1  a stylesheet with unguarded motion FAILS
+#   ARM 2  `@media screen and (prefers-reduced-motion: reduce)` — a full media
+#          prelude, which the old regex could not have matched — PASSES
+#   ARM 3  a commented-out declaration is not a declaration
+#   ARM 4  `transition: none` is how a fallback is WRITTEN, not motion
+#   ARM 5  SCSS `//` comments, without eating the `//` of a `url(https://…)`
+#   ARM 6  a repo-wide UNIVERSAL reset in one file guards every other file —
+#          the gate must accept the fix people will actually write
+#   ARM 7  minified/generated output (webpack `*.chunk.css`, no `.min` in the
+#          name) is not audited: the fix belongs in the source it compiled
+#   ARM 8  the markup arm still works — widening did not displace it
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_45_stylesheet_scope.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g45-css.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+_mkapp() {  # _mkapp <dir> — an app with a css/ and a CLEAN .vue
+    mkdir -p "$1/css" "$1/src"
+    printf '{"name":"fx","menu":[]}\n' > "$1/src/manifest.json"
+    cat > "$1/src/Clean.vue" <<'VUE'
+<template>
+	<div class="x">hi</div>
+</template>
+<script>
+export default { name: 'Clean' }
+</script>
+<style scoped>
+.x { color: red; }
+</style>
+VUE
+    (
+        cd "$1" || exit 1
+        git init -q .
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -qm init
+    ) >/dev/null 2>&1
+}
+
+# The log path is written to a FILE rather than a shell variable on purpose:
+# `$(_run45 …)` is a command substitution, i.e. a subshell, so an assignment
+# made inside it never reaches the caller. That is the same class of mistake
+# this whole suite exists to catch — a check reading a value that was never
+# actually set.
+_LAST_LOG_PTR="${_tmp}/last-log-path"
+_run45() {  # _run45 <appdir> -> echoes the gate-45 verdict line
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    printf '%s' "${logs}/hydra-gate-prefers-reduced-motion.log" > "${_LAST_LOG_PTR}"
+    (
+        cd "$1" || exit 1
+        git add -A >/dev/null 2>&1
+        git -c user.email=t@t -c user.name=t commit -qm wip >/dev/null 2>&1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" . 2>/dev/null
+    ) | grep -E '^\[gate-45\]' || true
+}
+
+_assert() {  # _assert <label> <expected-substring> <actual>
+    case "$3" in
+        *"$2"*) _ok "$1" ;;
+        *)      _bad "$1 — got: $3" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# ARM 1 — a stylesheet with unguarded motion is a FAIL.
+# This is the exact shape measured on openregister's css/main.css.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a1"
+_mkapp "${_app}"
+cat > "${_app}/css/main.css" <<'CSS'
+.spinner {
+	animation: spin 1s linear infinite;
+}
+.btn {
+	transition: background-color 0.3s ease;
+}
+CSS
+_out="$(_run45 "${_app}")"
+_assert "a css/ stylesheet with motion and no guard → FAIL" "FAIL" "${_out}"
+if grep -q 'css/main.css' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+    _ok "the finding NAMES the stylesheet"
+else
+    _bad "the finding does not name css/main.css"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — a full media prelude is a guard.
+#
+# The pre-#287 regex demanded `@media` followed IMMEDIATELY by `(`, so
+# `@media screen and (prefers-reduced-motion: reduce)` — valid, common, and
+# correct — would have been reported as a finding the moment stylesheets came
+# into scope. That is a false-positive engine, not an un-blinding.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a2"
+_mkapp "${_app}"
+cat > "${_app}/css/main.css" <<'CSS'
+.spinner {
+	animation: spin 1s linear infinite;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+	.spinner { animation: none; }
+}
+CSS
+_assert "'@media screen and (prefers-reduced-motion: reduce)' counts as a guard → PASS" \
+    "PASS" "$(_run45 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 3 + 4 + 5 — a commented-out declaration is not a declaration, a
+# `transition: none` is not motion, and SCSS `//` must not eat a URL.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a3"
+_mkapp "${_app}"
+cat > "${_app}/css/commented.css" <<'CSS'
+/* .dead { transition: all 2s ease; } */
+.live { color: blue; }
+CSS
+cat > "${_app}/css/fallback.css" <<'CSS'
+.b { transition: none; }
+.c { animation: none; }
+CSS
+mkdir -p "${_app}/src/styles"
+cat > "${_app}/src/styles/a.scss" <<'SCSS'
+// .commented { animation: pulse 1s infinite; }
+.y { background: url(https://example.test/y.png); }
+SCSS
+_assert "commented-out motion + 'transition: none' + SCSS // and a url(https://) → PASS" \
+    "PASS" "$(_run45 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 6 — a repo-wide UNIVERSAL reset guards every stylesheet.
+#
+# This is the remedy people write: one `@media (prefers-reduced-motion: reduce)
+# { *, *::before, *::after { …duration: 0.01ms !important } }`, once. A
+# strictly per-file rule would report every OTHER stylesheet as a finding the
+# day that reset lands — the gate would punish the correct fix.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a6"
+_mkapp "${_app}"
+cat > "${_app}/css/main.css" <<'CSS'
+.spinner { animation: spin 1s linear infinite; }
+CSS
+_assert "control: without the reset, that file is a finding → FAIL" "FAIL" "$(_run45 "${_app}")"
+cat > "${_app}/css/a11y.css" <<'CSS'
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.01ms !important;
+		transition-duration: 0.01ms !important;
+	}
+}
+CSS
+_assert "a universal reset in ANOTHER file guards the whole repo → PASS" "PASS" "$(_run45 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 7 — generated/minified output is not audited.
+#
+# app-versions ships five `css/main-<hash>.chunk.css` files, each a single
+# 3 kB line of webpack output with `data-v-` scoped rules and no `.min` in the
+# name. A finding there is unactionable in the file it is reported against.
+# Detected by CONTENT (a 500-character line), not by guessing at filenames.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a7"
+_mkapp "${_app}"
+{
+    printf '.a[data-v-06ad9b25]{animation:spin 1s linear infinite}'
+    i=0
+    while [ "${i}" -lt 60 ]; do printf '.p%s{color:red}' "${i}"; i=$((i + 1)); done
+    printf '\n'
+} > "${_app}/css/main-C-zpA6Y.chunk.css"
+_out="$(_run45 "${_app}")"
+_assert "a minified webpack chunk with unguarded motion is NOT audited → PASS" "PASS" "${_out}"
+
+# ---------------------------------------------------------------------------
+# ARM 8 — the ORIGINAL markup arm still works. Widening a gate's scope must
+# not displace what it already caught.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a8"
+_mkapp "${_app}"
+cat > "${_app}/src/Motion.vue" <<'VUE'
+<template>
+	<div class="m">hi</div>
+</template>
+<script>
+export default { name: 'Motion' }
+</script>
+<style scoped>
+.m { transition: opacity 0.4s ease; }
+</style>
+VUE
+_assert "a <style> block with unguarded motion is still a FAIL" "FAIL" "$(_run45 "${_app}")"
+
+echo ""
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_45_stylesheet_scope.sh: ALL GREEN"
+    exit 0
+fi
+echo "test_gate_45_stylesheet_scope.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/lib/test_gate_46_tests_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_46_tests_scope.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_46_tests_scope.sh — gate-46 must resolve `@spec` targets wherever
+# the tag is WRITTEN, and `tests/` is one of those places.
+#
+# WHAT THIS GUARDS (.github#322)
+# ------------------------------
+# Gate-46's enumerator was `find lib src`. It had never opened a test file,
+# and `tests/` is where a large share of the fleet's `@spec` tags live —
+# a test is the natural place to name the requirement it proves.
+#
+# Measured 2026-08-09 over the 21 apps carrying an `openspec/`: 272 unresolved
+# targets under `tests/`, across 16 repos, that no run had ever reported. The
+# textbook case is procest — `tests/Unit/BackgroundJob/DsoDeadlineJobTest.php`
+# annotates `@spec openspec/changes/dso-omgevingsloket/tasks.md#T14` against a
+# tasks.md numbering T01–T08 and V01–V10. There is no T14. The identical tag
+# in `lib/` would have failed this gate since #246.
+#
+# THE PLANTS ARE THE SHAPES THE REPOS ACTUALLY CONTAIN, not the minimal case:
+#   * `#T14` — the `T<n>` shorthand, against a real archived tasks.md, which is
+#     the exact procest finding. A minimal `#nonsense` plant would also fail,
+#     and would NOT have proven that the shorthand resolver treats a
+#     nine-task file honestly.
+#   * a target under `openspec/changes/<name>/` whose directory was ARCHIVED
+#     under a date prefix — the case #322 believed was unchecked. It resolves,
+#     and this suite pins that it resolves, so nobody "fixes" it into a
+#     false positive.
+#
+# BOTH DIRECTIONS. Arm 2 is the one that keeps this honest: a tag in `tests/`
+# whose target and anchor are real must still PASS, or widening the scope has
+# simply moved the blindness into noise.
+
+set -u
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_scripts="$(cd "${_here}/.." && pwd)"
+_runner="${HYDRA_GATES_RUNNER_UNDER_TEST:-${_scripts}/run-hydra-gates.sh}"
+
+_failures=0
+_ok()  { echo "  ok   — $1"; }
+_bad() { echo "  FAIL — $1"; _failures=$((_failures + 1)); }
+
+echo "test_gate_46_tests_scope.sh"
+
+_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g46-tests.XXXXXX")"
+trap 'rm -rf "${_tmp}"' EXIT
+
+# An app whose change directory has been ARCHIVED under a date prefix — the
+# normal end state of an OpenSpec change, and the state #322 mistook for a
+# missing file. `openspec/changes/dso-omgevingsloket/` no longer exists;
+# `openspec/changes/archive/2026-06-13-dso-omgevingsloket/` does.
+_mkapp() {  # _mkapp <dir>
+    mkdir -p "$1/lib" "$1/src" "$1/tests/Unit" \
+             "$1/openspec/changes/archive/2026-06-13-dso-omgevingsloket"
+    printf '{"name":"fx","menu":[]}\n' > "$1/src/manifest.json"
+    cat > "$1/openspec/changes/archive/2026-06-13-dso-omgevingsloket/tasks.md" <<'MD'
+# Tasks: dso-omgevingsloket
+
+## Implementation Tasks
+
+- [x] **T01**: Seed an omgevingsvergunning case type.
+- [x] **T02**: Create DsoCaseService.
+- [x] **T03**: Create BeschikkingGenerationService.
+
+## Verification Tasks
+
+- [x] **V01**: Config keys populated after install.
+MD
+    (
+        cd "$1" || exit 1
+        git init -q .
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -qm init
+    ) >/dev/null 2>&1
+}
+
+_LAST_LOG_PTR="${_tmp}/last-log-path"
+_run46() {  # _run46 <appdir> -> echoes the gate-46 verdict line
+    local logs="${_tmp}/logs.$$.${RANDOM}"
+    mkdir -p "${logs}"
+    printf '%s' "${logs}/hydra-gate-spec-anchor-existence.log" > "${_LAST_LOG_PTR}"
+    (
+        cd "$1" || exit 1
+        git add -A >/dev/null 2>&1
+        git -c user.email=t@t -c user.name=t commit -qm wip >/dev/null 2>&1
+        HYDRA_GATE_LOG_DIR="${logs}" bash "${_runner}" . 2>/dev/null
+    ) | grep -E '^\[gate-46\]' || true
+}
+
+_assert() {  # _assert <label> <expected-substring> <actual>
+    case "$3" in
+        *"$2"*) _ok "$1" ;;
+        *)      _bad "$1 — got: $3" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# ARM 1 — a dangling anchor in a TEST file is a finding.
+#
+# This is procest's shape verbatim: `#T14` against a tasks.md that stops at
+# T03/V01. `T<n>` resolves against HEADINGS and task ids only — deliberately
+# NOT positionally — so a nine-task file must not answer for a fourteenth.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a1"
+_mkapp "${_app}"
+cat > "${_app}/tests/Unit/DsoDeadlineJobTest.php" <<'PHP'
+<?php
+class DsoDeadlineJobTest {
+	/** @spec openspec/changes/dso-omgevingsloket/tasks.md#T14 */
+	public function testDeadlineWarning(): void {}
+}
+PHP
+_out="$(_run46 "${_app}")"
+_assert "a dangling #T14 anchor in tests/ → FAIL" "FAIL" "${_out}"
+if grep -q 'DsoDeadlineJobTest.php' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+    _ok "the finding NAMES the test file"
+else
+    _bad "the finding does not name the test file"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — ANTI-WIDENING. A tag in tests/ whose target and anchor are REAL must
+# PASS, and it must pass THROUGH THE ARCHIVE INDEX: the change directory the
+# tag names was archived under a date prefix and no longer exists at the
+# literal path. This is the resolution #322 believed was absent; pinning it
+# here stops a future "fix" from converting every archived tag in the fleet
+# into a false positive.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a2"
+_mkapp "${_app}"
+cat > "${_app}/tests/Unit/DsoDeadlineJobTest.php" <<'PHP'
+<?php
+class DsoDeadlineJobTest {
+	/** @spec openspec/changes/dso-omgevingsloket/tasks.md#T02 */
+	public function testDeadlineWarning(): void {}
+}
+PHP
+_assert "a REAL #T02 anchor, resolved through the date-prefixed archive → PASS" \
+    "PASS" "$(_run46 "${_app}")"
+
+# ---------------------------------------------------------------------------
+# ARM 3 — a target FILE that never existed is reported from tests/ too, not
+# only from lib/. The two failure modes are separate code paths in the helper.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a3"
+_mkapp "${_app}"
+cat > "${_app}/tests/Unit/GhostTest.php" <<'PHP'
+<?php
+class GhostTest {
+	/** @spec openspec/changes/does-not-exist-at-all/tasks.md#task-1 */
+	public function testGhost(): void {}
+}
+PHP
+_out="$(_run46 "${_app}")"
+_assert "a target file that never existed, tagged in tests/ → FAIL" "FAIL" "${_out}"
+if grep -q 'target file not found' "$(cat "${_LAST_LOG_PTR}")" 2>/dev/null; then
+    _ok "reported as 'target file not found', not as a bad anchor"
+else
+    _bad "the finding is not classified as 'target file not found'"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 4 — the original lib/ scope still works. Widening must not displace it.
+# ---------------------------------------------------------------------------
+_app="${_tmp}/a4"
+_mkapp "${_app}"
+cat > "${_app}/lib/Job.php" <<'PHP'
+<?php
+class Job {
+	/** @spec openspec/changes/dso-omgevingsloket/tasks.md#T99 */
+	public function run(): void {}
+}
+PHP
+_assert "a dangling anchor in lib/ is still a FAIL" "FAIL" "$(_run46 "${_app}")"
+
+echo ""
+if [ "${_failures}" -eq 0 ]; then
+    echo "test_gate_46_tests_scope.sh: ALL GREEN"
+    exit 0
+fi
+echo "test_gate_46_tests_scope.sh: ${_failures} FAILURE(S)"
+exit 1

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2476,9 +2476,39 @@ fi
 # its own file under src/modals/ or src/dialogs/, not inline in parent
 # components. ADR-004 hard rule. Observed 2026-04-30 on doriath.
 # ---------------------------------------------------------------------------
+# THE PATTERN REQUIRED A DELIMITER ON THE SAME LINE (#321).
+#
+# The test was `grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]'`. `grep` matches
+# line by line, so a tag opened across several lines — which is how Vue
+# components with more than one or two props are ACTUALLY written, and what
+# every formatter produces —
+#
+#     <NcDialog
+#         :open="showConfirm"
+#         name="Delete lead">
+#
+# has nothing after `<NcDialog` on its own line. The character class cannot
+# match end-of-line, so the tag was invisible.
+#
+# Measured 2026-08-09 on pipelinq: 0 of 9 real violations seen. The gate passed
+# its own planted true positive the whole time, because a plant is written on
+# one line. That is the trap this band keeps meeting — a minimal plant and a
+# real defect differing in precisely the feature the regex depends on.
+#
+# The delimiter itself is kept, and end-of-line is added to it: `<NcDialogHeader`
+# and `<NcModalX` must still NOT match, or the gate would report every
+# component whose name merely starts with the same letters.
+#
+# COMMENTS ARE MASKED (#294's lesson, applied before it costs anything).
+# Measured across the fleet: masking suppresses zero findings today, so this
+# buys no reduction now — it stops `<!-- <NcDialog … -->` in a TODO from
+# becoming a finding later, which is exactly how gate-20 acquired its
+# commented-out call.
 if [ -d src ]; then
     _mi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-modal-isolation.log
     : > "${_mi_log}"
+    : > "${_mi_log}.err"
+    _mi_rc=0
     # See gate-12 above: `src/` existing is not the same as `src/` containing a
     # Vue component, and this gate printed PASS over an empty glob on nldesign
     # (whose src/ holds one manifest.json). Counted so the two cases can be told
@@ -2492,13 +2522,40 @@ if [ -d src ]; then
         _mi_present=$((_mi_present + 1))
         _in_scope "${vue}" || continue
         _mi_scoped=$((_mi_scoped + 1))
-        if grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]' "${vue}" 2>/dev/null; then
-            echo "${vue}: inline NcModal/NcDialog — extract to src/modals/ or src/dialogs/" >> "${_mi_log}"
-        fi
+        # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262). stderr is
+        # kept and the status is read, so a broken interpreter reports `wiring`
+        # rather than leaving an empty log this gate would call clean.
+        set +e
+        python3 - "${vue}" <<'PYMI' >> "${_mi_log}" 2>>"${_mi_log}.err"
+import re, sys
+fname = sys.argv[1]
+try:
+    src = open(fname, encoding='utf-8', errors='replace').read()
+except Exception:
+    sys.exit(0)
+
+# HTML comments in the template, block and line comments in <script>.
+# `(?<![:\w])` keeps the `//` of a `https://` URL from blanking the rest of
+# the line — the same trap gate-45 hit on `url(https://…)`.
+src = re.sub(r'<!--.*?-->', lambda m: re.sub(r'[^\n]', ' ', m.group(0)), src, flags=re.DOTALL)
+src = re.sub(r'/\*.*?\*/', lambda m: re.sub(r'[^\n]', ' ', m.group(0)), src, flags=re.DOTALL)
+src = re.sub(r'(?<![:\w])//[^\n]*', lambda m: ' ' * len(m.group(0)), src)
+
+# The delimiter set, PLUS end-of-line and any other whitespace. A lookahead
+# rather than a consuming class so the boundary is asserted without being
+# eaten. `<NcDialogHeader` still does not match: `H` is neither whitespace,
+# `>`, `/`, nor end of input.
+if re.search(r'<(NcModal|NcDialog)(?=[\s>/]|$)', src):
+    print(f'{fname}: inline NcModal/NcDialog — extract to src/modals/ or src/dialogs/')
+PYMI
+        _mi_one=$?
+        [ "${_mi_one}" -ne 0 ] && _mi_rc=1
         # .vue only: NcModal/NcDialog are Vue components with a .vue-file rule.
     done < <(find src -name '*.vue' 2>/dev/null)
     _mi_fail=$(wc -l < "${_mi_log}" 2>/dev/null || echo 0)
-    if [ "${_mi_scoped}" -eq 0 ]; then
+    if [ "${_mi_rc}" -ne 0 ]; then
+        _skip 13 "modal-isolation" wiring "the inline modal-isolation checker exited non-zero on at least one of ${_mi_scoped} component(s) — no verdict was produced for them; inline NcModal/NcDialog markup is UNVERIFIED by this run. See ${_mi_log}.err."
+    elif [ "${_mi_scoped}" -eq 0 ]; then
         if [ "${_mi_present}" -eq 0 ]; then
             _skip 13 "modal-isolation" na "src/ exists but contains NO .vue component outside src/modals/ and src/dialogs/, so there is no parent component that could inline a modal. NcModal/NcDialog are Vue SFC components; a PHP/HTML template cannot instantiate one. Reported instead of PASS because an empty glob under an existing src/ is what let twelve gates certify nldesign in #225."
         else

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -5819,6 +5819,46 @@ fi
 #
 # Skill: .claude/skills/hydra-gate-spec-anchor-existence/SKILL.md
 # ---------------------------------------------------------------------------
+# THE SCOPE MUST BE EVERY PLACE A `@spec` TAG IS WRITTEN (#322).
+#
+# The enumerator was `find lib src`. It has never opened a test file — and
+# `tests/` is where a large share of the fleet's `@spec` tags live, because a
+# test is the natural place to name the requirement it proves. Measured
+# 2026-08-09 across the 21 apps that carry an `openspec/`: 272 unresolved
+# targets in `tests/`, in 16 repos, that no run has ever reported.
+#
+# The textbook case is procest. `tests/Unit/BackgroundJob/DsoDeadlineJobTest.php`
+# carries `@spec openspec/changes/dso-omgevingsloket/tasks.md#T14`, and that
+# tasks.md numbers its tasks T01–T08 and its verifications V01–V10. There is no
+# T14 and there never was. The identical tag in `lib/` would have failed this
+# gate since #246.
+#
+# `tests/` ONLY — `openspec/` IS DELIBERATELY NOT IN SCOPE.
+#
+# It looks like the obvious next directory and it is a trap, measured rather
+# than assumed: adding it yields 292 findings, and the bulk are documentation
+# TEMPLATES that quote the tag syntax rather than use it —
+# `openspec/changes/{name}/tasks.md#task-N`, `openspec/changes/<slug>/tasks.md`,
+# `openspec/.../tasks.md#task-N` — in context-briefs and proposals across
+# shillinq, pipelinq and others. Those placeholders cannot resolve and are not
+# meant to. Auditing them would make gate-46 a noise generator on exactly the
+# files that explain what the gate wants, which is how a real finding gets
+# buried. If per-document annotation is wanted later it needs a way to tell a
+# quoted example from a live tag; it is not this gate's job today.
+#
+# WHAT THIS IS NOT. #322 as filed reports that `tasks.md` targets are "never
+# existence-checked" — 353 of them on doriath. That premise does not hold on
+# this package, and the correction is recorded here so nobody re-fixes it: a
+# planted `@spec openspec/changes/does-not-exist-at-all/tasks.md#task-1` IS
+# reported as "target file not found", and a planted `#task-99999` against a
+# real tasks.md IS reported as "anchor not found". The 353 tags all resolve
+# through `build_archive_index`, which exists precisely for the
+# archived-under-a-date-prefix case the issue describes — doriath's
+# `openspec/changes/implement-user-sharing/tasks.md` resolves to
+# `openspec/changes/archive/2026-06-14-implement-user-sharing/tasks.md`, and
+# that file exists at the very commit the issue measured. What made the gate
+# say PASS there is ADR-020 diff scoping, not blindness. The REAL hole the
+# investigation uncovered is the one fixed above: `tests/` was never enumerated.
 _sae_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-anchor-existence.log
 : > "${_sae_log}"
 _sae_files=()
@@ -5826,7 +5866,7 @@ while IFS= read -r f; do
     [ -f "$f" ] || continue
     _in_scope "$f" || continue
     _sae_files+=("$f")
-done < <(find lib src \( -name '*.php' -o -name '*.vue' -o -name '*.js' -o -name '*.ts' -o -name '*.md' \) \
+done < <(find lib src tests \( -name '*.php' -o -name '*.vue' -o -name '*.js' -o -name '*.ts' -o -name '*.md' \) \
     -not -path '*/vendor/*' -not -path '*/node_modules/*' \
     -not -path '*/dist/*' -not -path '*/build/*' 2>/dev/null)
 _sae_ran=1
@@ -5840,7 +5880,7 @@ if [ "${#_sae_files[@]}" -eq 0 ]; then
     # the shape #258 removed from gates 19/25/62/63 and #268 then categorised.
     # Gates 4/6/7/28 have said `na` for the identical situation since #268.
     _sae_ran=0
-    _skip 46 "spec-anchor-existence" na "scope was empty — 0 lib/ or src/ file(s) in this diff, so NO @spec target was resolved. Diff-scoped out under ADR-020: nothing in this repository is missing, and no change the author could make would let this gate inspect a file the diff does not contain. It runs on the next PR that touches annotated code."
+    _skip 46 "spec-anchor-existence" na "scope was empty — 0 lib/, src/ or tests/ file(s) in this diff, so NO @spec target was resolved. Diff-scoped out under ADR-020: nothing in this repository is missing, and no change the author could make would let this gate inspect a file the diff does not contain. It runs on the next PR that touches annotated code."
 elif [ ! -f "${_sae_helper}" ]; then
     # A MISSING HELPER MUST NOT REPORT PASS (#147). The gate previously
     # carried its resolver inline, so "the helper is absent" was not a

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3288,13 +3288,42 @@ fi
 #
 # A grep that ERRORS (rc >= 2) is now a wiring skip, never a pass — the same
 # rule the helper-backed gates in this suite follow.
+#
+# ---------------------------------------------------------------------------
+# A COMMENTED-OUT CALL IS NOT A CALL (.github#294)
+# ---------------------------------------------------------------------------
+# The first thing the un-blinded gate reported in the fleet was not a call. It
+# was openconnector `lib/Service/SearchService.php:189`:
+#
+#     // $directory = $this->objectService->findObjects(filters: [...]);
+#
+# a line that has been commented out. grep has no idea what a comment is, so
+# the gate's very first live finding was false — and a gate whose first finding
+# is false is a gate people learn to ignore.
+#
+# The fix is the pass gate-5 received in #196: run the file through
+# `source_scope.py --mask php` first, which blanks `//`, `#` and `/* */`
+# comments while PRESERVING offsets and newlines, so grep still reports the
+# real line number. `#[` is left alone — it opens a PHP 8 attribute, not a
+# comment, and swallowing it would delete `#[NoAdminRequired]`.
+#
+# String CONTENTS are kept (php_mask's default). A fabricated method name
+# inside a string is not a call either, but blanking strings would delete
+# evidence other gates in this file rely on, and no fleet repo has that shape.
+#
+# The mask is a helper, so it inherits this gate's own rule: if it cannot run,
+# the gate reports `wiring` and NOT a pass. A mask that silently returned
+# nothing would blank every file and make this gate green everywhere — the
+# 2026-08-08 failure mode in a new costume.
 # ---------------------------------------------------------------------------
 if [ -d lib ]; then
     _or_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-or-objectservice-api.log
     : > "${_or_log}"
+    : > "${_or_log}.err"
     _or_hits=0
     _or_ran=1
     _or_broken=""
+    _or_mask="${SCRIPT_DIR}/lib/source_scope.py"
     # Receiver-anchored: the call must be made ON something named
     # `*[Oo]bjectService` — `$this->objectService->`, `$objectService->`,
     # `$this->orObjectService?->`. `$this->schemaMapper->createFromArray()` is
@@ -3304,9 +3333,23 @@ if [ -d lib ]; then
         [ -z "${_file}" ] && continue
         [ -f "${_file}" ] || continue
         _in_scope "${_file}" || continue
+        # Comments blanked BEFORE the search (#294). Offsets and newlines are
+        # preserved by php_mask, so grep's -n line numbers still address the
+        # real file.
+        set +e
+        _or_masked=$(python3 "${_or_mask}" --mask php "${_file}" 2>>"${_or_log}.err")
+        _or_mrc=$?
+        if [ "${_or_mrc}" -ne 0 ] || [ ! -f "${_or_mask}" ]; then
+            # A MASK THAT DID NOT RUN IS NOT AN EMPTY FILE. Falling back to the
+            # raw text would silently restore the #294 false positive; treating
+            # its empty output as clean would make this gate green everywhere.
+            _or_ran=0
+            _or_broken="${_file}"
+            break
+        fi
         # `--` terminates option parsing. The pattern is anchored on `$`, not
         # `-`, since #271, but the guard stays: it is the whole defect.
-        _hits=$(grep -nE -- "${_OR_FABRICATED_RX}" "${_file}" 2>/dev/null)
+        _hits=$(printf '%s\n' "${_or_masked}" | grep -nE -- "${_OR_FABRICATED_RX}" 2>/dev/null)
         _or_rc=$?
         if [ "${_or_rc}" -ge 2 ]; then
             # grep could not run (bad pattern, unreadable file, option-parse
@@ -3319,12 +3362,17 @@ if [ -d lib ]; then
         [ -z "${_hits}" ] && continue
         while IFS= read -r _line; do
             [ -z "${_line}" ] && continue
-            echo "${_file}:${_line}  rule=or-objectservice-fabricated-method" >> "${_or_log}"
+            # The match was made on the MASK; report the ORIGINAL line, so the
+            # log shows the code a reader will find at that line rather than a
+            # row of spaces where a comment used to be.
+            _or_no=${_line%%:*}
+            _or_src=$(sed -n "${_or_no}p" "${_file}" 2>/dev/null)
+            echo "${_file}:${_or_no}:${_or_src}  rule=or-objectservice-fabricated-method" >> "${_or_log}"
             _or_hits=$((_or_hits + 1))
         done <<< "${_hits}"
     done < <(_enum_tracked '\.php$' lib)
     if [ "${_or_ran}" -eq 0 ]; then
-        _skip 20 "or-objectservice-api" wiring "grep exited >= 2 on ${_or_broken} — the fabricated-ObjectService-method search did NOT complete, so no call site was judged. Calls to methods that do not exist on OpenRegister's ObjectService are UNVERIFIED by this run."
+        _skip 20 "or-objectservice-api" wiring "the comment mask or grep did NOT complete on ${_or_broken} — no call site was judged from that file onward. Calls to methods that do not exist on OpenRegister's ObjectService are UNVERIFIED by this run. See ${_or_log}.err."
     elif [ "${_or_hits}" -eq 0 ]; then
         _pass 20 "or-objectservice-api"
     else

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1339,6 +1339,45 @@ _a11y_has_markup_dir() {
     [ -d src ] || [ -d templates ] || [ -d appinfo/templates ]
 }
 
+# _a11y_style_files — every STANDALONE STYLESHEET this repo ships.
+#
+# WHY THIS EXISTS (.github#287)
+# -----------------------------
+# Gate-45 (prefers-reduced-motion) has never read a stylesheet. It scans
+# `<style>` blocks inside markup and nothing else, so every green it has
+# produced is a statement about markup, not about CSS. Motion in a `.css`
+# file — which is where a Nextcloud app's app-wide motion actually lives,
+# because `css/` is what `Util::addStyle()` loads — was invisible.
+#
+# Measured 2026-08-09:
+#   nldesign     3 stylesheets declaring motion, 0 `prefers-reduced-motion`
+#                guards (css/admin.css, css/systems/nldesign/theme.css,
+#                css/systems/summer-breeze/element-overrides.css) — gate-45 PASS
+#   openregister css/main.css, 7 motion declarations, 0 guards — gate-45 PASS
+#                both before and after the file was touched
+#
+# SCOPE mirrors `_a11y_markup_files` and adds `css/`, the Nextcloud-conventional
+# home for an app's stylesheets. Excluded on purpose:
+#   - the same generated/third-party trees (node_modules, vendor, dist, build,
+#     coverage, phpmetrics)
+#   - `*.min.css` — minified third-party output. A minified file is one line, so
+#     it would be audited as a single enormous block, and it is not ours to fix.
+_a11y_style_files() {
+    find css src templates appinfo/templates -type f \
+        \( -name '*.css' -o -name '*.scss' -o -name '*.sass' -o -name '*.less' \) \
+        2>/dev/null \
+        | grep -vE '(^|/)(node_modules|vendor|dist|build|coverage|phpmetrics|\.git)/' \
+        | grep -vE '\.min\.(css|scss|sass|less)$' \
+        || true
+}
+
+# The directories a stylesheet can live in. `css/` is deliberately included even
+# though no other a11y gate reads it: an app can ship `css/` with no src/ and no
+# templates/ at all, and that stylesheet is still loaded into a real page.
+_a11y_has_style_dir() {
+    [ -d css ] || _a11y_has_markup_dir
+}
+
 _skip() {
     set +e   # backstop — see the errexit invariant at the top of this file
     local _cat _reason
@@ -5587,12 +5626,80 @@ fi
 # counts as a claim someone can dispute, whereas `na` removes the gate from the
 # coverage arithmetic entirely — the run then reports "all applicable gates
 # green" with the defect inside it.
-if _a11y_has_markup_dir; then
+# A STYLESHEET IS WHERE THE MOTION ACTUALLY IS (#287).
+#
+# This gate scanned `<style>` blocks in markup and NOTHING ELSE — it had never
+# opened a `.css` file in its entire existence. In a Nextcloud app the app-wide
+# motion lives in `css/`, because that is what `Util::addStyle()` loads; a
+# `<style scoped>` block only ever styles one component.
+#
+# Measured 2026-08-09: nldesign ships three stylesheets with motion and zero
+# reduced-motion guards, and openregister's `css/main.css` has seven motion
+# declarations and zero guards. Gate-45 said PASS on both. Every gate-45 green
+# in the fleet before this commit was a statement about markup only.
+#
+# The unit differs by file type, and deliberately so:
+#   markup      one `<style>` block. A guard in a DIFFERENT block on the same
+#               page does not cover this one — `scoped` blocks are independent.
+#   stylesheet  the whole file. `@media (prefers-reduced-motion: reduce)`
+#               is conventionally written once at the bottom of a stylesheet
+#               and disables motion for everything above it, so requiring a
+#               guard per rule would flag correct code.
+if _a11y_has_style_dir; then
     _rm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-prefers-reduced-motion.log
     : > "${_rm_log}"
     : > "${_rm_log}.err"
     _rm_seen=0
     _rm_rc=0
+    # THE GATE MUST ACCEPT THE FIX PEOPLE WILL ACTUALLY WRITE (#287).
+    #
+    # The canonical remedy for unguarded motion is ONE universal reset, written
+    # once for the whole app:
+    #
+    #   @media (prefers-reduced-motion: reduce) {
+    #     *, *::before, *::after {
+    #       animation-duration: 0.01ms !important;
+    #       transition-duration: 0.01ms !important;
+    #     }
+    #   }
+    #
+    # It lives in a single stylesheet and covers every other one. A per-file
+    # rule would report every OTHER stylesheet as a finding the day that reset
+    # lands — the gate would punish the correct fix. So the whole style corpus
+    # is scanned once for a universal reset first, and a repo that has one is
+    # globally guarded.
+    #
+    # NOT diff-scoped, deliberately: the reset is usually in a file this PR did
+    # not touch. Scoping it would resurrect the false positives it exists to
+    # prevent. Measured 2026-08-09: NO repo in the fleet has one today, so this
+    # pre-pass suppresses nothing right now — it is here so that fixing the
+    # 43 findings this commit surfaces actually turns the gate green.
+    #
+    # Fails CLOSED: any error leaves the flag at 0, i.e. more findings, never
+    # fewer. A crashed pre-pass must not manufacture a global exemption.
+    _rm_global=0
+    if [ -n "$(_a11y_style_files)" ]; then
+        _rm_global=$(_a11y_style_files | python3 -c '
+import re, sys
+UNIVERSAL = re.compile(
+    r"@media[^{]*prefers-reduced-motion[^{]*\{(?:[^{}]|\{[^{}]*\})*?(?<![\w.#\[-])\*",
+    re.IGNORECASE | re.DOTALL)
+for line in sys.stdin:
+    p = line.strip()
+    if not p:
+        continue
+    try:
+        if UNIVERSAL.search(open(p, encoding="utf-8", errors="replace").read()):
+            print(1)
+            break
+    except Exception:
+        continue
+else:
+    print(0)
+' 2>>"${_rm_log}.err" || echo 0)
+        [ "${_rm_global}" = "1" ] || _rm_global=0
+    fi
+    export HYDRA_RM_GLOBAL_GUARD="${_rm_global}"
     while IFS= read -r vue; do
         _in_scope "${vue}" || continue
         _rm_seen=$((_rm_seen + 1))
@@ -5606,19 +5713,79 @@ if _a11y_has_markup_dir; then
         # is recoverable, and the status is read.
         set +e
         python3 - "$vue" <<'PYRM' >> "${_rm_log}" 2>>"${_rm_log}.err"
-import re, sys
+import os, re, sys
 fname = sys.argv[1]
 try:
-    src = open(fname).read()
+    src = open(fname, encoding='utf-8', errors='replace').read()
 except Exception:
     sys.exit(0)
-for m in re.finditer(r'<style\b[^>]*>(.*?)</style>', src, re.IGNORECASE | re.DOTALL):
-    block = m.group(1)
-    if not re.search(r'\b(transition|animation)\s*:', block):
-        continue
-    if re.search(r'@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)', block, re.IGNORECASE):
-        continue
-    print(f'{fname}: <style> rule=motion-without-reduced-motion-fallback')
+
+# A repo-wide universal reduced-motion reset covers every stylesheet AND every
+# scoped <style> block (it is `*` + `!important`), so it globally guards. See
+# the pre-pass in the runner for why this is not diff-scoped.
+if os.environ.get('HYDRA_RM_GLOBAL_GUARD') == '1':
+    sys.exit(0)
+
+STYLESHEET = re.compile(r'\.(css|scss|sass|less)$', re.IGNORECASE)
+MOTION = re.compile(r'\b(transition|animation)\s*:\s*([^;}]*)', re.IGNORECASE)
+
+# THE GUARD MUST RECOGNISE THE MEDIA QUERIES PEOPLE ACTUALLY WRITE (#287).
+#
+# The old pattern demanded `@media` followed IMMEDIATELY by `(`. It therefore
+# did not recognise `@media screen and (prefers-reduced-motion: reduce)`, nor
+# the `@media (prefers-reduced-motion)` shorthand, nor the inverse
+# `@media (prefers-reduced-motion: no-preference) { ...motion here... }` idiom.
+# All three are correct, and all three would have been reported as findings the
+# moment stylesheets came into scope — a false-positive engine.
+GUARD = re.compile(r'@media[^{]*prefers-reduced-motion', re.IGNORECASE)
+
+# A COMMENTED-OUT DECLARATION IS NOT A DECLARATION (#294, same lesson).
+def _mask_comments(text, scss):
+    text = re.sub(r'/\*.*?\*/', lambda m: re.sub(r'[^\n]', ' ', m.group(0)), text, flags=re.DOTALL)
+    if scss:
+        # `//` only in SCSS/SASS/LESS dialects, and never the `//` of a
+        # `url(https://...)`, which is why the colon is excluded before it.
+        text = re.sub(r'(?<!:)//[^\n]*', lambda m: ' ' * len(m.group(0)), text)
+    return text
+
+def _motion_without_guard(block):
+    """True when the block animates something and never guards it.
+
+    `transition: none` / `animation: none` are how a reduced-motion fallback
+    is WRITTEN. Counting them as motion would make every correct guard block
+    its own finding."""
+    if GUARD.search(block):
+        return False
+    for m in MOTION.finditer(block):
+        value = m.group(2).strip().lower()
+        if value.split()[0:1] in ([], ['none'], ['unset'], ['initial'], ['inherit']):
+            continue
+        return True
+    return False
+
+def _is_minified(text):
+    """Generated/minified output, detected by CONTENT rather than by filename.
+
+    `.min.css` is caught by the enumerator, but webpack writes `css/main-<hash>
+    .chunk.css` with no `.min` in the name — app-versions ships five of them,
+    every one a single 3 kB line of `data-v-` scoped rules. Findings in
+    generated CSS are unactionable in the file they are reported against: the
+    fix belongs in the source the bundler compiled. A 500-character line is
+    something no hand-written stylesheet has and every minified one does."""
+    return any(len(line) > 500 for line in text.split('\n'))
+
+if STYLESHEET.search(fname):
+    if _is_minified(src):
+        sys.exit(0)
+    scss = not fname.lower().endswith('.css')
+    if _motion_without_guard(_mask_comments(src, scss)):
+        print(f'{fname}: stylesheet rule=motion-without-reduced-motion-fallback')
+else:
+    for m in re.finditer(r'<style\b([^>]*)>(.*?)</style>', src, re.IGNORECASE | re.DOTALL):
+        attrs, block = m.group(1), m.group(2)
+        scss = bool(re.search(r'lang\s*=\s*["\']?(scss|sass|less)', attrs, re.IGNORECASE))
+        if _motion_without_guard(_mask_comments(block, scss)):
+            print(f'{fname}: <style> rule=motion-without-reduced-motion-fallback')
 PYRM
         # `$?` immediately after a heredoc-fed command is the command's status;
         # captured into a named variable rather than tested inline so
@@ -5626,17 +5793,17 @@ PYRM
         # a construct where `if ! cmd <<HEREDOC` is not available.
         _rm_one=$?
         [ "${_rm_one}" -ne 0 ] && _rm_rc=1
-    done < <(_a11y_markup_files)
+    done < <(_a11y_markup_files; _a11y_style_files)
     _rm_fail=$(wc -l < "${_rm_log}" 2>/dev/null || echo 0)
     if [ "${_rm_rc}" -ne 0 ]; then
-        _skip 45 "prefers-reduced-motion" wiring "the inline reduced-motion checker exited non-zero on at least one of ${_rm_seen} markup file(s) — no verdict was produced for them; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run. See ${_rm_log}.err."
+        _skip 45 "prefers-reduced-motion" wiring "the inline reduced-motion checker exited non-zero on at least one of ${_rm_seen} markup/stylesheet file(s) — no verdict was produced for them; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run. See ${_rm_log}.err."
     elif [ "${_rm_seen}" -eq 0 ]; then
         # AN UNOPENED SCOPE IS NEVER A PASS (#242/#240/#258/#268).
-        _skip 45 "prefers-reduced-motion" na "scope was empty — 0 markup file(s) (src/, templates/, appinfo/templates/) in this diff, so NO <style> block was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run."
+        _skip 45 "prefers-reduced-motion" na "scope was empty — 0 markup or stylesheet file(s) (css/, src/, templates/, appinfo/templates/) in this diff, so NO <style> block and NO stylesheet was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run."
     elif [ "${_rm_fail}" -eq 0 ]; then
         _pass 45 "prefers-reduced-motion"
     else
-        _fail 45 "prefers-reduced-motion" "${_rm_fail} <style> block(s) with motion but no reduced-motion fallback — see ${_rm_log}"
+        _fail 45 "prefers-reduced-motion" "${_rm_fail} <style> block(s)/stylesheet(s) with motion but no reduced-motion fallback — see ${_rm_log}"
     fi
 fi
 


### PR DESCRIPTION
Five gates that reported **PASS over real defects**. Every green each of them has produced is worth nothing, so each fix is proven in **both directions** — FAIL on the shape the repos actually contain, PASS on a clean one — and each carries a regression suite that goes **red against the pre-fix runner**.

| # | Gate | Was blind to | Fleet findings |
|---|---|---|---|
| #287 | 45 prefers-reduced-motion | every stylesheet — it had never opened a `.css` file | 0 → **37** |
| #322 | 46 spec-anchor-existence | `tests/`, never enumerated | 679 → **951** (+272) |
| #308 | 19 e2e-coverage | Playwright `testIgnore` | **0** (hole real, unexploited) |
| #321 | 13 modal-isolation | every multi-line-opened dialog | 8 → **92** files (+84) |
| #294 | 20 or-objectservice-api | comments — its first live finding was one | 2 → **1** |

---

## #287 — gate-45 has never read a stylesheet

`_a11y_markup_files` enumerates `.vue`/`.php`/`.html` and scans `<style>` blocks. In a Nextcloud app the app-wide motion lives in `css/`, because that is what `Util::addStyle()` loads; a `<style scoped>` block only ever styles one component.

Reproduced: `css/main.css` with `animation:` + `transition:` and no guard → `[gate-45] prefers-reduced-motion: PASS`. Real instances: **nldesign** 3 stylesheets, 0 guards; **openregister** `css/main.css`, 7 motion declarations, 0 guards.

The un-blinding needed four false-positive controls, because widening a gate fleet-wide is exactly what turns it into a noise generator:

- the guard regex demanded `@media` followed *immediately* by `(`, so `@media screen and (prefers-reduced-motion: reduce)` — valid and common — would have become a finding
- comments masked; `//` only in SCSS dialects and never the `//` of `url(https://…)`
- `transition: none` is how a fallback is **written**, not motion
- **a repo-wide universal reset in one file guards every other file** — otherwise the gate reports every other stylesheet the day the correct fix lands. Measured: no fleet repo has one today, so this suppresses nothing now; it exists so that fixing these 37 actually turns the gate green
- generated output skipped by **content** (a >500-char line), which catches webpack's `css/main-<hash>.chunk.css` that has no `.min` in its name — 6 findings in app-versions/openwoo dropped

**37 findings** over 40 repos; **14 in the GitHub fleet** (nextcloud-vue 8, nldesign 3, opencatalogi 1, openconnector 1, openregister 1). Existing markup arm unchanged at 143 — nothing widened by accident.

## #322 — gate-46, with a correction to the issue's premise

**The filed premise does not hold on this package**, and I've [posted the measurement on the issue](https://github.com/ConductionNL/.github/issues/322#issuecomment-5237964779) so it is corrected where it was read. Planted tags prove `tasks.md` targets **are** existence-checked; doriath's 353 all resolve through `build_archive_index`, which exists precisely for the archived-under-a-date-prefix case, and the archived file exists at the very commit the issue measured. What produced `PASS` there was ADR-020 diff scoping.

**The real hole the investigation found:** the enumerator is `find lib src`. It has never opened a test file. **272 unresolved targets under `tests/`, in 16 repos.** The textbook case is procest — `DsoDeadlineJobTest.php` annotates `tasks.md#T14` against a file numbering **T01–T08** and **V01–V10**.

**Landed as a hard FAIL**, not a WARN. Diff-scoped under ADR-020, so debt in an untouched test file never blocks a PR; the finding surfaces on the PR that edits it, which is when the tag should be re-checked. A WARN would reproduce the failure mode this band exists to remove.

**`openspec/` deliberately not added** — measured at 292 findings, dominated by documentation templates quoting the syntax (`openspec/changes/{name}/tasks.md#task-N`).

## #308 — gate-19 cannot see `testIgnore`

Every `*.spec.ts` under `tests/e2e/**` counted as a running test. Playwright disagrees. Proven by planting an anchor in a CI-ignored directory: **271 → 270 with the scenario reported COVERED**.

**A glob list would have been the bug.** `**/visual/**` and `**/docs-screenshots.spec.ts` sit in a `testIgnore` in fourteen fleet configs and are pulled **back in** by the `visual` / `docs-capture` projects via `testMatch`. Treating "named in some testIgnore" as dead would have stripped coverage credit from every visual and docs spec in the fleet. A file is dead only when **no** project would run it.

Validated against **all 21 real fleet configs**: every one parses; the only dead files anywhere are the `api-direct` trees excluded on purpose (openregister 25, openconnector 6). Visual and docs specs: 0 dead.

**Fleet finding count: zero.** Those `api-direct` files carry only prose mentions of `@e2e` plus one whole-spec tag with no slug. The hole is real and proven by a plant; nothing is exploiting it today, so this lands with no churn.

Conservative by construction — no config, an unparsable config, an extglob/brace pattern, a non-literal `testMatch`/`testDir` all resolve to **LIVE**, i.e. to the pre-existing behaviour. Comments masked first: every fleet config explains the replace-not-merge rule in prose containing `testIgnore:`.

## #321 — gate-13 misses every multi-line-opened dialog

`grep -qE '<NcModal[ \t>/]|<NcDialog[ \t>/]'` matches line by line, so

```vue
<NcDialog
    :open="showConfirm"
    name="Delete lead">
```

has nothing after `<NcDialog` on its own line and the character class cannot match end-of-line. **pipelinq: 0 of 9 real violations seen**, while the gate passed its own planted true positive the whole time — because a plant is written on one line and a real dialog is not.

The delimiter is **widened** to include end-of-line, not dropped, so `<NcDialogHeader>` still does not match. Comment masking also removes a **false positive** the old pattern had: it reported a `<NcModal>` inside a `/* */` block.

**8 → 92 files** across 10 repos — nextcloud-vue 50, procest 13, pipelinq 9, doriath 6, docudesk 4, openregister 3, softwarecatalog 3, decidesk 2, app-versions 1, hermiq 1. nextcloud-vue is the shared component library and accounts for over half; its findings are dialog components outside `src/dialogs/` rather than modals inlined in a parent. Hard FAIL, unchanged from what gate-13 already is; diff-scoped, so none of it blocks a PR that does not touch the file.

## #294 — gate-20 counted a commented-out call

The first thing the repaired gate reported in the fleet was openconnector `lib/Service/SearchService.php:189` — `// $directory = $this->objectService->findObjects(...)`. A gate whose first live finding is false is a gate people learn to ignore.

Applies the pass gate-5 got in #196: `source_scope.py --mask php`, which blanks `//`, `#` and `/* */` while preserving offsets so the reported line number still addresses the real file. `#[` is left alone — it opens a PHP 8 **attribute**, and the line these calls sit under is `#[NoAdminRequired]`. The log now shows the **original** source line, not the blanked mask.

The mask inherits the gate's own rule: if it cannot run, the gate reports `wiring`, **not** a pass. Falling back to raw text would restore the false positive; treating empty mask output as clean would make gate-20 green everywhere — the same failure mode in a new costume.

**2 → 1 findings.** The one kept is shillinq's real `findObject()` on a container-resolved `ObjectService`, the true yield #271 identified.

---

## Verification

Both-direction proof for every fix, plus a **negative control** — each new suite run against the pre-fix runner:

| Suite | vs pre-fix runner |
|---|---|
| `test_gate_45_stylesheet_scope.sh` (8 arms) | **3 red**, 5 anti-widening green |
| `test_gate_46_tests_scope.sh` (6 arms) | **5 red**, `lib/` arm green |
| `test_check_e2e_coverage.py` (+11 tests, 105 → 116) | **4 red**, 7 anti-widening green |
| `test_gate_13_multiline_dialog.sh` (7 arms) | **3 red**, 4 anti-widening green |
| `test_gate_20_comment_masking.sh` (8 arms) | **2 red**, 4 true-positive arms green |

Each suite's *anti-widening* arms stay green in **both** runs — the suites are not "everything fails".

- Every checker proven to have **lived**: `.err` 0 bytes on each measurement, never an exit code read in place of output.
- The three new `.sh` suites are picked up automatically by `tests/run-helper-suites.sh` (discovery-based, no workflow edit).
- `test_gate_45_to_55_acceptance.sh` run with `NODE_PATH` set — ajv preflight from #292 intact, **ALL GREEN**.
- `test_gate_a11y_markup_scope.sh` ALL PASS; `test_check_spec_anchors.py` 50/50; full `run-helper-suites.sh` green.
- No new `_skip` category introduced, so `--require-full-coverage` is unaffected. gate-13 and gate-20 **gain** a `wiring` skip for a crashed checker, replacing a silent pass.
- `quality.yml` untouched.

Closes #287
Closes #308
Closes #321
Closes #294
Refs #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
