### PR TITLE
fix(quality): a required additional app that will not enable must fail the job

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1730,11 +1730,45 @@ jobs:
               --admin-user admin \
               --admin-pass admin
           fi
+          # A REQUIRED additional app that does not enable is an ENVIRONMENT
+          # failure, and it must not be allowed to resurface as APPLICATION
+          # failures. It used to: `|| echo "::warning::…, continuing"` let the
+          # run proceed without the dependency, and the consuming app's tests
+          # then died on the absent classes.
+          #
+          # Measured on ConductionNL/hermiq, full-scope run 31490144919, six
+          # PHPUnit cells, perfect 6/6 correlation:
+          #
+          #   enable ok      -> Tests: 1500, Errors: 5, Failures: 1   (x3)
+          #   enable FAILED  -> Tests: 1500, Errors: 12               (x3)
+          #
+          # The seven extra "errors" were `Interface
+          # "OCA\OpenRegister\Service\Flow\IFlowNodeLogActions" not found` and
+          # `Call to undefined method MockObject_ToolRegistryFacade::
+          # describeTools()` — which read as app debt and were an absent app.
+          # Two distinct causes, one deterministic (OpenRegister declares
+          # min-version="32"; the cell was stable31) and one transient
+          # (`curl error 60 … self-signed certificate` during composer install
+          # left Twig missing, so enabling crashed). Both deserve a red job:
+          # the first is a real configuration error, the second is re-runnable.
+          #
+          # ⚠️ The failure flag goes through a FILE, not a variable. The loop
+          # body runs in a subshell (it is fed by a pipeline), so a variable set
+          # inside it is invisible after `done` — the same trap the gate runner
+          # documents at its gate-30 loop.
           if [ '${{ inputs.additional-apps }}' != '[]' ]; then
+            rm -f "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
             echo '${{ inputs.additional-apps }}' | jq -r '.[].app' | while read -r name; do
               echo "Enabling app: $name"
-              php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
+              if ! php occ app:enable "$name"; then
+                echo "::error::Failed to enable required additional app '$name'. This is an ENVIRONMENT failure, not an application failure — the run cannot measure this repository without it. Common causes: the app declares a min-version above the Nextcloud ref this cell tests, or its composer install did not complete."
+                echo "$name" >> "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
+              fi
             done
+            if [ -s "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed" ]; then
+              echo "::error::Aborting: $(tr '\n' ' ' < "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed")could not be enabled."
+              exit 1
+            fi
           fi
           chmod -R a+w config
 
@@ -1999,11 +2033,45 @@ jobs:
               --admin-user admin \
               --admin-pass admin
           fi
+          # A REQUIRED additional app that does not enable is an ENVIRONMENT
+          # failure, and it must not be allowed to resurface as APPLICATION
+          # failures. It used to: `|| echo "::warning::…, continuing"` let the
+          # run proceed without the dependency, and the consuming app's tests
+          # then died on the absent classes.
+          #
+          # Measured on ConductionNL/hermiq, full-scope run 31490144919, six
+          # PHPUnit cells, perfect 6/6 correlation:
+          #
+          #   enable ok      -> Tests: 1500, Errors: 5, Failures: 1   (x3)
+          #   enable FAILED  -> Tests: 1500, Errors: 12               (x3)
+          #
+          # The seven extra "errors" were `Interface
+          # "OCA\OpenRegister\Service\Flow\IFlowNodeLogActions" not found` and
+          # `Call to undefined method MockObject_ToolRegistryFacade::
+          # describeTools()` — which read as app debt and were an absent app.
+          # Two distinct causes, one deterministic (OpenRegister declares
+          # min-version="32"; the cell was stable31) and one transient
+          # (`curl error 60 … self-signed certificate` during composer install
+          # left Twig missing, so enabling crashed). Both deserve a red job:
+          # the first is a real configuration error, the second is re-runnable.
+          #
+          # ⚠️ The failure flag goes through a FILE, not a variable. The loop
+          # body runs in a subshell (it is fed by a pipeline), so a variable set
+          # inside it is invisible after `done` — the same trap the gate runner
+          # documents at its gate-30 loop.
           if [ '${{ inputs.additional-apps }}' != '[]' ]; then
+            rm -f "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
             echo '${{ inputs.additional-apps }}' | jq -r '.[].app' | while read -r name; do
               echo "Enabling app: $name"
-              php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
+              if ! php occ app:enable "$name"; then
+                echo "::error::Failed to enable required additional app '$name'. This is an ENVIRONMENT failure, not an application failure — the run cannot measure this repository without it. Common causes: the app declares a min-version above the Nextcloud ref this cell tests, or its composer install did not complete."
+                echo "$name" >> "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
+              fi
             done
+            if [ -s "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed" ]; then
+              echo "::error::Aborting: $(tr '\n' ' ' < "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed")could not be enabled."
+              exit 1
+            fi
           fi
 
       # ── Composer's DOWNLOAD cache, not `vendor/` ──────────────────────────
@@ -2370,11 +2438,45 @@ jobs:
               --admin-user admin \
               --admin-pass admin
           fi
+          # A REQUIRED additional app that does not enable is an ENVIRONMENT
+          # failure, and it must not be allowed to resurface as APPLICATION
+          # failures. It used to: `|| echo "::warning::…, continuing"` let the
+          # run proceed without the dependency, and the consuming app's tests
+          # then died on the absent classes.
+          #
+          # Measured on ConductionNL/hermiq, full-scope run 31490144919, six
+          # PHPUnit cells, perfect 6/6 correlation:
+          #
+          #   enable ok      -> Tests: 1500, Errors: 5, Failures: 1   (x3)
+          #   enable FAILED  -> Tests: 1500, Errors: 12               (x3)
+          #
+          # The seven extra "errors" were `Interface
+          # "OCA\OpenRegister\Service\Flow\IFlowNodeLogActions" not found` and
+          # `Call to undefined method MockObject_ToolRegistryFacade::
+          # describeTools()` — which read as app debt and were an absent app.
+          # Two distinct causes, one deterministic (OpenRegister declares
+          # min-version="32"; the cell was stable31) and one transient
+          # (`curl error 60 … self-signed certificate` during composer install
+          # left Twig missing, so enabling crashed). Both deserve a red job:
+          # the first is a real configuration error, the second is re-runnable.
+          #
+          # ⚠️ The failure flag goes through a FILE, not a variable. The loop
+          # body runs in a subshell (it is fed by a pipeline), so a variable set
+          # inside it is invisible after `done` — the same trap the gate runner
+          # documents at its gate-30 loop.
           if [ '${{ inputs.additional-apps }}' != '[]' ]; then
+            rm -f "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
             echo '${{ inputs.additional-apps }}' | jq -r '.[].app' | while read -r name; do
               echo "Enabling app: $name"
-              php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
+              if ! php occ app:enable "$name"; then
+                echo "::error::Failed to enable required additional app '$name'. This is an ENVIRONMENT failure, not an application failure — the run cannot measure this repository without it. Common causes: the app declares a min-version above the Nextcloud ref this cell tests, or its composer install did not complete."
+                echo "$name" >> "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
+              fi
             done
+            if [ -s "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed" ]; then
+              echo "::error::Aborting: $(tr '\n' ' ' < "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed")could not be enabled."
+              exit 1
+            fi
           fi
 
       # ── Composer's DOWNLOAD cache, not `vendor/` ──────────────────────────
@@ -3477,11 +3579,45 @@ jobs:
               --admin-user admin \
               --admin-pass admin
           fi
+          # A REQUIRED additional app that does not enable is an ENVIRONMENT
+          # failure, and it must not be allowed to resurface as APPLICATION
+          # failures. It used to: `|| echo "::warning::…, continuing"` let the
+          # run proceed without the dependency, and the consuming app's tests
+          # then died on the absent classes.
+          #
+          # Measured on ConductionNL/hermiq, full-scope run 31490144919, six
+          # PHPUnit cells, perfect 6/6 correlation:
+          #
+          #   enable ok      -> Tests: 1500, Errors: 5, Failures: 1   (x3)
+          #   enable FAILED  -> Tests: 1500, Errors: 12               (x3)
+          #
+          # The seven extra "errors" were `Interface
+          # "OCA\OpenRegister\Service\Flow\IFlowNodeLogActions" not found` and
+          # `Call to undefined method MockObject_ToolRegistryFacade::
+          # describeTools()` — which read as app debt and were an absent app.
+          # Two distinct causes, one deterministic (OpenRegister declares
+          # min-version="32"; the cell was stable31) and one transient
+          # (`curl error 60 … self-signed certificate` during composer install
+          # left Twig missing, so enabling crashed). Both deserve a red job:
+          # the first is a real configuration error, the second is re-runnable.
+          #
+          # ⚠️ The failure flag goes through a FILE, not a variable. The loop
+          # body runs in a subshell (it is fed by a pipeline), so a variable set
+          # inside it is invisible after `done` — the same trap the gate runner
+          # documents at its gate-30 loop.
           if [ '${{ inputs.additional-apps }}' != '[]' ]; then
+            rm -f "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
             echo '${{ inputs.additional-apps }}' | jq -r '.[].app' | while read -r name; do
               echo "Enabling app: $name"
-              php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."
+              if ! php occ app:enable "$name"; then
+                echo "::error::Failed to enable required additional app '$name'. This is an ENVIRONMENT failure, not an application failure — the run cannot measure this repository without it. Common causes: the app declares a min-version above the Nextcloud ref this cell tests, or its composer install did not complete."
+                echo "$name" >> "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed"
+              fi
             done
+            if [ -s "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed" ]; then
+              echo "::error::Aborting: $(tr '\n' ' ' < "${RUNNER_TEMP:-/tmp}/additional-app-enable-failed")could not be enabled."
+              exit 1
+            fi
           fi
 
       # ── Composer's DOWNLOAD cache, not `vendor/` ──────────────────────────


### PR DESCRIPTION
## What is wrong

`php occ app:enable "$name" || echo "::warning::Failed to enable $name, continuing..."`
lets a run proceed **without the dependency the repository under test is built on**.
The absence then resurfaces as *application* failures, which is indistinguishable from
real debt in the log — and a warning in a red job is invisible.

## Measurement

ConductionNL/hermiq, full-scope run `31490144919`, six PHPUnit cells. Perfect 6/6
correlation between `grep -c 'Failed to enable openregister'` and the error count:

| job | cell | enable | result |
|---|---|---|---|
| 93774658402 | 8.4 / stable33 | ok | `Tests: 1500, Errors: 5, Failures: 1` |
| 93774658407 | 8.3 / stable33 | ok | `Tests: 1500, Errors: 5, Failures: 1` |
| 93774658415 | 8.4 / stable32 | ok | `Tests: 1500, Errors: 5, Failures: 1` |
| 93774658413 | 8.3 / stable31 | **FAILED** | `Tests: 1500, Errors: 12` |
| 93774658418 | 8.3 / stable32 | **FAILED** | `Tests: 1500, Errors: 12` |
| 93774658420 | 8.4 / stable31 | **FAILED** | `Tests: 1500, Errors: 12` |

The seven extra "errors" were `Interface "OCA\OpenRegister\Service\Flow\IFlowNodeLogActions"
not found` and `Call to undefined method MockObject_ToolRegistryFacade::describeTools()`.
Two causes, **both** of which deserve a red job:
- **deterministic** — OpenRegister declares `min-version="32"`, the cell tested `stable31`;
- **transient** — `curl error 60 … self-signed certificate` during composer install left
  Twig missing, so `app:enable` crashed on `Class "Twig\Extension\AbstractExtension" not found`.

## Why this is a DRAFT — please sequence it

Merging this today turns **6 repos** red on a cell that is currently lying rather than
failing. Measured `nextcloud-test-refs` against `additional-apps` across the fleet — these
run a `stable31` cell while requiring `openregister` (min-version 32), so every one of
their stable31 cells is today measuring an instance **without OpenRegister**:

`app-versions` · `hermiq` · `hrmq` · `petstore` · `planix` · `nextcloud-app-template`

**hermiq is already fixed** (ConductionNL/hermiq#180 drops its `stable31` cell and
declares the truthful `min-version="32"`). The other five need the same one-line change
before this is merged. I have left it as a draft rather than merge it and hand five agents
an unexplained red cell mid-session — the sequencing is a fleet call, not mine.

## Implementation notes

Applied to all four install sites (phpunit, newman, both playwright legs).

⚠️ The failure flag goes through a **file, not a variable**: the loop body runs in a
subshell because it is fed by a pipeline, so a variable set inside it is invisible after
`done` — the same trap `run-hydra-gates.sh` documents at its gate-30 loop. Verified with a
three-app simulation: exit 0 when all enable, exit 1 when the **first** fails, exit 1 when
the **last** fails.

⚠️ Grep for this failure **with the app name** (`Failed to enable openregister`). The bare
`Failed to enable` also matches the workflow's own echoed script line, which contains
`$name` unexpanded — it returns 1 on a clean run and 2 on a failing one, so an off-by-one
reads as a correlation that is not there. That mis-measurement already happened once today.
