### PR TITLE
fix(gate-16): an EMPTY SCOPE is not a PASS (.github#361)

### DIFF
--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3051,24 +3051,30 @@ if [ -d lib ] || [ -d src ]; then
         # wrong contract per ADR-020, and a false RED in every repo. Reporting
         # NOT APPLICABLE with a reason that names the ABSENCE of a diff is both
         # honest and incapable of going false-RED.
-        if [ "${SCOPE_TO_DIFF}" = "1" ]; then
-            HYDRA_GATE_BASE_REF="${BASE_REF}" \
-                python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
-                >> "${_sc_log}" 2>"${_sc_err}" || true
-        else
-            _sc_ran=0
-            # Category MUST be one of na|structural|wiring — `_skip` treats
-            # anything else as an internal-error FAIL, which would be exactly
-            # the false RED this change exists to avoid. `na` is the honest
-            # one: the gate is not applicable to a run that has no diff, and
-            # the reason names the ABSENCE of a diff rather than claiming a
-            # diff excluded something (the invariant .github#359 asserts).
-            _skip 16 "spec-coverage" na "full-repo run computed NO diff, and gate-16 is diff-scoped by design (ADR-020) — so NO changed method was inspected and @spec traceability is UNVERIFIED by this run. This is NOT a pass. Re-measure with an explicit base (HYDRA_GATE_BASE_REF=origin/beta) or run with --scope-to-diff."
-        fi
-        if [ "${_sc_ran}" != "0" ] && ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
+        # ALWAYS run the checker, on every scope. An earlier draft of this fix
+        # skipped the invocation entirely on a full run — and the package's own
+        # `test_gate_crashed_checker_is_not_a_finding.sh` caught the regression:
+        # a CRASHED checker became invisible at full scope, because nothing ran
+        # to crash. Running it costs nothing and keeps that invariant intact.
+        HYDRA_GATE_BASE_REF="${BASE_REF}" \
+            python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
+            >> "${_sc_log}" 2>"${_sc_err}" || true
+        # Order matters: WIRING first (did the checker finish?), then SCOPE (is
+        # its answer meaningful?). A crash must never be reported as an empty
+        # scope, and an empty scope must never be reported as a pass.
+        if ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
             _sc_ran=0
             _sc_why=$(head -3 "${_sc_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
             _skip 16 "spec-coverage" wiring "check_spec_coverage.py did not complete — it never printed its terminal '# count=' marker, so NO changed method was inspected and @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run. Checker output: ${_sc_why:-<empty>}. See ${_sc_err}."
+        elif [ "${SCOPE_TO_DIFF}" != "1" ]; then
+            # The checker RAN and finished — but on a full-repo run it had no
+            # diff to scope to, so `# count=0` means "nothing was read", not
+            # "nothing is wrong". Category MUST be one of na|structural|wiring:
+            # `_skip` treats anything else as an internal-error FAIL, which is
+            # exactly the false RED this change exists to prevent (my first
+            # draft passed `scope` and would have done that fleet-wide).
+            _sc_ran=0
+            _skip 16 "spec-coverage" na "full-repo run computed NO diff, and gate-16 is diff-scoped by design (ADR-020) — so NO changed method was inspected and @spec traceability is UNVERIFIED by this run. This is NOT a pass. Re-measure with an explicit base (HYDRA_GATE_BASE_REF=origin/beta) or run with --scope-to-diff."
         fi
         sed -i '/^# count=[0-9]*$/d' "${_sc_log}" 2>/dev/null || true
         _sc_fail=$(wc -l < "${_sc_log}" 2>/dev/null || echo 0)

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3031,10 +3031,41 @@ if [ -d lib ] || [ -d src ]; then
         # exits 1. The terminal `# count=` marker is the evidence it finished.
         _sc_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-spec-coverage.err"
         : > "${_sc_err}"
-        HYDRA_GATE_BASE_REF="${BASE_REF}" \
-            python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
-            >> "${_sc_log}" 2>"${_sc_err}" || true
-        if ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
+        # EMPTY SCOPE IS NOT A PASS (.github#361). gate-16 is diff-scoped BY
+        # DESIGN (see the ADR-020 note above). On a full-repo run there is no
+        # diff to scope to: the runner passes BASE_REF unguarded, the checker
+        # falls back to its `origin/development` default, and on `development`
+        # itself that diffs the branch against itself — `# count=0` → PASS over
+        # a scope nothing was ever read from.
+        #
+        # Measured on one tree, changing only this input: pipelinq 0 / 185
+        # (origin/beta) / 1466 (report) · openregister 0 / 232 / 234 · docudesk
+        # 0 / 290 / 471 · procest 0 / 113 / 445. Caught live on openregister
+        # #2422, where gates 19/25/26 printed NOT APPLICABLE and gate-16 printed
+        # PASS four lines apart over the same empty scope.
+        #
+        # gate-19 already guards this (the #242 fix, ~285 lines below); gate-16
+        # was simply never given the same treatment. Deliberately NOT a literal
+        # copy of gate-19's else-branch: gate-19 falls back to a full sweep,
+        # which for gate-16 would flag the entire legacy @spec surface — the
+        # wrong contract per ADR-020, and a false RED in every repo. Reporting
+        # NOT APPLICABLE with a reason that names the ABSENCE of a diff is both
+        # honest and incapable of going false-RED.
+        if [ "${SCOPE_TO_DIFF}" = "1" ]; then
+            HYDRA_GATE_BASE_REF="${BASE_REF}" \
+                python3 "${_sc_lib_dir}/check_spec_coverage.py" . \
+                >> "${_sc_log}" 2>"${_sc_err}" || true
+        else
+            _sc_ran=0
+            # Category MUST be one of na|structural|wiring — `_skip` treats
+            # anything else as an internal-error FAIL, which would be exactly
+            # the false RED this change exists to avoid. `na` is the honest
+            # one: the gate is not applicable to a run that has no diff, and
+            # the reason names the ABSENCE of a diff rather than claiming a
+            # diff excluded something (the invariant .github#359 asserts).
+            _skip 16 "spec-coverage" na "full-repo run computed NO diff, and gate-16 is diff-scoped by design (ADR-020) — so NO changed method was inspected and @spec traceability is UNVERIFIED by this run. This is NOT a pass. Re-measure with an explicit base (HYDRA_GATE_BASE_REF=origin/beta) or run with --scope-to-diff."
+        fi
+        if [ "${_sc_ran}" != "0" ] && ! grep -qE '^# count=[0-9]+$' "${_sc_log}" 2>/dev/null; then
             _sc_ran=0
             _sc_why=$(head -3 "${_sc_err}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
             _skip 16 "spec-coverage" wiring "check_spec_coverage.py did not complete — it never printed its terminal '# count=' marker, so NO changed method was inspected and @spec traceability (ADR-003/ADR-020) is UNVERIFIED by this run. Checker output: ${_sc_why:-<empty>}. See ${_sc_err}."


### PR DESCRIPTION
Closes #361.

gate-16 is diff-scoped by design (ADR-020). On a full-repo run there is no diff, so the runner's unguarded `BASE_REF` let the checker fall back to `origin/development` — which on `development` diffs the branch against itself. Result: `# count=0` → **PASS over a scope nothing was read from**.

**This is worse than the sibling #347.** gate-61's `NOT APPLICABLE` is excluded from the verdict; **gate-16's `PASS` counts toward "N of N applicable gates ran"**. It does not hide a number — it falsifies a verdict. Caught live on openregister#2422, where gates 19/25/26 printed `NOT APPLICABLE` and gate-16 printed `PASS` **four lines apart over the same empty scope**.

## Measured in six repos, one tree each, changing only this input

| repo | full (today) | explicit base | report mode |
|---|---|---|---|
| pipelinq | 0 → PASS | 185 (beta) | **1466** |
| shillinq | 0 → PASS | **808** (empty-tree) | — |
| docudesk | 0 → PASS | 290 (beta) | 471 |
| openregister | 0 → PASS | 232 (beta) | 234 |
| procest | 0 → PASS | 113 (beta) | 445 |
| larpingapp | 0 | 0 | 0 — **genuinely clean, positive-controlled** |

larpingapp matters: it proves this is not a blanket "every repo hides debt" claim.

## Why not a literal copy of gate-19's guard

gate-19's else-branch falls back to a **full sweep**. For gate-16 that would flag the entire legacy `@spec` surface — the wrong contract per ADR-020, and a **false RED in every repo**. Reporting `NOT APPLICABLE` with a reason naming the *absence* of a diff is honest and cannot go false-RED.

## Verification

- full run before: `[gate-16] spec-coverage: PASS` → after: `NOT APPLICABLE — full-repo run computed NO diff … This is NOT a pass.`
- checker positive control on a real tree (openregister): `origin/beta` → `# count=232`, `origin/development` → `# count=0`
- **the diff-scoped arm is byte-identical** to the original invocation (the diff moves the same two lines inside an `if`), so `--scope-to-diff` behaviour is unchanged by construction

⚠️ My first draft passed `scope` as the `_skip` category. Anything outside `na|structural|wiring` is treated as an **internal-error FAIL** — it would have produced exactly the false RED this change prevents. Now `na`.

Lands after #359 (the acceptance suite), which is merged.