### PR TITLE
fix(gate-7): the auth token may be the FIRST segment too (.github#360)

### DIFF
--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -425,8 +425,37 @@ _DATA_ACCESS_RE = re.compile(
 # FAIL message endorses).  Gate-7 was confirmed NOT blind on that repo first:
 # a textbook IDOR planted into the tracked AgentVersionController took the
 # count 3 → 4.
+#
+# ``.github#360`` — THE TOKEN MAY ALSO COME FIRST.  ``#353`` relaxed where the
+# auth token may sit, but left the segment before it MANDATORY
+# (``[A-Z][A-Za-z0-9_]*`` with no ``?``), so the token could never be the first
+# segment after the prefix.  ``hasPermission()`` and ``canAccess()`` — about as
+# conventional as a per-object guard name gets — were therefore still reported
+# as unguarded IDOR, before AND after ``#353``.  Making that segment repeatable
+# and optional (``(?:[A-Z][a-z0-9_]*)*?``) admits the token in ANY position,
+# first included.  Measured, old regex vs new:
+#
+#     hasPermission canAccess isOwner isAllowed mayAccess hasAccess   ✗ → ✓
+#     canUserAccessAgent hasOwnerPermissionForRun isAdmin
+#     canEditPermission canViewOwner hasACLAccess assertOwner         ✓ → ✓
+#     canRender hasChanges canUserModifyAgent hasPendingRevision
+#     isVisible canDelete hasItems                                    ✗ → ✗
+#
+# AN AUTH TOKEN IS STILL REQUIRED, and the token SET is unchanged: the newly
+# admitted names are exactly ``{is,has,can,may}`` + token + optional object
+# noun.  ``canRender``/``hasChanges`` remain non-guards, which is the abuse
+# control — widening this to "any is/has/can/may method" would let gate-7 clear
+# real IDORs.  ``canUserModifyAgent`` also stays unmatched, correctly: "Modify"
+# is not an auth token, and an earlier note listing it beside
+# ``canUserAccessAgent`` as fixed by ``#353`` was wrong.
+#
+# Also corrected for the record: the ``#353`` commit message says ``canAccess``
+# matched.  Measured against BOTH the pre- and post-``#353`` regexes, it never
+# did.  ``#353`` was still a clean widening — nothing it used to match was lost
+# — but its message overstated the scope, and this comment is where that stops
+# being repeated.
 _GUARD_HELPER_NAME_RE = re.compile(
-    r"^(?:is|has|can|may)[A-Z][A-Za-z0-9_]*"
+    r"^(?:is|has|can|may)(?:[A-Z][a-z0-9_]*)*?"
     r"(?:Admin|Access|Permission|Permitted|Owner|Allowed|Authori[sz]ed)"
     r"(?:[A-Z][A-Za-z0-9_]*)?$"
     r"|^(?:assert|guard|deny|verify|authori[sz]e)[A-Za-z0-9_]*$"

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -2041,6 +2041,40 @@ class DraftController {
         self.assertFalse(matches("canUserModifyAgent"))
         self.assertFalse(matches("hasPendingRevision"))
 
+    def test_the_auth_token_may_be_the_first_segment(self):
+        """`.github#360` — the SHORT idiomatic guard names.
+
+        `#353` relaxed WHERE the auth token may sit but left the segment
+        before it mandatory, so the token could never come first.  The most
+        conventional per-object guard names in the fleet are exactly that
+        shape, and gate-7 reported every method delegating to one as an
+        unguarded IDOR — before AND after `#353`.  Measured end-to-end in
+        `test_gate7_verb_object_guards.sh`: a controller guarded by
+        `hasPermission()` and `canAccess()` produced 2 findings, and produces
+        0 now, while the same fixture still goes red under the pre-#360 regex.
+        """
+        matches = cni._GUARD_HELPER_NAME_RE.match
+        for name in (
+            "hasPermission", "canAccess", "isOwner", "isAllowed",
+            "mayAccess", "hasAccess", "isPermitted", "canAccessAgentForUser",
+        ):
+            self.assertTrue(matches(name), f"{name} should be a guard name")
+
+    def test_360_did_not_widen_into_silence(self):
+        """The abuse control for `#360`: no token, no guard.
+
+        Making the pre-token segment optional must not turn the pattern into
+        "any is/has/can/may method".  If it had, gate-7 would clear real
+        IDORs — the failure mode that is strictly worse than the false
+        positives `#360` removes.
+        """
+        matches = cni._GUARD_HELPER_NAME_RE.match
+        for name in (
+            "canRender", "hasChanges", "isVisible", "canDelete", "hasItems",
+            "isReady", "mayRetry", "canUserModifyAgent", "hasPendingRevision",
+        ):
+            self.assertFalse(matches(name), f"{name} must NOT be a guard name")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_gate7_verb_object_guards.sh
+++ b/hydra-gates/scripts/lib/test_gate7_verb_object_guards.sh
@@ -101,8 +101,11 @@ python3 - "${_OLDCK}" <<'PYREVERT'
 import re, sys
 p = sys.argv[1]
 s = open(p).read()
+# The CURRENT shape (post-#360: the middle segment is repeatable and optional,
+# so the auth token may lead). Updated when #360 reshaped it — the suite's own
+# guard below demanded exactly that rather than letting the arm rot.
 new_alt = (
-    'r"^(?:is|has|can|may)[A-Z][A-Za-z0-9_]*"\n'
+    'r"^(?:is|has|can|may)(?:[A-Z][a-z0-9_]*)*?"\n'
     '    r"(?:Admin|Access|Permission|Permitted|Owner|Allowed|Authori[sz]ed)"\n'
     '    r"(?:[A-Z][A-Za-z0-9_]*)?$"'
 )
@@ -180,13 +183,14 @@ fi
 
 # ===========================================================================
 echo
-echo "== live false-positive class: idiomatic short guard names =="
+echo "== idiomatic SHORT guard names: the auth token may come first (#360) =="
 # ===========================================================================
-# Measured end-to-end, not inferred from the regex: a controller guarded by
-# `hasPermission()` or `canAccess()` is STILL reported as an unguarded IDOR,
-# before and after #353. The middle `[A-Z][A-Za-z0-9_]*` segment is mandatory
-# and must precede the token, so the token can never be the FIRST segment after
-# the prefix.
+# Measured end-to-end, not inferred from the regex. This arm was a live KNOWN
+# DEFECT until `.github#360`: a controller guarded by `hasPermission()` or
+# `canAccess()` was reported as TWO unguarded IDORs, before AND after #353,
+# because the middle `[A-Z][A-Za-z0-9_]*` segment was mandatory and had to
+# precede the token — so the token could never be the FIRST segment after the
+# prefix. #360 made that segment repeatable and optional.
 _FP="${_WORK}/fp"
 mkdir -p "${_FP}/lib/Controller"
 cat > "${_FP}/${TARGET}" <<'PHPFP'
@@ -223,13 +227,39 @@ class AgentController extends Controller {
 PHPFP
 ( cd "${_FP}" && git init -q . && git config user.email f@example.invalid \
     && git config user.name F && git add -f . >/dev/null && git commit -qm fp >/dev/null )
-_fp_n="$( cd "${_FP}" && python3 "${CHECKER}" "${TARGET}" 2>/dev/null | grep -c . || true )"
-if [ "${_fp_n}" -gt 0 ]; then
-    _defect_n=$((_defect_n + 1))
-    printf 'KNOWN DEFECT (still live, unfiled) — %s\n' \
-        "gate-7 reports ${_fp_n} finding(s) against a controller guarded by hasPermission() and canAccess(). Both are per-object guards; neither is recognised. _GUARD_HELPER_NAME_RE requires a non-empty CamelCase segment BETWEEN the is/has/can/may prefix and the auth token, so the token can never be the first segment — 'hasPermission', 'canAccess', 'isOwner', 'mayAccess' and 'isAllowed' all fail, before AND after #353. Note the #353 commit message states 'canAccess matched' — measured against both regexes, it never did."
+_fp_out="$( cd "${_FP}" && python3 "${CHECKER}" "${TARGET}" 2>/dev/null )"
+_fp_n="$( printf '%s' "${_fp_out}" | grep -c . || true )"
+if [ "${_fp_n}" -eq 0 ]; then
+    _ok "hasPermission() and canAccess() are recognised as per-object guards (#360) — 0 findings"
 else
-    _bad "the hasPermission()/canAccess() false positives no longer reproduce — this is a FIX. Delete this known-defect arm and assert 0 findings instead."
+    _bad "gate-7 reports ${_fp_n} finding(s) against a controller guarded by hasPermission() and canAccess(). Both are genuine per-object guards. This is .github#360 returning: _GUARD_HELPER_NAME_RE must let the auth token be the FIRST segment after the is/has/can/may prefix. Findings: ${_fp_out}"
+fi
+
+# ANTI-DEAD-TEST for #360, the same treatment #353 gets above: substitute the
+# pre-#360 regex and require this arm to go RED. A fixture that passes under the
+# broken regex too would assert nothing about the fix.
+_OLD360="${_WORK}/check_no_admin_idor_PRE360.py"
+cp "${CHECKER}" "${_OLD360}"
+if ! python3 - "${_OLD360}" <<'PYREVERT360'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+new_alt = 'r"^(?:is|has|can|may)(?:[A-Z][a-z0-9_]*)*?"'
+old_alt = 'r"^(?:is|has|can|may)[A-Z][A-Za-z0-9_]*"'
+if new_alt not in s:
+    sys.stderr.write("REVERT-FAILED: the post-#360 regex shape was not found\n")
+    sys.exit(2)
+open(p, "w").write(s.replace(new_alt, old_alt, 1))
+PYREVERT360
+then
+    _bad "could not reconstruct the pre-#360 regex — _GUARD_HELPER_NAME_RE has been reshaped, so this control no longer proves the fixture is live. Re-derive the revert and update it here rather than deleting this arm."
+else
+    _old360_n="$( cd "${_FP}" && python3 "${_OLD360}" "${TARGET}" 2>/dev/null | grep -c . || true )"
+    if [ "${_old360_n}" -eq 2 ]; then
+        _ok "the short-guard arm goes RED (2 findings) under the pre-#360 regex — it genuinely discriminates fixed from broken"
+    else
+        _bad "the short-guard arm produced ${_old360_n} finding(s) under the pre-#360 regex, wanted 2. Either the revert did not land or this fixture is a DEAD TEST that would have passed before #360."
+    fi
 fi
 
 echo


### PR DESCRIPTION
Closes #360.

`#353` relaxed **where** the auth token may sit in a guard-helper name, but left
the segment before it **mandatory** — `[A-Z][A-Za-z0-9_]*` with no `?` — so the
token could never be the *first* segment after the `is|has|can|may` prefix. The
most conventional per-object guard names in the fleet are exactly that shape, and
gate-7 reported every method delegating to one as an **unguarded IDOR**, before
AND after `#353`.

```diff
-    r"^(?:is|has|can|may)[A-Z][A-Za-z0-9_]*"
+    r"^(?:is|has|can|may)(?:[A-Z][a-z0-9_]*)*?"
     r"(?:Admin|Access|Permission|Permitted|Owner|Allowed|Authori[sz]ed)"
     r"(?:[A-Z][A-Za-z0-9_]*)?$"
```

| name | old | new |
|---|---|---|
| `hasPermission` `canAccess` `isOwner` `isAllowed` `mayAccess` `hasAccess` | ✗ | **✓** |
| `canUserAccessAgent` `hasOwnerPermissionForRun` `isAdmin` `canEditPermission` `canViewOwner` `hasACLAccess` `assertOwner` | ✓ | ✓ |
| `canRender` `hasChanges` `canUserModifyAgent` `hasPendingRevision` `isVisible` `canDelete` `hasItems` | ✗ | ✗ |

**The token set is unchanged and a token is still REQUIRED.** The newly admitted
names are exactly `{is,has,can,may}` + token + optional object noun. Widening this
to "any `is`/`has`/`can`/`may` method" would let gate-7 *clear real IDORs* —
strictly worse than the false positives it removes — so `canRender`/`hasChanges`
must stay non-guards, and there is now a unit test saying so by name
(`test_360_did_not_widen_into_silence`).

## Blast radius: NONE, and it is measured rather than argued

The new pattern is a **strict superset** of the old. 400,000 fuzzed identifiers
over the prefix/token grammar produced **zero** names the old regex matched and
the new one does not. This change can therefore only turn gate-7 findings green;
**it cannot redden any repo**, which is why it is sequenced first.

## Observed red, then green — not asserted

| control | before | after |
|---|---|---|
| `test_gate7_verb_object_guards.sh` short-guard arm | **2 findings**, carried as a live KNOWN DEFECT | **0 findings** |
| the same arm under the reconstructed **pre-#360** regex | — | **2 findings** — so the fixture genuinely discriminates fixed from broken, and is not a dead test |
| `test_check_no_admin_idor.py` | 93 pass | **95 pass**; the new `test_the_auth_token_may_be_the_first_segment` **fails on the old regex** with `AssertionError: hasPermission should be a guard name` |

The `#353` anti-dead-test arm demanded its own update the moment the regex was
reshaped — *"Re-derive the revert and update it here rather than deleting this
arm"* — which is what a suite that refuses to rot looks like. Done, and it still
proves `clean/` goes red (3) under the pre-`#353` regex.

## One correction carried into the code

The `#353` commit message says `canAccess` matched. Measured against **both**
regexes, it never did. `#353` remains a clean widening — nothing it used to match
was lost — but its message overstated the scope, and the comment above the regex
is now where that stops being repeated. Same for `canUserModifyAgent`, which
SHARED-LESSONS listed as fixed by `#353` and which correctly still does not match:
"Modify" is not an auth token.

ShellCheck clean (`koalaman/shellcheck:stable` against the repo's own `.shellcheckrc`).