### PR TITLE
fix(gates): eight false-positive defects across gates 3/6/7/26/29/40/44/55

### DIFF
--- a/hydra-gates/scripts/lib/check_autocomplete.py
+++ b/hydra-gates/scripts/lib/check_autocomplete.py
@@ -67,10 +67,81 @@ HAS_AUTOCOMPLETE = re.compile(r'(?:^|\s)(?::|v-bind:)?autocomplete\s*=')
 NAME_LIKE = re.compile(
     r'(?:^|\s)(?::|v-bind:)?(?:name|id|v-model)\s*=\s*'
     r'(?:"([^"]+)"|\'([^\']+)\')')
-SEMANTIC = re.compile(
-    r'(email|tel(?:ephone)?|phone|firstname|lastname|fullname|address|street'
-    r'|city|postal|postcode|zip|country|password|username|organization'
-    r'|birthday|dob)', re.IGNORECASE)
+# WHICH TOKEN IS THE NOUN (.github#319)
+# ------------------------------------
+# This was a bare substring alternation with no word boundaries:
+#
+#     re.compile(r'(email|tel(?:ephone)?|phone|...|city|postal|zip|...)')
+#
+# so `city` matched inside `capa*city*`, and equally would match `opacity`,
+# `velocity`, `simplicity`, `electricity`; `tel` matched inside `ho*tel*`; `zip`
+# inside `g*zip*`/`un*zip*`. Measured on pipelinq: two `type="number"`
+# `min="1"` queue-capacity settings (`queue-edit-max-capacity`,
+# `queue-new-max-capacity`) reported as collecting a personal detail.
+#
+# TOKEN BOUNDARIES ALONE ARE NOT ENOUGH, which is why this does more than
+# #319's suggested `\b` anchoring. Measured on nldesign, all three findings:
+#
+#     nldesign-email-footer-org-name
+#     nldesign-email-footer-accessibility-url
+#     nldesign-email-footer-privacy-url
+#
+# `email` IS a whole hyphen-delimited token in each, so a `\b`-anchored regex
+# still fires — yet these are the EMAIL FOOTER settings, and the three fields
+# collect an organisation name and two URLs. None collects an email address.
+#
+# What separates them is WHERE the noun sits. An identifier names its subject
+# at the END and qualifies it at the front: `portal-change-email` collects an
+# email; `nldesign-email-footer-org-name` collects a NAME, and `email` there is
+# context ("the email footer"), not the datum. So the semantic term must fall
+# in the LAST TWO tokens.
+#
+# The window is two rather than one because the noun legitimately carries a
+# qualifier on either side:
+#
+#   postal-code   zip-code   phone-number   street-address   post-code
+#   emailRecipient                       <- noun first, qualifier after
+#
+# Measured: a strict last-token-only rule dropped nextcloud-vue's
+# `fieldIdFor('emailRecipient')` — an `<input type="email">` that genuinely
+# wants `autocomplete="email"` — so it was widened to two and that true
+# positive is pinned by a test.
+#
+# The vocabulary is deliberately NOT extended while fixing a false-positive
+# defect. `organisation` (British spelling) was tried and reverted: it made
+# decidesk's admin-settings "Organization name" field a finding, and that is
+# site configuration, not information about the user, so WCAG 1.3.5 does not
+# apply to it. Widening a vocabulary is a different change with a different
+# burden of proof.
+#
+# Every relaxation here ships with the true positive it must not swallow —
+# see `SemanticTokenBoundaries` in test_check_autocomplete.py.
+_SEMANTIC_TOKENS = {
+    'email', 'tel', 'telephone', 'phone', 'firstname', 'lastname', 'fullname',
+    'address', 'street', 'city', 'postal', 'postcode', 'zip', 'country',
+    'password', 'username', 'organization', 'birthday', 'dob',
+}
+
+_TOKEN_SPLIT = re.compile(r'[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])')
+
+
+def _tokens(value: str) -> list[str]:
+    """`portal-change-email` / `form.granteeEmail` -> lowercase word tokens."""
+    return [t.lower() for t in _TOKEN_SPLIT.split(value) if t]
+
+
+def _is_semantic(value: str) -> bool:
+    """True when the identifier NAMES a well-known personal detail."""
+    toks = _tokens(value)
+    if not toks:
+        return False
+    window = toks[-2:]
+    if any(t in _SEMANTIC_TOKENS for t in window):
+        return True
+    # `first-name` / `firstName` / `post-code` join into one known term.
+    if len(window) == 2 and (window[0] + window[1]) in _SEMANTIC_TOKENS:
+        return True
+    return False
 
 
 def scan_source(fname: str, src: str) -> list[str]:
@@ -94,7 +165,7 @@ def scan_source(fname: str, src: str) -> list[str]:
         # textbook case this gate has.
         for name_m in NAME_LIKE.finditer(attrs):
             val = name_m.group(1) if name_m.group(1) is not None else name_m.group(2)
-            if SEMANTIC.search(val):
+            if _is_semantic(val):
                 findings.append(
                     f'{fname}: <input name/id="{val}" ...> '
                     f'rule=semantic-input-without-autocomplete')

--- a/hydra-gates/scripts/lib/check_detail_page_discipline.py
+++ b/hydra-gates/scripts/lib/check_detail_page_discipline.py
@@ -420,9 +420,32 @@ def check_page(path, page, page_ids, findings):
     _collect(widgets, "icon", icons)
     for ic in icons:
         if isinstance(ic, str) and ic and ic not in ICON_REGISTRY:
+            # THE SYMPTOM IS SILENT, NOT A '?' (.github#304).
+            #
+            # This message used to say the icon "renders the '?' fallback".
+            # It does not. Read from nextcloud-vue
+            # src/components/CnWidgetGrid/widgetIcons.js:
+            #
+            #     export const DEFAULT_ICON = 'ViewDashboard'
+            #     export function getIconComponent (name) {
+            #         …
+            #         return DASHBOARD_ICONS[name] || DASHBOARD_ICONS[DEFAULT_ICON]
+            #     }
+            #
+            # An unknown name resolves to ViewDashboard — verified as
+            # DEFAULT_ICON in every shipped build checked (1.0.0-beta.197,
+            # 1.0.0-beta.220, 2.2.0-vue3.3, 2.2.0-vue3.6). A '?' would at least
+            # look broken; a generic dashboard glyph looks deliberate, so the
+            # author's intent is lost INVISIBLY. That is worse to triage, and
+            # saying it accurately is the difference between "someone will
+            # notice this in review" and "nobody ever will".
             findings.append(
                 f"{path}: page '{pid}' — widget icon '{ic}' is not in the shared "
-                f"icon registry (renders the '?' fallback, ADR-062 rule 8)"
+                f"icon registry, so it silently renders the DEFAULT icon "
+                f"('ViewDashboard') instead — the intent is lost with no visible "
+                f"breakage (ADR-062 rule 8). NOTE: this checks the nextcloud-vue "
+                f"widget vocabulary only; the app's own src/icons.js registration "
+                f"is gate-60's subject, and an icon must be in BOTH to render"
             )
 
     # (f) viewAllRoute / rowRoute must resolve to a page id.
@@ -482,9 +505,41 @@ def check_file(path, page_ids, findings, base_ref):
         check_page(path, page, page_ids, findings)
 
 
+_USAGE = (
+    "usage: check_detail_page_discipline.py <logfile> <manifest.json>...\n"
+    "\n"
+    "This helper writes its findings to <logfile> and ALWAYS exits 0 when it\n"
+    "runs — the runner decides FAIL by COUNTING LOG LINES, so the exit status\n"
+    "is not the verdict and a clean exit proves nothing about the result.\n"
+    "To read a verdict, read the log.\n"
+    "\n"
+    "It takes no options. `--app-dir` in particular is NOT this helper's\n"
+    "interface (it is check_visual_coverage.py's): passing it used to make\n"
+    "argv[1] the literal string '--app-dir', inspect nothing, print nothing\n"
+    "and exit 0 — a perfect silent false green over a tree with real findings.\n"
+    "See .github#304.\n"
+)
+
+
 def main(argv):
-    if len(argv) < 3:
-        return 0
+    # A MALFORMED INVOCATION MUST NOT LOOK CLEAN (.github#304).
+    #
+    # This used to be `if len(argv) < 3: return 0`, so every wrong call — a
+    # missing log path, an option this helper does not take — produced empty
+    # output and success. Measured:
+    #
+    #   check_detail_page_discipline.py --app-dir .
+    #     EXIT=0  stdout: 0 lines  stderr: 0 bytes   <- inspected NOTHING
+    #
+    #   check_detail_page_discipline.py <log> <24 manifests>   (the real contract)
+    #     EXIT=0  stderr: 0 bytes  findings written to the log: 28
+    #
+    # Two indistinguishable clean exits, one of which had opened no file at
+    # all. The runner reads `_dpd_rc`, so returning non-zero here surfaces as
+    # `SKIPPED (wiring)` — "no verdict was produced" — instead of PASS.
+    if len(argv) < 3 or any(a.startswith("-") for a in argv[1:]):
+        sys.stderr.write(_USAGE)
+        return 2
     log_path = argv[1]
     paths = argv[2:]
     base_ref = os.environ.get("HYDRA_GATE_BASE_REF", "").strip()

--- a/hydra-gates/scripts/lib/check_form_labels.py
+++ b/hydra-gates/scripts/lib/check_form_labels.py
@@ -71,6 +71,59 @@ NC_SLOT_COMPONENTS = {'nccheckboxradioswitch'}
 # `type=` values that carry their own name or take none.
 EXEMPT_INPUT_TYPES = {'hidden', 'submit', 'button', 'reset', 'image'}
 
+# NOT IN THE ACCESSIBILITY TREE (.github#273)
+# ------------------------------------------
+# An element that is not in the accessibility tree has no accessible name, so
+# `aria-label` on it is INERT. Demanding a name from one is demanding either a
+# no-op edit or the deletion of the very attribute that hides it — the same
+# unclosable shape `check_table_headers.py` already resolves by exempting a
+# `<th aria-hidden="true">`, because "a header with no accessible name names
+# nothing".
+#
+# #273 keyed this on `aria-hidden` / `tabindex="-1"`. MEASURED FLEET-WIDE, that
+# spelling matches NOTHING: of gate-40's 471 findings, `aria-hidden="true"`
+# appears on 0 and `display:none` on 8 — so an exemption written for
+# `aria-hidden` would have swallowed zero of the findings it was proposed for.
+# The canonical hidden file picker in this fleet is spelled with a style:
+#
+#   <input type="file" ref="fileInput" style="display: none" @change="onPick">
+#   <NcButton @click="$refs.fileInput.click()">Import</NcButton>
+#
+# Both spellings are therefore recognised, but NOT on the same terms, because
+# they are not equally static:
+#
+#   aria-hidden="true"   an explicit authored declaration that the element is
+#                        out of the tree. Honoured on any input, literal or
+#                        `:aria-hidden="true"` — the same evidence gate-43 uses.
+#
+#   display:none         a STYLE, and #273 is right that JS can toggle a style,
+#                        so an element hidden this way may be exposed at
+#                        runtime. Honoured ONLY for `type="file"`, where
+#                        hidden-and-clicked-programmatically is the canonical
+#                        pattern (the visible, labelled trigger is a separate
+#                        button) and a toggled-visible file input is not a real
+#                        shape. All 8 fleet occurrences are exactly this; 0 are
+#                        anything else, so the restriction costs nothing today
+#                        and is what stops the exemption becoming a blanket
+#                        "style yourself invisible to silence the gate".
+#
+# A dynamic `:aria-hidden="someVar"` is NOT accepted — its value is unknown at
+# scan time. See `NotInTheAccessibilityTree` in the tests, where each arm ships
+# with the true positive it must not swallow.
+ARIA_HIDDEN_TRUE = re.compile(r'(^|\s)(?::|v-bind:)?aria-hidden\s*=\s*[\'"]true[\'"]', re.IGNORECASE)
+DISPLAY_NONE = re.compile(r'(^|\s)style\s*=\s*[\'"][^\'"]*display\s*:\s*none', re.IGNORECASE)
+
+
+def _not_in_accessibility_tree(input_type: str, attrs: str) -> bool:
+    """True when the element is removed from the accessibility tree, so no
+    accessible name is possible and none can be demanded. See the note above
+    for why the two spellings carry different scopes."""
+    if ARIA_HIDDEN_TRUE.search(attrs):
+        return True
+    if input_type == 'file' and DISPLAY_NONE.search(attrs):
+        return True
+    return False
+
 TAG = re.compile(
     r'<(/?)([A-Za-z][A-Za-z0-9._:-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/?)>',
     re.DOTALL,
@@ -152,22 +205,65 @@ def scan_source(fname: str, src: str) -> list[str]:
             if v and _norm_expr(v) in label_for:
                 return True
         if name in NC_PROP_COMPONENTS:
-            # `input-id` is what an Nc* wrapper puts on the <input> it renders,
-            # and it is the documented way to point an EXTERNAL <label for> at
-            # that input. The association is real HTML — the same one accepted
+            # An Nc* wrapper is named by an EXTERNAL `<label for>` when the id
+            # that label points at is the id the wrapper puts on the `<input>`
+            # it renders. The association is real HTML — the same one accepted
             # for a native element two lines up — so it is an accessible name
             # by the same evidence.
             #
-            # Without this, a field written the way the shared components
-            # document it was reported as unlabelled, and the only way to
-            # close the finding was to add a redundant aria-label overriding
-            # the visible label, or a second visible one:
+            # TWO SPELLINGS REACH THE <input>, AND WHICH ONE DOES IS
+            # PER-COMPONENT (.github#310)
+            # ------------------------------------------------------
+            # `input-id` is a real prop on the NcSelect / NcActionInput /
+            # NcSelectUsers / NcFormBoxSwitch family, and it is kept here so
+            # this gate stays correct if one of those is ever added to
+            # NC_PROP_COMPONENTS.
             #
-            #   <label :for="filePathId">File path or glob</label>
-            #   <NcTextField :input-id="filePathId" ... />
-            v = _attr(attrs, 'input-id')
-            if v and _norm_expr(v) in label_for:
-                return True
+            # It is NOT a prop on NcTextField / NcInputField — the family this
+            # gate actually judges. Measured against the published package,
+            # which is the authority on a component's props:
+            #
+            #   nc-vue 9.9.0  `grep -ril inputid dist/components/NcTextField/
+            #                  dist/components/NcInputField/` -> no matches;
+            #                 NcTextField.vue.d.ts declares `id`, `label`,
+            #                 `placeholder`, `inputClass`, `helperText`,
+            #                 `modelValue` — no `inputId`.
+            #   nc-vue 8.39.0 zero occurrences of `inputId` in NcTextField.
+            #
+            # So `:input-id="x"` on an NcTextField is not a prop at all: it
+            # falls through `$attrs` onto the `<input>` as a literal
+            # `input-id="x"` attribute, which no browser or AT consumes.
+            #
+            # `id` is what reaches the `<input>`, on BOTH major lines:
+            #
+            #   9.9.0   NcInputField-5Sg6EUP6.mjs renders
+            #             createElementVNode("input", mergeProps(_ctx.$attrs, {
+            #               id: __props.id, ...
+            #           i.e. the declared `id` prop lands on the <input>.
+            #   8.39.0  NcInputField is `inheritAttrs: false` and computes
+            #             computedId() { return this.$attrs.id && this.$attrs.id !== ''
+            #                              ? this.$attrs.id : this.inputName }
+            #           i.e. a consumer-supplied `id` is DELIBERATELY read out
+            #           of $attrs and used as the input's id, with a generated
+            #           one only as the fallback.
+            #
+            # Before this, `<label for="x">` + `<NcTextField id="x">` — a
+            # correct, working association — was reported unlabelled (11 in
+            # openregister alone), and the only two edits that closed the
+            # finding were a no-op `input-id` attribute or an `aria-label`,
+            # which OVERRIDES the visible label and breaks WCAG 2.5.3 Label in
+            # Name. A gate whose only remediations are a no-op and a
+            # regression cannot be closed honestly.
+            #
+            # This is not a relaxation of the rule, it is the rule the native
+            # branch already applies: the id must still match a `<label for>`
+            # that exists in the file. An Nc* control with no `label` prop, no
+            # `aria-*`, no wrapping `<label>` and no matching `<label for>` is
+            # still reported.
+            for _attr_name in ('input-id', 'id'):
+                v = _attr(attrs, _attr_name)
+                if v and _norm_expr(v) in label_for:
+                    return True
         return False
 
     def _report(name: str, attrs: str, rule: str) -> None:
@@ -198,11 +294,12 @@ def scan_source(fname: str, src: str) -> list[str]:
 
         if name == 'input':
             t = (_attr(attrs, 'type') or 'text').strip().lower()
-            if t not in EXEMPT_INPUT_TYPES:
+            if t not in EXEMPT_INPUT_TYPES and not _not_in_accessibility_tree(t, attrs):
                 if not (_named_by_attrs(name, attrs) or label_depth > 0):
                     _report(raw_name, attrs, 'input-without-label')
         elif name == 'textarea':
-            if not (_named_by_attrs(name, attrs) or label_depth > 0):
+            if not _not_in_accessibility_tree('textarea', attrs) and not (
+                    _named_by_attrs(name, attrs) or label_depth > 0):
                 _report(raw_name, attrs, f'{name}-without-label')
         elif name in NC_PROP_COMPONENTS:
             named = _named_by_attrs(name, attrs) or label_depth > 0

--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -780,6 +780,45 @@ _OR_RBAC_ACCESS_RE = re.compile(
 # zero-input method that returns instance-wide data is a different defect class
 # (broken access control / information disclosure) and is out of this gate's
 # contract — condition 3 is what keeps such a method from being cleared here.
+#
+# ---------------------------------------------------------------------------
+# Pattern 3b — zero-input READ, without the session-identity requirement
+# ---------------------------------------------------------------------------
+#
+# .github#297. Condition 3 above is positive evidence of caller-scoping, and it
+# is the right requirement for an endpoint that returns the caller's OWN data.
+# But it also withheld the clear from a method that reads nothing caller-
+# specific at all — a static catalogue, a published public key, a feature flag
+# — and for those the scope note's own reasoning cuts the other way: the
+# finding is filed under `no-admin-idor`, and IDOR is *structurally impossible*
+# when the caller controls no value whatsoever. Every authenticated user
+# receives a byte-identical response; there is no reference to substitute.
+#
+# THIS DELIBERATELY MOVES THE LINE THE SCOPE NOTE ABOVE DREW, so it is bounded
+# by measurement rather than by argument. All six fleet findings that satisfy
+# it were read individually; every one is a single delegation to a
+# ZERO-ARGUMENT service call:
+#
+#   nldesign      CatalogController::tokenSets        -> getPublicCatalogue()
+#   openregister  FederatedConfigController::types    -> types()
+#   openregister  FederatedConfigController::publicKey-> publicKey()   (public by design)
+#   openregister  FlowController::eventCatalog        -> getCatalog()  (static triggers)
+#   doriath       SettingsController::getPolicy       -> getPolicy()
+#   procest       AssistantController::availability    -> isAvailable()
+#
+# None takes an argument, so no caller-controlled value can reach storage.
+#
+# THE ABUSE CONTROL is that this clears READS ONLY. A zero-input method that
+# MUTATES (`->save*`, `->delete*`, `->reset*`, `->purge*`, …) is still
+# reported: "the caller names no object" is not a reason to let an unguarded
+# side effect through, and a zero-parameter `purgeAll()` is precisely the shape
+# that argument would otherwise wave past. See
+# `ZeroInputReadOnlyEndpoints` in test_check_no_admin_idor.py, where each arm
+# ships with the true positive it must not swallow.
+#
+# What is NOT cleared, and stays out of contract as before: a zero-input method
+# that returns instance-wide data is still not an IDOR, but if it also writes,
+# or if it reads the request at all, this pattern does not apply.
 
 # Anything that pulls caller-controlled input in through the request object.
 # Presence of ANY of these disqualifies the pattern: the method then has an
@@ -792,6 +831,46 @@ _REQUEST_INPUT_RE = re.compile(
     r"|\$_(?:GET|POST|REQUEST|COOKIE|FILES)\b"
     r"|php://input"
 )
+
+# OBJECT ACCESS. Pattern 3b's second condition, and the one that keeps it from
+# becoming a blanket.
+#
+# The first draft of Pattern 3b cleared any zero-input READ, and that was too
+# wide — it swallowed
+#
+#     public function listEverything() { return $this->svc->findAll(); }
+#     public function index() { $data = $this->mapper->findAll(); ... }
+#
+# which are unscoped instance-wide enumerations, and which this suite already
+# pinned as findings (`test_zero_params_without_session_identity_still_flagged`,
+# `test_cors_plus_data_access_not_exempted`). Six existing tests failed on that
+# draft, which is exactly what they are for.
+#
+# So Pattern 3b also requires #297's own second condition: the body performs no
+# OBJECT ACCESS. What remains clearable is the shape actually measured in the
+# fleet — a single delegation to a zero-argument catalogue/config/status call
+# (`getPublicCatalogue()`, `publicKey()`, `getCatalog()`, `isAvailable()`) —
+# while anything that reaches the store still reports.
+_DATA_ACCESS_RE = re.compile(
+    r"->\s*(?:find|load|fetch|query|search|list|count)[A-Za-z0-9_]*\s*\("
+    r"|->\s*getObjects?\s*\("
+    r"|->\s*getBy[A-Za-z0-9_]*\s*\("
+    r"|->\s*mapper\b"
+    r"|->\s*objectService\b"
+    r"|\bObjectService\b"
+    r"|\bQueryBuilder\b"
+    r"|->\s*getQueryBuilder\s*\(",
+    re.IGNORECASE)
+
+# A side effect. Pattern 3b clears READS ONLY: "the caller names no object" is
+# not a reason to let an unguarded mutation through, and a zero-parameter
+# `purgeAll()` / `resetSettings()` is exactly the shape that argument would
+# otherwise wave past.
+_MUTATION_CALL_RE = re.compile(
+    r"->\s*(?:save|store|insert|update|delete|remove|create|persist|destroy"
+    r"|purge|reset|truncate|drop|flush|clear|revoke|grant|enable|disable"
+    r"|write|import|migrate|rebuild|regenerate|rotate|sync)[A-Za-z0-9_]*\s*\(",
+    re.IGNORECASE)
 
 # Positive evidence that the method is scoped to the *session* user.
 _SESSION_IDENTITY_RE = re.compile(
@@ -842,6 +921,34 @@ def _is_session_scoped_no_reference(params, body: str) -> bool:
     if _REQUEST_INPUT_RE.search(body):
         return False
     return bool(_SESSION_IDENTITY_RE.search(body))
+
+
+def _is_zero_input_read_only(params, body: str) -> bool:
+    """True when the caller controls NO value and the method only reads.
+
+    Pattern 3b (.github#297). With no parameters and no request reads there is
+    no direct object reference to substitute, so IDOR is structurally
+    impossible. Two further conditions keep the clear narrow:
+
+      * no MUTATION — "the caller names no object" is not a reason to let an
+        unguarded `purgeAll()` through;
+      * no OBJECT ACCESS — a zero-input `findAll()` is an unscoped instance-wide
+        enumeration, which this gate has always reported and still must.
+
+    What is left is the shape actually measured in the fleet: one delegation to
+    a zero-argument catalogue / config / status call.
+    """
+    if params is None:
+        return False
+    if params.strip() != "":
+        return False
+    if _REQUEST_INPUT_RE.search(body):
+        return False
+    if _MUTATION_CALL_RE.search(body):
+        return False
+    if _DATA_ACCESS_RE.search(body):
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1032,9 +1139,24 @@ def scan_file(path: str) -> int:
         # there is no direct object reference for an attacker to substitute,
         # so IDOR is not structurally possible. See the Pattern 3 commentary
         # for why all three conditions are required.
-        if _is_session_scoped_no_reference(_parameter_list(cleaned, sig_start), body):
+        _params = _parameter_list(cleaned, sig_start)
+        if _is_session_scoped_no_reference(_params, body):
             continue
 
+        # ---- Pattern 3b: zero-input READ, no session identity needed ----
+        # The caller controls no value at all, so there is no direct object
+        # reference to substitute and IDOR is structurally impossible. Reads
+        # only — a zero-input mutation still reports. See .github#297 and the
+        # Pattern 3b commentary.
+        if _is_zero_input_read_only(_params, body):
+            continue
+
+        # NOTE (.github#315): the guidance that goes with this finding — that
+        # the guard may live in a service or mapper two frames down — is
+        # printed ONCE by the runner's gate-7 FAIL message, not appended here.
+        # `filter_preexisting_methods.py` parses this line with
+        # `rule=(?P<rule>.+)$`, so anything added after `rule=` becomes part of
+        # the rule NAME and would silently break pre-existing filtering.
         print(
             f"{path}:{line_no} method={name} rule=no-auth-guard-in-body"
         )

--- a/hydra-gates/scripts/lib/check_orphan_auth.py
+++ b/hydra-gates/scripts/lib/check_orphan_auth.py
@@ -53,6 +53,17 @@ external caller anywhere in ``lib/`` or ``src/`` is fine — the gate only
 flags access-control methods that are *defined but never called*
 (OWASP A01:2021 — an unwired guard is identical to no guard).
 
+THE ROUTER IS ALSO A CALLER (.github#290)
+-----------------------------------------
+A routed controller action is reached by reflection from the route table,
+so it has no ``->method(`` call site anywhere and the corpus above cannot
+contain one. Such a method is therefore ALSO not an orphan when it is
+named in ``appinfo/routes.php`` (or ``appinfo/routes/*.php``) as
+``'<lowerCamelController>#<method>'``, or carries a ``#[Route]`` /
+``#[ApiRoute]`` attribute. This is keyed on the exact declaration that
+makes it reachable — see ``_is_routed`` — and applies to controllers only,
+because a service is not routable.
+
 Usage::
 
     python3 scripts/lib/check_orphan_auth.py <php-file> [<php-file> ...]
@@ -284,9 +295,97 @@ def _build_caller_corpus() -> str:
     return "\n".join(chunks)
 
 
+# ---------------------------------------------------------------------------
+# THE ROUTE TABLE IS A CALL SITE (.github#290)
+# --------------------------------------------
+# A ROUTED CONTROLLER ACTION HAS NO `->method(` ANYWHERE, EVER. Nextcloud's
+# router invokes it by reflection from the `'name' => 'liveTile#validateSource'`
+# entry in `appinfo/routes.php`, and the frontend calls the URL
+# (`/apps/launchpad/api/livetile/validate-source`), not the PHP method name. So
+# the `lib/` + `src/` corpus above — which is every caller this gate could see
+# — cannot contain a reference to it by construction.
+#
+# The result was that any controller action whose name happens to start with a
+# gate verb (`validate*`, `check*`, `is*`, `verify*`…) was reported
+# `defined-but-never-called` while being routed, called by the frontend and
+# unit-tested. Measured on launchpad: `LiveTileController::validateSource`,
+# routed at appinfo/routes.php:557, called from src/services/liveTileClient.js,
+# covered by tests/Unit/Controller/LiveTileControllerTest.php — reported as an
+# orphan.
+#
+# That is worse than noise. This gate's whole framing is "an unwired guard is
+# identical to no guard", so a false orphan is an accusation that a live
+# security check is dead — and it makes the real findings harder to trust.
+#
+# The match is keyed on the EXACT declaration that makes the method reachable,
+# so it is evidence, not a name heuristic: `<lowerCamelController>#<method>` in
+# the route table, or a `#[Route]` / `#[ApiRoute]` attribute on the method
+# itself (NC's attribute-routing form, which needs no routes.php entry).
+# ---------------------------------------------------------------------------
+_ROUTE_FILES = ("appinfo/routes.php",)
+_ROUTE_DIRS = ("appinfo/routes",)
+
+# `#[Route(...)]` / `#[ApiRoute(...)]` / `#[FrontpageRoute(...)]` — NC's
+# attribute routing. Present on the method's head, so no route table is needed.
+_ROUTE_ATTR_RE = re.compile(r"#\[\s*(?:\\?OCP\\AppFramework\\Http\\Attribute\\)?"
+                            r"(?:Api|Frontpage)?Route\s*\(", re.IGNORECASE)
+
+
+def _build_route_corpus() -> str:
+    """Every route-table source in the app, concatenated."""
+    chunks: list[str] = []
+    for name in _ROUTE_FILES:
+        p = Path(name)
+        if p.is_file():
+            try:
+                chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
+            except OSError:
+                pass
+    for name in _ROUTE_DIRS:
+        d = Path(name)
+        if not d.is_dir():
+            continue
+        for p in sorted(d.rglob("*.php")):
+            try:
+                chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
+            except OSError:
+                continue
+    return "\n".join(chunks)
+
+
+def _route_prefix(path: str) -> str | None:
+    """`lib/Controller/LiveTileController.php` -> `liveTile`.
+
+    Returns None for anything that is not a controller, so a SERVICE method is
+    never cleared by the route table — a service is not routable, and letting
+    one match here would be exactly the blanket this must not become.
+    """
+    m = re.search(r"(?:^|/)Controller/([A-Za-z0-9_]+)Controller\.php$",
+                  path.replace("\\", "/"))
+    if not m:
+        return None
+    cls = m.group(1)
+    return cls[:1].lower() + cls[1:]
+
+
+def _is_routed(path: str, method: str, head: str, route_corpus: str) -> bool:
+    """True when the router — not a `->method(` call — reaches this method."""
+    if _ROUTE_ATTR_RE.search(head):
+        return True
+    prefix = _route_prefix(path)
+    if not prefix:
+        return False
+    # `'liveTile#validateSource'` / `"liveTile#validateSource"`, quote-agnostic
+    # and whitespace-tolerant, but the controller AND the method must both
+    # match — `#validateSource` alone would clear the method on any controller.
+    pat = re.compile(r"['\"]" + re.escape(prefix) + r"\s*#\s*" + re.escape(method) + r"['\"]")
+    return bool(pat.search(route_corpus))
+
+
 def scan_files(files: list[str]) -> list[str]:
     """Return finding lines for the given candidate files."""
     corpus = _build_caller_corpus()
+    route_corpus = _build_route_corpus()
     findings: list[str] = []
     for f in files:
         try:
@@ -302,6 +401,9 @@ def scan_files(files: list[str]) -> list[str]:
             seen.add(name)
             caller_re = re.compile(r"->" + re.escape(name) + r"\s*\(")
             if caller_re.search(corpus):
+                continue
+            # The router is a caller the `lib/`+`src/` corpus cannot contain.
+            if _is_routed(f, name, head, route_corpus):
                 continue
             findings.append(f"{f}:{line_no} method={name} rule=defined-but-never-called")
     return findings

--- a/hydra-gates/scripts/lib/check_visual_coverage.py
+++ b/hydra-gates/scripts/lib/check_visual_coverage.py
@@ -128,6 +128,48 @@ def added_files(base_ref: str, cwd: Path) -> set[str]:
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_IMPORT_RE = re.compile(
+    r"""import\s+([A-Za-z_$][\w$]*)\s+from\s*['"]([^'"]+\.vue)['"]""")
+
+_ALIAS_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _alias_map(app_dir: Path) -> dict[str, str]:
+    """{imported identifier: repo-relative .vue path} across all of src/.
+
+    A manifest page's ``component`` is the name the app REGISTERED, which need
+    not match the filename — see the note in ``_resolve``. This follows the
+    default-import statement that created the alias.
+    """
+    key = str(app_dir.resolve())
+    cached = _ALIAS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    out: dict[str, str] = {}
+    for path in _src_code_files(app_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for ident, spec in _DEFAULT_IMPORT_RE.findall(text):
+            if spec.startswith("."):
+                target = (path.parent / spec).resolve()
+            elif spec.startswith("@/"):
+                target = (app_dir / "src" / spec[2:]).resolve()
+            elif spec.startswith("src/"):
+                target = (app_dir / spec).resolve()
+            else:
+                continue
+            try:
+                rel = str(target.relative_to(app_dir.resolve())).replace("\\", "/")
+            except ValueError:
+                continue
+            if target.is_file():
+                out.setdefault(ident, rel)
+    _ALIAS_CACHE[key] = out
+    return out
+
+
 def _manifest_page_components(app_dir: Path) -> dict[str, str]:
     """Return {component-relpath: page-id} for every ``"type": "page"`` entry in
     src/manifest.json whose ``component`` resolves to a src/ .vue file.
@@ -162,16 +204,28 @@ def _manifest_page_components(app_dir: Path) -> dict[str, str]:
         for p in (app_dir / "src").rglob(stem):
             if p.is_file():
                 return str(p.relative_to(app_dir)).replace("\\", "/")
-        return None
+        # THE MANIFEST NAMES THE REGISTERED COMPONENT, NOT THE FILE.
+        # `customComponents.js` registers a `.vue` under a different identifier:
+        #
+        #   import PortfolioReportView from './views/organisaties/PortfolioReport.vue'
+        #
+        # and the manifest page says `"component": "PortfolioReportView"`. No
+        # filename anywhere is `PortfolioReportView.vue`, so every lookup above
+        # misses and a REAL routed page (`/portfolio-report` on softwarecatalog)
+        # resolves to nothing. Follow the alias.
+        return _alias_map(app_dir).get(component)
+
+    def _record(node) -> None:
+        comp = node.get("component") or node.get("componentName") or ""
+        rel = _resolve(comp) if isinstance(comp, str) else None
+        if rel:
+            page_id = str(node.get("id") or node.get("name") or Path(rel).stem)
+            result[rel] = page_id
 
     def _walk(node):
         if isinstance(node, dict):
             if str(node.get("type", "")).lower() == "page":
-                comp = node.get("component") or node.get("componentName") or ""
-                rel = _resolve(comp) if isinstance(comp, str) else None
-                if rel:
-                    page_id = str(node.get("id") or node.get("name") or Path(rel).stem)
-                    result[rel] = page_id
+                _record(node)
             for v in node.values():
                 _walk(v)
         elif isinstance(node, list):
@@ -179,7 +233,128 @@ def _manifest_page_components(app_dir: Path) -> dict[str, str]:
                 _walk(v)
 
     _walk(data)
+
+    # MANIFEST V2: `type:"page"` NEVER OCCURS (.github#309)
+    # ----------------------------------------------------
+    # A v2 manifest declares its screens in a top-level `pages[]` array whose
+    # entries carry an `id`, a `route` and a `type` drawn from the RENDERER
+    # vocabulary — `index`, `detail`, `logs`, `dashboard`, `custom`, … — so the
+    # `type == "page"` test above matched NOTHING. Measured on openconnector:
+    # 35 declared pages, `_manifest_page_components()` resolved **0**. The
+    # manifest half of this gate has been dead on every v2 app, leaving only
+    # the src/views/ directory heuristic — which is the very thing #309 is
+    # about.
+    #
+    # A v2 entry is a page because it has a ROUTE. Only `type:"custom"` entries
+    # name a `component`; the rest are drawn by the manifest renderer and have
+    # no .vue file of their own, so there is nothing to demand a baseline for
+    # and they correctly contribute nothing here.
+    pages_node = data.get("pages") if isinstance(data, dict) else None
+    if isinstance(pages_node, list):
+        for entry in pages_node:
+            if isinstance(entry, dict) and entry.get("route"):
+                _record(entry)
     return result
+
+
+# ---------------------------------------------------------------------------
+# A DIRECTORY IS NOT A PAGE (.github#309)
+# ---------------------------------------
+# Rule (a) below — "a .vue ADDED under src/views/" — is a PATH-SHAPED PROXY for
+# a semantic property. Any child component that happens to live beside its page
+# was classified as a page. Measured full-tree:
+#
+#   openconnector    40 findings, of which src/views/Rule/actionForms/*.vue,
+#                    src/views/Synchronization/*Mapping*.vue and
+#                    src/views/admin/DsoPkiSettings.vue are not pages at all
+#                    (#309 measured 13 diff-scoped, 6 of them real)
+#   softwarecatalog  8 of 11 false (73%), all under src/views/settings/sections/**
+#                    and src/views/widgets/**
+#
+# Why the inflation is worse than a wrong number: for a NON-page, only the
+# third remedy the finding offers is reachable — `@visual exclude <reason>`. So
+# an over-matching heuristic systematically MANUFACTURES WAIVERS, and a fleet
+# trained to write waivers for false positives will write them for true ones.
+# `DsoPkiSettings.vue` is the sharpest case — NC renders it server-side through
+# the settings framework, so no amount of SPA e2e will ever "drive the page".
+#
+# The replacement asks for REACHABILITY, which is what "page" actually means,
+# and it is deliberately CONSERVATIVE: a file is dropped only when there is
+# positive evidence it is somebody's child. Absence of evidence keeps it in
+# scope, so a genuinely new page nothing has wired up yet is still flagged.
+#
+#   PAGE    named by a manifest `"type": "page"` entry            (routable), or
+#           referenced from a router module                       (routable), or
+#           imported by NOTHING in src/                (cannot be proved a child)
+#   CHILD   imported by some other src/ component that is not a router, and
+#           named by neither the manifest nor a router
+# ---------------------------------------------------------------------------
+_ROUTER_SIGNALS = ("createRouter(", "new VueRouter(", "vue-router", "createWebHashHistory")
+_SRC_CODE_EXT = (".vue", ".js", ".ts", ".mjs", ".jsx", ".tsx")
+
+
+def _src_code_files(app_dir: Path) -> list[Path]:
+    src = app_dir / "src"
+    if not src.is_dir():
+        return []
+    out: list[Path] = []
+    for p in src.rglob("*"):
+        if p.is_file() and p.suffix in _SRC_CODE_EXT:
+            if "node_modules" in p.parts:
+                continue
+            out.append(p)
+    return out
+
+
+def _import_graph(app_dir: Path) -> tuple[set[str], set[str]]:
+    """(imported_by_non_router, referenced_by_router) as sets of file stems.
+
+    Stems, not resolved paths: an import is written `./Rule/actionForms/UploadForm.vue`
+    or `@/views/UploadForm`, and resolving every alias form correctly is more
+    machinery than this decision needs. A stem collision can only ever make the
+    gate MORE conservative in the router set and less so in the child set, so
+    the tie-break below prefers 'page' whenever both fire.
+    """
+    imported_non_router: set[str] = set()
+    referenced_by_router: set[str] = set()
+    import_re = re.compile(
+        r"""(?:import\s+[^;\n]*?from\s*|import\s*\(\s*|require\s*\(\s*)['"]([^'"]+)['"]""")
+    for path in _src_code_files(app_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        rel = str(path.relative_to(app_dir)).replace("\\", "/")
+        is_router = (
+            "/router/" in f"/{rel}"
+            or Path(rel).stem.lower() in {"router", "routes"}
+            or any(sig in text for sig in _ROUTER_SIGNALS)
+        )
+        for spec in import_re.findall(text):
+            stem = Path(spec).name
+            if stem.endswith(".vue"):
+                stem = stem[:-4]
+            if not stem:
+                continue
+            if is_router:
+                referenced_by_router.add(stem)
+            else:
+                # A file importing ITSELF is not a parent of itself.
+                if stem != Path(rel).stem:
+                    imported_non_router.add(stem)
+    return imported_non_router, referenced_by_router
+
+
+def _is_child_component(rel: str, manifest_pages: dict[str, str],
+                        imported_non_router: set[str],
+                        referenced_by_router: set[str]) -> bool:
+    """True when *rel* is positively evidenced to be somebody's child."""
+    if rel in manifest_pages:
+        return False                      # the manifest says it is a page
+    stem = Path(rel).stem
+    if stem in referenced_by_router:
+        return False                      # the router says it is a page
+    return stem in imported_non_router    # only then is it a child
 
 
 def discover_new_pages(app_dir: Path, added: set[str]) -> list[dict]:
@@ -189,12 +364,17 @@ def discover_new_pages(app_dir: Path, added: set[str]) -> list[dict]:
     Deduplicated by path.
     """
     pages: dict[str, dict] = {}
-    # 1. ADDED .vue files under src/views or src/pages.
+    manifest_pages = _manifest_page_components(app_dir)
+    imported_non_router, referenced_by_router = _import_graph(app_dir)
+    # 1. ADDED .vue files under src/views or src/pages that are REACHABLE.
     for rel in added:
         if rel.endswith(".vue") and any(rel.startswith(d) for d in _PAGE_DIRS):
+            if _is_child_component(rel, manifest_pages, imported_non_router,
+                                   referenced_by_router):
+                continue
             pages[rel] = {"path": rel, "id": Path(rel).stem, "source": "dir"}
-    # 2. Manifest type:"page" entries whose component file was ADDED.
-    manifest_pages = _manifest_page_components(app_dir)
+    # 2. Manifest type:"page" entries whose component file was ADDED. A manifest
+    #    page is ALWAYS in scope — it is routable by declaration.
     for rel, page_id in manifest_pages.items():
         if rel in added and rel not in pages:
             pages[rel] = {"path": rel, "id": page_id, "source": "manifest"}

--- a/hydra-gates/scripts/lib/test_check_autocomplete.py
+++ b/hydra-gates/scripts/lib/test_check_autocomplete.py
@@ -165,5 +165,101 @@ class TheMutantIsTheWholePreFixChecker(unittest.TestCase):
             "fixture — the rewrite is unverified")
 
 
+class SemanticTokenBoundaries(unittest.TestCase):
+    """.github#319 — the SEMANTIC test was a bare substring alternation, so
+    `city` matched inside `capacity` and `tel` inside `hotel`.
+
+    But TOKEN BOUNDARIES ALONE DO NOT FIX IT, which is the part the issue's
+    suggested `\\b` anchoring would have missed. All three nldesign findings
+    have `email` as a WHOLE hyphen-delimited token:
+
+        nldesign-email-footer-org-name
+        nldesign-email-footer-accessibility-url
+        nldesign-email-footer-privacy-url
+
+    They are the email-FOOTER settings; the fields collect an organisation
+    name and two URLs. What separates them from a real one is which token is
+    the NOUN — an identifier names its subject at the end.
+
+    Each false positive below is paired with the true positive it must not
+    swallow, and the last class is the abuse control: qualifier tails.
+    """
+
+    # -- the false positives, gone ----------------------------------------
+    def test_fp_nldesign_email_footer_fields(self):
+        for name in ("nldesign-email-footer-org-name",
+                     "nldesign-email-footer-accessibility-url",
+                     "nldesign-email-footer-privacy-url"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    rules(f'<input type="text" id="{name}">',
+                          "templates/settings/admin.php"), [], name)
+
+    def test_fp_capacity_is_not_city(self):
+        for name in ("queue-edit-max-capacity", "queue-new-max-capacity",
+                     "max-capacity", "opacity", "velocity", "simplicity",
+                     "electricity"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    rules(f'<input type="number" min="1" name="{name}">'),
+                    [], name)
+
+    def test_fp_gzip_is_not_zip_and_hotel_is_not_tel(self):
+        for name in ("gzip", "unzip", "hotel", "hostel"):
+            with self.subTest(name=name):
+                self.assertEqual(rules(f'<input type="text" name="{name}">'),
+                                 [], name)
+
+    # -- THE TRUE POSITIVES THIS MUST NOT SWALLOW -------------------------
+    def test_tp_a_trailing_semantic_noun_still_fires(self):
+        # pipelinq's five real findings, verbatim.
+        for name in ("portal-phone", "portal-address", "portal-change-email",
+                     "form.granteeEmail", "portal-reset-email", "user-city"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    rules(f'<input type="text" id="{name}">'),
+                    ["semantic-input-without-autocomplete"], name)
+
+    def test_tp_a_noun_followed_by_a_qualifier_still_fires(self):
+        # nextcloud-vue CnExportWizard: `:id="fieldIdFor('emailRecipient')"` on
+        # an `<input type="email">`. A strict noun-must-be-LAST rule dropped
+        # this real finding; the two-token window is why it is back. If the
+        # window is ever narrowed to one, this is the test that says so.
+        self.assertEqual(
+            rules("""<input :id="fieldIdFor('emailRecipient')"
+                     v-model="formData.emailRecipient" type="email">"""),
+            ["semantic-input-without-autocomplete"])
+
+    def test_tp_camel_case_compounds_still_fire(self):
+        for name in ("firstName", "lastName", "fullName", "userName",
+                     "zipCode", "granteeEmail"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    rules(f'<input type="text" name="{name}">'),
+                    ["semantic-input-without-autocomplete"], name)
+
+    # -- THE ABUSE CONTROL ------------------------------------------------
+    # A generic tail word must let the noun one place back still count —
+    # otherwise `postal-code` and `phone-number`, the plainest WCAG 1.3.5
+    # fields there are, would go quiet. This is the arm that proves the
+    # "noun must be last" rule did not become "anything with a suffix passes".
+    def test_abuse_control_a_generic_tail_does_not_hide_the_noun(self):
+        for name in ("postal-code", "post-code", "zip-code", "phone-number",
+                     "tel-number", "street-address", "email-address"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    rules(f'<input type="text" name="{name}">'),
+                    ["semantic-input-without-autocomplete"], name)
+
+    def test_abuse_control_a_generic_tail_over_a_NON_noun_stays_quiet(self):
+        # The other side of the same rule: `org-name` and `privacy-url` have
+        # exactly the shape above, and must NOT fire.
+        for name in ("org-name", "privacy-url", "accessibility-url",
+                     "project-name", "queue-id", "footer-text"):
+            with self.subTest(name=name):
+                self.assertEqual(rules(f'<input type="text" name="{name}">'),
+                                 [], name)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_detail_page_icon_registry.py
+++ b/hydra-gates/scripts/lib/test_check_detail_page_icon_registry.py
@@ -92,5 +92,60 @@ class IconRegistryMirrorTest(unittest.TestCase):
         self.assertNotIn("NotAnIconAtAll", self.registry)
 
 
+class InvocationContractTest(unittest.TestCase):
+    """.github#304 — a MALFORMED INVOCATION MUST NOT LOOK CLEAN.
+
+    Two independent routes produced "looks clean" on a tree with 28 real
+    findings, and an agent triaging by exit status took both:
+
+      1. the helper exits 0 EVEN WITH FINDINGS — by design, because the runner
+         counts log lines. So a clean exit is not a verdict, and the usage text
+         now says so out loud.
+      2. `--app-dir .` — not this helper's interface — made argv[1] the literal
+         string '--app-dir', inspected nothing, printed nothing and exited 0.
+
+    Only (2) is fixable without changing the runner contract, and it is fixed
+    by rejecting options outright.
+    """
+
+    def _run(self, args):
+        import subprocess
+        import sys as _sys
+        return subprocess.run(
+            [_sys.executable, TARGET, *args],
+            capture_output=True, text=True)
+
+    def test_the_app_dir_trap_is_no_longer_a_silent_green(self):
+        r = self._run(["--app-dir", "."])
+        self.assertNotEqual(r.returncode, 0,
+                            "an option this helper does not take exited 0 having "
+                            "inspected nothing — a silent false green")
+        self.assertIn("usage:", r.stderr)
+
+    def test_a_missing_log_path_is_not_a_silent_green(self):
+        r = self._run([])
+        self.assertNotEqual(r.returncode, 0)
+
+    def test_the_usage_text_says_the_exit_code_is_not_the_verdict(self):
+        # The trap that cost the most time was believing exit 0 meant clean.
+        # If that sentence is ever dropped, this fails.
+        r = self._run(["--app-dir", "."])
+        self.assertIn("read the log", r.stderr.lower())
+
+    def test_positive_control_the_real_contract_still_runs(self):
+        # Without this, "reject everything" would satisfy the tests above.
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            man = os.path.join(d, "manifest.json")
+            with open(man, "w", encoding="utf-8") as f:
+                json.dump({"pages": [{"id": "X", "type": "detail",
+                                      "widgets": []}]}, f)
+            log = os.path.join(d, "out.log")
+            r = self._run([log, man])
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertTrue(os.path.exists(log) or True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_form_labels.py
+++ b/hydra-gates/scripts/lib/test_check_form_labels.py
@@ -201,6 +201,131 @@ class InputIdOnAWrapperComponent(unittest.TestCase):
         """), ["nctextfield-without-label-prop"])
 
 
+class PlainIdOnAWrapperComponent(unittest.TestCase):
+    """.github#310 — `id` is the attribute that reaches the `<input>` on the
+    NcTextField / NcInputField family, so `<label for="x">` + `<NcTextField
+    id="x">` is a correct association and must not be reported.
+
+    Evidence is the published package, which is the authority on props:
+    nc-vue 9.9.0's NcInputField renders `id: __props.id` onto its `<input>`;
+    8.39.0's is `inheritAttrs: false` and computes
+    `computedId() { return this.$attrs.id ? this.$attrs.id : this.inputName }`.
+    Neither declares `inputId` at all — `grep -ril inputid` across
+    `dist/components/NcTextField/` and `dist/components/NcInputField/`
+    returns nothing on 9.9.0, and 8.39.0 has zero occurrences.
+
+    The reason this one matters more than its count: the two edits that
+    closed the finding before were a no-op `input-id` attribute and an
+    `aria-label` that OVERRIDES the visible label (WCAG 2.5.3 Label in Name).
+    A gate whose only remediations are a no-op and a regression is a gate
+    that teaches the fleet to ship regressions.
+    """
+
+    def test_fp_a_literal_id_matching_a_label_for_associates(self):
+        # openregister, verbatim shape — 11 findings of exactly this.
+        self.assertEqual(rules("""
+            <label for="dolphin-endpoint">Dolphin API Endpoint</label>
+            <NcTextField id="dolphin-endpoint" v-model="fileSettings.dolphinApiEndpoint" />
+        """), [])
+
+    def test_fp_a_bound_id_matching_a_bound_label_for_associates(self):
+        self.assertEqual(rules("""
+            <label :for="`f-${uid}`">Endpoint</label>
+            <NcInputField :id="`f-${uid}`" :model-value="v" />
+        """), [])
+
+    # -- the true positives this must not swallow -------------------------
+    def test_tp_an_id_no_label_points_at_is_still_reported(self):
+        # THE ABUSE CONTROL. If the acceptance ever degrades into "has an id
+        # at all", every wrapper whose label was deleted, renamed or never
+        # written goes quiet — and `id` is on almost every control in the
+        # fleet, so that degradation would be a blanket, not a narrowing.
+        self.assertEqual(rules("""
+            <label for="some-other-field">Endpoint</label>
+            <NcTextField id="dolphin-endpoint" :model-value="v" />
+        """), ["nctextfield-without-label-prop"])
+
+    def test_tp_an_id_with_no_label_anywhere_is_still_reported(self):
+        self.assertEqual(rules("""
+            <NcTextField id="dolphin-endpoint" :model-value="v" />
+        """), ["nctextfield-without-label-prop"])
+
+    def test_tp_a_label_for_pointing_at_nothing_names_nothing(self):
+        # A `<label for>` with no control carrying that id is a dangling
+        # association; the unnamed control beside it is still unnamed.
+        self.assertEqual(rules("""
+            <label for="dolphin-endpoint">Dolphin API Endpoint</label>
+            <NcTextField :model-value="v" />
+        """), ["nctextfield-without-label-prop"])
+
+    def test_tp_a_bare_wrapper_with_no_naming_source_is_still_reported(self):
+        self.assertEqual(rules('<NcTextField :model-value="v" />'),
+                         ["nctextfield-without-label-prop"])
+
+
+class NotInTheAccessibilityTree(unittest.TestCase):
+    """.github#273 — an element out of the accessibility tree has no
+    accessible name, so `aria-label` on it is inert and the finding cannot be
+    closed honestly. Same principle `check_table_headers.py` already applies
+    to `<th aria-hidden="true">`.
+
+    #273 keyed this on `aria-hidden`/`tabindex`. Measured fleet-wide, that
+    spelling matches NOTHING: `aria-hidden="true"` appears on 0 of gate-40's
+    471 findings and `display:none` on 8 — ALL 8 of them `type="file"`. So the
+    exemption is written for the spelling that actually occurs, and the
+    `display:none` arm is bounded to `type="file"` because a style, unlike an
+    ARIA attribute, can be toggled by JS.
+
+    Four arms, after the model of openbuild's gate-54 verification — the third
+    is the one that proves the exemption stays narrow rather than becoming a
+    blanket.
+    """
+
+    # arm 1 — the canonical hidden picker is exempt
+    def test_fp_a_display_none_file_picker_is_exempt(self):
+        # openregister ImportRegister.vue / nldesign admin.php, verbatim shape.
+        self.assertEqual(rules(
+            '<input ref="fileInput" type="file" accept=".json" '
+            'style="display: none" @change="handleFileUpload">'), [])
+
+    def test_fp_an_aria_hidden_input_is_exempt(self):
+        # #273's own fixture shape.
+        self.assertEqual(rules(
+            '<input ref="picker" type="file" :aria-hidden="true" '
+            'tabindex="-1" @change="onPick">'), [])
+
+    # arm 2 — remove the hiding attribute and it must fail again
+    def test_tp_the_same_file_input_visible_is_still_reported(self):
+        self.assertEqual(rules(
+            '<input ref="fileInput" type="file" accept=".json" '
+            '@change="handleFileUpload">'), ["input-without-label"])
+
+    # arm 3 — THE ABUSE CONTROL. `display:none` must not become a blanket
+    # silencer for any control an author would rather not name. Only
+    # `type="file"` earns it; a hidden text field is a control that may be
+    # shown at any moment by the same JS that hid it.
+    def test_tp_display_none_on_a_non_file_input_is_still_reported(self):
+        self.assertEqual(rules(
+            '<input type="text" v-model="q" style="display: none">'),
+            ["input-without-label"])
+
+    def test_tp_display_none_on_a_textarea_is_still_reported(self):
+        self.assertEqual(rules(
+            '<textarea v-model="q" style="display: none"></textarea>'),
+            ["textarea-without-label"])
+
+    # arm 4 — a DYNAMIC aria-hidden proves nothing at scan time
+    def test_tp_a_bound_dynamic_aria_hidden_is_not_an_exemption(self):
+        self.assertEqual(rules(
+            '<input type="text" v-model="q" :aria-hidden="isCollapsed">'),
+            ["input-without-label"])
+
+    def test_tp_aria_hidden_false_is_not_an_exemption(self):
+        self.assertEqual(rules(
+            '<input type="text" v-model="q" aria-hidden="false">'),
+            ["input-without-label"])
+
+
 # --------------------------------------------------------------------------
 # Mode 4 — markup that does not ship.
 # --------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -1673,5 +1673,133 @@ class C extends Controller {
         self.assertEqual(self._scan(self._LEAK % ""), [])
 
 
+class ZeroInputReadOnlyEndpoints(unittest.TestCase):
+    """Pattern 3b (.github#297) — a routed method that takes NO parameters and
+    reads NOTHING from the request has no direct object reference for an
+    attacker to substitute, so IDOR is structurally impossible. Every
+    authenticated caller gets a byte-identical response.
+
+    Before this, the only way to close such a finding was
+    `@no-admin-idor-exempt <reason>` — and a reason-tag on a finding that was
+    never real is indistinguishable, six months later, from a reason-tag on one
+    that was. nldesign left the gate red rather than tag it.
+
+    THE RELAXATION IS BOUNDED TO READS. `_MUTATION_CALL_RE` keeps a zero-input
+    side effect reportable, because "the caller names no object" is not a
+    reason to let an unguarded `purgeAll()` through — that is the shape this
+    argument would otherwise wave past, and it is the abuse control here.
+    """
+
+    _TPL = """<?php
+class CatalogController {
+    #[NoAdminRequired]
+    public function %s
+}
+"""
+
+    def _scan1(self, method_src: str) -> list[str]:
+        return _scan(self._TPL % method_src)
+
+    # -- the false positives, gone ----------------------------------------
+    def test_fp_a_zero_input_catalogue_read_is_not_an_idor(self):
+        # nldesign CatalogController::tokenSets, verbatim.
+        self.assertEqual(self._scan1(
+            "tokenSets(): JSONResponse\n"
+            "    {\n"
+            "        return new JSONResponse(['tokenSets' => "
+            "$this->tokenSetService->getPublicCatalogue()]);\n"
+            "    }"), [])
+
+    def test_fp_a_published_public_key_is_not_an_idor(self):
+        # openregister FederatedConfigController::publicKey.
+        self.assertEqual(self._scan1(
+            "publicKey(): JSONResponse\n"
+            "    {\n"
+            "        return new JSONResponse(['publicKey' => "
+            "$this->service->publicKey()]);\n"
+            "    }"), [])
+
+    def test_fp_a_static_event_catalogue_is_not_an_idor(self):
+        # openregister FlowController::eventCatalog.
+        self.assertEqual(self._scan1(
+            "eventCatalog(): JSONResponse\n"
+            "    {\n"
+            "        $results = $this->eventCatalog->getCatalog();\n"
+            "        return new JSONResponse(['results' => $results, "
+            "'total' => count($results)]);\n"
+            "    }"), [])
+
+    # -- THE ABUSE CONTROL: reads only ------------------------------------
+    def test_abuse_control_a_zero_input_MUTATION_is_still_reported(self):
+        # No parameters, no request reads — and it deletes everything. If
+        # Pattern 3b ever drops its read-only condition, this goes quiet.
+        out = self._scan1(
+            "purgeAll(): JSONResponse\n"
+            "    {\n"
+            "        $this->objectService->deleteAll();\n"
+            "        return new JSONResponse(['purged' => true]);\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=purgeAll", out[0])
+
+    def test_abuse_control_a_zero_input_reset_is_still_reported(self):
+        out = self._scan1(
+            "resetSettings(): JSONResponse\n"
+            "    {\n"
+            "        $this->settingsService->resetToDefaults();\n"
+            "        return new JSONResponse(['ok' => true]);\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=resetSettings", out[0])
+
+    # -- THE ABUSE CONTROL THAT CAUGHT THE FIRST DRAFT --------------------
+    # Pattern 3b's first draft cleared any zero-input READ. These two shapes
+    # are why that was wrong, and six existing tests failed on it. They are
+    # restated here so the reason travels with the pattern rather than living
+    # only in the classes that happened to use them as fixtures.
+    def test_abuse_control_a_zero_input_findAll_is_still_reported(self):
+        out = self._scan1(
+            "listEverything(): JSONResponse\n"
+            "    {\n"
+            "        return new JSONResponse($this->svc->findAll());\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=listEverything", out[0])
+
+    def test_abuse_control_a_zero_input_mapper_read_is_still_reported(self):
+        out = self._scan1(
+            "index(): JSONResponse\n"
+            "    {\n"
+            "        $data = $this->mapper->findAll();\n"
+            "        return new JSONResponse($data);\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=index", out[0])
+
+    # -- THE TRUE POSITIVES THIS MUST NOT SWALLOW -------------------------
+    def test_tp_a_method_taking_an_id_is_still_reported(self):
+        # The moment the caller names an object, IDOR is possible again.
+        out = self._scan1(
+            "show(string $id): JSONResponse\n"
+            "    {\n"
+            "        return new JSONResponse($this->service->find($id));\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=show", out[0])
+
+    def test_tp_a_zero_param_method_that_READS_THE_REQUEST_is_still_reported(self):
+        # Zero declared parameters is not the same as zero caller input —
+        # `getParam` is the other door, and it is exactly what IDOR walks in
+        # through.
+        out = self._scan1(
+            "show(): JSONResponse\n"
+            "    {\n"
+            "        $id = $this->request->getParam('id');\n"
+            "        return new JSONResponse($this->service->find($id));\n"
+            "    }")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=show", out[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_orphan_auth.py
+++ b/hydra-gates/scripts/lib/test_check_orphan_auth.py
@@ -286,5 +286,141 @@ class MailService {
         self.assertEqual(_scan_in_repo("lib/Service/MailService.php", src), [])
 
 
+_LAUNCHPAD_CONTROLLER = """\
+<?php
+class LiveTileController {
+    public function validateSource(string $userId, string $url): JSONResponse
+    {
+        if (!$this->service->isHostAllowed($url)) {
+            throw new \\OCP\\AppFramework\\OCS\\OCSForbiddenException('blocked host');
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+}
+"""
+
+_ROUTES = """\
+<?php
+return ['routes' => [
+    ['name' => 'liveTile#validateSource', 'url' => '/api/livetile/validate-source', 'verb' => 'POST'],
+]];
+"""
+
+
+class RoutedControllerActionIsNotAnOrphan(unittest.TestCase):
+    """.github#290 — the router invokes a controller action by reflection from
+    `appinfo/routes.php`, so it has NO `->method(` call site anywhere and the
+    lib/+src/ corpus cannot contain one. Every routed action whose name starts
+    with a gate verb was reported `defined-but-never-called` while live.
+
+    Measured on launchpad: `LiveTileController::validateSource` — routed at
+    appinfo/routes.php:557, called from src/services/liveTileClient.js by URL,
+    and unit-tested — was reported as an orphan.
+
+    Each relaxation below ships with the true positive it must not swallow.
+    The route table is treated as EVIDENCE, not a name heuristic: the
+    controller and the method must both match the `'liveTile#validateSource'`
+    entry.
+    """
+
+    # -- the false positive, gone -----------------------------------------
+    def test_fp_a_routed_controller_action_is_not_an_orphan(self):
+        self.assertEqual(
+            _scan_in_repo("lib/Controller/LiveTileController.php",
+                          _LAUNCHPAD_CONTROLLER,
+                          {"appinfo/routes.php": _ROUTES}),
+            [])
+
+    def test_fp_a_routes_subdirectory_table_also_counts(self):
+        self.assertEqual(
+            _scan_in_repo("lib/Controller/LiveTileController.php",
+                          _LAUNCHPAD_CONTROLLER,
+                          {"appinfo/routes/api.php": _ROUTES}),
+            [])
+
+    def test_fp_an_attribute_routed_action_is_not_an_orphan(self):
+        # NC attribute routing needs no routes.php entry at all.
+        src = """\
+<?php
+class LiveTileController {
+    #[ApiRoute(verb: 'POST', url: '/api/livetile/validate-source')]
+    public function validateSource(string $userId, string $url): JSONResponse
+    {
+        if (!$this->service->isHostAllowed($url)) {
+            throw new \\OCP\\AppFramework\\OCS\\OCSForbiddenException('blocked host');
+        }
+        return new JSONResponse(['ok' => true]);
+    }
+}
+"""
+        self.assertEqual(
+            _scan_in_repo("lib/Controller/LiveTileController.php", src), [])
+
+    # -- THE TRUE POSITIVE THIS MUST NOT SWALLOW --------------------------
+    def test_tp_an_unrouted_controller_action_is_still_an_orphan(self):
+        # No route table at all: the method really is unreachable.
+        findings = _scan_in_repo("lib/Controller/LiveTileController.php",
+                                 _LAUNCHPAD_CONTROLLER)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=validateSource", findings[0])
+
+    def test_tp_a_route_table_naming_a_DIFFERENT_method_does_not_clear_it(self):
+        # THE ABUSE CONTROL. If the match ever degrades to "this controller
+        # appears in the route table", every unrouted action on a routed
+        # controller goes quiet — and that is most of them.
+        routes = """\
+<?php
+return ['routes' => [
+    ['name' => 'liveTile#index', 'url' => '/api/livetile', 'verb' => 'GET'],
+]];
+"""
+        findings = _scan_in_repo("lib/Controller/LiveTileController.php",
+                                 _LAUNCHPAD_CONTROLLER,
+                                 {"appinfo/routes.php": routes})
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=validateSource", findings[0])
+
+    def test_tp_a_route_on_a_DIFFERENT_controller_does_not_clear_it(self):
+        routes = """\
+<?php
+return ['routes' => [
+    ['name' => 'other#validateSource', 'url' => '/api/other/validate', 'verb' => 'POST'],
+]];
+"""
+        findings = _scan_in_repo("lib/Controller/LiveTileController.php",
+                                 _LAUNCHPAD_CONTROLLER,
+                                 {"appinfo/routes.php": routes})
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=validateSource", findings[0])
+
+    def test_tp_a_SERVICE_is_never_cleared_by_the_route_table(self):
+        # A service is not routable. This is the arm that proves the exemption
+        # stays inside the controller layer instead of becoming a blanket:
+        # the decidesk isTransitionAllowed/validateQuorum family lives in
+        # services, and a route entry must never quiet one.
+        src = """\
+<?php
+class MeetingService {
+    public function validateQuorum(string $userId, string $meetingId): bool
+    {
+        if (!$this->acl->isAllowed($userId)) {
+            throw new \\OCP\\AppFramework\\OCS\\OCSForbiddenException('no quorum rights');
+        }
+        return true;
+    }
+}
+"""
+        routes = """\
+<?php
+return ['routes' => [
+    ['name' => 'meeting#validateQuorum', 'url' => '/api/meeting/quorum', 'verb' => 'POST'],
+]];
+"""
+        findings = _scan_in_repo("lib/Service/MeetingService.php", src,
+                                 {"appinfo/routes.php": routes})
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=validateQuorum", findings[0])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_visual_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_visual_coverage.py
@@ -197,6 +197,185 @@ with _repo(3, covered=True) as t:
         out.strip()[-140:],
     )
 
+# ---------------------------------------------------------------------------
+# .github#309 — A DIRECTORY IS NOT A PAGE
+# ---------------------------------------------------------------------------
+# The `src/views/` rule is a path-shaped proxy: any child component living
+# beside its page was called a page. Measured full-tree, openconnector reported
+# 40 and softwarecatalog 17, the majority of both being rows, widgets, form
+# fragments and NC settings panels.
+#
+# The remedy the finding offers a non-page is only ever `@visual exclude`, so
+# an over-matching heuristic MANUFACTURES WAIVERS — and a fleet trained to
+# waive false positives will waive true ones.
+#
+# The replacement asks for reachability and is conservative: a file is dropped
+# only on POSITIVE evidence that it is somebody's child. Every arm below pairs
+# a relaxation with the true positive it must not swallow.
+print()
+print("== gate-26: a directory is not a page (.github#309) ==")
+
+
+def _repo_mixed(*, manifest: str | None = None,
+                extra: dict[str, str] | None = None) -> tempfile.TemporaryDirectory:
+    """A repo with one routed page and one child component beside it."""
+    tmp = tempfile.TemporaryDirectory()
+    root = Path(tmp.name)
+    (root / "src" / "views").mkdir(parents=True)
+    (root / "README.md").write_text("base\n")
+    _git(["init", "-q"], root)
+    _git(["add", "-A"], root)
+    _git(["commit", "-qm", "base"], root)
+    (root / "src" / "views" / "FlowDetailPage.vue").write_text(PAGE.format(n=1))
+    (root / "src" / "views" / "FlowStepRow.vue").write_text(PAGE.format(n=2))
+    # The page imports the row: that import is the evidence of child-ness.
+    (root / "src" / "views" / "FlowDetailPage.vue").write_text(
+        "<template><div><FlowStepRow /></div></template>\n"
+        "<script>\nimport FlowStepRow from './FlowStepRow.vue'\n"
+        "export default { name: 'FlowDetailPage', components: { FlowStepRow } }\n"
+        "</script>\n")
+    if manifest is not None:
+        (root / "src" / "manifest.json").write_text(manifest)
+    for rel, body in (extra or {}).items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    _git(["add", "-A"], root)
+    _git(["commit", "-qm", "add", "--allow-empty"], root)
+    return tmp
+
+
+_MANIFEST_V2 = """{
+  "pages": [
+    {"id": "FlowDetail", "type": "custom", "route": "/flows/:id", "component": "FlowDetailPage"}
+  ]
+}"""
+
+# arm 1 — the child component is no longer a finding; the routed page still is.
+with _repo_mixed(manifest=_MANIFEST_V2) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "arm 1: a child component beside its page is NOT reported",
+        "FlowStepRow" not in out,
+        out.strip()[-200:],
+    )
+    check(
+        "arm 1: the routed page beside it IS still reported",
+        rc == EXIT_FAIL and "FlowDetailPage.vue" in out and _reported_count(out) == 1,
+        f"rc={rc} out={out.strip()[-200:]}",
+    )
+
+# arm 2 — THE TRUE POSITIVE. With nothing importing it, a page-dir component
+# cannot be PROVED a child, so it stays in scope. Absence of evidence must not
+# become evidence of absence.
+with _repo(3) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "arm 2: unimported page-dir components are all still reported",
+        rc == EXIT_FAIL and _reported_count(out) == 3,
+        f"rc={rc} out={out.strip()[-160:]}",
+    )
+
+# arm 3 — THE ABUSE CONTROL. A manifest page is ALWAYS in scope, even when some
+# other component also imports it. Otherwise a single stray import anywhere in
+# src/ would silence a genuinely routed screen — the blanket this must not be.
+_IMPORTER = ("<template><div><FlowDetailPage /></div></template>\n"
+             "<script>\nimport FlowDetailPage from './views/FlowDetailPage.vue'\n"
+             "export default { name: 'Shell' }\n</script>\n")
+with _repo_mixed(manifest=_MANIFEST_V2, extra={"src/Shell.vue": _IMPORTER}) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "arm 3: a manifest-declared page stays in scope even when imported",
+        rc == EXIT_FAIL and "FlowDetailPage.vue" in out,
+        f"rc={rc} out={out.strip()[-200:]}",
+    )
+
+# arm 4 — a router reference is reachability too, with no manifest at all.
+_ROUTER = ("import { createRouter } from 'vue-router'\n"
+           "import FlowDetailPage from './views/FlowDetailPage.vue'\n"
+           "export default createRouter({ routes: [{ path: '/flows/:id',"
+           " component: FlowDetailPage }] })\n")
+with _repo_mixed(extra={"src/router.js": _ROUTER, "src/Shell.vue": _IMPORTER}) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "arm 4: a router-referenced page stays in scope with no manifest",
+        rc == EXIT_FAIL and "FlowDetailPage.vue" in out,
+        f"rc={rc} out={out.strip()[-200:]}",
+    )
+    check(
+        "arm 4: the child beside it is still dropped",
+        "FlowStepRow" not in out,
+        out.strip()[-200:],
+    )
+
+# ---------------------------------------------------------------------------
+# .github#309 (second defect, found while fixing the first) — the manifest half
+# of this gate was DEAD on every manifest-V2 app. `type:"page"` never occurs in
+# a v2 manifest; screens are declared in a top-level `pages[]` array whose
+# `type` is a RENDERER kind (index/detail/custom/…). Measured on openconnector:
+# 35 declared pages, 0 resolved.
+#
+# And the `component` a v2 page names is the REGISTERED identifier, which need
+# not match the filename — softwarecatalog's `/portfolio-report` names
+# `PortfolioReportView`, aliased by `customComponents.js` to
+# `views/organisaties/PortfolioReport.vue`. Without following that alias the
+# reachability rule above drops a genuinely routed page.
+print()
+print("== gate-26: manifest-V2 pages resolve, including aliased components ==")
+
+_MANIFEST_ALIASED = """{
+  "pages": [
+    {"id": "FlowDetail", "type": "custom", "route": "/flows/:id", "component": "FlowDetailView"}
+  ]
+}"""
+_ALIAS_REGISTRY = ("import FlowDetailView from './views/FlowDetailPage.vue'\n"
+                   "export default { FlowDetailView }\n")
+
+sys.path.insert(0, str(HERE))
+import check_visual_coverage as _cvc  # noqa: E402
+
+with _repo_mixed(manifest=_MANIFEST_V2) as t:
+    # Directly on the unit that was broken: 0 resolved on every v2 app.
+    getattr(_cvc, '_ALIAS_CACHE', {}).clear()
+    _mp = _cvc._manifest_page_components(Path(t.name if hasattr(t, "name") else str(t)))
+    check(
+        "a manifest-V2 pages[] entry resolves to its component file",
+        list(_mp.values()) == ["FlowDetail"],
+        f"resolved={_mp}",
+    )
+
+with _repo_mixed(manifest=_MANIFEST_ALIASED,
+                 extra={"src/customComponents.js": _ALIAS_REGISTRY,
+                        "src/Shell.vue": _IMPORTER}) as t:
+    getattr(_cvc, '_ALIAS_CACHE', {}).clear()
+    _mp = _cvc._manifest_page_components(Path(t.name if hasattr(t, "name") else str(t)))
+    check(
+        "a v2 page whose component is an ALIAS resolves to the aliased file",
+        list(_mp.keys()) == ["src/views/FlowDetailPage.vue"],
+        f"resolved={_mp}",
+    )
+    rc, out = _run(Path(t), None)
+    check(
+        "a v2 page whose component is an ALIAS still resolves and is reported",
+        rc == EXIT_FAIL and "FlowDetailPage.vue" in out,
+        f"rc={rc} out={out.strip()[-220:]}",
+    )
+
+# The control for the alias resolver: an alias that points at NOTHING must not
+# invent a page.
+_MANIFEST_DANGLING = """{
+  "pages": [
+    {"id": "Ghost", "type": "custom", "route": "/ghost", "component": "NoSuchView"}
+  ]
+}"""
+with _repo_mixed(manifest=_MANIFEST_DANGLING) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "a manifest component resolving to no file adds no page",
+        "NoSuchView" not in out,
+        out.strip()[-200:],
+    )
+
 print()
 print(f"{_passed}/{_passed + len(_failed)} passed")
 if _failed:

--- a/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
+++ b/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_29_gitignore_negation.sh — gate-29 must read a `!` line as a
+# NEGATION, not as an ignore rule (.github#293).
+#
+# WHAT WENT WRONG
+# ---------------
+# gate-29 built its lookup prefix with
+#
+#     _prefix=$(echo "${_pat}" | sed -E 's|^/||; s|/$||; s|^\!||')
+#                                                    ^^^^^^^^^^
+#
+# — it STRIPPED the `!` and then looked the remainder up in `git ls-files`. A
+# `!` line does the OPPOSITE of an ignore rule: it un-ignores. So a negation
+# that matches a tracked file is the CORRECT, INTENDED state, and gate-29
+# reported it as an oversight.
+#
+# Measured on ConductionNL/openbuild@development:
+#
+#     ignore_pattern=!tests/vitest/setup.js      tracked_file=tests/vitest/setup.js
+#     ignore_pattern=!tests/e2e/global-setup.ts  tracked_file=tests/e2e/global-setup.ts
+#
+# Those two lines exist to rescue real source from a broader `**/setup*` rule:
+#
+#     **/setup*
+#     !tests/vitest/setup.js
+#     !tests/e2e/global-setup.ts
+#
+# WHY IT IS WORSE THAN NOISE
+# --------------------------
+# The finding pushes the author toward DELETING the negations — which would
+# ignore two real test files. The gate as written can talk someone into causing
+# the exact defect it exists to detect, and it is unclosable: openbuild fixed
+# its 5 genuine findings (openbuild#161) and gate-29 still reported 2.
+#
+# NOT `git check-ignore`
+# ----------------------
+# `git check-ignore -q` EXITS 0 WHEN A NEGATION MATCHES, so an exit-code probe
+# reports "ignored" for a file that is explicitly un-ignored. The gate's own
+# docblock already refuses that command for a different reason (it answers from
+# the working tree and calls a tracked file "not ignored"). This fix therefore
+# does not reach for it: a `!` line is simply not an ignore rule, which is a
+# question about the pattern, not about the filesystem.
+#
+# Run: bash scripts/lib/test_gate_29_gitignore_negation.sh
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+RUNNER="${LIB_DIR}/../run-hydra-gates.sh"
+
+_fail_count=0
+_pass_count=0
+
+_ok()   { echo "  PASS — $1"; _pass_count=$((_pass_count + 1)); }
+_bad()  { echo "  FAIL — $1"; _fail_count=$((_fail_count + 1)); }
+
+if [ ! -f "${RUNNER}" ]; then
+	echo "FAIL — runner not found at ${RUNNER}"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Build a throwaway app repo with a BASE commit and a HEAD commit whose diff
+# adds .gitignore lines. gate-29 is intrinsically diff-relative, so the fixture
+# has to be a real two-commit git history — this is the gate's actual contract,
+# not a stand-in for it.
+#
+# Args: <gitignore-lines-added-at-HEAD> <tracked-file-1> [<tracked-file-2>...]
+# Echoes the gate-29 findings (log lines), one per line.
+# ---------------------------------------------------------------------------
+_run_gate29() {
+	local added="$1"; shift
+	local root rc
+	root="$(mktemp -d "${TMPDIR:-/tmp}/g29fixture.XXXXXX")" || return 1
+	(
+		cd "${root}" || exit 1
+		git init -q .
+		git config user.email t@example.com
+		git config user.name t
+		git config commit.gpgsign false
+		# BASE: the tracked files exist, .gitignore is empty.
+		local f
+		for f in "$@"; do
+			mkdir -p "$(dirname "${f}")"
+			echo "// real source" > "${f}"
+		done
+		printf '# base\n' > .gitignore
+		git add -A >/dev/null 2>&1
+		git commit -qm base >/dev/null 2>&1
+		git branch -f base HEAD >/dev/null 2>&1
+		# HEAD: the diff ADDS the ignore lines under test.
+		printf '%s\n' "${added}" >> .gitignore
+		git add -A >/dev/null 2>&1
+		git commit -qm head >/dev/null 2>&1
+	) >/dev/null 2>&1 || { rm -rf "${root}"; return 1; }
+
+	local logdir out
+	logdir="$(mktemp -d "${TMPDIR:-/tmp}/g29logs.XXXXXX")"
+	out="$(cd "${root}" && HYDRA_GATE_LOG_DIR="${logdir}" \
+		bash "${RUNNER}" --scope-to-diff --base base 2>&1)"
+	rc=$?
+	# Read the LOG, never the exit code — the runner's status is an aggregate
+	# over 60+ gates and says nothing about gate-29.
+	if [ -f "${logdir}/hydra-gate-gitignore-then-commit.log" ]; then
+		cat "${logdir}/hydra-gate-gitignore-then-commit.log"
+	fi
+	# Surface the verdict line on stderr so a human debugging this suite can
+	# see whether the gate ran at all.
+	printf '%s\n' "${out}" | grep -E '\[(hydra-gates\] )?gate-29' >&2
+	rm -rf "${root}" "${logdir}"
+	return 0
+}
+
+echo "== gate-29: a '!' line is a NEGATION, not an ignore rule (.github#293) =="
+echo
+
+# ---------------------------------------------------------------------------
+# ARM 1 — the false positive must be GONE.
+# openbuild's exact shape: a broad rule plus the negations that rescue real
+# source from it, with both rescued files tracked.
+# ---------------------------------------------------------------------------
+_out="$(_run_gate29 '**/setup*
+!tests/vitest/setup.js
+!tests/e2e/global-setup.ts' tests/vitest/setup.js tests/e2e/global-setup.ts 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 1: negations over tracked files report 0 (openbuild's shape)"
+else
+	_bad "arm 1: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — THE TRUE POSITIVE MUST STILL FIRE.
+# A plain ignore rule over a tracked path is the defect gate-29 exists for
+# (opencatalogi#539: 116 .phpunit.cache/ files shipped alongside the new rule).
+# If arm 1's fix ever degrades into "skip anything with a bang in it", or into
+# skipping the whole loop, this goes quiet.
+# ---------------------------------------------------------------------------
+_out="$(_run_gate29 'docs/build/' docs/build/index.html 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -ge 1 ] && printf '%s' "${_out}" | grep -q 'tracked_file=docs/build/index.html'; then
+	_ok "arm 2: a plain ignore rule over a tracked file still FAILS (${_n} finding(s))"
+else
+	_bad "arm 2: expected >=1 finding naming docs/build/index.html, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 3 — THE ABUSE CONTROL. A diff that adds BOTH a real ignore rule and a
+# negation must still report the real one. This is the arm that proves the
+# skip stays narrow: it would fail if the fix short-circuited the whole
+# pattern loop on seeing a negation, or skipped the rest of the file.
+# ---------------------------------------------------------------------------
+_out="$(_run_gate29 '!tests/vitest/setup.js
+docs/build/' tests/vitest/setup.js docs/build/index.html 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'tracked_file=docs/build/index.html'; then
+	_ok "arm 3: negation skipped, the real rule beside it still reported"
+elif printf '%s' "${_out}" | grep -q 'ignore_pattern=!'; then
+	_bad "arm 3: a '!' pattern was reported as an ignore rule:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+else
+	_bad "arm 3: expected exactly 1 finding (docs/build/index.html), got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 4 — a negation whose path is NOT tracked is still not a finding, and the
+# gate must not crash or invert on it.
+# ---------------------------------------------------------------------------
+_out="$(_run_gate29 '!tests/vitest/setup.js' src/main.js 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 4: a negation over an untracked path reports 0"
+else
+	_bad "arm 4: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+echo
+echo "== summary: ${_pass_count} passed, ${_fail_count} failed =="
+[ "${_fail_count}" -eq 0 ] || exit 1
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
+++ b/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
@@ -71,7 +71,7 @@ fi
 # ---------------------------------------------------------------------------
 _run_gate29() {
 	local added="$1"; shift
-	local root rc
+	local root
 	root="$(mktemp -d "${TMPDIR:-/tmp}/g29fixture.XXXXXX")" || return 1
 	(
 		cd "${root}" || exit 1

--- a/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
+++ b/hydra-gates/scripts/lib/test_gate_29_gitignore_negation.sh
@@ -97,11 +97,10 @@ _run_gate29() {
 
 	local logdir out
 	logdir="$(mktemp -d "${TMPDIR:-/tmp}/g29logs.XXXXXX")"
+	# The runner's exit status is DELIBERATELY not captured: it aggregates 60+
+	# gates and says nothing about gate-29. The verdict is the log.
 	out="$(cd "${root}" && HYDRA_GATE_LOG_DIR="${logdir}" \
 		bash "${RUNNER}" --scope-to-diff --base base 2>&1)"
-	rc=$?
-	# Read the LOG, never the exit code — the runner's status is an aggregate
-	# over 60+ gates and says nothing about gate-29.
 	if [ -f "${logdir}/hydra-gate-gitignore-then-commit.log" ]; then
 		cat "${logdir}/hydra-gate-gitignore-then-commit.log"
 	fi

--- a/hydra-gates/scripts/lib/test_gate_3_bodiless_declaration.sh
+++ b/hydra-gates/scripts/lib/test_gate_3_bodiless_declaration.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_3_bodiless_declaration.sh — gate-3's `caller-identity-ignored` rule
+# must not judge a BODILESS declaration (.github#291).
+#
+# WHAT WENT WRONG
+# ---------------
+# The rule extracts a method body with
+#
+#     awk -v start=N 'NR >= start { print; if (NR > start && /^    \}/) exit }'
+#
+# whose terminator is a line matching `^    \}`. An INTERFACE file contains no
+# such line: its methods end in `;` and the interface's own closing brace sits
+# at column 0. So for an interface method the awk ran to EOF and called the
+# result "the body", the `< 4` skip (whose own comment says it means to skip
+# "abstract/interface forwards") never fired, and the parameter appeared
+# exactly once — on the signature — so the method was reported.
+#
+# Measured on pipelinq, `lib/Service/Cti/CtiAdapterInterface.php:78`:
+#
+#     public function subscribeToPresence(string $userId, string $extension): void;
+#
+# 92-line file, declaration at line 78, `grep -cE '^    \}'` = 0, extraction =
+# 15 lines. Reported `rule=caller-identity-ignored param=$userId`.
+#
+# WHY IT IS UNCLOSABLE
+# --------------------
+# The parameter is part of the interface CONTRACT and is genuinely used by the
+# implementor. A declaration cannot reference anything, so the only edits that
+# silence it are deleting the parameter (breaking the contract) or moving the
+# method away from the end of the file. Neither is a fix.
+#
+# Run: bash scripts/lib/test_gate_3_bodiless_declaration.sh
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+RUNNER="${LIB_DIR}/../run-hydra-gates.sh"
+
+_fail_count=0
+_pass_count=0
+_ok()  { echo "  PASS — $1"; _pass_count=$((_pass_count + 1)); }
+_bad() { echo "  FAIL — $1"; _fail_count=$((_fail_count + 1)); }
+
+[ -f "${RUNNER}" ] || { echo "FAIL — runner not found at ${RUNNER}"; exit 1; }
+
+# Run gate-3 over a repo containing one file; echo the caller-identity findings.
+# Args: <relative-path> <file-content>
+_run_gate3() {
+	local rel="$1" content="$2" root logdir out
+	root="$(mktemp -d "${TMPDIR:-/tmp}/g3fixture.XXXXXX")" || return 1
+	mkdir -p "${root}/$(dirname "${rel}")"
+	printf '%s' "${content}" > "${root}/${rel}"
+	(
+		cd "${root}" || exit 1
+		git init -q .
+		git config user.email t@example.com
+		git config user.name t
+		git config commit.gpgsign false
+		git add -A && git commit -qm base
+	) >/dev/null 2>&1
+	logdir="$(mktemp -d "${TMPDIR:-/tmp}/g3logs.XXXXXX")"
+	out="$(cd "${root}" && HYDRA_GATE_LOG_DIR="${logdir}" bash "${RUNNER}" . 2>&1)"
+	# READ THE LOG, NOT THE EXIT CODE — the runner's status aggregates 60+ gates.
+	grep 'caller-identity-ignored' "${logdir}/hydra-gate-stub-scan.log" 2>/dev/null
+	rm -rf "${root}" "${logdir}"
+	return 0
+}
+
+# The pipelinq fixture: a long interface whose LAST method declares $userId.
+# The trailing docblocks matter — they are what put the declaration >=4 lines
+# from EOF, which is the condition under which the old code reported it.
+_INTERFACE='<?php
+
+namespace OCA\Pipelinq\Service\Cti;
+
+/**
+ * Adapter contract for a CTI provider.
+ */
+interface CtiAdapterInterface
+{
+    /**
+     * Place an outbound call.
+     *
+     * @param string $extension The extension to dial.
+     *
+     * @return void
+     */
+    public function dial(string $extension): void;
+
+    /**
+     * Subscribe to presence updates for a user.
+     *
+     * @param string $userId    The user whose presence to watch.
+     * @param string $extension The extension to bind.
+     *
+     * @return void
+     */
+    public function subscribeToPresence(string $userId, string $extension): void;
+
+    /**
+     * Verify a webhook payload signature.
+     *
+     * @param string $payload   Raw body.
+     * @param string $signature Provider signature header.
+     *
+     * @return bool
+     */
+    public function verifySignature(string $payload, string $signature): bool;
+}
+'
+
+# The TRUE POSITIVE: a real class method with a body that ignores $userId.
+# This is decidesk#45's shape, the defect the rule exists for.
+_STUB_CLASS='<?php
+
+namespace OCA\Pipelinq\Service;
+
+class PresenceService
+{
+    /**
+     * Subscribe to presence updates.
+     *
+     * @param string $userId    The caller.
+     * @param string $extension The extension.
+     *
+     * @return void
+     */
+    public function subscribeToPresence(string $userId, string $extension): void
+    {
+        $this->logger->info("subscribing");
+        $this->bus->dispatch(new Subscribe($extension));
+        return;
+    }
+}
+'
+
+# The other true positive: a real class method that DOES use $userId.
+_GOOD_CLASS='<?php
+
+namespace OCA\Pipelinq\Service;
+
+class PresenceService
+{
+    /**
+     * Subscribe to presence updates.
+     *
+     * @param string $userId    The caller.
+     * @param string $extension The extension.
+     *
+     * @return void
+     */
+    public function subscribeToPresence(string $userId, string $extension): void
+    {
+        $this->logger->info("subscribing " . $userId);
+        $this->bus->dispatch(new Subscribe($userId, $extension));
+        return;
+    }
+}
+'
+
+echo "== gate-3: a bodiless declaration has no body to ignore a param in (#291) =="
+echo
+
+# ARM 1 — the false positive is GONE.
+_out="$(_run_gate3 "lib/Service/Cti/CtiAdapterInterface.php" "${_INTERFACE}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 1: an interface declaration is not reported (pipelinq's shape)"
+else
+	_bad "arm 1: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 2 — THE TRUE POSITIVE MUST STILL FIRE. Same method name, same parameter,
+# but a real body that never touches it: decidesk#45's unfinished stub.
+_out="$(_run_gate3 "lib/Service/PresenceService.php" "${_STUB_CLASS}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'method=subscribeToPresence'; then
+	_ok "arm 2: a real method body that ignores \$userId is STILL reported"
+else
+	_bad "arm 2: expected exactly 1 finding for subscribeToPresence, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 3 — THE ABUSE CONTROL. The skip keys on the SIGNATURE TERMINATOR, not on
+# "the file mentions an interface" and not on the method name. A class method
+# whose signature ends in `{` must be judged normally — otherwise a rule that
+# meant to spare declarations would spare every method whose return type
+# happens to be written like one.
+_out="$(_run_gate3 "lib/Service/PresenceService.php" "${_GOOD_CLASS}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 3: a real method that USES \$userId is not reported"
+else
+	_bad "arm 3: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 4 — a SHORT interface, to show the `< 4` skip was never the safety net it
+# was taken for. Measured against the unfixed runner this arm ALSO reports:
+# the extraction from the declaration to EOF is exactly 4 lines, so `< 4` does
+# not fire and a two-method interface is judged like a stub. The bug was never
+# about being last in the file, only about there being no `^    \}` to stop at.
+_out="$(_run_gate3 "lib/Service/Cti/OtherInterface.php" '<?php
+
+interface OtherInterface
+{
+    public function subscribeToPresence(string $userId, string $extension): void;
+
+    public function dial(string $extension): void;
+}
+' 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 4: a mid-file interface declaration stays unreported"
+else
+	_bad "arm 4: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+echo
+echo "== summary: ${_pass_count} passed, ${_fail_count} failed =="
+[ "${_fail_count}" -eq 0 ] || exit 1
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_3_bodiless_declaration.sh
+++ b/hydra-gates/scripts/lib/test_gate_3_bodiless_declaration.sh
@@ -60,9 +60,15 @@ _run_gate3() {
 		git add -A && git commit -qm base
 	) >/dev/null 2>&1
 	logdir="$(mktemp -d "${TMPDIR:-/tmp}/g3logs.XXXXXX")"
+	# The runner's exit status is DELIBERATELY not captured: it aggregates 60+
+	# gates and says nothing about gate-3. The verdict is the log.
 	out="$(cd "${root}" && HYDRA_GATE_LOG_DIR="${logdir}" bash "${RUNNER}" . 2>&1)"
 	# READ THE LOG, NOT THE EXIT CODE — the runner's status aggregates 60+ gates.
 	grep 'caller-identity-ignored' "${logdir}/hydra-gate-stub-scan.log" 2>/dev/null
+	# Surface gate-3's own verdict line on stderr so a human debugging this
+	# suite can see whether the gate ran at all rather than guessing from an
+	# empty result — an unrun gate and a clean one look identical otherwise.
+	printf '%s\n' "${out}" | grep -E '\[gate-3\]' >&2
 	rm -rf "${root}" "${logdir}"
 	return 0
 }
@@ -70,6 +76,7 @@ _run_gate3() {
 # The pipelinq fixture: a long interface whose LAST method declares $userId.
 # The trailing docblocks matter — they are what put the declaration >=4 lines
 # from EOF, which is the condition under which the old code reported it.
+# shellcheck disable=SC2016  # $userId is PHP source, not a shell expansion — single quotes are REQUIRED here
 _INTERFACE='<?php
 
 namespace OCA\Pipelinq\Service\Cti;
@@ -112,6 +119,7 @@ interface CtiAdapterInterface
 
 # The TRUE POSITIVE: a real class method with a body that ignores $userId.
 # This is decidesk#45's shape, the defect the rule exists for.
+# shellcheck disable=SC2016  # $userId is PHP source, not a shell expansion — single quotes are REQUIRED here
 _STUB_CLASS='<?php
 
 namespace OCA\Pipelinq\Service;
@@ -136,6 +144,7 @@ class PresenceService
 '
 
 # The other true positive: a real class method that DOES use $userId.
+# shellcheck disable=SC2016  # $userId is PHP source, not a shell expansion — single quotes are REQUIRED here
 _GOOD_CLASS='<?php
 
 namespace OCA\Pipelinq\Service;
@@ -202,6 +211,7 @@ fi
 # the extraction from the declaration to EOF is exactly 4 lines, so `< 4` does
 # not fire and a two-method interface is judged like a stub. The bug was never
 # about being last in the file, only about there being no `^    \}` to stop at.
+# shellcheck disable=SC2016  # $userId is PHP source, not a shell expansion — single quotes are REQUIRED here
 _out="$(_run_gate3 "lib/Service/Cti/OtherInterface.php" '<?php
 
 interface OtherInterface

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1586,6 +1586,38 @@ while IFS= read -r f; do
             _method=$(echo "$_sig" | grep -oE 'function\s+\w+' | awk '{print $2}')
             _param=$(echo "$_sig" | grep -oE '\$(uid|callerUid|userId|caller)\b' | head -1)
             [ -z "$_method" ] || [ -z "$_param" ] && continue
+            # A BODILESS DECLARATION HAS NO BODY TO IGNORE THE PARAM IN
+            # (.github#291).
+            #
+            # The body extraction below stops at a line matching `^    \}`. An
+            # INTERFACE file contains no such line — its methods end in `;` and
+            # the interface's own closing brace is at column 0 — so for an
+            # interface method the awk ran from the declaration to EOF and
+            # called the result "the body". The `< 4` skip below, whose comment
+            # says it means to skip "abstract/interface forwards", therefore
+            # never fired: the synthesised body is as long as the rest of the
+            # file.
+            #
+            # Measured on pipelinq: `lib/Service/Cti/CtiAdapterInterface.php:78`
+            #
+            #     public function subscribeToPresence(string $userId, string $extension): void;
+            #
+            # 92-line file, declaration at 78, zero `^    \}` matches, extraction
+            # = 15 lines, reported as `rule=caller-identity-ignored`.
+            #
+            # There is NO correct fix available to the app author: the parameter
+            # is part of the interface contract and is genuinely used by the
+            # implementor (`AsteriskAdapter::subscribeToPresence` references
+            # `$userId` — and is still checked here, with a real body). A
+            # declaration cannot reference anything. The only ways to silence it
+            # were to delete the parameter, breaking the contract, or to move the
+            # method away from the end of the file.
+            #
+            # Decide it on the SIGNATURE's terminator, which is the property that
+            # actually distinguishes the two: `;` = declaration, `{` = body.
+            _sig_region=$(awk -v start="${_line_no}" 'NR >= start { printf "%s", $0; if (/[;{]/) exit }' "$f")
+            _sig_term=$(printf '%s' "${_sig_region}" | grep -oE '[;{]' | head -1)
+            [ "${_sig_term}" = ";" ] && continue
             _body=$(awk -v start="${_line_no}" 'NR >= start { print; if (NR > start && /^    \}/) exit }' "$f")
             _body_lines=$(echo "${_body}" | wc -l)
             # A legitimate ≥3-line method that accepts a caller-identity
@@ -2071,7 +2103,19 @@ if [ "${_idor_ran}" -eq 1 ]; then
     if [ "${_idor_fail}" -eq 0 ]; then
         _pass 7 "no-admin-idor"
     else
-        _fail 7 "no-admin-idor" "${_idor_fail} method(s) with NoAdminRequired + no guard — see ${_idor_log}"
+        # THE GUARD MAY BE TWO FRAMES DOWN (.github#315). The checker can only
+        # read the controller method's own body. On a repo that enforces
+        # multi-tenancy at the DATA-ACCESS layer, the service in between looks
+        # unscoped — `findAll(filters:)`, `updateFromArray(id:)`, no
+        # organisation in sight — because the scoping lives in the MAPPER
+        # (`MultiTenancyTrait::applyOrganisationFilter()`).
+        #
+        # Measured on openregister: 8 of 9 findings were that shape, and TWO
+        # WERE NEARLY FILED AS VULNERABILITIES by a reader who stopped at the
+        # service layer — which is where reading naturally stops, because the
+        # service is what the controller calls. Saying so here costs nothing
+        # and is the difference between a triage and a wrong security report.
+        _fail 7 "no-admin-idor" "${_idor_fail} method(s) with NoAdminRequired + no guard — see ${_idor_log}. BEFORE treating any of these as real: the checker sees ONLY the controller method body. If the endpoint reaches storage through a service or mapper, check whether the guard is enforced THERE (e.g. an organisation/tenant filter applied in the query builder) — and note that a deliberate 404-style tenancy refusal IS a guard, chosen so a 403 cannot become an existence oracle for another tenant's ids."
     fi
 fi
 
@@ -4026,6 +4070,12 @@ _gi_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-gitignore-then-commit.log
 : > "${_gi_log}"
 _gi_ran=0
 _gi_new_count=0
+# Negations added by this diff. Counted separately from _gi_new_count because a
+# `!` line is not an ignore rule, but it IS a line this gate read and decided
+# about — folding it into "nothing was added" would print a verdict that
+# misdescribes the diff, and folding it into "rules checked" would claim a
+# lookup that never happened. See .github#293.
+_gi_neg_count=0
 if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -f .gitignore ]; then
     # Lines newly added to .gitignore in this PR (excluding blanks + comments)
     _new_ignores=$(git -c safe.directory='*' diff "${BASE_REF}...HEAD" -- .gitignore 2>/dev/null \
@@ -4034,10 +4084,41 @@ if [ "${SCOPE_TO_DIFF}" = "1" ] && [ -f .gitignore ]; then
     if [ -n "${_new_ignores}" ]; then
         while IFS= read -r _pat; do
             [ -z "${_pat}" ] && continue
+            # A LEADING `!` IS A NEGATION — IT UN-IGNORES (.github#293).
+            #
+            # This loop used to strip the bang (`sed 's|^\!||'`) and look the
+            # remainder up in `git ls-files`, which inverts the rule's meaning:
+            # a `!` line that matches a tracked file is the CORRECT, INTENDED
+            # state, not an oversight. Measured on openbuild@development:
+            #
+            #   ignore_pattern=!tests/vitest/setup.js      tracked=tests/vitest/setup.js
+            #   ignore_pattern=!tests/e2e/global-setup.ts  tracked=tests/e2e/global-setup.ts
+            #
+            # both of which exist to rescue real source from a broader
+            # `**/setup*` rule three lines above them.
+            #
+            # That is worse than a noisy finding: the only edit that clears it
+            # is DELETING the negations, which would ignore two real test
+            # files — so the gate could talk an author into causing the exact
+            # defect it exists to detect. It was also unclosable; openbuild
+            # fixed its 5 genuine findings (openbuild#161) and this stayed at 2.
+            #
+            # NOTE FOR ANY FUTURE EDIT: do NOT reach for `git check-ignore` to
+            # decide this. It EXITS 0 WHEN A NEGATION MATCHES, so an exit-code
+            # probe reports "ignored" for a file that is explicitly un-ignored
+            # — the wrong instrument in the other direction. Whether a line is
+            # an ignore rule is a property of the PATTERN, answered here.
+            case "${_pat}" in
+                [[:space:]]*\!*|\!*)
+                    case "$(printf '%s' "${_pat}" | sed -E 's|^[[:space:]]+||')" in
+                        \!*) _gi_neg_count=$((_gi_neg_count + 1)); continue ;;
+                    esac
+                    ;;
+            esac
             _gi_new_count=$((_gi_new_count + 1))
             # Strip leading slash + trailing slash to get the directory/file
             # prefix to match against `git ls-files` output.
-            _prefix=$(echo "${_pat}" | sed -E 's|^/||; s|/$||; s|^\!||')
+            _prefix=$(echo "${_pat}" | sed -E 's|^/||; s|/$||')
             [ -z "${_prefix}" ] && continue
             # Skip wildcard-only entries (e.g. "*.log") — they'd match too broadly
             # in `git ls-files` and the real signal is path-prefix shape.
@@ -4064,8 +4145,17 @@ if [ "${_gi_fail}" -ne 0 ]; then
 elif [ "${_gi_ran}" -eq 1 ] && [ "${_gi_new_count}" -gt 0 ]; then
     # The only shape that earns a PASS: a diff that really added ignore rules,
     # each of which was really looked up against the tracked file list.
-    echo "[hydra-gates] gate-29 gitignore-then-commit: ${_gi_new_count} newly-added .gitignore rule(s) checked against the tracked file list; none has tracked files behind it."
+    _gi_neg_note=""
+    if [ "${_gi_neg_count}" -gt 0 ]; then
+        _gi_neg_note=" ${_gi_neg_count} negation(s) (\`!\`) were NOT looked up — a negation un-ignores, so a tracked file behind one is the intended state (.github#293)."
+    fi
+    echo "[hydra-gates] gate-29 gitignore-then-commit: ${_gi_new_count} newly-added .gitignore rule(s) checked against the tracked file list; none has tracked files behind it.${_gi_neg_note}"
     _pass 29 "gitignore-then-commit"
+elif [ "${_gi_ran}" -eq 1 ] && [ "${_gi_neg_count}" -gt 0 ]; then
+    # The diff added lines, but every one of them was a negation. Saying
+    # "adds no non-comment line" here (the branch below) would misdescribe the
+    # diff, and PASS would claim a lookup that never happened.
+    _skip 29 "gitignore-then-commit" na "the diff adds ${_gi_neg_count} .gitignore line(s) and every one is a NEGATION (\`!\`), which un-ignores rather than ignores. A tracked file behind a negation is the intended state, so there is no new ignore rule whose path could already be tracked. See .github#293."
 elif [ "${SCOPE_TO_DIFF}" != "1" ]; then
     _skip 29 "gitignore-then-commit" na "this check is intrinsically diff-relative — it asks whether THIS change adds an ignore rule over files that are already tracked — and this run is not --scope-to-diff, so there is no set of newly-added rules to look up. Nothing was inspected and nothing could be. It runs on every PR."
 elif [ ! -f .gitignore ]; then


### PR DESCRIPTION
Eight gates that reported findings against **correct code**. Several prescribed a fix that would have introduced a real defect, and three were **unclosable** — no honest edit cleared them.

Closes #310, #273, #290, #293, #309, #319, #291, #297, #315. Adds the two points #304 still needed after #324.

## The bar applied to every change

1. prove the false positive is gone; 2. **prove the true positive still fires**; 3. add an abuse control wherever the relaxation could become a blanket. Every number below is **full-tree, measured per repo** — no fleet averages.

**Two of these caught me:**

* gate-26's first draft took openconnector from 40 findings to **0** — it swallowed the six real pages too. Root cause was a second, deeper defect (below).
* gate-7's first draft made **six existing tests go red**, because a zero-input `findAll()` is an unscoped enumeration, not a safe endpoint. That is exactly what the abuse-control bar is for.

## Fleet-wide finding counts

Re-measured immediately before merge, both arms in the same pass — **the baselines move while you work**, because other agents are fixing these apps concurrently. The DELTA is what this PR causes; the absolute numbers are a snapshot.

| gate | before | after | delta |
|---|---|---|---|
| 26 visual-coverage | 510 | **209** | **−301** |
| 40 form-label-association | 485 | **398** | **−87** |
| 7 no-admin-idor | 20 | **15** | **−5** |
| 44 autocomplete-attr | 16 | **13** | **−3** |
| 3 stub-scan | 6 | **5** | **−1** |
| 6 orphan-auth | 5 | **4** | **−1** |
| 29 gitignore-then-commit | openbuild 2 | **0** | unclosable, now clean |
| 55 detail-page-discipline | decidesk 28 | **28** | findings were real; message + invocation fixed |

**−398 false positives** in total.

⚠️ An earlier revision of this description said gate-7 was `24 → 18 (−6)`. That was measured a few hours earlier; `openregister::FederatedConfigController::types` has since left gate-7's scope entirely because openregister#2398 removed its `#[NoAdminRequired]`. Five methods are cleared by Pattern 3b now, not six — the sixth was fixed in the app, not by this PR.

## Per gate

**gate-40 (#310, #273)** — `inputId` is not a prop on `NcTextField`/`NcInputField` (absent from 9.9.0 typings, zero occurrences in 8.39.0), so the prescribed `:input-id` was inert. `id` is what reaches the `<input>`: 9.9.0 renders `id: __props.id`; 8.39.0 is `inheritAttrs:false` with `computedId() { return this.$attrs.id ? this.$attrs.id : this.inputName }`. The Nc* branch now accepts a plain `id` matching a `<label for>`, as the native branch already did. The only prior remedies were a no-op and an `aria-label` that overrides the visible label (WCAG 2.5.3). For #273: `aria-hidden` matched **0** of 471 fleet findings and `display:none` matched **8**, all `type="file"` — so the exemption is keyed on "not in the accessibility tree" with `display:none` bounded to `type="file"`, because a style can be toggled by JS.

**gate-26 (#309)** — the `src/views/` rule is a path-shaped proxy, so rows, widgets and NC settings panels were "pages" whose only reachable remedy is a waiver. Replaced with reachability, dropping a file only on **positive evidence** of child-ness. Found while fixing it: **`type:"page"` never occurs in a manifest-V2 app**, so the manifest half of this gate was dead everywhere (openconnector: 35 declared pages, **0 resolved**) — and a v2 `component` names the *registered* identifier, which an import may alias to a differently-named file. All 6 of openconnector's genuine pages retained; all 7 named false positives gone.

**gate-7 (#297, #315)** — Pattern 3b: zero parameters + no request reads + **no mutation** + **no object access**. Clears five methods (six when measured; one has since left scope), each read individually, all single delegations to a zero-argument catalogue/config/status call. The FAIL message now says the guard may live in a mapper or service two frames down, and that a 404-style tenancy refusal *is* a guard — the note that would have prevented two near-miss vulnerability reports. It sits on the runner message, not the finding line, because `filter_preexisting_methods.py` parses `rule=(?P<rule>.+)$`.

**gate-29 (#293)** — the prefix builder **stripped** a leading `!` and looked the remainder up, so a negation read as an ignore rule; the only closing edit was deleting negations that rescue two real test files. `git check-ignore` deliberately not used — it exits 0 when a negation matches *and* answers from the working tree.

**gate-44 (#319)** — token boundaries alone were **not** enough: `email` is a whole token in `nldesign-email-footer-org-name`, which collects a name. The semantic term must now fall in the **last two** tokens. Window is two, not one, so `emailRecipient` (a real `type="email"` finding) survives. I tried adding `organisation` to the vocabulary and **reverted it** — it made decidesk's site-config field a finding.

**gate-3 (#291)** — an interface file has no `^    \}`, so "the body" ran to EOF. Decided on the signature terminator instead. The `< 4` skip never protected these: a two-method interface extracts to exactly 4 lines. Fixed-indent terminator left alone — measured **0** tab-indented method closes across four repos.

**gate-55 (#304)** — an unknown icon resolves to `DEFAULT_ICON = ViewDashboard`, not `?`, so intent is lost *invisibly*; message corrected and now points at gate-60 for the app-level half. `--app-dir` made argv[1] a log path, inspected nothing and exited 0 — malformed invocations now exit 2 with usage text stating that **exit status is not the verdict**.

**gate-6 (#290)** — a routed action has no `->method(` anywhere. Cleared by `'<lowerCamelController>#<method>'` or a `#[Route]`/`#[ApiRoute]` attribute; controllers only, since a service is not routable.

## Verification

All **53** discovered helper suites green with `NODE_PATH` set (so `test_gate_45_to_55_acceptance.sh` reports no phantom gate-53 defects). Two new runner-driven suites — `test_gate_29_gitignore_negation.sh` and `test_gate_3_bodiless_declaration.sh` — are auto-discovered and add ~7s. Every helper was invoked **exactly as the runner invokes it**, reading the log rather than the exit code, with a 0-byte `.err` to prove the checker lived.
