### PR TITLE
fix(gate-61): an empty scope has two causes and only one of them is a diff (.github#347)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_scope_matrix.sh
+++ b/hydra-gates/scripts/lib/test_gate_scope_matrix.sh
@@ -166,17 +166,41 @@ else
     _bad "the --full run did not announce itself as unscoped; the rest of this arm is unsafe to interpret"
 fi
 
+#
+# `.github#347` HAS LANDED, so this arm now asserts the CORRECT behaviour
+# instead of recording the defect. The verdict deliberately stays `na` — the
+# invocation comment in the runner records that sweeping the tree on an
+# unscoped run was tried and reverted, because the builder runs unscoped and
+# `--all` would surface the whole backlog as blocking findings on every build.
+# What changed is that the REASON no longer names a diff the run never
+# computed, and that the size of what went unread is stated.
 _v="$(gf_verdict "${_out}" 61)"
-_still_broken=1
 case "${_v}" in
     *"NOT APPLICABLE"*)
-        # Is the reason a diff-based one? That is the specific defect.
-        if printf '%s' "${_v}" | grep -qF 'out of scope'; then _still_broken=0; fi
+        _ok "gate-61 on --full declines rather than sweeping — the verdict that was deliberately preserved"
         ;;
+    *FAIL*)
+        _bad ".github#347 was fixed by SWEEPING THE WHOLE TREE on an unscoped run. That was tried and reverted before: the BUILDER runs unscoped, so this surfaces the fleet's whole registration backlog as blocking findings on every build. Expected NOT APPLICABLE with an honest reason. Got: ${_v:0:160}"
+        ;;
+    *)  _bad "gate-61 on --full gave an unrecognised verdict: ${_v:0:160}" ;;
 esac
-_known_defect ".github#347" \
-    "gate-61 on --full reports NOT APPLICABLE citing 'the diff against origin/development put every post-event registration out of scope' — on a run that computed no diff, over a tree whose single registration the positive control just failed. 0 of 1 inspected." \
-    "${_still_broken}"
+if printf '%s' "${_v}" | grep -qF 'out of scope'; then
+    _bad ".github#347 is LIVE: gate-61 on --full still claims 'the diff ... put every post-event registration out of scope', on a run whose own preamble says it computed no diff, over a tree whose single registration the positive control just failed. 0 of 1 inspected, and the reason cites a diff that does not exist."
+else
+    _ok "gate-61's --full reason no longer claims a diff excluded anything"
+fi
+if printf '%s' "${_v}" | grep -qF 'computed NO diff'; then
+    _ok "gate-61's --full reason names the ABSENCE of a diff — the falsifiable form"
+else
+    _bad "gate-61's --full reason does not state that the run computed no diff, so a reader still cannot tell an empty scope from an empty tree: ${_v:0:200}"
+fi
+# The size of what went unread must be stated, or the skip is unfalsifiable in
+# the other direction: '0 of 1' and '0 of 45' print identically without it.
+if printf '%s' "${_v}" | grep -qE 'ADVISORY.*[0-9]+ registration\(s\) carrying [0-9]+ finding\(s\)'; then
+    _ok "gate-61's --full skip states the size of the backlog it did not inspect"
+else
+    _bad "gate-61's --full skip does not state how many registrations went unread — the advisory sweep is missing, so '0 of 1' and '0 of 45' are typographically identical: ${_v:0:200}"
+fi
 
 # ===========================================================================
 echo

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7897,7 +7897,58 @@ if [ -d lib/AppInfo ]; then
         # EMPTY SCOPE. This gate is always diff-scoped (ADR-020), so on any PR
         # that touches no listener EVERY registration falls out of scope. That
         # used to print PASS (.github#276).
-        _skip 61 "listener-work-placement" na "the diff against '${BASE_REF}' put every post-event registration out of scope, so NONE were inspected. Diff-scoped out under ADR-020 — the fleet's 149-registration backlog is a work-list, not a reason to block an unrelated PR. This gate runs on the next PR that touches a listener registration. See ${_lwp_log}."
+        #
+        # BUT AN EMPTY SCOPE HAS TWO CAUSES AND ONLY ONE OF THEM IS A DIFF
+        # (.github#347). `bin/hydra-gates` forwards `--base` only on a
+        # diff-scoped run, so on `--full` the runner keeps its own
+        # `origin/development` default and hands it over anyway. On
+        # `development` itself that diffs the branch against itself, the
+        # checker returns 3, and this gate printed
+        #
+        #   NOT APPLICABLE — the diff against 'origin/development' put every
+        #   post-event registration out of scope
+        #
+        # two lines after the run's own preamble said `Base ref: n/a — --full
+        # requested`. THERE WAS NO DIFF. The verdict was defensible; the stated
+        # reason named a thing that did not exist, and an unfalsifiable reason
+        # is how this stood fleet-wide for weeks. Sibling of `.github#361` —
+        # `check_listener_placement.py:555` carries the same non-empty argparse
+        # default. Positive control on the same tree, changing only the scope
+        # flag: `--all` -> 45 registrations checked, 3 failures.
+        #
+        # THE VERDICT DOES NOT CHANGE, DELIBERATELY. Sweeping the tree on an
+        # unscoped run was tried here before and reverted (see the invocation
+        # comment above): the builder runs unscoped, so `--all` would surface
+        # the fleet's whole registration backlog as blocking findings on every
+        # build. `na` with an HONEST reason is the third answer — it cannot go
+        # false-RED, and it stops the run claiming an exclusion nothing
+        # performed. What was missing was the SIZE of what went unread, so an
+        # advisory sweep supplies it: informational, never a verdict.
+        if [ "${SCOPE_TO_DIFF}" = "1" ]; then
+            _skip 61 "listener-work-placement" na "the diff against '${BASE_REF}' put every post-event registration out of scope, so NONE were inspected. Diff-scoped out under ADR-020 — the fleet's 149-registration backlog is a work-list, not a reason to block an unrelated PR. This gate runs on the next PR that touches a listener registration. See ${_lwp_log}."
+        else
+            # ADVISORY ONLY. Its exit status is discarded on purpose: a sweep
+            # that finds inherited debt must not become this run's verdict, and
+            # a sweep that CRASHES must not either — the count is quoted only
+            # when the helper printed its own terminal summary line.
+            _lwp_all_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-listener-work-placement.advisory.log
+            python3 "${SCRIPT_DIR}/lib/check_listener_placement.py" . --all \
+                > "${_lwp_all_log}" 2>&1 || true
+            #
+            # THE SUMMARY IS RECOMPOSED, NOT QUOTED. The helper's own line ends
+            # "…, 0 out of scope: 1 failure(s)", and pasting that in would put
+            # the phrase "out of scope" back into a reason on a run that
+            # computed no scope — the exact sentence this fix removes, smuggled
+            # in as a quotation. The suite asserts against that phrase
+            # gate-agnostically and caught it here.
+            _lwp_backlog=""
+            if grep -qE '^checked [0-9]+ post-event registration' "${_lwp_all_log}" 2>/dev/null; then
+                _lwp_all_n=$(grep -oE '^checked [0-9]+ post-event registration' "${_lwp_all_log}" | tail -1 | grep -oE '[0-9]+' | head -1)
+                _lwp_all_f=$(grep -oE '[0-9]+ failure\(s\)' "${_lwp_all_log}" | tail -1 | grep -oE '[0-9]+' | head -1)
+                _lwp_backlog=" ADVISORY, and it decides nothing here: a whole-tree sweep of this same tree reaches ${_lwp_all_n:-an unreported number of} registration(s) carrying ${_lwp_all_f:-an unreported number of} finding(s), NONE of which this run judged — see ${_lwp_all_log}."
+            fi
+            _skip 61 "listener-work-placement" na "this run computed NO diff (--full / unscoped), and gate-61 is diff-scoped by design (ADR-078/ADR-020, it is about NEW debt) — so NO post-event registration was inspected and ADR-078 work placement is UNVERIFIED by this run. This is NOT a clean bill of health, and NO diff excluded anything: there was no diff. Re-measure with an explicit base (HYDRA_GATE_BASE_REF=origin/beta) or run with --scope-to-diff.${_lwp_backlog} See ${_lwp_log}."
+        fi
     elif [ "${_lwp_rc}" -eq 4 ]; then
         _skip 61 "listener-work-placement" na "this repo registers no post-object-event listener, so there is no work to place on or off the write path (ADR-078). See ${_lwp_log}."
     elif ! _helper_finished "${_lwp_log}" '^checked [0-9]+ (post-event )?registration\(s\)'; then


### PR DESCRIPTION
Closes #347.

`bin/hydra-gates` forwards `--base` only on a diff-scoped run, so on `--full` the
runner keeps its own `origin/development` default and hands it over anyway. On
`development` itself that diffs the branch against itself, the checker returns 3,
and gate-61 printed

```
[gate-61] listener-work-placement: NOT APPLICABLE — the diff against
'origin/development' put every post-event registration out of scope
```

**two lines after** the run's own preamble said `Base ref: n/a — --full requested`.
**There was no diff.** Sibling of `#361`: `check_listener_placement.py:555` carries
the same non-empty argparse default.

## The verdict does not change, and that is deliberate

Sweeping the tree on an unscoped run **was tried here before and reverted** — the
runner's own invocation comment records it. The **builder** runs unscoped, so
`--all` surfaces the fleet's whole registration backlog as blocking findings on
every build. `na` with an **honest** reason is the third answer: it cannot go
false-RED, and it stops the run claiming an exclusion nothing performed.

**Blast radius: zero.** No verdict changes in any repo, at any scope.

## What was actually missing was the number

`0 of 1 inspected` and `0 of 45 inspected` printed identically. An advisory
whole-tree sweep now supplies it — informational, exit status discarded, and quoted
only when the helper printed its own terminal summary, so a sweep that finds
inherited debt cannot become this run's verdict and a sweep that **crashes** cannot
either.

Measured on **openregister @ development**: `--all` reaches **45** post-event
registrations carrying **3** findings — exactly the number SHARED-LESSONS records as
hidden by this defect. It is now on the verdict line.

## ⚠️ The advisory summary is recomposed, not quoted

The helper's own line ends `…, 0 out of scope: 3 failure(s)`. Pasting it in put the
phrase **`out of scope`** straight back into a reason on a run that computed no
scope — the exact sentence this fix removes, smuggled in as a quotation. The suite's
**gate-agnostic** property (*a `NOT APPLICABLE` may not blame a diff on a `--full`
run*) caught it, listing gate-61 among the blamers again after the "fix". Worth
recording: the generic invariant caught a regression the gate-specific assertions
would have passed.

## Fixture — red before, green after

Same tree, only the scope flag changed:

| | result |
|---|---|
| before | **3 assertions RED** — *"#347 is LIVE: gate-61 still claims 'the diff … put every post-event registration out of scope'"*; the reason does not state the run computed no diff; the backlog size is not stated |
| after | **13 passed / 0 failed**, and gate-61 drops off the *"gates blaming a diff on a `--full` run"* list, which now reads `6 7 8 9` |

The `_known_defect` entry for `#347` is replaced by positive assertions, as its own
text demanded (*"flip this assertion and delete the entry"*). The gates 6/7/8/9
wording defect is a separate, still-unfiled entry and is untouched.

ShellCheck clean.