### PR TITLE
fix(gate-19): score the Playwright config CI executes, not the one at the root

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -1199,21 +1199,121 @@ def _regexes(raw: str | None) -> list[re.Pattern[str]] | None:
     return out or None
 
 
+_WF_TEST_PATH_RE = re.compile(
+    r"^[^\S\n]*playwright-test-path[^\S\n]*:[^\S\n]*(['\"]?)([^'\"#\n]+)\1",
+    re.MULTILINE)
+
+
+def _declared_test_path(app_dir: Path) -> str:
+    """The `playwright-test-path` the app's CI actually declares.
+
+    Resolution mirrors how the value reaches the shared workflow:
+
+      1. ``$PLAYWRIGHT_TEST_PATH`` — set by a caller or a local run
+      2. the ``playwright-test-path:`` input in the app's own caller workflow
+      3. ``tests/e2e`` — the shared workflow's declared default
+
+    Read out of the caller workflow rather than plumbed through a new env var
+    on purpose: the gate has to agree with the file that decides the
+    behaviour, and a second source of truth would drift from it exactly the
+    way the root config drifted from the CI config.
+    """
+    env = os.environ.get("PLAYWRIGHT_TEST_PATH", "").strip()
+    if env:
+        return env.strip("/")
+    wf_dir = app_dir / ".github" / "workflows"
+    if wf_dir.is_dir():
+        for wf in sorted(wf_dir.glob("*.y*ml")):
+            try:
+                text = wf.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for m in _WF_TEST_PATH_RE.finditer(text):
+                value = m.group(2).strip().strip("/")
+                # `#` starts a YAML comment, so a commented-out or
+                # documentation line yields nothing usable. Several fleet
+                # workflows explain this input at length directly above it.
+                if value and not value.startswith("#"):
+                    return value
+    return "tests/e2e"
+
+
+def _resolve_config(app_dir: Path) -> Path | None:
+    """The config CI executes — NOT necessarily the one at the repo root.
+
+    THE GATE READ A DIFFERENT FILE THAN CI RAN (.github#331)
+    -------------------------------------------------------
+    The shared workflow does exactly this:
+
+        CONFIG="${{ inputs.playwright-test-path }}/playwright.config.ts"
+        if [ ! -f "$CONFIG" ] && [ -f "playwright.config.ts" ]; then
+          CONFIG="playwright.config.ts"
+        fi
+        npx playwright test --config="$CONFIG"
+
+    so a config under `playwright-test-path` WINS over the root one. This gate
+    read the root config unconditionally, so in every repo carrying both it
+    scored a suite CI never executes.
+
+    Measured 2026-08-10 on openregister, which declares
+    `playwright-test-path: tests/e2e/ci`:
+
+        root config   testDir './tests/e2e'  -> 63 spec files
+        CI config     testDir '.'            ->  4 spec files
+        @e2e anchors  205 under tests/e2e, and ZERO of them under tests/e2e/ci
+
+    Every "covered" verdict gate-19 ever produced on that repo came from a
+    file CI does not run.
+
+    `.ts` is tried first at both locations because that is the literal the
+    workflow builds; the other extensions are a fallback for repos that do not
+    go through the shared workflow at all.
+    """
+    sub = _declared_test_path(app_dir)
+    if sub:
+        cand = app_dir / sub / "playwright.config.ts"
+        if cand.is_file():
+            return cand
+    cand = app_dir / "playwright.config.ts"
+    if cand.is_file():
+        return cand
+    for name in _PW_CONFIGS:
+        cand = app_dir / name
+        if cand.is_file():
+            return cand
+    return None
+
+
 class _PlaywrightScope:
     """Answers: would ANY project run this test file?"""
 
     def __init__(self, app_dir: Path) -> None:
         self.parsed = False
         self.test_dir = ""
+        self.config_dir = ""
+        self.config_rel = ""
         self.projects: list[tuple[list[str] | None, list[re.Pattern[str]] | None]] = []
-        for name in _PW_CONFIGS:
-            cfg = app_dir / name
-            if cfg.is_file():
-                try:
-                    self._parse(_strip_ts_comments(cfg.read_text(encoding="utf-8")))
-                except OSError:
-                    return
-                return
+        cfg = _resolve_config(app_dir)
+        if cfg is None:
+            return
+        try:
+            self.config_rel = os.path.relpath(str(cfg), str(app_dir)).replace(os.sep, "/")
+        except ValueError:
+            self.config_rel = cfg.name
+        # `testDir` is relative to the CONFIG's own directory, not to the repo
+        # root. openregister's CI config says `testDir: '.'` and means
+        # `tests/e2e/ci`, not the whole repository — reading it as repo-relative
+        # is what makes a 4-file suite look like a 63-file one.
+        try:
+            self.config_dir = os.path.relpath(str(cfg.parent), str(app_dir)).replace(os.sep, "/")
+        except ValueError:
+            return
+        if self.config_dir == ".":
+            self.config_dir = ""
+        try:
+            self._parse(_strip_ts_comments(cfg.read_text(encoding="utf-8")))
+        except OSError:
+            return
 
     def _parse(self, text: str) -> None:
         m = re.search(r"\bprojects\s*:\s*\[", text)
@@ -1236,11 +1336,17 @@ class _PlaywrightScope:
         else:
             top = text
 
+        # `testDir` is resolved against the CONFIG's directory (#331). An absent
+        # `testDir` means the config's own directory, which is Playwright's
+        # documented default and NOT "the whole repository".
         td = _value_after(top, "testDir")
+        raw = ""
         if td:
             lit = _STR_RE.findall(td)
             if lit:
-                self.test_dir = lit[0].lstrip("./").rstrip("/")
+                raw = lit[0]
+        joined = os.path.normpath(os.path.join(self.config_dir or ".", raw or "."))
+        self.test_dir = "" if joined in (".", "") else joined.replace(os.sep, "/").strip("/")
 
         top_ignore = _patterns(_value_after(top, "testIgnore"))
         top_match = _regexes(_value_after(top, "testMatch"))
@@ -1263,8 +1369,21 @@ class _PlaywrightScope:
         """True unless the config PROVES no project executes this file."""
         if not self.parsed or not self.projects:
             return True
+        # OUTSIDE `testDir` IS NOT RUN, AND THAT IS THE WHOLE POINT (#331).
+        #
+        # This used to return True here — "outside a testDir we may have
+        # mis-read, never accuse". That caution was sound while the gate was
+        # reading the ROOT config, whose `testDir` spans everything anyway. It
+        # is exactly wrong once the CI config is resolved: openregister's CI
+        # config confines the suite to `tests/e2e/ci`, and 59 of its 63 spec
+        # files are outside it. Treating "outside testDir" as run is what made
+        # 205 anchors in never-executed files count as proof.
+        #
+        # The safety property is kept where it belongs — `test_dir` is only
+        # non-empty when a literal was parsed, and an absent `testDir` leaves
+        # it at the config's own directory, per Playwright's default.
         if self.test_dir and not rel_to_app.startswith(self.test_dir + "/"):
-            return True   # outside a testDir we may have mis-read — never accuse
+            return False
         rel_to_dir = (rel_to_app[len(self.test_dir) + 1:]
                       if self.test_dir and rel_to_app.startswith(self.test_dir + "/")
                       else rel_to_app)
@@ -1339,8 +1458,9 @@ def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
                 elif ref not in live:
                     dead[ref] = (
                         f"referenced only by a file no Playwright project "
-                        f"runs — excluded by playwright.config testIgnore/"
-                        f"testMatch ({rel})"
+                        f"runs — {rel} is outside testDir or excluded by "
+                        f"testIgnore/testMatch in {scope.config_rel or 'playwright.config.ts'}, "
+                        f"which is the config CI executes"
                         if not file_runs else
                         f"referenced only by a test that never runs ({rel})"
                     )

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -1837,5 +1837,161 @@ class GlobTranslationTest(unittest.TestCase):
         self.assertIsNone(cec._glob_to_re("**/{a,b}/**"))
 
 
+# ---------------------------------------------------------------------------
+# .github#331 — the gate read a DIFFERENT config than CI executes.
+#
+# The shared workflow does:
+#
+#     CONFIG="${{ inputs.playwright-test-path }}/playwright.config.ts"
+#     if [ ! -f "$CONFIG" ] && [ -f "playwright.config.ts" ]; then
+#       CONFIG="playwright.config.ts"
+#     fi
+#     npx playwright test --config="$CONFIG"
+#
+# so a config under `playwright-test-path` WINS. The gate read the root one
+# unconditionally, and scored a suite CI never runs.
+#
+# The fixture below is openregister's real layout: a root config whose
+# `testDir` spans all of `tests/e2e`, and a `tests/e2e/ci/playwright.config.ts`
+# whose `testDir: '.'` means `tests/e2e/ci` — its OWN directory, not the repo
+# root. Measured on that repo: 63 spec files under `tests/e2e`, 4 under
+# `tests/e2e/ci`, 205 `@e2e` anchors, and ZERO of them in the executed path.
+_ROOT_CONFIG = """
+import { defineConfig } from '@playwright/test'
+export default defineConfig({
+\ttestDir: './tests/e2e',
+\tprojects: [{ name: 'chromium' }],
+})
+"""
+
+# `testDir: '.'` is relative to THIS FILE's directory.
+_CI_CONFIG = """
+import { defineConfig } from '@playwright/test'
+export default defineConfig({
+\ttestDir: '.',
+\tprojects: [{ name: 'chromium' }],
+})
+"""
+
+_CALLER_WF = """
+name: Code Quality
+on: [push]
+jobs:
+  quality:
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: demo
+      enable-playwright: true
+      playwright-test-path: tests/e2e/ci
+"""
+
+
+class PlaywrightConfigResolutionTest(unittest.TestCase):
+    """The gate must score the config CI runs, not the one at the root."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self._env = os.environ.pop("PLAYWRIGHT_TEST_PATH", None)
+        self.addCleanup(self._restore_env)
+        _write(self.root, "openspec/specs/saved-search-views/spec.md", _SPEC_MD)
+        self.ref = "saved-search-views::presentation-of-a-saved-view"
+        self.tag = ("// @e2e openspec/specs/saved-search-views/spec.md"
+                    "#presentation-of-a-saved-view\n"
+                    "test('renders', async ({ page }) => {\n"
+                    "  await page.goto('/apps/openregister/views')\n"
+                    "})\n")
+
+    def _restore_env(self):
+        os.environ.pop("PLAYWRIGHT_TEST_PATH", None)
+        if self._env is not None:
+            os.environ["PLAYWRIGHT_TEST_PATH"] = self._env
+
+    def _two_configs(self):
+        _write(self.root, "playwright.config.ts", _ROOT_CONFIG)
+        _write(self.root, "tests/e2e/ci/playwright.config.ts", _CI_CONFIG)
+        _write(self.root, ".github/workflows/code-quality.yml", _CALLER_WF)
+
+    # -- the defect ---------------------------------------------------------
+    def test_an_anchor_OUTSIDE_the_executed_config_does_NOT_cover(self):
+        # openregister's shape: the anchor sits in tests/e2e/, which the ROOT
+        # config runs and the CI config does not. 205 real anchors are here.
+        self._two_configs()
+        _write(self.root, "tests/e2e/search-views.spec.ts", self.tag)
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertNotIn(self.ref, live)
+        self.assertIn(self.ref, dead)
+        self.assertIn("tests/e2e/ci/playwright.config.ts", dead[self.ref])
+
+    # -- the reverse --------------------------------------------------------
+    def test_the_same_anchor_INSIDE_the_executed_config_DOES_cover(self):
+        self._two_configs()
+        _write(self.root, "tests/e2e/ci/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    # -- one config or two, per the coordinator's don't-double-count note ----
+    def test_a_repo_that_COLLAPSED_to_one_root_config_still_covers(self):
+        # launchpad#85 / openregister#2410 remove the second config. After
+        # that, tests/e2e IS the executed path and the anchor must count.
+        _write(self.root, "playwright.config.ts", _ROOT_CONFIG)
+        _write(self.root, ".github/workflows/code-quality.yml", _CALLER_WF)
+        _write(self.root, "tests/e2e/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    def test_no_workflow_at_all_falls_back_to_the_root_config(self):
+        _write(self.root, "playwright.config.ts", _ROOT_CONFIG)
+        _write(self.root, "tests/e2e/search-views.spec.ts", self.tag)
+        live, _dead = cec.collect_ref_status(self.root)
+        self.assertIn(self.ref, live)
+
+    # -- resolution details -------------------------------------------------
+    def test_testDir_dot_means_the_configs_OWN_directory_not_the_repo_root(self):
+        self._two_configs()
+        scope = cec._PlaywrightScope(self.root)
+        self.assertEqual(scope.config_rel, "tests/e2e/ci/playwright.config.ts")
+        self.assertEqual(scope.test_dir, "tests/e2e/ci")
+
+    def test_the_declared_path_is_read_from_the_caller_workflow(self):
+        self._two_configs()
+        self.assertEqual(cec._declared_test_path(self.root), "tests/e2e/ci")
+
+    def test_a_QUOTED_declared_path_is_read(self):
+        # hermiq writes it as `playwright-test-path: "tests/e2e/spec-coverage"`.
+        _write(self.root, ".github/workflows/code-quality.yml",
+               'jobs:\n  q:\n    with:\n'
+               '      playwright-test-path: "tests/e2e/spec-coverage"\n')
+        self.assertEqual(cec._declared_test_path(self.root),
+                         "tests/e2e/spec-coverage")
+
+    def test_a_COMMENTED_OUT_declaration_is_not_configuration(self):
+        # Several fleet workflows explain this input at length right above it.
+        _write(self.root, ".github/workflows/code-quality.yml",
+               "jobs:\n  q:\n    with:\n"
+               "      # playwright-test-path: tests/e2e/ci  <- historical\n"
+               "      app-name: demo\n")
+        self.assertEqual(cec._declared_test_path(self.root), "tests/e2e")
+
+    def test_the_env_var_wins_over_the_workflow(self):
+        self._two_configs()
+        os.environ["PLAYWRIGHT_TEST_PATH"] = "tests/e2e"
+        self.assertEqual(cec._declared_test_path(self.root), "tests/e2e")
+
+    def test_the_default_is_the_shared_workflows_own_default(self):
+        self.assertEqual(cec._declared_test_path(self.root), "tests/e2e")
+
+    def test_a_config_at_the_DEFAULT_path_beats_the_root_one(self):
+        # opencatalogi / openconnector / doriath / softwarecatalog / larpingapp
+        # all carry tests/e2e/playwright.config.ts alongside a root config and
+        # declare no explicit path.
+        _write(self.root, "playwright.config.ts", _ROOT_CONFIG)
+        _write(self.root, "tests/e2e/playwright.config.ts",
+               "export default { testDir: '.', projects: [{ name: 'chromium' }] }\n")
+        scope = cec._PlaywrightScope(self.root)
+        self.assertEqual(scope.config_rel, "tests/e2e/playwright.config.ts")
+        self.assertEqual(scope.test_dir, "tests/e2e")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Gate-19 parsed the **root** `playwright.config.ts`. The shared workflow runs a different file:

```bash
CONFIG="${{ inputs.playwright-test-path }}/playwright.config.ts"
if [ ! -f "$CONFIG" ] && [ -f "playwright.config.ts" ]; then
  CONFIG="playwright.config.ts"
fi
npx playwright test --config="$CONFIG"
```

A config under `playwright-test-path` **wins**. In every repo carrying both, the gate was scoring a suite CI never executes.

## Reproduction — openregister, both configs still present on `development`

| | `testDir` | spec files |
|---|---|---|
| root `playwright.config.ts` | `'./tests/e2e'` | **63** |
| `tests/e2e/ci/playwright.config.ts` | `'.'` → `tests/e2e/ci` | **4** |

`@e2e` anchors: **205 under `tests/e2e`, ZERO under `tests/e2e/ci`.** Every "covered" verdict gate-19 ever produced on that repo came from a file CI does not run.

Confirmed at the runner's own interface — invoked exactly as `run-hydra-gates.sh` invokes it, reading the **log**, not the exit code:

```
rc=1   stderr 0 bytes   859 findings
64 findings now cite tests/e2e/ci/playwright.config.ts by name
```

64 is the same number the fleet sweep found. No `Traceback`/`SyntaxError`/`AttributeError` anywhere in the 95 KB log — the interpreter lived.

## Two resolution bugs, both fixed

**1 — which file.** `playwright-test-path` is honoured: `$PLAYWRIGHT_TEST_PATH`, else the app's own caller workflow, else the shared workflow's default `tests/e2e`; then the same *exists-else-fall-back-to-root* rule. Read out of the caller workflow rather than plumbed through a new env var, so the gate agrees with the file that decides the behaviour — a second source of truth would drift exactly the way the root config drifted from the CI config. **`quality.yml` is untouched.**

**2 — what `testDir` means.** It is relative to the **config's** directory, not the repo root. openregister's CI config says `testDir: '.'` and means `tests/e2e/ci`. Reading it as repo-relative is what makes a 4-file suite look like a 63-file one. An absent `testDir` now means the config's own directory — Playwright's documented default.

Consequently *outside `testDir`* now means **not run**. That branch used to return "runs", on the reasoning that a mis-read `testDir` should never accuse. Sound while the gate read the root config, whose `testDir` spans everything; exactly wrong once the CI config is resolved.

## Fleet-wide finding count, measured before merging

Uncovered scenarios **6663 → 6785, +122**, in exactly **two** repos:

| repo | `playwright-test-path` | uncovered before | after | Δ |
|---|---|---|---|---|
| openregister | `tests/e2e/ci` | 796 | 860 | **+64** |
| hermiq | `tests/e2e/spec-coverage` | 433 | 491 | **+58** |

**Every other repo is unchanged.** This is the correct direction — a scenario "covered" by a test CI never ran is not covered. **hermiq was not in the original sweep** and is a second live instance of the same class; its canonical `development` carries both configs today.

Config resolution validated against all 20 real fleet repos: each resolves to the file the workflow would pick, and the six repos with a second config under the default `tests/e2e` (opencatalogi, openconnector, doriath, softwarecatalog, larpingapp, + doriath's) keep a `testDir` spanning `tests/e2e`, so their scenario counts do not move.

**No double-counting.** Repos with a single root config do not move at all. The collapse work in launchpad#85 and openregister#2410 is complementary — and a dedicated test arm pins that a *collapsed* repo still counts its anchors, so this stays correct whichever way those land.

## Both directions

11 new tests, 116 → **127**. Against the pre-fix helper:

| arm | pre-fix |
|---|---|
| anchor **outside** the executed config does NOT cover | **FAIL** (counted as covered) |
| anchor **inside** the executed config DOES cover | ok |
| repo **collapsed** to one root config still covers | ok |
| no caller workflow → falls back to root | ok |

The three must-not-change arms are green in **both** runs — the suite is not "everything fails". The remaining new arms exercise API that does not exist pre-fix (`_declared_test_path`, `config_rel`).

Also covered: quoted declarations (`"tests/e2e/spec-coverage"` — hermiq's spelling), commented-out declarations being ignored, `$PLAYWRIGHT_TEST_PATH` winning, and a config at the **default** path beating the root one.

`test_check_e2e_coverage.py` 127/127; full `run-helper-suites.sh` green.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
