### PR TITLE
fix(gate-24): the JS probe knew one of two registration APIs (.github#349)

### DIFF
--- a/hydra-gates/scripts/lib/test_gates_23_33_never_green_over_nothing.sh
+++ b/hydra-gates/scripts/lib/test_gates_23_33_never_green_over_nothing.sh
@@ -219,6 +219,49 @@ fi
 
 # ===========================================================================
 echo
+echo "== gate-24: BOTH registration APIs count as having leaves (.github#349) =="
+# ===========================================================================
+# `clean/` has no parity wrapper AND no leaf, so its NOT APPLICABLE above is
+# correct. Drop ONE file on top of it — a leaf registered through
+# `OCA.OpenRegister.integrations.register(...)`, the direct form — and the
+# verdict must become SKIPPED (structural): the repo now has a server↔JS pair
+# to correlate and nothing correlated it.
+#
+# The distinction is not cosmetic. `na` does NOT count against coverage;
+# `structural` does. A gate that misreads its own subject matter as absent
+# switches itself off silently, and prints a confident absence claim while
+# doing it — measured on decidesk, whose registered leaf id was enumerable from
+# the live JS registry in the same repo's Playwright run.
+#
+# THE PAIRED ARM MATTERS: `clean/` untouched must STAY `na`. A fix that made
+# gate-24 structural everywhere would pass a one-armed version of this test and
+# would be a false gap in every repo in the fleet.
+_DIRECT="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-24-direct.XXXXXXXX")"
+cp -r "${FIXTURES}/clean/." "${_DIRECT}/"
+cp "${FIXTURES}/direct-registry-overlay/src/integration-leaf-direct.js" "${_DIRECT}/src/"
+if [ ! -f "${_DIRECT}/src/integration-leaf-direct.js" ]; then
+    _bad "the direct-registry overlay did not land — every assertion in this arm would be vacuous"
+elif grep -rq 'scripts/check-integration-parity.sh' "${_DIRECT}" 2>/dev/null \
+     || [ -f "${_DIRECT}/scripts/check-integration-parity.sh" ]; then
+    _bad "the direct-registry arm inherited a parity wrapper from clean/, so it exercises the wrapper path and not the leaf-detection path this arm is about"
+elif _run "${_DIRECT}"; then
+    _expect 24 "SKIPPED (structural)" \
+        "gate-24 recognises a leaf registered via integrations.register( — structural, not na"
+    _expect 24 "DOES register integration leaves" \
+        "gate-24 says WHY it is structural"
+    # And the reason must not still claim the repo has no leaves.
+    _l24="$(_verdict 24)"
+    case "${_l24}" in
+        *"registers no integration leaves at all"*)
+            _bad "gate-24 still asserts 'registers no integration leaves at all' over a tree that registers one — .github#349 is live: ${_l24:0:160}"
+            ;;
+        *)  _ok "gate-24 no longer claims the leaf set is empty" ;;
+    esac
+fi
+rm -rf "${_DIRECT}"
+
+# ===========================================================================
+echo
 echo "== gate-23 in WARN mode: a finding must still be VISIBLE =="
 # ===========================================================================
 # Before the bake-in epoch the linter exits 0 whatever it found, so the gate

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3877,12 +3877,39 @@ _parity_has_js=0
 if [ -d lib ] && grep -rqE 'new[[:space:]]+LeafDescriptor[[:space:]]*\(' lib/ --include='*.php' 2>/dev/null; then
     _parity_has_php=1
 fi
-if [ -d src ] && grep -rqE '\bregisterIntegration[[:space:]]*\(' src/ 2>/dev/null; then
+# THE JS PROBE MUST MATCH BOTH SUPPORTED REGISTRATION APIs, NOT ONE.
+#
+# `registerIntegration(descriptor)` is the convenience wrapper exported from
+# @conduction/nextcloud-vue (src/integrations/registry.js). The registry object
+# it wraps is equally canonical and is called directly as
+# `OCA.OpenRegister.integrations.register(descriptor)` — including by
+# nextcloud-vue's OWN built-in leaves (src/integrations/builtin/files.js).
+#
+# Probing for only the wrapper made this gate produce a FALSE ABSENCE CLAIM, and
+# the claim was load-bearing: an app registering leaves via the direct form was
+# told "this repo registers no integration leaves at all", which routes it to
+# `na` (not counted as a gap) instead of `structural` (counted). So the one gate
+# that exists to correlate the server and JS halves of a leaf switched itself
+# off, silently, in exactly the repos that have leaves to correlate.
+#
+# MEASURED across the fleet checkout, both forms are live:
+#   registerIntegration(     -> hermiq/src/integration-leaf.js,
+#                               openconnector/src/integration.js,
+#                               procest/src/main.js
+#   integrations.register(   -> decidesk/src/integrations/registerDecisionsLeaf.js,
+#                               openregister/src/main.js
+# decidesk registers `decidesk-decisions` through the second form and was
+# reported by this gate as having no leaves at all, on a --full run, while that
+# very id was present in the live JS registry.
+#
+# `integrations\.register` cannot collide with `unregister(` (the qualifier is
+# part of the match) nor with `registerIntegrationIcons(` (the `\(` anchors it).
+if [ -d src ] && grep -rqE '\b(registerIntegration|integrations\.register)[[:space:]]*\(' src/ 2>/dev/null; then
     _parity_has_js=1
 fi
 if [ ! -f scripts/check-integration-parity.sh ]; then
     if [ "${_parity_has_php}" = "0" ] && [ "${_parity_has_js}" = "0" ]; then
-        _skip 24 "integration-parity" na "no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no \`new LeafDescriptor(\` in lib/ and no \`registerIntegration(\` in src/. There is no server↔JS pair for parity to correlate."
+        _skip 24 "integration-parity" na "no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no \`new LeafDescriptor(\` in lib/ and neither \`registerIntegration(\` nor \`integrations.register(\` in src/. There is no server↔JS pair for parity to correlate."
     else
         _skip 24 "integration-parity" structural "no scripts/check-integration-parity.sh, but this repo DOES register integration leaves (lib/ LeafDescriptor: ${_parity_has_php}, src/ registerIntegration: ${_parity_has_js}). server↔JS leaf parity (ADR-066 Decisions 4/7: phantom render surfaces, orphan JS registrations, renderMode mismatch) is UNVERIFIED — a leaf whose other half never registered is invisible to this run."
     fi
@@ -3911,7 +3938,7 @@ if [ -f scripts/check-integration-parity.sh ]; then
         if grep -qiE 'skipping|not found locally|could not be located' "${_parity_log}" 2>/dev/null \
             && ! grep -qE '^(✓|✗)' "${_parity_log}" 2>/dev/null; then
             if [ "${_parity_has_php}" = "0" ] && [ "${_parity_has_js}" = "0" ]; then
-                _skip 24 "integration-parity" na "scripts/check-integration-parity.sh ran but SKIPPED (it could not locate the canonical JS check), and this repo registers no integration leaves at all — no \`new LeafDescriptor(\` in lib/ and no \`registerIntegration(\` in src/. There is no server↔JS pair for parity to correlate. See ${_parity_log}."
+                _skip 24 "integration-parity" na "scripts/check-integration-parity.sh ran but SKIPPED (it could not locate the canonical JS check), and this repo registers no integration leaves at all — no \`new LeafDescriptor(\` in lib/ and neither \`registerIntegration(\` nor \`integrations.register(\` in src/. There is no server↔JS pair for parity to correlate. See ${_parity_log}."
             else
                 _skip 24 "integration-parity" structural "scripts/check-integration-parity.sh ran but SKIPPED — it could not locate the canonical JS check, so NOTHING was correlated — while this repo DOES register integration leaves (lib/ LeafDescriptor: ${_parity_has_php}, src/ registerIntegration: ${_parity_has_js}). server↔JS leaf parity (ADR-066 Decisions 4/7: phantom render surfaces, orphan JS registrations, renderMode mismatch) is UNVERIFIED by this run — this is NOT a pass. See ${_parity_log}."
             fi

--- a/hydra-gates/scripts/test-fixtures/gates-23-33/direct-registry-overlay/src/integration-leaf-direct.js
+++ b/hydra-gates/scripts/test-fixtures/gates-23-33/direct-registry-overlay/src/integration-leaf-direct.js
@@ -1,0 +1,35 @@
+/**
+ * THE SECOND CANONICAL REGISTRATION FORM — `.github#349`.
+ *
+ * The convenience wrapper exported from @conduction/nextcloud-vue is the form
+ * gate-24 already knew. The registry object it wraps is equally canonical and
+ * is called directly, as below — including by nextcloud-vue's OWN built-in
+ * leaves (src/integrations/builtin/files.js).
+ *
+ * gate-24's JS probe knew only the wrapper. An app registering this way was
+ * told, verbatim, "this repo registers no integration leaves at all", which
+ * routes the gate to `na` — NOT counted against coverage — instead of
+ * `structural`, which is. So the one gate that exists to correlate the server
+ * and JS halves of a leaf switched itself off in exactly the repos that have
+ * halves to correlate. Measured live on decidesk, whose `decidesk-decisions`
+ * id was in `window.OCA.OpenRegister.integrations.list()` in the same repo's
+ * Playwright run while gate-24 reported the set empty.
+ *
+ * ⚠️ THIS COMMENT MUST NOT NAME THE WRAPPER FUNCTION FOLLOWED BY AN OPEN
+ * PAREN. gate-24's probes are plain greps over file TEXT, comments included,
+ * so an explanatory sentence spelling the wrapper call out is indistinguishable
+ * from a registration. The first draft of this file did exactly that, and the
+ * arm below went GREEN against the PRE-#349 runner — a dead test that looked
+ * like coverage. Same family as `.github#358` (gates 19 and 26 parse prose),
+ * encountered while writing the fixture for a different gate.
+ *
+ * This file is an OVERLAY dropped on top of `clean/`, which has neither a
+ * parity wrapper nor any leaf. `clean/` alone is legitimately NOT APPLICABLE;
+ * `clean/` + this file must be SKIPPED (structural).
+ */
+;(function (target) {
+	target.OCA.OpenRegister.integrations.register({
+		id: 'gateplant-direct-agent',
+		renderMode: 'mount',
+	})
+})(window)


### PR DESCRIPTION
Supersedes #349 — same runner change, rebased onto `main`, now **with a fixture**
and with the blast radius **measured** instead of estimated.

## The change

gate-24 decides applicability from its own subject matter: does this repo register
integration leaves at all? The JS half looked only for the convenience wrapper
exported from `@conduction/nextcloud-vue`. The registry object it wraps is equally
canonical and is called directly — including by nextcloud-vue's own built-in leaves
(`src/integrations/builtin/files.js`).

So an app using the direct form was told, verbatim, *"this repo registers no
integration leaves at all"*. That sentence is load-bearing: it routes the gate to
`na`, which does **not** count against coverage, instead of `structural`, which does.
The one gate that exists to correlate the server and JS halves of a leaf therefore
switched itself off precisely in repos that have halves to correlate — while printing
a confident absence claim.

## ⚠️ This corrects #349's own body

#349 states the verdict moves *"in at least two repos"* and names **openregister**.
**It does not.** Measured by running the runner over each fleet checkout, old vs new,
with nothing else changed:

| repo | old runner | new runner |
|---|---|---|
| **decidesk** | `NOT APPLICABLE` | **`SKIPPED (structural)`** |
| openregister | `PASS` | `PASS` |
| openconnector | `PASS` | `PASS` |
| hermiq | `PASS` | `PASS` |

openregister ships `scripts/check-integration-parity.sh`, so gate-24 takes the
wrapper path and passes either way. **Exactly one repo changes.**

## Blast radius, stated plainly

decidesk's new verdict is honest — it registers `decidesk-decisions` (that id was
enumerable from `window.OCA.OpenRegister.integrations.list()` in its own Playwright
run while gate-24 reported the set empty) and it ships no parity check. But
`structural` **counts** against coverage, decidesk sets `enable-hydra-gates: true`,
and it inherits `hydra-gates-require-full-coverage: true` (the shared workflow's
default). **So decidesk's Code Quality run will exit 98 until it adds the parity
wrapper** that openregister, openconnector, hermiq and procest already carry.

This is a known and closable shape, not a new one: the shared workflow's own input
description already records hermiq and openconnector as having exactly this gap.

## The fixture — red before, green after

A paired arm on the existing `clean/` bundle: **one overlaid file** registering a
leaf through the direct form. `clean/` alone stays `NOT APPLICABLE` (asserted,
unchanged — a fix that made gate-24 structural everywhere would pass a one-armed
version of this test); `clean/` + that file must be `SKIPPED (structural)`.

```
runner @765d0817 (pre-fix)   FAIL x3 — "gate-24 still asserts 'registers no
                             integration leaves at all' over a tree that registers one"
runner @06fa782  (post-fix)  PASS x3, and the clean arm still na
```

### The first draft of the fixture was a DEAD TEST

It went **green against the pre-fix runner**. Its explanatory comment named the
wrapper function followed by an open paren, and gate-24's probe is a plain grep over
file **text** — so the prose *describing* the defect satisfied the gate being
described. That is `.github#358`'s shape met while fixturing a different gate. The
warning is now written into the fixture file itself.

Full suite: 73 passed / 2 quarantined / 1 failed, the failure being the pre-existing
`ajv is not resolvable` `needs-external` skip. ShellCheck clean.