### PR TITLE
fix(gate-47): a pure rename is not a security change

### DIFF
--- a/hydra-gates/scripts/lib/check_security_cochange.py
+++ b/hydra-gates/scripts/lib/check_security_cochange.py
@@ -170,23 +170,44 @@ def line_is_security_relevant(line: str) -> bool:
     return bool(_CODE_TOKEN_RE.search(line))
 
 
-def changed_lines(base_ref: str, path: str, cwd: str) -> list[str]:
+def changed_lines(base_ref: str, path: str, cwd: str,
+                  old_path: str | None = None) -> list[str]:
     """The added/removed lines for *path*, without diff framing.
 
     `-U0` so no context line is mistaken for a change: context is precisely
     the code the PR did NOT touch, and treating it as touched is the defect
     this function exists to remove.
+
+    *old_path* is the pre-rename spelling when the file was renamed, and it
+    MUST be in the pathspec alongside *path*. A pathspec is applied BEFORE
+    rename detection runs, so asking for the destination alone deletes the
+    source side of the pair from the diff and git has nothing left to match
+    it against — it then reports the destination as `new file mode` with
+    every line added. A pure move of a file that merely CONTAINS a security
+    token (`requesttoken`, a session lookup) therefore classified as a
+    security change of the whole file, which is the same
+    classify-the-file-not-the-hunks defect this module was written to
+    remove, arriving through the pathspec instead of through grep.
+
+    Measured 2026-08-10 on pipelinq#763: `git mv src/components/X.vue
+    src/dialogs/X.vue` (`similarity index 100%`, `0 insertions(+), 0
+    deletions(-)`) was reported by this gate as 230 added lines and one
+    security-touching change.
+
+    With both spellings present git pairs them again, so a pure rename
+    yields no lines and a rename-with-edits yields exactly its real hunks.
     """
+    pathspec = [path] if old_path is None else [old_path, path]
     proc = subprocess.run(
         ["git", "-c", "safe.directory=*", "diff", "-U0", "--no-color",
-         f"{base_ref}...HEAD", "--", path],
+         "-M", f"{base_ref}...HEAD", "--", *pathspec],
         cwd=cwd, capture_output=True, text=True, check=False,
     )
     out = proc.stdout
     if not out.strip():
         proc = subprocess.run(
             ["git", "-c", "safe.directory=*", "diff", "-U0", "--no-color",
-             base_ref, "--", path],
+             "-M", base_ref, "--", *pathspec],
             cwd=cwd, capture_output=True, text=True, check=False,
         )
         out = proc.stdout
@@ -217,10 +238,36 @@ def changed_files(base_ref: str, cwd: str) -> list[str]:
     return [ln.strip() for ln in out.splitlines() if ln.strip()]
 
 
+def rename_map(base_ref: str, cwd: str) -> dict[str, str]:
+    """``{destination: source}`` for every file the diff reports as renamed.
+
+    Read once, unscoped, so rename detection actually has both sides to pair.
+    `changed_lines` needs the source spelling to ask git a question whose
+    answer is not an artefact of the pathspec — see its docstring.
+    """
+    out = ""
+    for ref in (f"{base_ref}...HEAD", base_ref):
+        proc = subprocess.run(
+            ["git", "-c", "safe.directory=*", "diff", "--name-status",
+             "-M", "--no-color", ref],
+            cwd=cwd, capture_output=True, text=True, check=False,
+        )
+        out = proc.stdout
+        if out.strip():
+            break
+    renames: dict[str, str] = {}
+    for raw in out.splitlines():
+        parts = raw.split("\t")
+        if len(parts) == 3 and parts[0].startswith("R"):
+            renames[parts[2].strip()] = parts[1].strip()
+    return renames
+
+
 def scan(base_ref: str, cwd: str = ".") -> tuple[list[str], bool]:
     """(security-touching files, whether the diff also touches a test)."""
     files = changed_files(base_ref, cwd)
     has_test = any(is_test_path(f) for f in files)
+    renames = rename_map(base_ref, cwd)
     security: list[str] = []
     for f in files:
         if is_security_path(f):
@@ -228,7 +275,7 @@ def scan(base_ref: str, cwd: str = ".") -> tuple[list[str], bool]:
             continue
         if not _CANDIDATE_RE.match(f):
             continue
-        for line in changed_lines(base_ref, f, cwd):
+        for line in changed_lines(base_ref, f, cwd, renames.get(f)):
             if line_is_security_relevant(line):
                 security.append(f)
                 break

--- a/hydra-gates/scripts/lib/test_check_security_cochange.py
+++ b/hydra-gates/scripts/lib/test_check_security_cochange.py
@@ -49,6 +49,23 @@ class _Repo:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(body, encoding="utf-8")
 
+    def move(self, src: str, dst: str) -> None:
+        """`git mv`, with the destination directory created first.
+
+        `git mv` FAILS when the destination directory does not exist, and
+        `_git` swallows the error (check=False, output captured). A test that
+        moved into a new directory therefore changed nothing, committed
+        nothing, and diffed an EMPTY change set — which every assertion of the
+        form `assertEqual(security, [])` passes for the wrong reason. Caught
+        by `test_the_rename_map_pairs_source_to_destination`, which asserts a
+        NON-empty result and so cannot pass on an empty diff.
+        """
+        (self.root / dst).parent.mkdir(parents=True, exist_ok=True)
+        proc = subprocess.run(["git", "-C", str(self.root), "mv", src, dst],
+                              check=False, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise AssertionError(f"git mv {src} -> {dst} failed: {proc.stderr}")
+
     def commit(self, msg: str) -> str:
         self._git("add", "-A")
         self._git("commit", "-qm", msg)
@@ -408,6 +425,80 @@ class AnnotationMustBeInACodePosition(unittest.TestCase):
         repo.commit("reword one docblock sentence")
         security, has_test = repo.scan(base)
         self.assertEqual(security, [])
+
+
+VUE_WITH_CSRF = """<template>
+  <div class="import"/>
+</template>
+
+<script>
+export default {
+  methods: {
+    async upload() {
+      return axios.post(url, body, {
+        headers: { requesttoken: OC.requestToken },
+      })
+    },
+  },
+}
+</script>
+"""
+
+
+class RenamesAreNotContentChanges(unittest.TestCase):
+    """A pathspec is applied BEFORE rename detection.
+
+    Asking git for the destination path alone removes the source side of the
+    pair, so git reports the destination as `new file mode` with every line
+    added — and a pure move of a file that merely CONTAINS a security token
+    classified as a security change of the whole file. That is the same
+    classify-the-file-not-the-hunks defect this module exists to remove,
+    arriving through the pathspec instead of through grep.
+
+    Measured 2026-08-10 on pipelinq#763, where `git mv
+    src/components/ContactImportDialog.vue src/dialogs/` — `similarity index
+    100%`, `0 insertions(+), 0 deletions(-)` — was reported as 230 added
+    lines and one security-touching change, on a PR that changed no code at
+    all.
+    """
+
+    def setUp(self):
+        self.repo = _Repo()
+
+    def tearDown(self):
+        self.repo.close()
+
+    def test_fp_a_pure_rename_is_not_a_security_change(self):
+        self.repo.write("src/components/ImportDialog.vue", VUE_WITH_CSRF)
+        base = self.repo.commit("base")
+        self.repo.move("src/components/ImportDialog.vue",
+                       "src/dialogs/ImportDialog.vue")
+        self.repo.commit("move the dialog into src/dialogs (gate-13)")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, [])
+
+    def test_tp_a_rename_that_also_edits_security_code_still_fires(self):
+        self.repo.write("src/components/ImportDialog.vue",
+                        VUE_WITH_CSRF.replace(
+                            "        headers: { requesttoken: OC.requestToken },\n", ""))
+        base = self.repo.commit("base")
+        self.repo.move("src/components/ImportDialog.vue",
+                       "src/dialogs/ImportDialog.vue")
+        self.repo.write("src/dialogs/ImportDialog.vue", VUE_WITH_CSRF)
+        self.repo.commit("move the dialog AND add a CSRF header")
+        security, _ = self.repo.scan(base)
+        self.assertEqual(security, ["src/dialogs/ImportDialog.vue"])
+
+    def test_the_rename_map_pairs_source_to_destination(self):
+        self.repo.write("src/components/ImportDialog.vue", VUE_WITH_CSRF)
+        base = self.repo.commit("base")
+        self.repo.move("src/components/ImportDialog.vue",
+                       "src/dialogs/ImportDialog.vue")
+        self.repo.commit("move")
+        self.assertEqual(
+            csc.rename_map(base, str(self.repo.root)),
+            {"src/dialogs/ImportDialog.vue": "src/components/ImportDialog.vue"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`check_security_cochange.changed_lines()` asked git for the diff of **one** path:

```
git diff -U0 base...HEAD -- src/dialogs/X.vue
```

A pathspec is applied **before** rename detection runs. Naming only the destination removes the source side of the pair from the diff, so git has nothing left to match against and reports the destination as `new file mode` with **every line added**.

A pure `git mv` of a file that merely *contains* a security token (`requesttoken`, `IUserSession`, …) therefore classified as a security-touching change of the whole file — the same *classify-the-file-not-the-hunks* defect this module was written to remove, arriving through the pathspec instead of through grep.

## Measured

On **pipelinq#763**. `git mv src/components/ContactImportDialog.vue src/dialogs/` — required by gate-13 (modal-isolation) — is reported by git itself as:

```
src/{components => dialogs}/ContactImportDialog.vue | 0
1 file changed, 0 insertions(+), 0 deletions(-)
similarity index 100%
```

gate-47 read that as **230 added lines** and reported:

```
[gate-47] security-change-has-tests: FAIL — 1 security-touching change(s) without a test co-change
```

on a PR that changed no code at all. The remaining remedies were the opt-out or a token test — and this module's own docstring already names that outcome:

> A gate whose finding cannot be acted on truthfully is an unclosable gate, and unclosable gates are how a suite loses its readers.

## The fix

Read the rename map once, **unscoped** (`git diff --name-status -M`), and pass **both** spellings in the pathspec so git can pair them again.

- a pure rename yields **no** lines
- a rename **with** edits still yields exactly its real hunks

So nothing that used to fire stops firing.

## Tests (+3)

New class `RenamesAreNotContentChanges`:

| test | asserts |
|---|---|
| `test_fp_a_pure_rename_is_not_a_security_change` | a pure rename of a CSRF-carrying component is **not** reported |
| `test_tp_a_rename_that_also_edits_security_code_still_fires` | a rename that **also** adds a CSRF header **is** still reported |
| `test_the_rename_map_pairs_source_to_destination` | the map pairs destination → source |

## A note on the fixture — it nearly shipped broken

`git mv` **fails when the destination directory does not exist**, and `_Repo._git` swallows the error (`check=False`, output captured). All three tests initially moved into a directory that did not exist, so they changed nothing, committed nothing, and diffed an **empty change set** — and `assertEqual(security, [])` passes for the wrong reason on an empty diff.

Only the rename-map test caught it, because it asserts a **non-empty** result and therefore *cannot* pass on an empty diff.

`_Repo` gains a `move()` helper that creates the destination directory and **raises** on a failed `git mv`.

## Both directions proven

| arm | result |
|---|---|
| repaired fixture + **original** gate | FP test **fails** (`['src/dialogs/ImportDialog.vue'] != []`), rename-map test **errors** |
| repaired fixture + **fixed** gate | **23 tests OK** |

The pre-existing 20 tests are untouched and still pass.

## Blast radius

pipelinq consumes this workflow and the gate package at `@main`, so this reaches every repo in the fleet as soon as it lands. The change is confined to how the diff is *read*; no token vocabulary, path pattern, or opt-out behaviour is altered.