### PR TITLE
fix(gate-54): a polymorphic reference had no authorable form

### DIFF
--- a/hydra-gates/scripts/lib/check_relation_dialect.py
+++ b/hydra-gates/scripts/lib/check_relation_dialect.py
@@ -50,6 +50,13 @@ lines are advisory and never fail the gate):
                         with ``format: uuid`` + a relation-shaped description
                         but NO ``$ref`` (conservative: format:uuid alone is
                         NOT enough — NC-user-id fields legitimately lack $ref).
+                        Two identifiers are exempt because no local schema key
+                        can express them: ``x-external-register`` (the target
+                        lives in another app's register) and
+                        ``x-relation-schema-field`` (POLYMORPHIC — the target is
+                        named per row by a sibling discriminator). Neither is a
+                        waiver: the discriminator must be a real sibling
+                        property, and both forbid a ``$ref``.
   c. FILTER PLACEMENT — ``x-relation-filter`` anywhere except directly on a
                         property; or on a property that is not a relation
                         (filter on non-relation is inert).
@@ -365,6 +372,58 @@ def _is_external_ref(prop):
     return isinstance(prop, dict) and bool(str(prop.get("x-external-register") or "").strip())
 
 
+def _discriminator_of(prop):
+    """The sibling property that names this identifier's target schema, or ``''``.
+
+    A POLYMORPHIC reference points at a different schema per ROW: the target is
+    chosen by a sibling discriminator field, not fixed at author time. A single
+    ``$ref`` cannot express it, and picking one of the possible targets would
+    make the register state something false — OpenRegister would then resolve
+    every row against that one schema.
+
+    Measured 2026-08-10 on scholiq (gate package 94c855b). Two report rows
+    carry exactly this shape:
+
+      ``CoursePackageImportReport.entries[].targetId`` — "UUID of the created
+      object named by targetType", where the sibling ``targetType`` is one of
+      Course / Lesson / Material / Item / LtiToolPlacement / Assignment / Rubric.
+      ``LearningRecordExport.coverageReport[].sourceId`` — "UUID of the source
+      object this entry reports on", discriminated by the sibling
+      ``sourceSchema``.
+
+    Both arms failed, exactly as the cross-app case did before
+    ``x-external-register`` existed:
+
+      WITH    a ``$ref``  -> the register asserts ONE target for a field whose
+                             target varies per row; check (f) passes only
+                             because the lie resolves.
+      WITHOUT a ``$ref``  -> check (b) "relation-shaped property ... lacks
+                             canonical $ref (ADR-062 rule 7)".
+
+    So the only route to green was rewording the description until
+    ``_RELATION_DESC_RE`` stopped matching — degrading documentation to dodge a
+    regex, the one thing a gate must never reward.
+
+    The marker is ``x-relation-schema-field: <siblingPropertyName>``, and it is
+    deliberately NOT a waiver: the named sibling must EXIST on the same object
+    (checked below), so declaring it is a claim the gate verifies rather than a
+    string that silences a rule. Like ``x-external-register`` it suppresses ONLY
+    the two ``$ref`` rules; filter placement and token validation still apply.
+
+    Read from the property, or from its ``items`` for the array form — the same
+    two places ``_ref_of`` looks for a ``$ref``.
+    """
+    if not isinstance(prop, dict):
+        return ""
+    val = str(prop.get("x-relation-schema-field") or "").strip()
+    if val:
+        return val
+    items = prop.get("items")
+    if isinstance(items, dict):
+        return str(items.get("x-relation-schema-field") or "").strip()
+    return ""
+
+
 def _ref_of(prop):
     """Return (raw_ref_value, is_array) for a relation property, or (None,_).
 
@@ -428,7 +487,7 @@ def _resolve_ref(ref, keys):
 _MAX_PROPERTY_DEPTH = 12
 
 
-def _collect_properties(props, prefix, depth, seen, out):
+def _collect_properties(props, prefix, depth, seen, out, parents=None):
     """Recursively collect every schema property into ``out``.
 
     Appends ``(qualified_name, prop_dict, declaration_line, depth)`` for each
@@ -446,6 +505,12 @@ def _collect_properties(props, prefix, depth, seen, out):
     is also called on dicts assembled in tests and by future callers, so the
     guard is unconditional; ``_MAX_PROPERTY_DEPTH`` bounds depth as well. Both
     guards terminate quietly — they are protection against a crash, not checks.
+
+    ``parents`` is an OPTIONAL out-dict mapping ``id(prop)`` to the ``properties``
+    map the property was declared in — i.e. its SIBLINGS. Only the polymorphic
+    discriminator check needs it, and it is optional rather than a sixth tuple
+    element so that every existing caller (and every existing test that unpacks
+    the 4-tuple) keeps working unchanged.
     """
     if not isinstance(props, dict) or depth > _MAX_PROPERTY_DEPTH:
         return
@@ -458,6 +523,8 @@ def _collect_properties(props, prefix, depth, seen, out):
         seen.add(id(prop))
         qname = pname if prefix == "" else f"{prefix}.{pname}"
         out.append((qname, prop, plines.get(pname, 0), depth))
+        if parents is not None:
+            parents[id(prop)] = props
 
         items = prop.get("items")
         item_nodes = [items] if isinstance(items, dict) else (
@@ -465,9 +532,11 @@ def _collect_properties(props, prefix, depth, seen, out):
         )
         for node in item_nodes:
             _collect_properties(
-                node.get("properties"), f"{qname}.items", depth + 1, seen, out
+                node.get("properties"), f"{qname}.items", depth + 1, seen, out, parents
             )
-        _collect_properties(prop.get("properties"), qname, depth + 1, seen, out)
+        _collect_properties(
+            prop.get("properties"), qname, depth + 1, seen, out, parents
+        )
 
 
 # --------------------------------------------------------------------------
@@ -508,17 +577,38 @@ def check_file(path, keys, findings, base_ref):
         lc_has_transitions = isinstance(lc, dict) and bool(lc.get("transitions"))
 
         collected = []
-        _collect_properties(props, "", 0, set(), collected)
+        parents = {}
+        _collect_properties(props, "", 0, set(), collected, parents)
         property_ids.update(id(prop) for _q, prop, _l, _d in collected)
 
         for pname, prop, pline, depth in collected:
             in_diff = changed is None or pline in changed
 
+            # A polymorphic identifier names its discriminator instead of a
+            # target. The claim is VERIFIED here, not taken on trust: a
+            # discriminator that is not a sibling property cannot name a schema
+            # at runtime, so the marker would be decoration. Reported whether or
+            # not the description happens to trip _RELATION_DESC_RE — an
+            # unresolvable discriminator is wrong on its own terms.
+            disc = _discriminator_of(prop)
+            if disc and disc not in (parents.get(id(prop)) or {}):
+                findings.append((path, (
+                    f"{path}: {sname}.{pname} — x-relation-schema-field names "
+                    f"'{disc}', which is not a property of the same object; a "
+                    f"discriminator that does not exist cannot name a target "
+                    f"schema (ADR-062 rule 7)"
+                )))
+                # Deliberately NOT falling through to (b). One defect, one fix
+                # (name a real discriminator) — emitting "lacks canonical $ref"
+                # as well would count it twice, which is the exact ratio defect
+                # the module docstring pins for gate 53.
+
             # (b) relation-shape heuristic — property-level diff scoped.
-            # A cross-app identifier is exempt: there is no local schema key it
-            # could ever name (see _is_external_ref).
+            # Two identifiers are exempt because no local schema key can express
+            # them: a cross-app reference (see _is_external_ref) and a
+            # polymorphic one whose target varies per row (_discriminator_of).
             if (in_diff and _has_uuid_format(prop) and not _is_relation_prop(prop)
-                    and not _is_external_ref(prop)):
+                    and not _is_external_ref(prop) and not disc):
                 desc = prop.get("description") or ""
                 items = prop.get("items")
                 if isinstance(items, dict):
@@ -592,6 +682,16 @@ def check_file(path, keys, findings, base_ref):
                     f"OpenRegister resolves $ref within one register set and "
                     f"cannot reach another app's schema — drop the $ref and keep "
                     f"the bare identifier (ADR-062 rule 7)"
+                )))
+            elif ref is not None and _discriminator_of(prop):
+                # Same shape, opposite direction: the register declares that the
+                # target is chosen per row AND pins one target. One of the two
+                # is false, and the $ref is the one OpenRegister would act on.
+                findings.append((path, (
+                    f"{path}: {sname}.{pname} — carries x-relation-schema-field "
+                    f"'{_discriminator_of(prop)}' AND $ref '{ref}'; a target "
+                    f"chosen per row cannot also be fixed at author time — drop "
+                    f"the $ref and keep the bare identifier (ADR-062 rule 7)"
                 )))
             elif ref is not None:
                 verdict, norm = _resolve_ref(ref, keys)

--- a/hydra-gates/scripts/lib/test_check_relation_dialect.py
+++ b/hydra-gates/scripts/lib/test_check_relation_dialect.py
@@ -519,5 +519,118 @@ class EndToEndTest(_Base):
         self.assertNotIn("placed off a property", text)
 
 
+# --------------------------------------------------------------------------
+# 5c. Polymorphic references — the gate must be CLOSABLE here too.
+#
+# Measured 2026-08-10 on scholiq (gate package 94c855b). Two report rows point
+# at a DIFFERENT schema per row, named by a sibling discriminator:
+#
+#   CoursePackageImportReport.entries[].targetId  ← sibling `targetType`
+#     (Course / Lesson / Material / Item / LtiToolPlacement / Assignment / Rubric)
+#   LearningRecordExport.coverageReport[].sourceId ← sibling `sourceSchema`
+#
+# Both arms failed, the same way the cross-app case did before
+# `x-external-register` existed:
+#
+#   WITHOUT $ref -> "relation-shaped property ... lacks canonical $ref"   (b)
+#   WITH    $ref -> resolves, and is a LIE: OpenRegister would resolve every
+#                   row against the one schema the author happened to pick.
+#
+# So the only route to green was rewording the description until
+# `_RELATION_DESC_RE` stopped matching. The marker is
+# `x-relation-schema-field: <siblingPropertyName>`, and it is a CLAIM THE GATE
+# VERIFIES — the named sibling must exist — not a string that silences a rule.
+# --------------------------------------------------------------------------
+class PolymorphicReferenceTest(_Base):
+    @staticmethod
+    def _entries(target_extra=None):
+        """An array of report rows: a discriminator + the identifier it names."""
+        target = {
+            "type": "string",
+            "format": "uuid",
+            "nullable": True,
+            "description": "UUID of the created object named by targetType.",
+            "x-relation-schema-field": "targetType",
+            "title": "Target ID",
+        }
+        target.update(target_extra or {})
+        return {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "targetType": {
+                        "type": "string",
+                        "title": "Target Type",
+                        "description": "The schema the resource was materialised as.",
+                    },
+                    "targetId": target,
+                },
+            },
+        }
+
+    def test_polymorphic_identifier_without_ref_is_accepted(self):
+        """The correct authoring must PASS — this is the closable arm."""
+        msgs = self.run_check(_register({"entries": self._entries()}))
+        self.assertEqual(
+            msgs, [],
+            "a polymorphic identifier naming a real sibling discriminator and "
+            f"carrying no $ref is correctly authored, got {msgs}",
+        )
+
+    def test_the_true_positive_survives_without_the_marker(self):
+        """CONTROL, and the whole point. Drop the marker and the SAME fixture
+        must go red — otherwise the exemption is just a hole and this suite
+        would be green about a rule that no longer fires."""
+        entries = self._entries()
+        del entries["items"]["properties"]["targetId"]["x-relation-schema-field"]
+        msgs = self.run_check(_register({"entries": entries}))
+        self.assertEqual(len(msgs), 1, f"expected exactly one finding, got {msgs}")
+        self.assertIn("lacks canonical $ref", msgs[0])
+
+    def test_a_discriminator_that_is_not_a_sibling_is_reported(self):
+        """The marker is a verified claim. Naming a field that does not exist
+        cannot resolve a schema at runtime, so it is decoration — and if this
+        passed, `x-relation-schema-field: anything` would be a blanket waiver."""
+        entries = self._entries()
+        entries["items"]["properties"]["targetId"]["x-relation-schema-field"] = "nope"
+        msgs = self.run_check(_register({"entries": entries}))
+        self.assertEqual(len(msgs), 1, f"expected exactly one finding, got {msgs}")
+        self.assertIn("not a property of the same object", msgs[0])
+
+    def test_polymorphic_marker_plus_a_ref_is_reported(self):
+        """Declaring both says the target varies per row AND is fixed. The
+        `$ref` is the half OpenRegister acts on, so the fix is to drop it."""
+        msgs = self.run_check(_register({
+            "entries": self._entries({"$ref": "skill"}),
+        }))
+        self.assertEqual(len(msgs), 1, f"expected exactly one finding, got {msgs}")
+        self.assertIn("x-relation-schema-field", msgs[0])
+        self.assertIn("drop the $ref", msgs[0])
+
+    def test_marker_does_not_excuse_a_bad_filter_token(self):
+        """Control: the exemption is scoped to the $ref rules only."""
+        msgs = self.run_check(_register({
+            "entries": self._entries({"x-relation-filter": {"setting": "@bogus"}}),
+        }))
+        self.assertTrue(any("unknown token" in m for m in msgs),
+                        f"filter validation must still apply, got {msgs}")
+
+    def test_marker_on_a_top_level_property_resolves_against_its_siblings(self):
+        """The discriminator is looked up among the property's OWN siblings at
+        whatever depth it sits — not only inside an array's items."""
+        msgs = self.run_check(_register({
+            "sourceSchema": {"type": "string", "title": "Source Schema"},
+            "sourceId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "UUID of the source object this entry reports on.",
+                "x-relation-schema-field": "sourceSchema",
+                "title": "Source ID",
+            },
+        }))
+        self.assertEqual(msgs, [], f"expected a clean run, got {msgs}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The defect

Gate 54 `relation-dialect` cannot be closed for an identifier whose **target schema varies per row**. Measured 2026-08-10 on scholiq (gate package `94c855b`):

| property | discriminator |
|---|---|
| `CoursePackageImportReport.entries[].targetId` | sibling `targetType` — Course/Lesson/Material/Item/LtiToolPlacement/Assignment/Rubric |
| `LearningRecordExport.coverageReport[].sourceId` | sibling `sourceSchema` |

Both arms fail, exactly as the cross-app case did before `x-external-register` existed:

```
WITHOUT $ref -> (b) "relation-shaped property ... lacks canonical $ref (ADR-062 rule 7)"
WITH    $ref -> resolves, and is a LIE: OpenRegister would resolve EVERY row against
                the one schema the author happened to pick, including rows that are
                a different schema.
```

The only remaining route to green was rewording the description until `_RELATION_DESC_RE` stopped matching — degrading documentation to dodge a regex, which **this module's own docstring already names as the thing a gate must never reward**.

## The fix

`x-relation-schema-field: <siblingPropertyName>`, mirroring the `x-external-register` precedent. **It is not a waiver** — it is a claim the gate verifies:

- the named sibling **must exist** on the same object. Without this, `x-relation-schema-field: anything` would be a blanket silencer.
- marker **+ `$ref`** is still reported — the two claims contradict and the `$ref` is the half OpenRegister acts on.
- it suppresses **only** the two `$ref` rules. Filter placement and token validation still apply (control test).

Findings stay 1:1 with defects: a bogus discriminator does *not* also emit "lacks canonical $ref". My own new test caught that double-count before this shipped — it is the ratio defect the docstring pins for gate 53.

`_collect_properties` gains an **optional** `parents` out-dict rather than a sixth tuple element, so every existing caller and every existing test that unpacks the 4-tuple is untouched.

## Evidence — both directions

- **6 new tests**, including `test_the_true_positive_survives_without_the_marker`: removes the marker from the *same* fixture and asserts it goes red. Without that control the exemption would just be a hole.
- `test_check_relation_dialect`: **34/34**. Full discovered helper suites: **69 passed, 0 failed** (2 pre-existing quarantines untouched).
- **On the real register**: the *unmodified upstream* checker **still reports both findings against the annotated scholiq register**. The descriptions are byte-identical and still trip the regex — the app side dodged nothing. Only the gate learning the concept clears them.

## Note for reviewers

This touches shared fleet tooling consumed live at `main`, so I have **not** self-merged. ADR-062 rule 7 should gain a sentence naming the polymorphic form; happy to open that against hydra once the shape here is agreed.

Consumer: ConductionNL/scholiq (register annotation held behind this).