### PR TITLE
test(gates): repo-shaped acceptance suite — scope matrix, exit-code semantics, coverage ratchet

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,18 @@
+# ShellCheck configuration for ConductionNL/.github
+#
+# external-sources: follow `. "${SOME_ROOT}/path/helper.sh"` when the script
+# carries a `# shellcheck source=./helper.sh` directive above it.
+#
+# Without this, ShellCheck emits SC1091 ("Not following: ... was not specified
+# as input") for every sourced helper. The workflow's wrapper step exits 1 on
+# ANY finding — including `note:` severity — so three of those notes were enough
+# to fail the build even though the ShellCheck action itself reported success.
+#
+# The `# shellcheck source=` directives were already present and correct; they
+# simply had no effect because external sourcing was not enabled. This turns
+# them on rather than suppressing the diagnostic, so a genuinely missing or
+# misspelled helper path is still reported.
+#
+# Note: .github/workflows/shellcheck.yml already lists `.shellcheckrc` in its
+# `paths:` trigger, so this file was expected to exist and did not.
+external-sources=true

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -16,3 +16,18 @@
 # Note: .github/workflows/shellcheck.yml already lists `.shellcheckrc` in its
 # `paths:` trigger, so this file was expected to exist and did not.
 external-sources=true
+
+# source-path: resolve a `# shellcheck source=./helper.sh` directive relative to
+# the directory of the script that carries it, not to the process working
+# directory.
+#
+# Needed because the CI action invokes shellcheck from the repository root, so
+# `./gate_fixture_support.sh` resolved to <repo-root>/gate_fixture_support.sh and
+# reported `openBinaryFile: does not exist`. With external-sources alone the
+# diagnostic simply changed from "was not specified as input" to "does not
+# exist" — it was following the directive, just from the wrong base.
+#
+# SCRIPTDIR keeps the existing `source=./gate_fixture_support.sh` directives
+# correct whether a script is run from the repo root, from its own directory, or
+# by the suite runner.
+source-path=SCRIPTDIR

--- a/hydra-gates/scripts/lib/gate_fixture_support.sh
+++ b/hydra-gates/scripts/lib/gate_fixture_support.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# gate_fixture_support.sh — shared helpers for the repo-shaped gate suites.
+#
+# NOTE ON THE FILENAME: this file deliberately does NOT start with `test_`.
+# tests/run-helper-suites.sh DISCOVERS `scripts/lib/test_*` and executes each as
+# a suite; a shared library picked up by that glob would be run as a test, find
+# no assertions, and exit 0 — an empty green, which is the exact failure mode
+# this package keeps getting bitten by.
+#
+# WHY REAL GIT REPOS
+# ------------------
+# The existing fixture families are plain directories tracked inside the
+# `.github` repo. That works for unscoped runs, because the gates enumerate
+# through `git ls-files`, which resolves against `.github`'s own index. It
+# cannot express a DIFF: there is no base ref and no history to diff against.
+#
+# That is precisely why no existing fixture could have caught gate-61, whose
+# defect is a SCOPE bug — the checker is correct and the wrapper hands it the
+# wrong scope. It is also why none of them can catch the disk-vs-committed
+# divergence class (gate-16 reads `@spec` from disk while deriving its changed
+# method set from committed history, so an UNCOMMITTED plant yields a false
+# PASS and can manufacture a false "this gate is blind").
+#
+# So these helpers materialise a fixture as a real repository with a real base
+# ref and a real HEAD, and every plant is COMMITTED before it is measured.
+
+# gf_build_repo <dest> <src-tree> <base-spec> <head-spec>
+#
+#   base-spec / head-spec are newline-free shell snippets executed inside the
+#   repo, letting a caller shape each commit. `origin/development` is created as
+#   a genuine remote-tracking ref (refs/remotes/origin/development) so the
+#   wrapper's own auto-detection chain resolves it exactly as it does in CI.
+#
+# `git init -b` is NOT used: the git on this host predates it and fails with
+# "unknown switch `b'", leaving an uninitialised directory that every later
+# command reports as "not a git repository" — which reads like a fixture bug
+# rather than a tooling one.
+gf_build_repo() {
+    local _dest="$1" _src="$2"
+    rm -rf "${_dest}"; mkdir -p "${_dest}"
+    cp -r "${_src}/." "${_dest}/"
+    (
+        cd "${_dest}" || exit 1
+        git init -q . || exit 1
+        git symbolic-ref HEAD refs/heads/development
+        git config user.email fixture@example.invalid
+        git config user.name "Gate Fixture"
+        git config commit.gpgsign false
+    )
+}
+
+# gf_commit_all <repo> <message>
+# `git add -f` because a fixture may deliberately ship a .gitignore that hides
+# its own plant (the gate-4 shape) — and also because these trees are copied
+# out of a repo that ignores build artefacts. NEVER `git add -A` at the caller
+# level: these checkouts are shared between sessions.
+gf_commit_all() {
+    local _repo="$1" _msg="$2"
+    ( cd "${_repo}" && git add -f . >/dev/null 2>&1 && git commit -qm "${_msg}" )
+}
+
+# gf_commit_paths <repo> <message> <path...>
+gf_commit_paths() {
+    local _repo="$1" _msg="$2"; shift 2
+    ( cd "${_repo}" && git add -f "$@" >/dev/null 2>&1 && git commit -qm "${_msg}" )
+}
+
+# gf_mark_base <repo>  — point origin/development at the current HEAD.
+gf_mark_base() {
+    ( cd "$1" && git update-ref refs/remotes/origin/development "$(git rev-parse HEAD)" )
+}
+
+# gf_run_wrapper <repo> <logdir> [args...] -> stdout+stderr of bin/hydra-gates
+# Drives the REAL distributable entry point, not the runner underneath it. The
+# gate-61 defect lives in bin/hydra-gates (it does not forward `--base` on
+# `--full`), so a suite that called run-hydra-gates.sh directly would miss it.
+gf_run_wrapper() {
+    local _repo="$1" _logdir="$2"; shift 2
+    mkdir -p "${_logdir}"
+    HYDRA_GATE_LOG_DIR="${_logdir}" HYDRA_OR_GATE_BLOCK_AFTER_EPOCH=0 \
+        bash "${GF_PKG_ROOT}/bin/hydra-gates" "$@" --app-dir "${_repo}" 2>&1
+}
+
+# gf_verdict <output> <gate-n>
+gf_verdict() { printf '%s' "$1" | grep -E "^\[gate-$2\] " | head -1; }

--- a/hydra-gates/scripts/lib/test_gate19_coverage_credibility.sh
+++ b/hydra-gates/scripts/lib/test_gate19_coverage_credibility.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate19_coverage_credibility.sh — a tag is not a test.
+#
+# WHY THIS EXISTS
+# ---------------
+# gate-19's number is the one most often quoted in fleet reporting, and four
+# separate defects make it directional rather than exact. Three of them share a
+# single shape: **something that is not a running test is credited as coverage.**
+#
+#   .github#356  a requirement-level `@e2e exclude` silently exempts every
+#                SIBLING scenario. openbuild: 471 of 509 exclusions (92.5%)
+#                share a reason, across only 42 distinct reasons, one covering
+#                32 scenarios.
+#   .github#343  a FILE-level `@e2e` tag is credited without checking the test
+#                body. A file can be credited for scenarios nothing in it
+#                exercises.
+#   .github#345  an `@e2e exclude` is read as POSITIVE coverage — excluding a
+#                scenario and covering it are indistinguishable to the gate.
+#   (decidesk)   a `test.skip(true, …)` guard, whose condition can never be
+#                false, still carries `@e2e` and still credits coverage. ~10
+#                such tests, plus 4 named for tabs that only assert that
+#                `#app-root` mounted.
+#
+# MEASURED HERE, on the canonical package:
+#
+#   req-inherit/     ONE exclude line, THREE scenarios beneath it
+#                    -> PASS — 0 reference(s) in e2e suite
+#   file-level-tag/  a file whose only test is `test.skip(true)`
+#                    -> PASS — 2 reference(s) in e2e suite
+#   honest/          two scenarios, two tests that really run and really assert
+#                    -> PASS — 2 reference(s) in e2e suite
+#
+# Read those last two again: **the dishonest arm and the honest arm produce
+# byte-identical verdicts.** That is the finding. A number you cannot distinguish
+# from its own counterfeit is not a measurement.
+#
+# WHY FOUR ARMS AND NOT TWO
+# -------------------------
+# `scenario-level/` currently behaves CORRECTLY — an exclusion on one scenario
+# does not leak to its sibling. It is fixtured anyway, because the obvious fix
+# for #356 (stop inheriting exclusions) can easily over-correct into "no
+# exclusion ever applies", and a suite with only a planted arm would score that
+# as a repair. Every arm below differs from its neighbour by exactly one thing.
+#
+# Run: bash scripts/lib/test_gate19_coverage_credibility.sh
+set -uo pipefail
+
+GF_PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+export GF_PKG_ROOT
+# shellcheck source=./gate_fixture_support.sh
+. "${GF_PKG_ROOT}/scripts/lib/gate_fixture_support.sh"
+
+FIX="${GF_PKG_ROOT}/scripts/test-fixtures/e2e-credibility"
+CHECKER="${GF_PKG_ROOT}/scripts/lib/check_e2e_coverage.py"
+
+_fail_n=0; _pass_n=0; _defect_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+_known_defect() {
+    local _issue="$1" _desc="$2" _still="$3"
+    if [ "${_still}" -eq 0 ]; then
+        _defect_n=$((_defect_n + 1))
+        printf 'KNOWN DEFECT (still live, %s) — %s\n' "${_issue}" "${_desc}"
+    else
+        _bad "${_issue} appears to be FIXED — '${_desc}' no longer reproduces. Flip this assertion to enforce the correct behaviour and delete the _known_defect entry."
+    fi
+}
+
+for _arm in req-inherit scenario-level file-level-tag honest; do
+    [ -d "${FIX}/${_arm}" ] || { echo "FAIL — fixture arm ${_arm} missing at ${FIX}"; exit 1; }
+done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/hydra-e2ec.XXXXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Materialise each arm as a real, COMMITTED repository. Committed, not merely
+# written to disk: gate-16's changed-method set comes from committed history
+# while its annotations are read from disk, and an uncommitted plant there
+# yields a false PASS. Same discipline everywhere so no suite in this package
+# can be fooled by working-tree state.
+_arm_out() {  # <arm> -> checker stdout
+    # Two statements, not one: under `set -u`, `local _a="$1" _r="${WORK}/${_a}"`
+    # declares both names before assigning, so the second initialiser reads _a
+    # while it is still unset and aborts the function with "unbound variable".
+    # The function then returns nothing, which reaches the caller as an empty
+    # verdict — and an empty verdict grades exactly like a failing one.
+    local _a="$1"
+    local _r="${WORK}/${_a}"
+    if [ ! -d "${_r}" ]; then
+        mkdir -p "${_r}"; cp -r "${FIX}/${_a}/." "${_r}/"
+        ( cd "${_r}" && git init -q . && git symbolic-ref HEAD refs/heads/development \
+            && git config user.email fixture@example.invalid && git config user.name F \
+            && git config commit.gpgsign false \
+            && git add -f . >/dev/null && git commit -qm "fixture ${_a}" >/dev/null )
+    fi
+    ( cd "${_r}" && python3 "${CHECKER}" . 2>&1 )
+}
+
+# ===========================================================================
+echo "== positive control: the honest arm really does pass =="
+# ===========================================================================
+# Without this, every "PASS" below is ambiguous between "correctly covered" and
+# "the checker cannot see this tree at all".
+_honest="$(_arm_out honest)"
+if printf '%s' "${_honest}" | grep -q 'PASS — 2 reference'; then
+    _ok "honest/ passes with 2 genuine references — the gate CAN pass legitimately"
+else
+    echo "FAIL — the positive control did not pass. Either the fixture stopped being"
+    echo "       honest or the checker cannot read it. Refusing to grade the rest."
+    printf '%s\n' "${_honest}" | sed 's/^/       /'
+    exit 1
+fi
+
+# ===========================================================================
+echo
+echo "== control arm: a SCENARIO-level exclusion must not leak to its sibling =="
+# ===========================================================================
+_scen="$(_arm_out scenario-level)"
+if printf '%s' "${_scen}" | grep -q 'uncovered-sibling'; then
+    _ok "scenario-level/ still reports the un-excluded sibling by name"
+else
+    _bad "scenario-level/ no longer names 'uncovered-sibling'. If this broke while fixing #356, the fix over-corrected: an exclusion is now leaking to siblings, or every exclusion has been made inert. Got: $(printf '%s' "${_scen}" | tail -1)"
+fi
+
+# ===========================================================================
+echo
+echo "== .github#356 — a REQUIREMENT-level exclude exempts every sibling =="
+# ===========================================================================
+_req="$(_arm_out req-inherit)"
+echo "   verdict: $(printf '%s' "${_req}" | tail -1)"
+_still=1
+printf '%s' "${_req}" | grep -q 'PASS' && _still=0
+_known_defect ".github#356" \
+    "ONE '@e2e exclude' in a requirement body exempted all THREE scenarios beneath it; the gate printed 'PASS — 0 reference(s) in e2e suite' — announcing that the e2e suite references nothing, and calling that a pass. This is the openbuild shape: 471 of 509 exclusions share a reason, one covering 32 scenarios." \
+    "${_still}"
+
+# The reporting half of #356: even if inheritance stays, the OUTPUT must let a
+# reader tell a wholly-excluded spec from a covered one.
+_states_counts=1
+if printf '%s' "${_req}" | grep -qiE '[0-9]+ (scenario|of them)[^.]*exclud|exclud[^.]*: *[0-9]+'; then
+    _states_counts=0
+fi
+if [ "${_states_counts}" -eq 0 ]; then
+    _ok "the output states how many scenarios were excluded"
+else
+    _defect_n=$((_defect_n + 1))
+    printf 'KNOWN DEFECT (still live, %s) — %s\n' ".github#356 (reporting)" \
+        "the verdict states neither the number of EXEMPTED scenarios nor the number of DISTINCT reasons. A spec whose every scenario is excluded by one line is typographically identical to a fully covered one, which is why 92.5 percent duplication survived unnoticed in openbuild."
+fi
+
+# ===========================================================================
+echo
+echo "== .github#343 + the never-false test.skip guard =="
+# ===========================================================================
+_tagged="$(_arm_out file-level-tag)"
+echo "   verdict: $(printf '%s' "${_tagged}" | tail -1)"
+_still=1
+printf '%s' "${_tagged}" | grep -q 'PASS' && _still=0
+_known_defect ".github#343 + skip-guard" \
+    "a FILE-level '@e2e' docblock credited 2 scenarios in a file whose ONLY test is 'test.skip(true, …)' — a condition that can never be false — and whose single assertion is merely that #app-root is visible. Nothing ran; both scenarios were credited." \
+    "${_still}"
+
+# ===========================================================================
+echo
+echo "== the load-bearing one: honest and counterfeit must be DISTINGUISHABLE =="
+# ===========================================================================
+# This is the assertion that actually matters. Fixing #343 or #356 without making
+# this true would leave the number just as unreadable as it is now.
+_h="$(printf '%s' "${_honest}" | tail -1)"
+_t="$(printf '%s' "${_tagged}" | tail -1)"
+if [ "${_h}" = "${_t}" ]; then
+    _defect_n=$((_defect_n + 1))
+    printf 'KNOWN DEFECT (still live, %s) — %s\n' "gate-19 legibility" \
+        "the honest arm and the counterfeit arm emit BYTE-IDENTICAL verdicts: '${_h}'. Two scenarios covered by two real tests, and two scenarios credited to a permanently-skipped file, are the same sentence. A number you cannot distinguish from its counterfeit is not a measurement."
+else
+    _ok "honest and counterfeit arms are distinguishable ('${_h}' vs '${_t}')"
+fi
+
+# ===========================================================================
+echo
+echo "== a bare '@e2e exclude' with no reason must remain non-compliant =="
+# ===========================================================================
+# An exemption's reason is a testable claim; a bare exclusion is unfalsifiable.
+_bare_dir="${WORK}/bare"
+mkdir -p "${_bare_dir}/openspec/specs/bare" "${_bare_dir}/appinfo"
+cp "${FIX}/honest/appinfo/info.xml" "${_bare_dir}/appinfo/"
+cat > "${_bare_dir}/openspec/specs/bare/spec.md" <<'SPEC'
+# Bare exclusion spec
+
+### Requirement: Bare
+
+#### Scenario: bare exclusion
+
+@e2e exclude
+
+- WHEN a THEN b
+SPEC
+( cd "${_bare_dir}" && git init -q . && git symbolic-ref HEAD refs/heads/development \
+    && git config user.email f@example.invalid && git config user.name F \
+    && git add -f . >/dev/null && git commit -qm bare >/dev/null )
+_bare_out="$( cd "${_bare_dir}" && python3 "${CHECKER}" . 2>&1 )"
+if printf '%s' "${_bare_out}" | grep -qiE 'FAIL|bare|no reason|reason required'; then
+    _ok "a bare '@e2e exclude' is rejected — $(printf '%s' "${_bare_out}" | tail -1 | cut -c1-80)"
+else
+    _bad "a bare '@e2e exclude' (no reason) was ACCEPTED: $(printf '%s' "${_bare_out}" | tail -1)"
+fi
+
+# ===========================================================================
+echo
+echo "== end-to-end through the real wrapper, not just the checker =="
+# ===========================================================================
+# Everything above drives the checker directly, which is fast and precise but
+# cannot see wrapper-level defects (that is how gate-61 hid). Run one arm the
+# way CI does.
+_wrap_repo="${WORK}/req-inherit"
+_wout="$(gf_run_wrapper "${_wrap_repo}" "${WORK}/log-wrap" --full)"
+_wv="$(gf_verdict "${_wout}" 19)"
+if [ -z "${_wv}" ]; then
+    _bad "gate-19 emitted no verdict through the wrapper on the req-inherit arm"
+else
+    _ok "the wrapper reaches gate-19 on this fixture — ${_wv:0:90}"
+fi
+
+echo
+echo "== summary =="
+echo "   passed:        ${_pass_n}"
+echo "   failed:        ${_fail_n}"
+echo "   known defects: ${_defect_n} (live, each named above)"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL gate-19 credibility controls PASSED (${_defect_n} known defect(s) still live)"
+exit 0

--- a/hydra-gates/scripts/lib/test_gate7_verb_object_guards.sh
+++ b/hydra-gates/scripts/lib/test_gate7_verb_object_guards.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate7_verb_object_guards.sh — gate-7 had 86 unit tests and was wrong.
+#
+# WHY THIS EXISTS
+# ---------------
+# This is the load-bearing argument for the whole repo-shaped suite, so it gets
+# its own file. `_GUARD_HELPER_NAME_RE` required the auth token to be the FINAL
+# CamelCase segment. Every one of gate-7's 86 unit tests passed. The regex was
+# self-consistent — it matched the strings its author had thought of. What no
+# unit test could contain was a real repository that spells its predicates
+# VERB-OBJECT: hermiq's `canUserAccessAgent()`. All three of hermiq's gate-7
+# findings were false positives, and each one accused a genuinely-guarded
+# endpoint of being an unguarded IDOR.
+#
+# Fixed and merged as `.github#353`. This suite exists so it STAYS fixed.
+#
+# THE ANTI-DEAD-TEST CONTROL (the reason this file is not just an expect.conf row)
+# -------------------------------------------------------------------------------
+# The author of #353 hit this exact trap: their first "now passes" fixture
+# passed IDENTICALLY under the old regex, so it asserted nothing about the fix.
+# They caught it only by reverting the relaxation and counting reds.
+#
+# A fixture that cannot distinguish the fixed code from the broken code is a
+# dead test that looks like coverage — the same disease this whole suite
+# diagnoses, one level up. So this file does the revert ITSELF, every run: it
+# substitutes the pre-#353 regex and requires the clean arm to go RED. If it
+# does not, the fixture has stopped proving anything and that is a hard failure.
+#
+# Run: bash scripts/lib/test_gate7_verb_object_guards.sh
+set -uo pipefail
+
+GF_PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+FIX="${GF_PKG_ROOT}/scripts/test-fixtures/gate-acceptance/auth-guards"
+CHECKER="${GF_PKG_ROOT}/scripts/lib/check_no_admin_idor.py"
+TARGET="lib/Controller/AgentController.php"
+
+_fail_n=0; _pass_n=0; _defect_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+for _a in planted clean; do
+    [ -f "${FIX}/${_a}/${TARGET}" ] || { echo "FAIL — fixture arm ${_a} missing at ${FIX}"; exit 1; }
+done
+
+_findings() {  # <arm> [checker-path]
+    local _arm="$1"
+    local _ck="${2:-${CHECKER}}"
+    ( cd "${FIX}/${_arm}" && python3 "${_ck}" "${TARGET}" 2>/dev/null )
+}
+
+# ===========================================================================
+echo "== the fixed regex: clean is clean, planted names exactly the two plants =="
+# ===========================================================================
+_clean_out="$(_findings clean)"
+_clean_n="$(printf '%s' "${_clean_out}" | grep -c . || true)"
+if [ "${_clean_n}" -eq 0 ]; then
+    _ok "clean/ produces 0 findings — verb-object guards are recognised (#353)"
+else
+    _bad "clean/ produced ${_clean_n} finding(s); every method there carries a real per-object guard: ${_clean_out}"
+fi
+
+_planted_out="$(_findings planted)"
+_planted_n="$(printf '%s' "${_planted_out}" | grep -c . || true)"
+if [ "${_planted_n}" -eq 2 ]; then
+    _ok "planted/ produces exactly 2 findings"
+else
+    _bad "planted/ produced ${_planted_n} finding(s), wanted 2: ${_planted_out}"
+fi
+# NAME the plants — a count alone would be satisfied by flagging everything.
+for _m in show update; do
+    if printf '%s' "${_planted_out}" | grep -q "method=${_m}\b"; then
+        _ok "planted/ names method=${_m}"
+    else
+        _bad "planted/ never named method=${_m} — a bare count is not a finding"
+    fi
+done
+# ...and must NOT flag the one method that kept its guard, or the gate is just
+# reporting every #[NoAdminRequired] method it can see.
+if printf '%s' "${_planted_out}" | grep -q 'method=diff\b'; then
+    _bad "planted/ flagged method=diff, which KEEPS its verb-object guard through loadAccessibleAgent() — the gate is flagging attributes, not missing guards"
+else
+    _ok "planted/ leaves method=diff alone — the guarded transitive path is still recognised"
+fi
+
+# ===========================================================================
+echo
+echo "== ANTI-DEAD-TEST: revert the #353 relaxation and count the reds =="
+# ===========================================================================
+# If clean/ passes under the OLD regex too, this fixture proves nothing about
+# #353 and must not be counted as coverage for it.
+_WORK="$(mktemp -d "${TMPDIR:-/tmp}/hydra-g7.XXXXXXXX")"
+trap 'rm -rf "${_WORK}"' EXIT
+_OLDCK="${_WORK}/check_no_admin_idor_OLD.py"
+cp "${CHECKER}" "${_OLDCK}"
+
+# The pre-#353 first alternative: the auth token had to be the FINAL segment.
+# Restored by deleting the trailing optional-segment group that #353 added.
+python3 - "${_OLDCK}" <<'PYREVERT'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+new_alt = (
+    'r"^(?:is|has|can|may)[A-Z][A-Za-z0-9_]*"\n'
+    '    r"(?:Admin|Access|Permission|Permitted|Owner|Allowed|Authori[sz]ed)"\n'
+    '    r"(?:[A-Z][A-Za-z0-9_]*)?$"'
+)
+old_alt = (
+    'r"^(?:is|has|can|may)[A-Z]\\w*"\n'
+    '    r"(?:Admin|Access|Permission|Permitted|Owner|Allowed|Authori[sz]ed)$"'
+)
+if new_alt not in s:
+    sys.stderr.write("REVERT-FAILED: the post-#353 regex shape was not found\n")
+    sys.exit(2)
+open(p, "w").write(s.replace(new_alt, old_alt, 1))
+PYREVERT
+_revert_rc=$?
+
+if [ "${_revert_rc}" -ne 0 ]; then
+    _bad "could not reconstruct the pre-#353 regex — _GUARD_HELPER_NAME_RE has been reshaped, so this control no longer proves the fixture is live. Re-derive the revert from \`git show 3c8da4c\` and update it here rather than deleting this arm."
+else
+    _old_out="$(_findings clean "${_OLDCK}")"
+    _old_n="$(printf '%s' "${_old_out}" | grep -c . || true)"
+    if [ "${_old_n}" -gt 0 ]; then
+        _ok "clean/ goes RED (${_old_n} finding(s)) under the pre-#353 regex — the fixture genuinely discriminates fixed from broken"
+    else
+        _bad "clean/ passes under the OLD regex too (${_old_n} findings). This fixture is a DEAD TEST: it would have been green before #353 and asserts nothing about the fix. Add a method whose guard the old regex rejects."
+    fi
+    # And the old regex must still catch the real plants, or the revert broke
+    # something else and the red above is not the red we think it is.
+    _old_planted_n="$(_findings planted "${_OLDCK}" | grep -c . || true)"
+    if [ "${_old_planted_n}" -ge 2 ]; then
+        _ok "the reverted checker still catches the genuine plants (${_old_planted_n}) — the revert changed guard RECOGNITION, not the gate's ability to run"
+    else
+        _bad "the reverted checker found only ${_old_planted_n} planted IDOR(s); the revert broke the checker rather than narrowing it, so the control above is not measuring what it claims"
+    fi
+fi
+
+# ===========================================================================
+echo
+echo "== abuse controls: an auth token is still REQUIRED =="
+# ===========================================================================
+# #353 relaxed the token's POSITION, never the requirement. If `canRender`
+# started counting as a guard, the fix would have widened gate-7 into silence.
+_ABUSE="${_WORK}/abuse"
+mkdir -p "${_ABUSE}/lib/Controller"
+cat > "${_ABUSE}/${TARGET}" <<'PHPABUSE'
+<?php
+namespace OCA\ScopeFixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+class AgentController extends Controller {
+	#[NoAdminRequired]
+	public function render(int $id): JSONResponse {
+		$agent = $this->access->findAgent($id);
+		if (!$this->canRender($agent)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($agent);
+	}
+
+	private function canRender(array $agent): bool {
+		return $agent['template'] !== null;
+	}
+}
+PHPABUSE
+( cd "${_ABUSE}" && git init -q . && git config user.email f@example.invalid \
+    && git config user.name F && git add -f . >/dev/null && git commit -qm abuse >/dev/null )
+_abuse_n="$( cd "${_ABUSE}" && python3 "${CHECKER}" "${TARGET}" 2>/dev/null | grep -c . || true )"
+if [ "${_abuse_n}" -ge 1 ]; then
+    _ok "canRender() is still NOT accepted as a guard — the token requirement survived #353"
+else
+    _bad "canRender() was accepted as an authorization guard. #353 relaxed the token's POSITION; if it has been widened to accept any is/has/can/may method, gate-7 now clears real IDORs."
+fi
+
+# ===========================================================================
+echo
+echo "== live false-positive class: idiomatic short guard names =="
+# ===========================================================================
+# Measured end-to-end, not inferred from the regex: a controller guarded by
+# `hasPermission()` or `canAccess()` is STILL reported as an unguarded IDOR,
+# before and after #353. The middle `[A-Z][A-Za-z0-9_]*` segment is mandatory
+# and must precede the token, so the token can never be the FIRST segment after
+# the prefix.
+_FP="${_WORK}/fp"
+mkdir -p "${_FP}/lib/Controller"
+cat > "${_FP}/${TARGET}" <<'PHPFP'
+<?php
+namespace OCA\ScopeFixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+
+class AgentController extends Controller {
+	#[NoAdminRequired]
+	public function a(int $id): JSONResponse {
+		$o = $this->access->findAgent($id);
+		if (!$this->hasPermission($o, $this->userId)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($o);
+	}
+
+	#[NoAdminRequired]
+	public function b(int $id): JSONResponse {
+		$o = $this->access->findAgent($id);
+		if (!$this->canAccess($o, $this->userId)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($o);
+	}
+
+	private function hasPermission(array $o, string $u): bool { return $o['ownerId'] === $u; }
+	private function canAccess(array $o, string $u): bool { return $o['ownerId'] === $u; }
+}
+PHPFP
+( cd "${_FP}" && git init -q . && git config user.email f@example.invalid \
+    && git config user.name F && git add -f . >/dev/null && git commit -qm fp >/dev/null )
+_fp_n="$( cd "${_FP}" && python3 "${CHECKER}" "${TARGET}" 2>/dev/null | grep -c . || true )"
+if [ "${_fp_n}" -gt 0 ]; then
+    _defect_n=$((_defect_n + 1))
+    printf 'KNOWN DEFECT (still live, unfiled) — %s\n' \
+        "gate-7 reports ${_fp_n} finding(s) against a controller guarded by hasPermission() and canAccess(). Both are per-object guards; neither is recognised. _GUARD_HELPER_NAME_RE requires a non-empty CamelCase segment BETWEEN the is/has/can/may prefix and the auth token, so the token can never be the first segment — 'hasPermission', 'canAccess', 'isOwner', 'mayAccess' and 'isAllowed' all fail, before AND after #353. Note the #353 commit message states 'canAccess matched' — measured against both regexes, it never did."
+else
+    _bad "the hasPermission()/canAccess() false positives no longer reproduce — this is a FIX. Delete this known-defect arm and assert 0 findings instead."
+fi
+
+echo
+echo "== summary =="
+echo "   passed:        ${_pass_n}"
+echo "   failed:        ${_fail_n}"
+echo "   known defects: ${_defect_n} (live, each named above)"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL gate-7 verb-object controls PASSED (${_defect_n} known defect(s) still live)"
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_acceptance_matrix.sh
+++ b/hydra-gates/scripts/lib/test_gate_acceptance_matrix.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_acceptance_matrix.sh — the never-green-over-nothing property,
+# generalised from two gates to the whole declared inventory.
+#
+# WHY THIS EXISTS
+# ---------------
+# On 2026-08-11 a fleet sweep proved gate defects by hand, one planted true
+# positive at a time, in ten repositories. Every defect it found was in a gate
+# that had NO repo-shaped fixture. That is not a coincidence — it is the
+# selection effect. The gates with fixtures were the gates that could not
+# quietly stop working.
+#
+# THE ARGUMENT AGAINST RELYING ON THE UNIT TESTS
+# ----------------------------------------------
+# scripts/lib/ ships ~71 helper self-tests. They are worth having and they are
+# not sufficient, and we know the exact size of the gap:
+#
+#   gate-7 has 86 unit tests. All 86 passed. The gate was still wrong.
+#
+# `_GUARD_HELPER_NAME_RE` demanded the auth token be the FINAL CamelCase
+# segment, so hermiq's verb-object predicates — `canUserAccessAgent()`,
+# `canUserModifyAgent()` — were not recognised as guards and all three of its
+# gate-7 findings were false positives. The regex was self-consistent; the unit
+# tests asserted the regex against strings the regex's author had thought of.
+# What none of them could contain was a real repository that spells its
+# predicates differently. Only a repo-shaped fixture driven through the REAL
+# wrapper closes that.
+#
+# Three more from the same day, all invisible to a unit test by construction:
+#   gate-61  a SCOPE bug. The checker is fine. `bin/hydra-gates` does not
+#            forward `--base` on `--full`, so the gate is handed a base that
+#            produces an empty diff and reports NOT APPLICABLE — 0 of 45
+#            registrations inspected, fleet-wide, on every workflow_dispatch.
+#   gate-4   its INPUT was hidden. `.gitignore` excluded composer.lock, so the
+#            gate had never audited anything in any repository.
+#   gate-19  returned its finding COUNT as an exit STATUS. A byte holds 255, so
+#            256 findings would have exited 0 = PASS.
+# A unit test over a checker function sees none of these: they live in the
+# wrapper, the filesystem, and the process boundary.
+#
+# WHAT THIS SUITE ASSERTS
+# -----------------------
+# For every bundle under scripts/test-fixtures/gate-acceptance/:
+#   planted/  every declared gate must FAIL **and its output must NAME the
+#             planted subject**. A nonzero count is not enough: a gate that
+#             fails for an unrelated reason, or that reports a bare number,
+#             passed this suite for free before we required the name.
+#   clean/    the SAME gates must PASS. Without this arm, "widen the checker
+#             until everything trips it" is a passing repair.
+#
+# NOT APPLICABLE over a fixture built to trigger the gate is a FAILURE of the
+# suite, never an excuse. That is the exact shape of the gate-61 defect.
+#
+# THE COVERAGE RATCHET
+# --------------------
+# A hand-maintained list of covered gates is the failure mode this package has
+# already been bitten by twice (the four-named-suites CI list; the fixture dirs
+# that never existed). So coverage is COMPUTED from the bundles, diffed against
+# the runner's own declared inventory, and every uncovered gate must appear in
+# UNCOVERED.md with a reason. The list can only shrink:
+#   * a gate in UNCOVERED.md that now HAS a fixture   -> hard failure
+#   * a declared gate with neither fixture nor entry  -> hard failure
+# So a gate added to the runner cannot land silently untested, and a fixture
+# added cannot leave a stale excuse behind.
+#
+# Run: bash scripts/lib/test_gate_acceptance_matrix.sh
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+BUNDLES="${PKG_ROOT}/scripts/test-fixtures/gate-acceptance"
+UNCOVERED_FILE="${BUNDLES}/UNCOVERED.md"
+# Gates fixtured by a dedicated suite outside gate-acceptance/ (gates-23-33,
+# scope-matrix, e2e-credibility). Counted as COVERED. Without this the ratchet
+# reports eleven genuinely-tested gates as untested, and a ratchet that cries
+# wolf is a ratchet somebody switches off.
+ELSEWHERE_FILE="${BUNDLES}/COVERED-ELSEWHERE.md"
+
+_fail_n=0
+_pass_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# The declared inventory, read from the runner ITSELF — the same source the
+# COVERAGE line counts against. Hardcoding 64 here would rot the moment a gate
+# is added, and rot silently, which is the whole disease.
+# ---------------------------------------------------------------------------
+mapfile -t DECLARED < <(
+    grep -oE '_(pass|fail|skip|na) [0-9]+ "[^"]+"' "${RUNNER}" 2>/dev/null \
+        | sed -E 's/_[a-z]+ ([0-9]+) "([^"]+)"/\1 \2/' \
+        | sort -n -u -k1,1
+)
+if [ "${#DECLARED[@]}" -lt 40 ]; then
+    echo "FAIL — read only ${#DECLARED[@]} declared gates out of ${RUNNER}."
+    echo "       The inventory grep no longer matches the runner's shape. Refusing"
+    echo "       to report coverage against an inventory we could not read: an"
+    echo "       inventory of 0 would make this suite trivially complete."
+    exit 1
+fi
+echo "== runner declares ${#DECLARED[@]} gates =="
+
+# ---------------------------------------------------------------------------
+# Run helper. Mirrors test_gates_23_33_never_green_over_nothing.sh.
+# ---------------------------------------------------------------------------
+_OUT=""
+_LOGDIR=""
+_run() {  # <fixture-dir> [runner args...]
+    local _dir="$1"; shift
+    _LOGDIR="$(mktemp -d "${TMPDIR:-/tmp}/hydra-accept.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_LOGDIR}" \
+        HYDRA_OR_GATE_BLOCK_AFTER_EPOCH=0 \
+        bash "${RUNNER}" "$@" "${_dir}" 2>&1 || true)"
+    # An abort before the summary leaves per-gate PASS lines on stdout and
+    # reads exactly like a clean run. Refuse to grade a run that did not finish.
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "run in ${_dir} ABORTED before the summary — the verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_verdict() {  # <gate-n> -> that gate's verdict line
+    printf '%s' "${_OUT}" | grep -E "^\[gate-$1\] " | head -1
+}
+
+# _grade <gate-n> <wanted-status> <arm> <bundle>
+# wanted-status is FAIL / PASS / NOT APPLICABLE / SKIPPED
+_grade() {
+    local _g="$1" _want="$2" _arm="$3" _bundle="$4" _line
+    _line="$(_verdict "${_g}")"
+    if [ -z "${_line}" ]; then
+        _bad "[${_bundle}/${_arm}] gate-${_g} emitted NO verdict line at all — a gate that says nothing is not a pass"
+        return 1
+    fi
+    # A gate that reports NOT APPLICABLE over a fixture authored to trigger it
+    # is the gate-61 defect. Name it as such rather than as a generic mismatch.
+    if [ "${_want}" = "FAIL" ] && printf '%s' "${_line}" | grep -q 'NOT APPLICABLE'; then
+        _bad "[${_bundle}/${_arm}] gate-${_g} reported NOT APPLICABLE over a fixture built to TRIGGER it — this is the gate-61 shape (a gate with nothing in scope prints the same word as a gate that looked and found nothing). Line: ${_line}"
+        return 1
+    fi
+    case "${_line}" in
+        *"${_want}"*) _ok "[${_bundle}/${_arm}] gate-${_g} ${_want} — ${_line:0:100}"; return 0 ;;
+        *) _bad "[${_bundle}/${_arm}] gate-${_g} wanted '${_want}', got: ${_line}"; return 1 ;;
+    esac
+}
+
+# _names <gate-n> <log-basename> <subject> <bundle>
+# THE LOAD-BEARING ASSERTION: the finding must name the planted subject.
+_names() {
+    local _g="$1" _log="$2" _subject="$3" _bundle="$4"
+    # "-" means: the subject is stated on stdout rather than in a side log.
+    if [ "${_log}" = "-" ]; then
+        if printf '%s' "${_OUT}" | grep -qF -- "${_subject}"; then
+            _ok "[${_bundle}/planted] gate-${_g} NAMES '${_subject}' on stdout"
+        else
+            _bad "[${_bundle}/planted] gate-${_g} failed but never NAMED '${_subject}' on stdout — a bare count is not a finding"
+        fi
+        return
+    fi
+    local _f="${_LOGDIR}/${_log}"
+    if [ ! -f "${_f}" ]; then
+        _bad "[${_bundle}/planted] gate-${_g} wrote no ${_log} — it failed without recording WHAT failed"
+        return
+    fi
+    if grep -qF -- "${_subject}" "${_f}"; then
+        _ok "[${_bundle}/planted] gate-${_g} NAMES '${_subject}' in ${_log}"
+    else
+        _bad "[${_bundle}/planted] gate-${_g} failed but '${_subject}' is not in ${_log} — it failed for some OTHER reason, so this fixture proves nothing. Log head: $(head -3 "${_f}" | tr '\n' ' ')"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Discover bundles. Discovery, not a list — see the header.
+# ---------------------------------------------------------------------------
+if [ ! -d "${BUNDLES}" ]; then
+    echo "FAIL — ${BUNDLES} does not exist. Every assertion below would be"
+    echo "       vacuous, which is precisely the defect this suite exists to catch."
+    exit 1
+fi
+
+mapfile -t BUNDLE_DIRS < <(find "${BUNDLES}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+if [ "${#BUNDLE_DIRS[@]}" -eq 0 ]; then
+    echo "FAIL — discovered ZERO fixture bundles. An empty run is not a green run."
+    exit 1
+fi
+echo "== discovered ${#BUNDLE_DIRS[@]} fixture bundle(s) =="
+echo
+
+COVERED=()
+
+for _bundle in "${BUNDLE_DIRS[@]}"; do
+    _bdir="${BUNDLES}/${_bundle}"
+    _expect="${_bdir}/expect.conf"
+    if [ ! -f "${_expect}" ]; then
+        _bad "bundle '${_bundle}' has no expect.conf — a fixture nothing asserts against is not coverage"
+        continue
+    fi
+    if [ ! -d "${_bdir}/planted" ] || [ ! -d "${_bdir}/clean" ]; then
+        _bad "bundle '${_bundle}' is missing planted/ or clean/ — one arm alone cannot fail in both directions"
+        continue
+    fi
+
+    # expect.conf lines: gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject...>
+    mapfile -t _rows < <(grep -E '^gate[[:space:]]' "${_expect}" || true)
+    if [ "${#_rows[@]}" -eq 0 ]; then
+        _bad "bundle '${_bundle}' expect.conf declares no gate rows"
+        continue
+    fi
+
+    echo "== ${_bundle}: planted/ — every declared gate must FAIL and NAME its subject =="
+    if _run "${_bdir}/planted"; then
+        for _row in "${_rows[@]}"; do
+            read -r _kw _g _log _pv _cv _subject <<< "${_row}"
+            COVERED+=("${_g}")
+            if _grade "${_g}" "${_pv}" planted "${_bundle}"; then
+                [ "${_pv}" = "FAIL" ] && _names "${_g}" "${_log}" "${_subject}" "${_bundle}"
+            fi
+        done
+    fi
+
+    echo "== ${_bundle}: clean/ — the SAME gates must not fire (no widening) =="
+    if _run "${_bdir}/clean"; then
+        for _row in "${_rows[@]}"; do
+            read -r _kw _g _log _pv _cv _subject <<< "${_row}"
+            _grade "${_g}" "${_cv}" clean "${_bundle}"
+        done
+    fi
+    echo
+done
+
+# ---------------------------------------------------------------------------
+# The coverage ratchet.
+# ---------------------------------------------------------------------------
+echo "== coverage ratchet =="
+
+# Fold in the gates covered by dedicated sibling suites.
+_elsewhere=()
+if [ -f "${ELSEWHERE_FILE}" ]; then
+    while read -r _n; do
+        [ -n "${_n}" ] && _elsewhere+=("${_n}") && COVERED+=("${_n}")
+    done < <(grep -oE '^\| *gate-[0-9]+' "${ELSEWHERE_FILE}" 2>/dev/null | grep -oE '[0-9]+' || true)
+    echo "   counted ${#_elsewhere[@]} gate(s) as covered by a sibling suite (COVERED-ELSEWHERE.md)"
+else
+    _bad "no COVERED-ELSEWHERE.md at ${ELSEWHERE_FILE} — gates fixtured by the sibling suites would be miscounted as untested"
+fi
+
+mapfile -t COVERED_U < <(printf '%s\n' "${COVERED[@]}" | sort -n -u)
+
+if [ ! -f "${UNCOVERED_FILE}" ]; then
+    _bad "no UNCOVERED.md at ${UNCOVERED_FILE} — without it, an uncovered gate is indistinguishable from a covered one"
+else
+    _uncovered_declared=()
+    while read -r _line; do
+        _uncovered_declared+=("${_line}")
+    done < <(grep -oE '^\| *gate-[0-9]+' "${UNCOVERED_FILE}" 2>/dev/null | grep -oE '[0-9]+' || true)
+
+    _is_covered() { local n="$1" c; for c in "${COVERED_U[@]}"; do [ "$c" = "$n" ] && return 0; done; return 1; }
+    _is_listed()  { local n="$1" c; for c in "${_uncovered_declared[@]}"; do [ "$c" = "$n" ] && return 0; done; return 1; }
+
+    _rot=0
+    # (a) a gate listed as uncovered that now HAS a fixture -> un-list it.
+    for _n in "${_uncovered_declared[@]}"; do
+        if _is_covered "${_n}"; then
+            _bad "gate-${_n} is listed in UNCOVERED.md but now HAS planted/clean coverage. Delete its row so CI enforces it from here on — the list may only shrink."
+            _rot=$((_rot + 1))
+        fi
+    done
+    # (b) a declared gate with neither a fixture nor a reasoned entry.
+    for _entry in "${DECLARED[@]}"; do
+        _n="${_entry%% *}"; _nm="${_entry#* }"
+        if ! _is_covered "${_n}" && ! _is_listed "${_n}"; then
+            _bad "gate-${_n} (${_nm}) is DECLARED by the runner but has neither a planted/clean fixture nor a reasoned row in UNCOVERED.md. A gate can be added to the runner and never tested; this is that moment."
+            _rot=$((_rot + 1))
+        fi
+    done
+    [ "${_rot}" -eq 0 ] && _ok "coverage ratchet intact — every declared gate is either fixtured or listed with a reason"
+fi
+
+echo
+echo "== coverage =="
+echo "   declared gates:      ${#DECLARED[@]}"
+echo "   with planted/clean:  ${#COVERED_U[@]}"
+echo "   covered gate ids:    ${COVERED_U[*]}"
+
+echo
+echo "== summary =="
+echo "   passed: ${_pass_n}"
+echo "   failed: ${_fail_n}"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL gate acceptance controls PASSED (${#COVERED_U[@]} of ${#DECLARED[@]} gates fixtured)"
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_exit_code_semantics.sh
+++ b/hydra-gates/scripts/lib/test_gate_exit_code_semantics.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_exit_code_semantics.sh — a byte holds 255.
+#
+# WHY THIS EXISTS
+# ---------------
+# `.github#209`: gate-19 returned its finding COUNT as its exit STATUS. 266
+# findings exited as 10. **256 findings would have exited 0 = PASS.**
+# gate-26 had the identical defect: 260 uncovered page components -> exit 4 ->
+# "FAIL — 4", and at 256 it would have gone green while its own stdout read
+# "FAIL — 256". openconnector's long-quoted "21" was really 266.
+#
+# Both are fixed. This suite exists so they STAY fixed, and so the same shape
+# cannot appear in a 65th gate. Note what makes it invisible to a unit test:
+# the truncation happens at the PROCESS boundary, in the byte the shell reads.
+# A Python test calling the checker as a function sees the real integer and
+# passes. You have to cross exec() to see it at all.
+#
+# THE FOUR PROPERTIES
+# -------------------
+#   1. STATIC   — no checker may exit with a finding count.
+#   2. DYNAMIC  — a real 300-finding tree must report 300, not 300 & 255 = 44,
+#                 and above all not PASS.
+#   3. DYNAMIC  — a checker that PRINTS findings and exits 0 (which is what
+#                 `sys.exit(256)` looks like from the shell) must not be read as
+#                 a pass. This is the residual half of #209 and it is CURRENTLY
+#                 LIVE — see the known defect below.
+#   4. INVARIANT— no gate may report PASS while its own log states FAIL.
+#                 Property 4 is the general form of 1-3 and is worth more than
+#                 all of them: it holds for every gate, including ones nobody
+#                 has thought to test, and it is cheap to evaluate on any run.
+#
+# Run: bash scripts/lib/test_gate_exit_code_semantics.sh
+set -uo pipefail
+
+GF_PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+export GF_PKG_ROOT
+# shellcheck source=./gate_fixture_support.sh
+. "${GF_PKG_ROOT}/scripts/lib/gate_fixture_support.sh"
+
+_fail_n=0; _pass_n=0; _defect_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+_known_defect() {
+    local _issue="$1" _desc="$2" _still="$3"
+    if [ "${_still}" -eq 0 ]; then
+        _defect_n=$((_defect_n + 1))
+        printf 'KNOWN DEFECT (still live, %s) — %s\n' "${_issue}" "${_desc}"
+    else
+        _bad "${_issue} appears to be FIXED — '${_desc}' no longer reproduces. Flip this assertion to enforce the correct behaviour and delete the _known_defect entry."
+    fi
+}
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/hydra-exit.XXXXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+# ===========================================================================
+echo "== property 1 (static): no checker returns a finding count as its status =="
+# ===========================================================================
+# `sys.exit(<digit>)` / `sys.exit(EXIT_FAIL)` / `sys.exit(main(...))` are
+# statuses. `sys.exit(len(findings))` or `sys.exit(count)` is #209.
+#
+# `sys.exit(main(...))` is permitted because it is the normal Python idiom, and
+# the risk it carries — main() returning a COUNT — is covered by part (b) below
+# and, definitively, by property 4. Verified by hand at the time of writing:
+# check_visual_coverage.py and check_spec_coverage.py both return EXIT_*
+# constants or a bounded 0/1, never a tally.
+_bad_exits="$(grep -n 'sys\.exit(' "${GF_PKG_ROOT}"/scripts/lib/check_*.py 2>/dev/null \
+    | grep -vE 'sys\.exit\([0-9]\)' \
+    | grep -vE 'sys\.exit\(main\(' \
+    | grep -vE 'sys\.exit\(EXIT_[A-Z_]+\)' || true)"
+if [ -z "${_bad_exits}" ]; then
+    _ok "(a) every checker exits with a bounded status, never a bare count"
+else
+    _bad "(a) checker(s) exit with a non-status expression — the #209 shape. A count above 255 wraps, and at exactly 256 it wraps to 0 = PASS:"
+    printf '%s\n' "${_bad_exits}" | sed 's/^/       /'
+fi
+
+# (b) The three checkers that HAD this defect must keep a BOUNDED exit contract.
+# Two vocabularies are in use and both are correct, so the assertion accepts
+# either — asserting only `EXIT_FAIL` would have failed
+# check_custom_widget_ratchet.py, which is properly fixed and simply spells it
+# `return 1 if findings else 0` while putting the real tally on stdout as
+# `[custom-widget-ratchet] findings=N`. That checker's own header documents why:
+# an exit status is one byte AND is also how the interpreter reports a crash, so
+# a traceback exiting 1 was once reported as `FAIL — 1 custom-widget finding(s)`
+# — a plausible, actionable, entirely fictional finding.
+for _hist in check_e2e_coverage.py check_visual_coverage.py check_custom_widget_ratchet.py; do
+    _f="${GF_PKG_ROOT}/scripts/lib/${_hist}"
+    if [ ! -f "${_f}" ]; then
+        _bad "(b) ${_hist} is missing — it is one of the three checkers that carried the #209 defect"
+    elif grep -qE '\bEXIT_(FAIL|PASS)\b|return 1 if ' "${_f}"; then
+        _ok "(b) ${_hist} keeps a bounded exit contract (named status or 1/0)"
+    else
+        _bad "(b) ${_hist} has neither EXIT_* constants nor a 1/0 return — it carried the #209 count-as-status defect once; check it has not gone back to returning a tally"
+    fi
+done
+
+# ===========================================================================
+echo
+echo "== property 2 (dynamic): 300 real findings must report 300 =="
+# ===========================================================================
+_R="${WORK}/bulk"
+mkdir -p "${_R}/openspec/specs/bulk" "${_R}/appinfo"
+cp "${GF_PKG_ROOT}/scripts/test-fixtures/scope-matrix/app/appinfo/info.xml" "${_R}/appinfo/"
+( cd "${_R}" && git init -q . && git symbolic-ref HEAD refs/heads/development \
+    && git config user.email f@example.invalid && git config user.name F \
+    && git config commit.gpgsign false )
+echo "# base" > "${_R}/README.md"
+gf_commit_paths "${_R}" "base" README.md appinfo
+gf_mark_base "${_R}"
+
+# 300 scenarios, none covered by any e2e test. Generated rather than committed:
+# the property under test IS the volume, and 300 hand-written stanzas in the
+# repository would be 1200 lines of noise that nobody would ever re-read.
+{
+    echo "# Bulk spec"; echo; echo "### Requirement: Bulk"; echo
+    _i=1
+    while [ "${_i}" -le 300 ]; do
+        echo "#### Scenario: bulk scenario ${_i}"; echo; echo "- WHEN x THEN y"; echo
+        _i=$((_i + 1))
+    done
+} > "${_R}/openspec/specs/bulk/spec.md"
+gf_commit_paths "${_R}" "spec: 300 uncovered scenarios" openspec
+
+_out="$(gf_run_wrapper "${_R}" "${WORK}/log-bulk")"
+_v="$(gf_verdict "${_out}" 19)"
+case "${_v}" in
+    *"FAIL — 300 scenario"*) _ok "gate-19 reports 300, uncorrupted — ${_v:0:70}" ;;
+    *"FAIL — 44 scenario"*)  _bad "gate-19 reported 44 = 300 & 255. The count is being taken from the exit byte (#209 has regressed)." ;;
+    *PASS*)                  _bad "gate-19 reported PASS over 300 uncovered scenarios — a green over 300 findings." ;;
+    *)                       _bad "gate-19 wanted 'FAIL — 300 scenario', got: ${_v:0:140}" ;;
+esac
+
+# ===========================================================================
+echo
+echo "== property 4 (invariant): no gate may PASS while its own log states FAIL =="
+# ===========================================================================
+# Evaluated on the real run above. Generic: applies to every gate that writes a
+# log, including gates nobody has written a fixture for.
+_liars=0
+for _log in "${WORK}"/log-bulk/hydra-gate-*.log; do
+    [ -f "${_log}" ] || continue
+    grep -qE '^FAIL[ —-]' "${_log}" 2>/dev/null || continue
+    _base="$(basename "${_log}" .log)"; _name="${_base#hydra-gate-}"
+    _line="$(printf '%s' "${_out}" | grep -E "^\[gate-[0-9]+\] ${_name}: PASS" || true)"
+    if [ -n "${_line}" ]; then
+        echo "       ${_line:0:110}"
+        echo "         ...but ${_base}.log says: $(grep -E '^FAIL[ —-]' "${_log}" | head -1 | cut -c1-90)"
+        _liars=$((_liars + 1))
+    fi
+done
+if [ "${_liars}" -eq 0 ]; then
+    _ok "no gate reported PASS while its own log recorded a FAIL"
+else
+    _bad "${_liars} gate(s) reported PASS over a log that states FAIL — the verdict and the evidence disagree"
+fi
+
+# ===========================================================================
+echo
+echo "== property 3 (dynamic): a checker that prints findings and exits 0 =="
+# ===========================================================================
+# `sys.exit(256)` is indistinguishable from `sys.exit(0)` at the shell. This
+# substitutes a checker that does exactly that, and asks whether the gate
+# notices. It does not. MEASURED on the canonical package (a fresh clone of
+# origin/main), not on an adjacent stale checkout:
+#
+#   [gate-19] e2e-coverage: PASS
+#   hydra-gate-e2e-coverage.log:  FAIL — 256 scenario(s) missing @e2e
+#   wrapper exit: 0
+#
+# NOTE ON SCOPE OF THE CLAIM. This is NOT "gate-19 is broken today": property 1
+# above proves no shipped checker returns a count, so nothing currently triggers
+# it. It is that the #209 REPAIR was made in the message and not in the verdict —
+# `run-hydra-gates.sh` greps the count out of stdout for the FAIL text, but still
+# branches PASS/FAIL on `$?`. The blast radius is any future checker, or any
+# checker whose exit contract drifts. An earlier agent nearly filed "#209 is only
+# half-fixed" from a STALE adjacent checkout and was wrong on the facts; this is
+# a different and narrower claim, measured on the canonical package.
+_PKG="${WORK}/pkg"
+mkdir -p "${_PKG}"
+cp -r "${GF_PKG_ROOT}" "${_PKG}/hydra-gates"
+cat > "${_PKG}/hydra-gates/scripts/lib/check_e2e_coverage.py" <<'PYSTUB'
+import sys
+# Simulates .github#209 exactly: 256 findings, `sys.exit(256)`.
+# A byte holds 255, so the shell observes 0.
+print("FAIL — 256 scenario(s) missing @e2e")
+sys.exit(256)
+PYSTUB
+
+_stubout="$(HYDRA_GATE_LOG_DIR="${WORK}/log-stub" mkdir -p "${WORK}/log-stub" && \
+    HYDRA_GATE_LOG_DIR="${WORK}/log-stub" bash "${_PKG}/hydra-gates/bin/hydra-gates" \
+        --app-dir "${_R}" 2>&1 || true)"
+_v="$(gf_verdict "${_stubout}" 19)"
+_still=1
+case "${_v}" in *PASS*) _still=0 ;; esac
+_known_defect ".github#209 (residual half)" \
+    "gate-19 reports PASS while hydra-gate-e2e-coverage.log reads 'FAIL — 256 scenario(s) missing @e2e'. The count is parsed from stdout for the MESSAGE, but the VERDICT still branches on \$?, so a checker that exits 256 (== 0 at the shell) is read as a pass. Latent, not active: no shipped checker returns a count (property 1)." \
+    "${_still}"
+
+# Whatever the verdict, the invariant from property 4 must catch it. If this
+# ever fails, property 4 has stopped being a safety net for the whole class.
+if grep -qE '^FAIL' "${WORK}/log-stub/hydra-gate-e2e-coverage.log" 2>/dev/null \
+   && printf '%s' "${_v}" | grep -q PASS; then
+    _ok "property 4 DOES catch the exit-0-with-findings case (verdict PASS vs log FAIL)"
+elif printf '%s' "${_v}" | grep -qv PASS; then
+    _ok "the exit-0-with-findings case is no longer read as a pass"
+fi
+
+# ===========================================================================
+echo
+echo "== property 5: the wrapper's exit code agrees with its own summary =="
+# ===========================================================================
+# The wrapper returns the FAILURE COUNT, deliberately (flows route on it), with
+# 99 reserved for "could not run". That is only safe while the count is a number
+# of GATES (max 64) and never a number of FINDINGS.
+_R2="${WORK}/clean2"
+mkdir -p "${_R2}/appinfo"
+cp "${GF_PKG_ROOT}/scripts/test-fixtures/scope-matrix/app/appinfo/info.xml" "${_R2}/appinfo/"
+( cd "${_R2}" && git init -q . && git symbolic-ref HEAD refs/heads/development \
+    && git config user.email f@example.invalid && git config user.name F \
+    && echo x > README.md && git add -f . >/dev/null && git commit -qm base >/dev/null \
+    && git update-ref refs/remotes/origin/development HEAD \
+    && echo y >> README.md && git add -f README.md >/dev/null && git commit -qm next >/dev/null )
+
+mkdir -p "${WORK}/log-rc"
+HYDRA_GATE_LOG_DIR="${WORK}/log-rc" bash "${GF_PKG_ROOT}/bin/hydra-gates" \
+    --app-dir "${_R2}" > "${WORK}/rc.txt" 2>&1
+_rc=$?
+# NOT `grep -c ... || echo 0`: grep exits 1 on zero matches, so the fallback
+# APPENDS a second "0" and the variable becomes "0\n0", which every later
+# integer test rejects with "integer expression expected" — and those errors go
+# to stderr while the assertion still prints PASS.
+_declared_fail="$(grep -E '^\[gate-[0-9]+\].*: FAIL' "${WORK}/rc.txt" 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${_rc}" -eq 99 ]; then
+    _bad "the wrapper exited 99 (could not run at all) on a well-formed fixture"
+elif [ "${_declared_fail}" -eq 0 ] && [ "${_rc}" -ne 0 ]; then
+    _bad "wrapper exit ${_rc} but no gate reported FAIL — the exit code and the summary disagree"
+elif [ "${_declared_fail}" -gt 0 ] && [ "${_rc}" -eq 0 ]; then
+    _bad "wrapper exit 0 while ${_declared_fail} gate(s) reported FAIL — a failing run read as success"
+else
+    _ok "wrapper exit (${_rc}) agrees with the number of FAIL verdicts (${_declared_fail})"
+fi
+if [ "${_rc}" -gt 64 ] && [ "${_rc}" -ne 99 ]; then
+    _bad "wrapper exit ${_rc} exceeds the 64-gate inventory — it is carrying a FINDING count, not a gate count, and will wrap at 256"
+else
+    _ok "wrapper exit is a gate count (<= 64) or the reserved 99, so it cannot wrap a byte"
+fi
+
+echo
+echo "== summary =="
+echo "   passed:        ${_pass_n}"
+echo "   failed:        ${_fail_n}"
+echo "   known defects: ${_defect_n} (live, each named above)"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL exit-code semantics controls PASSED (${_defect_n} known defect(s) still live)"
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_exit_code_semantics.sh
+++ b/hydra-gates/scripts/lib/test_gate_exit_code_semantics.sh
@@ -232,7 +232,7 @@ _rc=$?
 # APPENDS a second "0" and the variable becomes "0\n0", which every later
 # integer test rejects with "integer expression expected" — and those errors go
 # to stderr while the assertion still prints PASS.
-_declared_fail="$(grep -E '^\[gate-[0-9]+\].*: FAIL' "${WORK}/rc.txt" 2>/dev/null | wc -l | tr -d ' ')"
+_declared_fail="$(grep -cE '^\[gate-[0-9]+\].*: FAIL' "${WORK}/rc.txt" 2>/dev/null || true)"
 if [ "${_rc}" -eq 99 ]; then
     _bad "the wrapper exited 99 (could not run at all) on a well-formed fixture"
 elif [ "${_declared_fail}" -eq 0 ] && [ "${_rc}" -ne 0 ]; then

--- a/hydra-gates/scripts/lib/test_gate_scope_matrix.sh
+++ b/hydra-gates/scripts/lib/test_gate_scope_matrix.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_scope_matrix.sh — the same gate, the same tree, three scopes.
+#
+# WHY THIS EXISTS
+# ---------------
+# gate-61 passes at one scope and is stone dead at another. Nothing that runs at
+# a single scope could ever have caught it, and nothing did: it was dead on
+# EVERY `--full` run, fleet-wide, and reported `NOT APPLICABLE` — which does not
+# count against coverage — so it never appeared in any red cell anywhere.
+#
+# Reproduced from scratch in a synthetic repository, through the real
+# `bin/hydra-gates`, with the tree held constant and ONLY the scope flag changed:
+#
+#   checker `--all` (positive control)  1 registration checked, 1 FAILURE, names the file
+#   wrapper, diff TOUCHING the listener FAIL — 1 post-event listener(s)
+#   wrapper, diff NOT touching it       NOT APPLICABLE   (legitimate, ADR-020)
+#   wrapper `--full`                    NOT APPLICABLE — "the diff against
+#                                       'origin/development' put every post-event
+#                                       registration out of scope"
+#
+# The `--full` line cites a diff on a run whose own preamble two lines earlier
+# says `Base ref: n/a — --full requested, scanning the entire tree.` **There was
+# no diff.** `bin/hydra-gates` does not forward `--base` on `--full`, so the
+# runner keeps its hardcoded `origin/development` default and gate-61 passes it
+# to the checker unconditionally.
+#
+# THE GENERAL PROPERTY, which outlives this one gate:
+#
+#   A `NOT APPLICABLE` whose stated reason names a DIFF is invalid on a run that
+#   computed no diff.
+#
+# That is brief item 4, and it is worth more than a gate-61-specific assertion
+# because it catches the NEXT gate that does this. Note the discrimination it
+# needs: gates 29/47/48 also decline on a `--full` run, and they are RIGHT to —
+# their reason says "this run is not diff-scoped, so there is no change set to
+# classify". A co-change gate genuinely cannot exist without a change set. The
+# defect is not "mentions a diff"; it is "claims a diff EXCLUDED something",
+# on a run that had no diff, while the subject matter is sitting in the tree.
+#
+# KNOWN DEFECTS
+# -------------
+# `.github#347` (the gate-61 fix) is deliberately HELD — landing it turns a
+# permanently-green gate red in ten repos at once. So this suite cannot assert
+# the correct behaviour yet. It asserts the DEFECT instead, loudly, and fails
+# the moment the behaviour changes, which is the signal to flip the assertion.
+# A known defect that is merely commented out is a defect nobody is watching.
+#
+# Run: bash scripts/lib/test_gate_scope_matrix.sh
+set -uo pipefail
+
+GF_PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+export GF_PKG_ROOT
+# shellcheck source=./gate_fixture_support.sh
+. "${GF_PKG_ROOT}/scripts/lib/gate_fixture_support.sh"
+
+SRC="${GF_PKG_ROOT}/scripts/test-fixtures/scope-matrix/app"
+CHECKER="${GF_PKG_ROOT}/scripts/lib/check_listener_placement.py"
+
+_fail_n=0; _pass_n=0; _defect_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+# _known_defect <issue> <description> <condition-result 0=defect-still-present>
+# A live defect is reported, not hidden. If the condition no longer holds the
+# fix has landed and the assertion must be flipped — that is a hard failure, so
+# the entry cannot rot into a permanent excuse.
+_known_defect() {
+    local _issue="$1" _desc="$2" _still="$3"
+    if [ "${_still}" -eq 0 ]; then
+        _defect_n=$((_defect_n + 1))
+        printf 'KNOWN DEFECT (still live, %s) — %s\n' "${_issue}" "${_desc}"
+    else
+        _bad "${_issue} appears to be FIXED — '${_desc}' no longer reproduces. Flip this assertion to enforce the correct behaviour and delete the _known_defect entry."
+    fi
+}
+
+if [ ! -d "${SRC}" ]; then
+    echo "FAIL — scope-matrix fixture missing at ${SRC}; every assertion below would be vacuous."
+    exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/hydra-scope.XXXXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+# ===========================================================================
+echo "== positive control: the subject IS detectable in this tree =="
+# ===========================================================================
+# Without this, a NOT APPLICABLE at full scope is ambiguous between "the gate is
+# dead" and "the fixture never contained anything". Run FIRST, always.
+gf_build_repo "${WORK}/inherited" "${SRC}"
+gf_commit_all "${WORK}/inherited" "base: app with inherited listener debt"
+gf_mark_base  "${WORK}/inherited"
+printf '\n- unrelated doc tweak\n' >> "${WORK}/inherited/docs/CHANGELOG.md"
+gf_commit_paths "${WORK}/inherited" "docs: unrelated change" docs/CHANGELOG.md
+
+_pc="$(cd "${WORK}/inherited" && python3 "${CHECKER}" . --all 2>&1)"
+if printf '%s' "${_pc}" | grep -qF 'lib/Listener/InheritedDebtListener.php'; then
+    _ok "positive control: checker --all NAMES lib/Listener/InheritedDebtListener.php"
+else
+    echo "FAIL — the positive control did not fire: check_listener_placement.py --all"
+    echo "       did not name the planted listener in a tree that contains it. EITHER the"
+    echo "       fixture stopped containing the plant OR the checker went blind. Both are"
+    echo "       fatal here, because every arm below reads a NOT APPLICABLE as meaningful"
+    echo "       only if this control proves the subject was findable. Refusing to grade."
+    printf '%s\n' "${_pc}" | sed 's/^/       /'
+    exit 1
+fi
+if printf '%s' "${_pc}" | grep -qE 'checked 1 post-event registration'; then
+    _ok "positive control: exactly 1 registration is present to be judged"
+else
+    _bad "positive control: expected 'checked 1 post-event registration', got: $(printf '%s' "${_pc}" | tail -2 | tr '\n' ' ')"
+fi
+
+# ===========================================================================
+echo
+echo "== arm 1 — DIFF scope, diff does NOT touch the listener =="
+# ===========================================================================
+# ADR-020: inherited debt must not block an unrelated PR. NOT APPLICABLE here is
+# correct, and it is the only arm in which it is correct.
+_out="$(gf_run_wrapper "${WORK}/inherited" "${WORK}/log-diff-untouched")"
+_v="$(gf_verdict "${_out}" 61)"
+case "${_v}" in
+    *"NOT APPLICABLE"*) _ok "gate-61 declines on an unrelated diff (ADR-020) — correct" ;;
+    "") _bad "gate-61 emitted no verdict at all on the unrelated-diff arm" ;;
+    *) _bad "gate-61 on an unrelated diff wanted NOT APPLICABLE, got: ${_v:0:140}" ;;
+esac
+
+# ===========================================================================
+echo
+echo "== arm 2 — DIFF scope, diff DOES touch the listener =="
+# ===========================================================================
+# Proves the gate can fire through the wrapper at all. If this arm ever goes
+# NOT APPLICABLE, the gate is dead at EVERY scope and arm 3 below proves nothing.
+gf_build_repo "${WORK}/newdebt" "${SRC}"
+rm "${WORK}/newdebt/lib/Listener/InheritedDebtListener.php"
+gf_commit_all "${WORK}/newdebt" "base: no listener yet"
+gf_mark_base  "${WORK}/newdebt"
+cp "${SRC}/lib/Listener/InheritedDebtListener.php" "${WORK}/newdebt/lib/Listener/"
+gf_commit_paths "${WORK}/newdebt" "feat: add the listener (NEW debt)" lib/Listener/InheritedDebtListener.php
+
+_out="$(gf_run_wrapper "${WORK}/newdebt" "${WORK}/log-diff-touched")"
+_v="$(gf_verdict "${_out}" 61)"
+case "${_v}" in
+    *FAIL*) _ok "gate-61 FAILS when the diff adds the listener — ${_v:0:90}" ;;
+    *) _bad "gate-61 did NOT fail on a diff that ADDS a violating listener; got: ${_v:0:140}" ;;
+esac
+if grep -qF 'InheritedDebtListener.php' "${WORK}/log-diff-touched/hydra-gate-listener-work-placement.log" 2>/dev/null; then
+    _ok "gate-61 NAMES the planted listener in its log"
+else
+    _bad "gate-61 failed without naming InheritedDebtListener.php — a bare count is not a finding"
+fi
+
+# ===========================================================================
+echo
+echo "== arm 3 — FULL scope, same tree as arm 1 =="
+# ===========================================================================
+# `--full` exists to report inherited debt. The positive control above proves
+# the debt is there and findable. Anything other than a FAIL here is the defect.
+_out="$(gf_run_wrapper "${WORK}/inherited" "${WORK}/log-full" --full)"
+
+if printf '%s' "${_out}" | grep -qF 'Base ref: n/a — --full requested'; then
+    _ok "the --full run states it computed no diff"
+else
+    _bad "the --full run did not announce itself as unscoped; the rest of this arm is unsafe to interpret"
+fi
+
+_v="$(gf_verdict "${_out}" 61)"
+_still_broken=1
+case "${_v}" in
+    *"NOT APPLICABLE"*)
+        # Is the reason a diff-based one? That is the specific defect.
+        if printf '%s' "${_v}" | grep -qF 'out of scope'; then _still_broken=0; fi
+        ;;
+esac
+_known_defect ".github#347" \
+    "gate-61 on --full reports NOT APPLICABLE citing 'the diff against origin/development put every post-event registration out of scope' — on a run that computed no diff, over a tree whose single registration the positive control just failed. 0 of 1 inspected." \
+    "${_still_broken}"
+
+# ===========================================================================
+echo
+echo "== the general property: no NOT APPLICABLE may blame a diff on a --full run =="
+# ===========================================================================
+# Generic, gate-agnostic. Catches the next gate that does this.
+#
+# Legitimate on --full (asserted, so a regression to the bad wording is caught):
+#   "this run is NOT diff-scoped, so there is no change set to classify"
+# Illegitimate on --full:
+#   "N file(s) in this diff" / "put ... out of scope"  -> a diff DID the excluding
+mapfile -t _blamers < <(
+    printf '%s\n' "${_out}" \
+        | grep -E '^\[gate-[0-9]+\].*NOT APPLICABLE' \
+        | grep -E 'in this diff|out of scope|the diff against' \
+        | grep -oE '^\[gate-[0-9]+\]' | grep -oE '[0-9]+' | sort -n -u
+)
+echo "   gates blaming a diff on a --full run: ${_blamers[*]:-none}"
+
+# 6 and 7 are a WORDING defect, not a verdict defect: this fixture ships no
+# lib/Controller at all, so their NOT APPLICABLE is substantively right and only
+# their stated reason is wrong. Recorded separately so the two are never conflated.
+_EXPECTED_WORDING_ONLY=(6 7 8 9)
+_unexpected=()
+for _g in "${_blamers[@]:-}"; do
+    [ -z "${_g}" ] && continue
+    _known=0
+    for _w in "${_EXPECTED_WORDING_ONLY[@]}" 61; do [ "${_g}" = "${_w}" ] && _known=1; done
+    [ "${_known}" -eq 0 ] && _unexpected+=("${_g}")
+done
+if [ "${#_unexpected[@]}" -eq 0 ]; then
+    _ok "no NEW gate blames a diff for an exclusion on a --full run"
+else
+    _bad "gate(s) ${_unexpected[*]} report NOT APPLICABLE citing a diff on a --full run, and are not a recorded known defect. Either the gate is scope-dead (the gate-61 shape) or its reason is wrong. Investigate before adding it to the list."
+fi
+
+_wording_live=1
+for _g in "${_blamers[@]:-}"; do [ "${_g}" = "6" ] && _wording_live=0; done
+_known_defect "wording (unfiled)" \
+    "gates 6/7/8/9 decline on --full with the reason '0 ... file(s) in this diff'. The verdict is right (this tree has no lib/Controller) but the reason names a diff the run never computed — the same sentence pattern that made gate-61's lie unreadable for weeks." \
+    "${_wording_live}"
+
+# And the legitimate wording must STAY legitimate.
+_v29="$(gf_verdict "${_out}" 29)"
+if printf '%s' "${_v29}" | grep -qF 'intrinsically diff-relative'; then
+    _ok "gate-29 declines on --full with an honest reason ('intrinsically diff-relative') — the good pattern"
+else
+    _bad "gate-29's --full reason changed; it used to state honestly that the run is not diff-scoped. Got: ${_v29:0:140}"
+fi
+
+# ===========================================================================
+echo
+echo "== coverage accounting: NOT APPLICABLE must carry a reason =="
+# ===========================================================================
+# Brief item 4. A bare `NOT APPLICABLE` is unfalsifiable — the whole gate-61
+# story is that a reason nobody could check stood for weeks.
+_bare=0
+while IFS= read -r _line; do
+    # everything after "NOT APPLICABLE" should be an em-dash + prose
+    if ! printf '%s' "${_line}" | grep -qE 'NOT APPLICABLE (—|-) .{20,}'; then
+        echo "       bare: ${_line:0:120}"
+        _bare=$((_bare + 1))
+    fi
+done < <(printf '%s\n' "${_out}" | grep -E '^\[gate-[0-9]+\].*NOT APPLICABLE')
+if [ "${_bare}" -eq 0 ]; then
+    _ok "every NOT APPLICABLE on the --full run carries a stated reason"
+else
+    _bad "${_bare} NOT APPLICABLE verdict(s) carry no reason — an unfalsifiable skip"
+fi
+
+echo
+echo "== summary =="
+echo "   passed:        ${_pass_n}"
+echo "   failed:        ${_fail_n}"
+echo "   known defects: ${_defect_n} (live, each named above)"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL scope-matrix controls PASSED (${_defect_n} known defect(s) still live)"
+exit 0

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/openspec/specs/tag/spec.md
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/openspec/specs/tag/spec.md
@@ -1,0 +1,14 @@
+# File-level tag spec
+
+Fixture for `.github#343` and for the never-false `test.skip` guard found in
+decidesk. Two ordinary scenarios, no exclusions anywhere.
+
+### Requirement: Tagged
+
+#### Scenario: alpha
+
+- WHEN a THEN b
+
+#### Scenario: beta
+
+- WHEN c THEN d

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/tests/e2e/tagged.spec.js
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/file-level-tag/tests/e2e/tagged.spec.js
@@ -1,0 +1,18 @@
+/**
+ * A FILE-LEVEL tag claiming both scenarios. Nothing in the body exercises
+ * either of them (`.github#343`: the tag is credited without checking the test
+ * body), and the file's only test is UNCONDITIONALLY skipped — `test.skip(true)`
+ * is a condition that can never be false — so even the assertion it does carry
+ * never runs. The one assertion present is `#app-root` visible, which is the
+ * decidesk shape: a test named for a tab that only proves the app mounted.
+ *
+ * @e2e tag::alpha
+ * @e2e tag::beta
+ */
+import { test, expect } from '@playwright/test'
+
+test.skip(true, 'permanently skipped — the condition can never be false')
+
+test('mounts', async ({ page }) => {
+	await expect(page.locator('#app-root')).toBeVisible()
+})

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/openspec/specs/tag/spec.md
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/openspec/specs/tag/spec.md
@@ -1,0 +1,14 @@
+# Honest coverage spec
+
+The clean arm. Two scenarios, each referenced by a test that really runs and
+really asserts something specific to that scenario. Nothing here may fire.
+
+### Requirement: Tagged
+
+#### Scenario: alpha
+
+- WHEN a THEN b
+
+#### Scenario: beta
+
+- WHEN c THEN d

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/tests/e2e/alpha.spec.js
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/tests/e2e/alpha.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+// @e2e tag::alpha
+test('alpha — submitting a stores the record', async ({ page }) => {
+	await page.goto('/index.php/apps/scopefixture/')
+	await page.getByRole('button', { name: 'Submit A' }).click()
+	await expect(page.getByText('Record stored')).toBeVisible()
+})

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/tests/e2e/beta.spec.js
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/honest/tests/e2e/beta.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+// @e2e tag::beta
+test('beta — submitting c shows the result', async ({ page }) => {
+	await page.goto('/index.php/apps/scopefixture/')
+	await page.getByRole('button', { name: 'Submit C' }).click()
+	await expect(page.getByText('Result shown')).toBeVisible()
+})

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/req-inherit/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/req-inherit/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/req-inherit/openspec/specs/sib/spec.md
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/req-inherit/openspec/specs/sib/spec.md
@@ -1,0 +1,26 @@
+# Sibling inheritance spec
+
+Fixture for `.github#356`. ONE `@e2e exclude` in the REQUIREMENT body, three
+scenarios beneath it, none of which carries an exclusion of its own and none of
+which any e2e test references.
+
+The gate currently reports `PASS — 0 reference(s) in e2e suite` over this file.
+Measured on openbuild, this shape accounts for 471 of 509 exclusions (92.5%)
+sharing a reason across only 42 distinct reasons, one of them covering 32
+scenarios.
+
+### Requirement: Sibling handling
+
+@e2e exclude write-only field, invisible to a response-shape assertion
+
+#### Scenario: alpha sibling
+
+- WHEN a is submitted THEN the record is stored
+
+#### Scenario: beta sibling
+
+- WHEN b is submitted THEN the record is rejected
+
+#### Scenario: gamma sibling
+
+- WHEN c is submitted THEN a conflict is reported

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/scenario-level/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/scenario-level/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/e2e-credibility/scenario-level/openspec/specs/sib/spec.md
+++ b/hydra-gates/scripts/test-fixtures/e2e-credibility/scenario-level/openspec/specs/sib/spec.md
@@ -1,0 +1,22 @@
+# Scenario-level exclusion spec
+
+The CONTROL arm for `.github#356`. Identical shape to req-inherit/ except the
+exclusion sits on ONE SCENARIO instead of the requirement body.
+
+This currently behaves CORRECTLY — the uncovered sibling is reported. It is
+fixtured so that a fix for #356 which over-corrects (killing requirement-level
+exclusion outright, or leaking scenario-level exclusion) is caught in the other
+direction. A repair that makes every exclusion inert would pass a one-armed
+suite.
+
+### Requirement: Sibling handling
+
+#### Scenario: excluded sibling
+
+@e2e exclude write-only field, invisible to a response-shape assertion
+
+- WHEN a is written THEN nothing is echoed in the response
+
+#### Scenario: uncovered sibling
+
+- WHEN b happens THEN c is shown

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
@@ -1,0 +1,33 @@
+# COVERED-ELSEWHERE.md — gates fixtured by a suite outside `gate-acceptance/`
+
+The coverage ratchet in `scripts/lib/test_gate_acceptance_matrix.sh` computes
+coverage from `expect.conf` rows inside `gate-acceptance/` bundles. Several gates
+are already driven through the real wrapper by a dedicated suite that predates —
+or is too specific for — the generic bundle format. Without this file the ratchet
+would report them as untested, which is a false alarm, and a ratchet that cries
+wolf gets switched off.
+
+**This is not an exemption list.** Every gate below HAS repo-shaped planted/clean
+coverage; only the location differs. The driver counts these as covered, so:
+
+* a gate listed here must be genuinely covered by the named suite — if that suite
+  is deleted or stops asserting the gate, this row becomes a lie the ratchet
+  cannot see. Keep the suite name accurate.
+* a gate listed here must NOT also appear in `UNCOVERED.md`.
+
+The driver reads this file by grepping `^\| *gate-[0-9]+` and extracting the number,
+identically to `UNCOVERED.md`.
+
+| gate | name | suite | fixtures |
+|---|---|---|---|
+| gate-19 | e2e-coverage | `test_gate19_coverage_credibility.sh` | `test-fixtures/e2e-credibility/{req-inherit,scenario-level,file-level-tag,honest}` — `.github#356`, `#343`, `#345` and the never-false `test.skip` guard |
+| gate-23 | or-abstraction-anti-patterns | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-24 | integration-parity | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-26 | visual-coverage | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-27 | no-phantom-cross-app-rpc | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` + an injected crashing checker |
+| gate-29 | gitignore-then-commit | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/clean` (asserts `na`, never `PASS`, on an unscoped run) |
+| gate-30 | public-monitoring | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-31 | img-alt | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-32 | semantic-controls | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-33 | axe-core | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
+| gate-61 | listener-work-placement | `test_gate_scope_matrix.sh` | `test-fixtures/scope-matrix/app` — push / full / diff matrix, `.github#347` |

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
@@ -1,0 +1,106 @@
+# UNCOVERED.md — declared gates with no planted/clean acceptance bundle
+
+This file is the **reasoned exception list** for the coverage ratchet in
+`scripts/lib/test_gate_acceptance_matrix.sh`.
+
+Every gate declared by `scripts/run-hydra-gates.sh` must EITHER have a
+planted/clean fixture bundle under `scripts/test-fixtures/gate-acceptance/<bundle>/`
+(with an `expect.conf` naming it), OR appear as a row below with a reason.
+The driver reads this file by grepping `^\| *gate-[0-9]+` and extracting the
+number, so the first column cell of every row must literally start with
+`gate-<number>`.
+
+**The list may only SHRINK.** Two conditions are hard CI failures:
+
+* a gate listed here that has since gained a planted/clean bundle — delete its
+  row, so CI enforces it from that point on;
+* a declared gate that appears in neither place — a gate cannot be added to the
+  runner and left untested in silence.
+
+Gates already covered by a repo-shaped bundle are deliberately absent from this
+table: **23, 24, 26, 27, 29, 30, 31, 32, 33** (`scripts/test-fixtures/gates-23-33/`
+via `scripts/lib/test_gates_23_33_never_green_over_nothing.sh`), **61**
+(`scripts/test-fixtures/scope-matrix/` via `scripts/lib/test_gate_scope_matrix.sh`)
+and **19** (`scripts/test-fixtures/e2e-credibility/` via
+`scripts/lib/test_gate19_coverage_credibility.sh`).
+
+## What the categories claim
+
+A reason is a testable claim, so each row states which of four kinds it is.
+
+* `no-fixture-yet` — nothing blocks it; a bundle simply has not been authored.
+  The reason names roughly what the planted subject would be.
+* `needs-diff` — the gate is intrinsically diff-relative and needs a purpose-built
+  git history, not just a directory of files.
+* `needs-external` — the gate depends on something a fixture directory cannot
+  cheaply supply. The exact dependency is named.
+* `advisory-only` — the gate is WARN-only by design, so a planted arm cannot go
+  red. **No gate currently qualifies**; the category is documented so that a
+  future WARN-only gate is classified rather than mis-filed as `no-fixture-yet`.
+
+Two notes on authoring, both measured rather than assumed:
+
+1. `scripts/test-fixtures/gate-acceptance/auth-guards/` exists but carries no
+   `expect.conf` and no source files beyond `appinfo/info.xml`, so it currently
+   contributes **zero** covered gates. It is a stub, not coverage.
+2. `_enum_tracked` prefers `git ls-files`, and a fixture directory sits inside
+   this repository's own work tree — so a planted file must be **committed** to
+   be enumerated at all. An untracked plant reproduces the very silence these
+   bundles exist to expose.
+
+## The list
+
+| gate | name | category | reason |
+|---|---|---|---|
+| gate-1 | spdx-headers | no-fixture-yet | A planted `lib/Service/Unlicensed.php` with no `@license`/`@copyright` docblock tags would trip it; the clean arm is the same file carrying both. Nothing blocks authoring this. |
+| gate-2 | forbidden-patterns | no-fixture-yet | A planted `lib/Service/Debug.php` containing `var_dump($x);` (and the `die;` language-construct form, which the pre-`check_forbidden_patterns.py` grep missed) would trip it; the clean arm keeps the file and drops the calls. |
+| gate-3 | stub-scan | no-fixture-yet | A planted `lib/BackgroundJob/EmptyJob.php` whose `run()` body does no non-logger call, plus a `lib/Service/` method taking `$userId` and never referencing it, would trip both arms of the checker. Nothing blocks it. |
+| gate-4 | composer-audit | needs-external | Requires the `composer` binary on PATH **and** a network round-trip to the Packagist security-advisories API, since `composer audit --locked` resolves advisories remotely. A planted arm would additionally need a lock pinning a package with a live published CVE, which rots as advisories are superseded. |
+| gate-5 | route-auth | no-fixture-yet | `scripts/test-fixtures/route-auth/` and `fq-route-names/` already exercise this gate, but through `scripts/lib/test_gate_route_auth.sh`, which drives the checker's helper level rather than a planted/clean pair through the real wrapper. A planted `appinfo/routes.php` entry whose controller method carries no auth attribute would give it wrapper-level coverage. |
+| gate-6 | orphan-auth | no-fixture-yet | A planted `lib/Service/AccessService.php::isTransitionAllowed()` carrying an authorisation-domain signal and called from nowhere in `lib/` or `src/` would trip it; the clean arm adds one production caller. Nothing blocks it. |
+| gate-8 | unsafe-auth-resolver | no-fixture-yet | A planted `lib/Service/DecisionService.php::getAuthorizationService()` ending `catch (\Throwable) { return null; }` would trip it; the clean arm rethrows. Nothing blocks it. |
+| gate-9 | semantic-auth | no-fixture-yet | A planted controller method annotated `#[NoAdminRequired]` whose body calls `requireAdmin()` would trip it; the clean arm swaps the attribute for `#[AuthorizedAdminSetting(...)]`. Nothing blocks it. |
+| gate-10 | initial-state | no-fixture-yet | A planted `src/AdminRoot.vue` reading `document.getElementById('x').dataset.version` (and the two-step form, which the old single-line regex could not see) would trip it; the clean arm uses `loadState()`. Nothing blocks it. |
+| gate-11 | admin-router | no-fixture-yet | A planted `src/main.js` calling `createRouter()` with a `{ path: '/settings', component: AdminRoot }` entry would trip it; the clean arm registers the component via `AdminSettings.php` only. Nothing blocks it. |
+| gate-12 | nc-input-labels | no-fixture-yet | A planted `.vue` component with an `<NcSelect>` carrying neither `inputLabel` nor `ariaLabelCombobox` — written multi-line and after a `:reduce="(o) => o.id"` prop, which is what defeated the old `[^>]*` extractor — would trip it. Nothing blocks it. |
+| gate-13 | modal-isolation | no-fixture-yet | A planted `src/components/Thing.vue` opening a multi-line `<NcDialog` tag inline (the shape that made 0 of pipelinq's 9 real violations visible) would trip it; the clean arm moves it to `src/dialogs/`. Nothing blocks it. |
+| gate-14 | route-reachability | no-fixture-yet | `scripts/test-fixtures/route-registration/` and `fq-route-names/` already exercise this gate, but through `scripts/lib/test_gate_route_registration.sh` at helper level, not as a planted/clean pair through the wrapper. A planted `Response`-returning controller method with no route entry, plus a route naming a method that does not exist, would cover both invariants at wrapper level. |
+| gate-15 | dashboard-antipattern | no-fixture-yet | A planted `src/manifest.json` with a `type:"dashboard"` page whose widget body slot template renders `<CnDashboardPage>` would trip it; the clean arm renders an ordinary widget component. Nothing blocks it. |
+| gate-16 | spec-coverage | needs-diff | `check_spec_coverage.py` derives its subject set from `git diff -U0` against `$HYDRA_GATE_BASE_REF`; with no changed-line set it prints `# count=0` and exits 0, so a directory of files alone can never make the planted arm go red. It needs a purpose-built two-commit history, not a fixture tree. |
+| gate-17 | redundant-controller | no-fixture-yet | A planted `lib/Controller/MeetingController.php::index()` whose body is a literal pass-through to OpenRegister's `ObjectService` would trip it; the clean arm deletes the wrapper. Runs full-tree when unscoped, so no diff is required. |
+| gate-18 | notification-dialect | no-fixture-yet | A planted `lib/Settings/register.json` whose `x-openregister-notifications` block uses the obsolete singular `channel`/`recipient` + `lifecycleEnter` dialect would trip the blocking half (a); the clean arm uses plural `channels`/`recipients` + `trigger.type`. Half (b) is advisory and never decides the verdict. |
+| gate-20 | or-objectservice-api | no-fixture-yet | A planted `lib/Service/Thing.php` calling `$this->objectService->findObjects(...)` would trip it; the clean arm calls `findAll()`. A second clean file with the same call **commented out** would pin the `source_scope.py --mask php` behaviour. Nothing blocks it. |
+| gate-21 | conflict-markers | no-fixture-yet | A planted tracked file under `lib/` carrying git's canonical `<<<<<<< `/`=======`/`>>>>>>> ` marker shapes at start-of-line would trip it; the clean arm is the resolved file. Nothing blocks it. |
+| gate-22 | manifest-validation | needs-external | `scripts/test-fixtures/manifest-validation/` exists but feeds `check_manifest.js` directly via `test_check_manifest.sh` rather than driving the wrapper. Wrapper-level coverage additionally needs `node` on PATH **and** `ajv/dist/2020` resolvable: no `node_modules` ships anywhere in this package, so today the validator exits 3 and the clean arm cannot go green. |
+| gate-25 | contract-coverage | no-fixture-yet | A planted `appinfo/routes.php` entry plus a `#[PublicPage]` controller method with no Postman collection assertion, no PHPUnit controller test and no `@contract exclude <reason>` would trip it. The helper audits the full tree when unscoped, so no diff is required. |
+| gate-28 | license-triangle | no-fixture-yet | A planted `composer.json` declaring `"license": "EUPL-1.2"` alongside a `lib/` PHP file whose docblock says `@license MIT` would trip it; the clean arm makes the two agree. Nothing blocks it. |
+| gate-34 | window-confirm | no-fixture-yet | A planted `src/components/Thing.vue` calling `window.confirm(...)` — and the bracket form `window['confirm'](...)`, which the old regex missed — would trip it; the clean arm uses `NcDialog`. Nothing blocks it. |
+| gate-35 | img-alt-empty-only | no-fixture-yet | A planted `<img :src="user.avatarUrl" alt="">` (and the single-quoted `alt=''` spelling, which was invisible until recently) would trip it; the clean arm gives the image a real text alternative. Nothing blocks it. |
+| gate-36 | tabindex-positive | no-fixture-yet | A planted markup file with `tabindex="5"` — plus the single-quoted `tabindex='5'` form, for which the fleet has zero occurrences and therefore no live regression pressure — would trip it; the clean arm uses `"0"`. Nothing blocks it. |
+| gate-37 | aria-hidden-focusable | no-fixture-yet | A planted element with `aria-hidden="true"` and `tabindex="0"` would trip it; the clean arm must include the canonical `aria-hidden` + `tabindex="-1"` hidden file input, which is correct code this gate previously reported. Nothing blocks it. |
+| gate-38 | skip-link | no-fixture-yet | `scripts/test-fixtures/monitoring-skiplink/` exists but is driven by `scripts/lib/test_gate_monitoring_and_skiplink.sh` at helper level, not as a planted/clean pair through the wrapper. A planted `src/App.vue` that is neither an `<NcContent>` nor a `<CnAppRoot>` and carries no skip-link anchor would give it wrapper-level coverage. |
+| gate-39 | button-name | no-fixture-yet | A planted `<button><CloseIcon /></button>` with no accessible name would trip it; the clean arm must include a `:title="t('app', 'Remove tab')"` bound name, which is the shape that produced all 22 of openbuild's false positives. Nothing blocks it. |
+| gate-40 | form-label-association | no-fixture-yet | A planted bare `<input type="text">` with no label association would trip it; the clean arm must include an `<NcCheckboxRadioSwitch>` labelled by default-slot content only, which is the relaxation this gate depends on. Nothing blocks it. |
+| gate-41 | html-lang | no-fixture-yet | A planted `templates/standalone.php` that emits `<html>` without a `lang=` attribute would trip it; the clean arm adds `lang`. A second clean template whose PHP comment merely mentions `<html>` would pin the `php_template_scope.emitted_markup` behaviour. |
+| gate-42 | link-text-quality | no-fixture-yet | A planted `<a href="/docs">Click here</a>` would trip it; the clean arm gives the anchor descriptive text. Nothing blocks it. |
+| gate-43 | table-headers | no-fixture-yet | A planted `<table>` in which one `<th>` carries `scope="col"` and another carries none would trip it — the exact case a single `scope=` used to green — and the clean arm scopes every header. Nothing blocks it. |
+| gate-44 | autocomplete-attr | no-fixture-yet | A planted `<input id="e" type="text" name="email">` with no `autocomplete=` would trip it, and it doubles as the regression case for "first name-like attribute wins". The clean arm adds `autocomplete="email"`. Nothing blocks it. |
+| gate-45 | prefers-reduced-motion | no-fixture-yet | A planted `css/main.css` declaring `transition: all .3s` with no `@media (prefers-reduced-motion: reduce)` block would trip it; the clean arm adds the guard. The clean arm must NOT ship a universal `*` reset, which globally suppresses every finding. |
+| gate-46 | spec-anchor-existence | no-fixture-yet | A planted `@spec openspec/specs/nope/spec.md#no-such-anchor` in a `lib/` file (and one under `tests/`, the directory the enumerator only recently gained) would trip it; the clean arm points at a spec file and heading that exist. Nothing blocks it. |
+| gate-47 | security-change-has-tests | needs-diff | The gate reports `na` outright unless `--scope-to-diff` is active with a resolvable base, because its whole subject is "which hunks did this change touch, and did it also touch a test". It needs a purpose-built commit pair, which a static fixture directory cannot express. |
+| gate-48 | csrf-cochange | needs-diff | Same shape as gate-47: "was `@NoCSRFRequired` REMOVED" is a property of a change set, not of a checkout, and the gate reports `na` on any non-diff-scoped run. It needs a two-commit history where the attribute is present in the base and absent in the head. |
+| gate-49 | controller-exception-translation | no-fixture-yet | A planted `lib/Controller/ThingController.php::destroy()` calling `$this->objectService->deleteObject(...)` with neither a `catch` nor a `@throws` would trip it; the clean arm catches `\Throwable`, which must be accepted (it was rejected on hermiq#162). Nothing blocks it. |
+| gate-50 | security-config-fail-mode | no-fixture-yet | A planted `$this->appConfig->getValueString(Application::APP_ID, 'listing_register', '')` with no empty-value guard within the window would trip it — using the class-constant app id, which was the measured blind spot. The clean arm adds `if ($reg === '' \|\| $sch === '')`. |
+| gate-51 | schema-property-titles | no-fixture-yet | A planted `lib/Settings/register.json` with a schema property carrying neither `title` nor `description` would trip it; the clean arm supplies both. Unscoped runs ratchet every property, so no diff is required. |
+| gate-52 | custom-widget-ratchet | no-fixture-yet | A planted `kind:"widget"` component-registry entry with no `_note` field would trip the justification half, which is what runs unscoped; the clean arm adds the `_note`. The count-ratchet half additionally needs a base ref and is therefore not exercised by a fixture pair. |
+| gate-53 | effective-manifest-crossref | needs-external | `scripts/test-fixtures/effective-manifest/` exists but is driven at helper level by `test_check_manifest_crossref.js` / `test_build_effective_manifest.js`, not through the wrapper. Wrapper-level coverage needs `node` plus `ajv/dist/2020` resolvable from `scripts/lib`; no `node_modules` ships in this package, so the gate currently fails closed with "ajv not resolvable" on both arms. |
+| gate-54 | relation-dialect | no-fixture-yet | A planted `lib/Settings/register.json` carrying the banned per-schema `x-openregister-relations` block, or a `format:uuid` relation property with no `$ref`, would trip it; the clean arm uses the ADR-062 canonical shape. Nothing blocks it. |
+| gate-55 | detail-page-discipline | no-fixture-yet | A planted `type:"detail"` page declaring both page-level `widgets[]` and `config.widgets` (render-path shadowing) would trip it; the clean arm keeps one render path. Unscoped runs check every detail page in the manifest, so no diff is required. |
+| gate-56 | register-handler-resolution | no-fixture-yet | A planted `lib/Settings/register.d/10-thing.json` naming a `guard` class that does not exist in the tree, plus a real class with a `::method` that was never written, would trip both rules; the clean arm ships both. Nothing blocks it. |
+| gate-57 | orphaned-write-capability | no-fixture-yet | A planted `lib/Service/JournalEmitter.php::emit()` with no non-test production caller and no register.d/listener/background-job seam would trip it; the clean arm wires one of the recognised seams. Nothing blocks it. |
+| gate-58 | e2e-networkidle | no-fixture-yet | A planted `tests/e2e/nav.spec.ts` calling `page.waitForLoadState('networkidle')` would trip it; the clean arm uses `waitUntil: 'domcontentloaded'`, and should also carry a comment merely *mentioning* networkidle, which used to be counted as a live call. Unscoped runs put every e2e file in scope. |
+| gate-59 | unclosable-gate | no-fixture-yet | A planted `lib/Service/SettingsInitializer.php` reading a `configuration_version` config key that nothing anywhere writes would trip it; the clean arm writes it after the guarded setup. Unscoped runs walk all of `lib/`, so no diff is required. |
+| gate-60 | icon-vocabulary | needs-external | The planted arm can go red without help (an invented MDI name returns 1), but the clean arm **cannot go green**: with `node_modules/vue-material-design-icons` absent the helper returns `EXIT_TOOLING_MISSING` (5) and the runner reports SKIPPED (wiring), never PASS. A bundle needs that package's `*.vue` files present under the fixture. |
+| gate-62 | store-plane | no-fixture-yet | A planted `src/manifest.json` whose store/templates/catalogue naming or discovery breaks ADR-080 would trip it; the clean arm conforms. The runner omits `--base` on unscoped runs, so a fixture directory is enough. |
+| gate-63 | settings-surface | no-fixture-yet | A planted `src/manifest.json` placing a settings surface against ADR-079 would trip it; the clean arm conforms. Same helper and same unscoped behaviour as gate-62, so a fixture directory is enough. |
+| gate-64 | apphost-autoload-prelude | no-fixture-yet | A planted `lib/AppInfo/Application.php` whose `register()` resolves an `OCA\OpenRegister\AppHost\` class without first registering OpenRegister's PSR-4 prefix would trip it; the clean arm adds the autoload prelude. The clean arm should also carry a lazy service closure merely *mentioning* an AppHost class, which must not be flagged. |

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/appinfo/routes.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+return [
+	'routes' => [
+		['name' => 'agent#show',   'url' => '/api/agents/{id}', 'verb' => 'GET'],
+		['name' => 'agent#update', 'url' => '/api/agents/{id}', 'verb' => 'PUT'],
+		['name' => 'agent#diff',   'url' => '/api/agents/{id}/diff', 'verb' => 'GET'],
+	],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/lib/Controller/AgentController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/lib/Controller/AgentController.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * The CLEAN arm for gate-7 (.github#353).
+ *
+ * Every `#[NoAdminRequired]` method here is guarded by a predicate spelled
+ * VERB-OBJECT — `canUserAccessAgent()`, `hasOwnerPermissionForAgent()` — which is how
+ * hermiq spells its predicates and which `_GUARD_HELPER_NAME_RE` used to reject,
+ * because it required the auth token (Access / Admin / Permission / …) to be the
+ * FINAL CamelCase segment.
+ *
+ * All three of hermiq's gate-7 findings were false positives from exactly this.
+ *
+ * ⚠️ NOT `canUserModifyAgent()`, although SHARED-LESSONS lists it beside
+ * `canUserAccessAgent()` as one of hermiq's predicates. Measured against the
+ * merged #353 regex: `canUserModifyAgent` is still NOT recognised, because
+ * "Modify" is not one of the required auth tokens. #353 relaxed the token's
+ * POSITION, not the token set. Using it here made the clean arm emit a finding
+ * and would have been read as "the fix did not work".
+ *
+ * This file must produce ZERO findings. Under the pre-#353 regex it produces
+ * THREE — that is asserted directly by the suite, because a fixture that passes
+ * identically before and after the fix proves nothing about the fix. (The #353
+ * author hit precisely this: their first "now passes" fixture also passed under
+ * the old regex.)
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\Controller;
+
+use OCA\ScopeFixture\Service\AgentAccessService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class AgentController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly AgentAccessService $access,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Shape 1 — the guard is called IN BODY, verb-object spelling.
+	 */
+	#[NoAdminRequired]
+	public function show(int $id): JSONResponse {
+		$agent = $this->access->findAgent($id);
+		if ($agent === null || !$this->canUserAccessAgent($agent, $this->userId)) {
+			// The 404-style tenancy refusal this gate's own FAIL message endorses.
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($agent);
+	}
+
+	/**
+	 * Shape 2 — a different verb, same verb-object spelling.
+	 */
+	#[NoAdminRequired]
+	public function update(int $id, array $data): JSONResponse {
+		$agent = $this->access->findAgent($id);
+		if ($agent === null || !$this->hasOwnerPermissionForAgent($agent, $this->userId)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($this->access->apply($agent, $data));
+	}
+
+	/**
+	 * Shape 3 — the Pattern-4 transitive closure: the decision and the refusal
+	 * are split across a loader and its caller, so neither half alone shows both.
+	 */
+	#[NoAdminRequired]
+	public function diff(int $id): JSONResponse {
+		$agent = $this->loadAccessibleAgent($id);
+		if ($agent === null) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($this->access->diff($agent));
+	}
+
+	private function loadAccessibleAgent(int $id): ?array {
+		$agent = $this->access->findAgent($id);
+		if ($agent === null || !$this->canUserAccessAgent($agent, $this->userId)) {
+			return null;
+		}
+		return $agent;
+	}
+
+	private function canUserAccessAgent(array $agent, string $userId): bool {
+		return $agent['ownerId'] === $userId || $this->access->isShared($agent, $userId);
+	}
+
+	private function hasOwnerPermissionForAgent(array $agent, string $userId): bool {
+		return $agent['ownerId'] === $userId;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/lib/Service/AgentAccessService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/clean/lib/Service/AgentAccessService.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\Service;
+
+class AgentAccessService {
+
+	public function findAgent(int $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function isShared(array $agent, string $userId): bool {
+		return in_array($userId, $agent['sharedWith'] ?? [], true);
+	}
+
+	public function apply(array $agent, array $data): array {
+		return array_merge($agent, $data);
+	}
+
+	public function diff(array $agent): array {
+		return ['id' => $agent['id'], 'changes' => []];
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/expect.conf
@@ -1,0 +1,14 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# <subject-substring> is the LOAD-BEARING part. The driver requires the planted
+# arm's finding to NAME it. A gate that fails with a bare count, or that fails
+# for some unrelated reason, does not prove this fixture triggered it.
+#
+# Bundle: auth-guards — gate-7 (no-admin-idor), .github#353.
+# planted/ removes the per-object guard from show() and update() while LEAVING
+# diff() guarded, so a checker that simply flagged every #[NoAdminRequired]
+# method would score 3 here and be caught by the count, not just the verdict.
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS lib/Controller/AgentController.php

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/appinfo/routes.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+return [
+	'routes' => [
+		['name' => 'agent#show',   'url' => '/api/agents/{id}', 'verb' => 'GET'],
+		['name' => 'agent#update', 'url' => '/api/agents/{id}', 'verb' => 'PUT'],
+		['name' => 'agent#diff',   'url' => '/api/agents/{id}/diff', 'verb' => 'GET'],
+	],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/lib/Controller/AgentController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/lib/Controller/AgentController.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * The PLANTED arm for gate-7.
+ *
+ * Byte-for-byte the clean arm's structure, with the guard REMOVED from
+ * `show()` and `update()`. Any authenticated user can read or overwrite any
+ * agent by id — textbook IDOR (OWASP A01:2021, ADR-005 Rule 3).
+ *
+ * `diff()` KEEPS its verb-object guard through `loadAccessibleAgent()`. It is
+ * here so the planted arm is not uniformly guilty: a checker that simply
+ * flagged every `#[NoAdminRequired]` method would score 3/3 here and look
+ * correct. It must find exactly the two that lost their guard.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\Controller;
+
+use OCA\ScopeFixture\Service\AgentAccessService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class AgentController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly AgentAccessService $access,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * PLANTED IDOR — no per-object guard of any kind.
+	 */
+	#[NoAdminRequired]
+	public function show(int $id): JSONResponse {
+		$agent = $this->access->findAgent($id);
+		return new JSONResponse($agent);
+	}
+
+	/**
+	 * PLANTED IDOR — writes to an arbitrary id.
+	 */
+	#[NoAdminRequired]
+	public function update(int $id, array $data): JSONResponse {
+		$agent = $this->access->findAgent($id);
+		return new JSONResponse($this->access->apply($agent, $data));
+	}
+
+	/**
+	 * NOT planted — keeps the verb-object guard via the loader.
+	 */
+	#[NoAdminRequired]
+	public function diff(int $id): JSONResponse {
+		$agent = $this->loadAccessibleAgent($id);
+		if ($agent === null) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($this->access->diff($agent));
+	}
+
+	private function loadAccessibleAgent(int $id): ?array {
+		$agent = $this->access->findAgent($id);
+		if ($agent === null || !$this->canUserAccessAgent($agent, $this->userId)) {
+			return null;
+		}
+		return $agent;
+	}
+
+	private function canUserAccessAgent(array $agent, string $userId): bool {
+		return $agent['ownerId'] === $userId || $this->access->isShared($agent, $userId);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/lib/Service/AgentAccessService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/planted/lib/Service/AgentAccessService.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\Service;
+
+class AgentAccessService {
+
+	public function findAgent(int $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function isShared(array $agent, string $userId): bool {
+		return in_array($userId, $agent['sharedWith'] ?? [], true);
+	}
+
+	public function apply(array $agent, array $data): array {
+		return array_merge($agent, $data);
+	}
+
+	public function diff(array $agent): array {
+		return ['id' => $agent['id'], 'changes' => []];
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/scope-matrix/app/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/scope-matrix/app/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>scopefixture</id>
+	<name>Scope Matrix Fixture</name>
+	<summary>Fixture app for the gate scope matrix. Not a real app.</summary>
+	<description>Exists so the gate suite can express push / full / diff scopes against a real git history.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ScopeFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/scope-matrix/app/docs/CHANGELOG.md
+++ b/hydra-gates/scripts/test-fixtures/scope-matrix/app/docs/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## Unreleased

--- a/hydra-gates/scripts/test-fixtures/scope-matrix/app/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/scope-matrix/app/lib/AppInfo/Application.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\AppInfo;
+
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\ScopeFixture\Listener\InheritedDebtListener;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap {
+
+	public const APP_ID = 'scopefixture';
+
+	public function __construct() {
+		parent::__construct(self::APP_ID);
+	}
+
+	public function register(IRegistrationContext $context): void {
+		// Registered in the BASE commit. The diff never touches this line, so a
+		// diff-scoped run legitimately skips it and a --full run must not.
+		$context->registerEventListener(ObjectCreatedEvent::class, InheritedDebtListener::class);
+	}
+
+	public function boot(IBootContext $context): void {
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/scope-matrix/app/lib/Listener/InheritedDebtListener.php
+++ b/hydra-gates/scripts/test-fixtures/scope-matrix/app/lib/Listener/InheritedDebtListener.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * INHERITED DEBT — deliberately planted for the gate-61 scope regression.
+ *
+ * This listener is registered on a POST event (`ObjectCreatedEvent`) and does a
+ * synchronous `saveObject()` on the write path, with no `ListenerDeferralService`
+ * and no `@listener-placement` annotation. That is exactly the ADR-078 violation
+ * gate-61 exists to detect.
+ *
+ * It is present in the BASE commit as well as HEAD, so the diff never touches it.
+ * A diff-scoped run is therefore RIGHT to pass over it (ADR-020: the backlog is a
+ * work-list, not a reason to redden an unrelated PR). A `--full` run is NOT: the
+ * whole point of `--full` is to report inherited debt.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ScopeFixture\Listener;
+
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+class InheritedDebtListener implements IEventListener {
+
+	public function __construct(
+		private readonly \OCA\OpenRegister\Service\ObjectService $objectService,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof ObjectCreatedEvent) {
+			return;
+		}
+		// A second write INSIDE the first write's request. No deferral, no
+		// reason-bearing annotation.
+		$this->objectService->saveObject('audit', 'trail', [
+			'subject' => $event->getObject()->getUuid(),
+		]);
+	}
+}


### PR DESCRIPTION
## Why

We keep proving gates work by hand, one planted true positive at a time, in every app. This builds the suite instead.

**The argument this is built around:** gate-7 has **86 unit tests, they all passed, and the gate was still wrong.** Its regex was self-consistent; what it could not see was a real repo naming its auth predicates verb-object (`canUserAccessAgent`). Only a repo-shaped fixture driven through the **real wrapper** catches that. Same for gate-61 (a *scope* bug), gate-4 (`.gitignore` hid its input), gate-19 (returned its finding count as an **exit status** — 256 findings would have exited 0 = PASS). None of those live in a checker function.

## What lands

Five suites, **auto-discovered** by `tests/run-helper-suites.sh` — no workflow edit, which is the point of discovery.

| suite | property |
|---|---|
| `test_gate_acceptance_matrix.sh` | planted must FAIL **and NAME the subject**; clean must PASS; `NOT APPLICABLE` over a fixture built to trigger the gate is a suite FAILURE |
| `test_gate_scope_matrix.sh` | the same tree at push / full / diff |
| `test_gate_exit_code_semantics.sh` | a byte holds 255 |
| `test_gate19_coverage_credibility.sh` | a tag is not a test |
| `test_gate7_verb_object_guards.sh` | `#353`, with an anti-dead-test control |

### The coverage ratchet
Coverage is **computed** from the bundles and diffed against the runner's own declared inventory — never a hand-maintained list, the failure mode this package has already been bitten by twice. Every declared gate is either fixtured or carries a reasoned row in `UNCOVERED.md` (52 gates, categorised `no-fixture-yet` / `needs-diff` / `needs-external` / `advisory-only`). **The list can only shrink.** **12 of 64** gates now have planted/clean coverage through the real `bin/hydra-gates`.

## Defects reproduced and pinned

Each is asserted as a live `KNOWN DEFECT` that **fails loudly the moment the behaviour changes**, so no entry can rot into a permanent excuse. None of the held PRs were merged.

- **`#347` gate-61** — reproduced from scratch in a synthetic repo. Tree constant, only the scope flag changed: `--all` finds and names the listener; a diff touching it FAILs; `--full` reports `NOT APPLICABLE — the diff against 'origin/development' put every post-event registration out of scope`, on a run whose own preamble reads `Base ref: n/a — --full requested`.
- **`#356`** — ONE `@e2e exclude` in a requirement body exempted all THREE scenarios beneath it: `PASS — 0 reference(s) in e2e suite`. Scenario-level exclusion is fixtured as a **control**, so a fix that over-corrects is caught too.
- **`#343` + the never-false `test.skip`** — a file-level tag credited 2 scenarios in a file whose only test is `test.skip(true, …)`. The honest arm and the counterfeit arm emit **byte-identical verdicts**. That is the finding.
- **`#209`** — repaired in the *message*, not the *verdict*: the count is parsed from stdout, but `PASS`/`FAIL` still branches on `$?`. Latent (no shipped checker returns a count) and now pinned by a general invariant: **no gate may report PASS while its own log states FAIL.**
- **gate-7, unfiled** — `hasPermission()` and `canAccess()` guards are still reported as unguarded IDOR, before *and* after `#353`. The regex requires a non-empty segment between the `is/has/can/may` prefix and the auth token, so the token can never be first. (The `#353` message states "canAccess matched"; measured against both regexes, it never did.)

Generalised gate-agnostically: **a `NOT APPLICABLE` that claims a diff EXCLUDED something is invalid on a run that computed no diff.** Gates 29/47/48 decline *honestly* on `--full` and are asserted as the good pattern; gates 6/7/8/9 give a right verdict with a wrong reason and are recorded.

## Proving the suite can fail

A suite for gates is subject to exactly the disease it diagnoses, so each control was broken deliberately and observed red, then restored.

| # | breakage | result |
|---|---|---|
| A | blind `check_listener_placement.py`'s registration regex | **red** at the positive control |
| A′ | *first attempt* patched the identifier in a **docstring** (line 56, not the regex at 129) | **stayed green — correctly.** An invalid plant is not evidence of a blind suite |
| B | simulate `#347` landing (`--all` on unscoped runs) | **red**: "`#347` appears to be FIXED — flip this assertion" |
| C | delete a row from `UNCOVERED.md` | **red**: "gate-1 is DECLARED but has neither a fixture nor a reasoned row" |
| D | re-add a now-fixtured gate to `UNCOVERED.md` | **red**: "listed but now HAS coverage — the list may only shrink" |
| E | point the planted expectation at a file the gate never names | **red**: "failed for some OTHER reason, so this fixture proves nothing" |
| F | anti-dead-test: revert the `#353` relaxation | clean arm goes **red (3 findings)** — the fixture genuinely discriminates fixed from broken |

Breakage **F** runs on **every execution**, not once: the `#353` author's first "now passes" fixture passed identically under the old regex, so the suite re-derives that proof each run.

## Not weakened

No baselines, no excludes-to-dodge, no deleted or skipped tests, no widened thresholds. Gates that genuinely cannot be fixture-tested are listed in `UNCOVERED.md` with the exact blocking dependency named, rather than given a fixture that passes vacuously.
