### PR TITLE
fix(axe): the axe runner could never resolve @playwright/test

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2888,7 +2888,45 @@ jobs:
           # --no-save: this checkout is the app's own tree, and the report is
           # the artefact we want out of it — not a mutated package.json.
           npm install --no-save --no-audit --no-fund "@axe-core/playwright@${{ inputs.axe-version }}"
-          node -e "const m=require('@axe-core/playwright'); if (typeof (m.AxeBuilder||m.default)!=='function') { console.error('::error::@axe-core/playwright installed but exports no AxeBuilder constructor.'); process.exit(1);} console.log('@axe-core/playwright resolved.');"
+
+          # ── this control used to pass for the wrong reason ─────────────────
+          #
+          # The runner is executed BY ABSOLUTE PATH from OUTSIDE this package
+          # tree (`${GITHUB_WORKSPACE}/gates/...`, see the next step), and
+          # CommonJS resolves a module's own `require` calls by walking up from
+          # the DIRECTORY OF THE FILE — never from the process cwd. `gates/` is
+          # a sibling of `server/`, so that walk never reaches
+          # `server/apps/<app>/node_modules` and nothing the step above
+          # installed is reachable.
+          #
+          # `node -e`, which is what this control was, resolves from the cwd —
+          # here `server/apps/<app>` — so it found the package the runner could
+          # not and printed success. docudesk#423 died one step later on
+          # `Cannot find module '@playwright/test'` with this control green
+          # directly above it.
+          #
+          # NODE_PATH is a global fallback consulted whatever directory the
+          # entry file sits in, so it is what makes the cross-tree invocation
+          # resolve at all. The probe then asks the question through
+          # `createRequire` ANCHORED ON THE RUNNER, so it resolves exactly the
+          # way the runner does and fails exactly when the runner would.
+          export NODE_PATH="${PWD}/node_modules"
+          RUNNER="${GITHUB_WORKSPACE}/gates/hydra-gates/scripts/axe-run.cjs" \
+          node -e "
+            const { createRequire } = require('module');
+            const req = createRequire(process.env.RUNNER);
+            const m = req('@axe-core/playwright');
+            if (typeof (m.AxeBuilder || m.default) !== 'function') {
+              console.error('::error::@axe-core/playwright installed but exports no AxeBuilder constructor.');
+              process.exit(1);
+            }
+            const pw = req('@playwright/test');
+            if (!pw.chromium) {
+              console.error('::error::@playwright/test resolved from the axe runner but exports no chromium.');
+              process.exit(1);
+            }
+            console.log('axe runner resolves @playwright/test and @axe-core/playwright.');
+          "
 
       - name: Run axe-core against the app routes
         id: axe
@@ -2942,6 +2980,13 @@ jobs:
           # `bash -e` would abort on a failing node before `RC=$?` ever ran, so
           # the cleanup would be skipped and the reason lost. Same `&& / ||`
           # idiom the hydra-gates job uses for the same reason.
+          # NODE_PATH, because the entry file is in `gates/` and the packages
+          # are in `server/apps/<app>/node_modules`. CommonJS resolves from the
+          # entry file's own directory upwards, and those two paths are
+          # siblings — without this the runner cannot require `@playwright/test`
+          # no matter what the install step put on disk. See the probe in that
+          # step for the measurement.
+          NODE_PATH="${PWD}/node_modules" \
           node "${GITHUB_WORKSPACE}/gates/hydra-gates/scripts/axe-run.cjs" && RC=0 || RC=$?
           exit "$RC"
 


### PR DESCRIPTION
## gate-33 has never been able to run in any caller repo

`enable-axe: true` executes the runner by absolute path:

```
cd "server/apps/<app>"
node "${GITHUB_WORKSPACE}/gates/hydra-gates/scripts/axe-run.cjs"
```

The packages it requires are installed by the step above into `server/apps/<app>/node_modules`. CommonJS resolves a module's own `require` calls by walking up from the **directory of the entry file** — never from the process cwd — and `gates/` is a *sibling* of `server/`. The walk goes `gates/hydra-gates/scripts/node_modules`, `gates/hydra-gates/node_modules`, `gates/node_modules`, `<workspace>/node_modules`, and stops. It never enters `server/`.

So `require('@playwright/test')` throws `MODULE_NOT_FOUND` on the first repo that ever opted in — **ConductionNL/docudesk#423**, where Playwright itself was green and all 82 e2e tests passed before the axe step died on a message that names neither accessibility nor the layout that caused it.

## The control above it passed for the wrong reason

```
node -e "const m=require('@axe-core/playwright'); ... console.log('@axe-core/playwright resolved.');"
```

`node -e` resolves from the cwd the step had just `cd`-ed into. It measured *whether the package was on disk*, not *whether the runner could reach it* — and printed `@axe-core/playwright resolved.` on the very run whose next step could resolve nothing. It would print the same line on every future break of this kind.

## The fix

* `NODE_PATH="${PWD}/node_modules"` on the runner invocation — NODE_PATH is a global fallback consulted regardless of where the entry file sits, which is the property this cross-tree layout needs.
* the control now resolves via `createRequire` **anchored on the runner**, and checks `@playwright/test` too. It fails exactly when the runner would.

## Both directions, on the real `axe-run.cjs`

Reconstructed the runner's real directory layout (`gates/` sibling to `server/apps/dd/node_modules`) and ran the actual file:

| arm | result |
|---|---|
| runner, no `NODE_PATH` | `Error: Cannot find module '@playwright/test'` |
| runner, `NODE_PATH` set | `::error::axe-runner: AXE_BASE_URL is empty.` |
| **old** control, either arm | `PASS` — this is the defect |
| **new** probe, no `NODE_PATH` | exit 1, `MODULE_NOT_FOUND` |
| **new** probe, `NODE_PATH` set | `PASS` |

Row 2 is the proof the fix works: the runner gets past resolution and reaches its own env validation. Row 3 is why this was invisible.

## Step size

The ~20 KB per-step limit that once made this workflow resolve to zero jobs is respected: the two touched `run:` blocks are 2.1 KB and 2.6 KB.
