### PR TITLE
feat(quality-config): adopt Nextcloud's coding standard — stricter, never different

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,7 +395,17 @@ jobs:
       - name: Fetch Nextcloud server for occ
         run: |
           set -euo pipefail
-          NCVERSION=$(grep -oP '(?<=min-version=")[0-9]+' appinfo/info.xml | head -1)
+          # ANCHORED TO THE <nextcloud> ELEMENT ON PURPOSE. info.xml carries
+          # min-version on <php> too, and <php> comes FIRST in every fleet
+          # app. Measured across all 18 on 2026-08-12, an unanchored
+          # `(?<=min-version=")[0-9]+` returned:
+          #   13 apps -> 8    (from <php min-version="8.3"/>)
+          #   portaliq -> 28  (from a <nextcloud> further down, but the WRONG one)
+          # The first form fails loudly, because updates.nextcloud.com has no
+          # NC 8. The second does not: it resolves a real server and signs the
+          # app against a Nextcloud four majors below what it supports.
+          NCVERSION=$(grep -oP '<nextcloud[^>]*min-version="\K[0-9]+' appinfo/info.xml | head -1)
+          [ -n "${NCVERSION}" ] || { echo "::error::appinfo/info.xml declares no <nextcloud min-version>."; exit 1; }
           echo "App declares min-version ${NCVERSION}; fetching that server to sign with."
           URL=$(curl -sS "https://updates.nextcloud.com/updater_server/latest?channel=stable&version=${NCVERSION}" | jq -r '.downloads.zip[0]')
           if [ -z "$URL" ] || [ "$URL" = "null" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,54 @@ jobs:
 
       # ── Package ──
 
+      # ── Commit the version to the repository, BEFORE the tag exists ──
+      #
+      # This retires "Version Is Not In The Repository". The version used to
+      # exist only inside the built package: `sed` rewrote appinfo/info.xml in
+      # the copy under package/, and the committed file kept whatever stale
+      # number was last hand-edited.
+      #
+      # That is incompatible with Nextcloud's own release template, which reads
+      # the version FROM appinfo/info.xml and asserts the tag matches:
+      #
+      #     [ "$APP_VERSION" = "v$(xpath info.xml //version)" ]
+      #
+      # Following Nextcloud means the repository has to be the source of truth,
+      # so the bump is committed here and the tag is cut from that commit. The
+      # tag then names a tree whose info.xml says what the tag says.
+      #
+      # `[skip ci]` because this commit changes one number in one XML file and
+      # the quality suite has already run on the code being released. Without
+      # it, every release starts a second full pipeline on a tree that differs
+      # from the tested one by a version string.
+      #
+      # No push on a dry run and no push when the number has not moved — a
+      # re-run of a release that already happened must not create an empty
+      # commit and re-tag it.
+      - name: Commit the version bump
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -oP '(?<=<version>)[^<]+' appinfo/info.xml | head -1)
+          if [ "$CURRENT" = "${{ env.NEW_VERSION }}" ]; then
+            echo "appinfo/info.xml already says ${{ env.NEW_VERSION }} — nothing to commit."
+            exit 0
+          fi
+          sed -i "s|<version>.*</version>|<version>${{ env.NEW_VERSION }}</version>|" appinfo/info.xml
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add appinfo/info.xml
+          git commit -m "chore(release): ${{ env.NEW_VERSION }} [skip ci]"
+          if ! git push origin HEAD:${{ github.ref_name }}; then
+            echo "::error::Could not push the version bump to ${{ github.ref_name }}."
+            echo "The tag must name a tree whose appinfo/info.xml matches it, so this"
+            echo "is a hard stop rather than a warning — releasing past it would put"
+            echo "the old version number inside a package labelled with the new one."
+            echo "If the branch is protected, allow the GitHub Actions bot to push to"
+            echo "it, or route the bump through a PR before the release runs."
+            exit 1
+          fi
+          echo "Committed ${CURRENT} -> ${{ env.NEW_VERSION }} on ${{ github.ref_name }}"
+
       - name: Copy files into package directory
         run: |
           mkdir -p package/${{ inputs.app-name }}
@@ -323,6 +371,57 @@ jobs:
         run: |
           echo "${{ secrets.NEXTCLOUD_SIGNING_KEY }}" > signing-key.key
           echo "${{ secrets.NEXTCLOUD_SIGNING_CERT }}" > signing-cert.crt
+
+      # ── Nextcloud's own integrity signature ──
+      #
+      # THE GAP THIS CLOSES: every release this fleet has ever published went
+      # out WITHOUT appinfo/signature.json. We signed the tarball — which is
+      # what the App Store API authenticates the upload with — and stopped
+      # there. Nextcloud's integrity checker verifies something else entirely:
+      # a per-file manifest INSIDE the app directory. Without it, `occ
+      # integrity:check-app <app>` reports the app as unverifiable, and an
+      # administrator running an integrity check sees our apps as the ones that
+      # cannot be vouched for.
+      #
+      # `occ` has to come from somewhere, so the server is fetched at the
+      # version the app declares it needs. Reading min-version from info.xml
+      # rather than hardcoding it is the same principle as
+      # icewind1991/nextcloud-version-matrix: the release cannot drift from what
+      # the app says it supports, because it is computed from it.
+      #
+      # NOT continue-on-error. An unsigned package that ships looks exactly like
+      # a signed one until an administrator checks, which is precisely the class
+      # of silent gap this whole change is about.
+      - name: Fetch Nextcloud server for occ
+        run: |
+          set -euo pipefail
+          NCVERSION=$(grep -oP '(?<=min-version=")[0-9]+' appinfo/info.xml | head -1)
+          echo "App declares min-version ${NCVERSION}; fetching that server to sign with."
+          URL=$(curl -sS "https://updates.nextcloud.com/updater_server/latest?channel=stable&version=${NCVERSION}" | jq -r '.downloads.zip[0]')
+          if [ -z "$URL" ] || [ "$URL" = "null" ]; then
+            echo "::warning::No stable download for NC ${NCVERSION}; falling back to the beta channel."
+            URL=$(curl -sS "https://updates.nextcloud.com/updater_server/latest?channel=beta&version=${NCVERSION}" | jq -r '.downloads.zip[0]')
+          fi
+          [ -n "$URL" ] && [ "$URL" != "null" ] || { echo "::error::Could not resolve a Nextcloud server download for min-version ${NCVERSION}."; exit 1; }
+          curl -sSL "$URL" -o nextcloud.zip
+          unzip -q nextcloud.zip
+          test -f nextcloud/occ || { echo "::error::The downloaded archive has no nextcloud/occ."; exit 1; }
+
+      - name: Sign the app with occ integrity:sign-app
+        run: |
+          set -euo pipefail
+          php nextcloud/occ integrity:sign-app \
+            --privateKey="$PWD/signing-key.key" \
+            --certificate="$PWD/signing-cert.crt" \
+            --path="$PWD/package/${{ inputs.app-name }}"
+          SIG="package/${{ inputs.app-name }}/appinfo/signature.json"
+          # POSITIVE CONTROL. `integrity:sign-app` exits 0 on several paths that
+          # produce no manifest, so the exit code alone is not evidence. Assert
+          # the artefact exists and actually enumerates files.
+          test -f "$SIG" || { echo "::error::integrity:sign-app exited 0 but wrote no ${SIG}. The package would ship unsigned."; exit 1; }
+          COUNT=$(jq -r '.hashes | length' "$SIG" 2>/dev/null || echo 0)
+          [ "${COUNT:-0}" -gt 0 ] || { echo "::error::${SIG} exists but hashes 0 files — an empty manifest verifies nothing."; exit 1; }
+          echo "Signed ${COUNT} file(s) into ${SIG}"
 
       - name: Create tarball
         run: |

--- a/docs/WayOfWork/ci-cd.md
+++ b/docs/WayOfWork/ci-cd.md
@@ -1,0 +1,286 @@
+---
+id: ci-cd
+title: CI/CD and Code Standards
+sidebar_label: CI/CD and Code Standards
+sidebar_position: 4
+description: What our pipeline actually runs, where the configuration lives, and exactly where we diverge from Nextcloud's own app CI/CD
+---
+
+# CI/CD and Code Standards
+
+We build Nextcloud apps, and Nextcloud has its own app CI/CD conventions. Ours is
+not the same. Most of the differences are deliberate; a few are accidents worth
+knowing about before they bite you. This page states both, so that a contributor
+arriving from the Nextcloud ecosystem — or an auditor asking why our checks look
+unfamiliar — can see the whole picture in one place.
+
+Two companion pages stay authoritative for what they cover:
+[Development Pipeline](development-pipeline.md) for the branch flow and
+[Release Process](release-process.md) for versioning.
+
+## One pipeline, eighteen thin callers
+
+Every core app's `.github/workflows/code-quality.yml` is a caller. The pipeline
+itself is one reusable workflow:
+
+```yaml
+jobs:
+  quality:
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: myapp
+      # …feature flags…
+```
+
+Consumed at `@main`, deliberately. A pinned ref is a silent expiry date: 22 repos
+once sat on gate package `v1.0.1` while 16 gates were dead fleet-wide and every
+one of them reported PASS.
+
+`quality.yml` emits up to **18 job groups**, not the four the older docs describe:
+
+| Group | Jobs |
+| --- | --- |
+| PHP Quality | `lint`, `phpcs`, `phpmd`, `psalm`, `phpstan`, `phpmetrics` (matrix) |
+| Vue Quality | `eslint`, `stylelint` (matrix) |
+| Frontend | `Frontend Build`, `Frontend Tests (unit)`, `Frontend Check (…)` per declared npm script |
+| Tests | `PHPUnit` (PHP × Nextcloud matrix), `Integration Tests (Newman)`, `E2E Tests (Playwright)` |
+| Accessibility | `axe-core` (opt-in) |
+| Supply chain | `Security (composer)`, `Security (npm)`, `License (composer)`, `License (npm)`, `SBOM` |
+| Governance | `Hydra Gates`, `Coverage Baseline Protection`, `Features Extract`, `Journeydoc Capture` |
+| Rollup | `Quality Report` |
+
+### Nextcloud's equivalent
+
+Nextcloud ships **workflow templates**, not a reusable workflow: an app copies
+`lint-php-cs.yml`, `psalm.yml`, `lint-eslint.yml`, `node-test.yml`,
+`phpunit-*.yml`, `appstore-build-publish.yml` and so on from `nextcloud/.github`
+into its own repo, and a `sync-workflow-templates` job keeps them refreshed.
+
+| | Conduction | Nextcloud |
+| --- | --- | --- |
+| Shape | one reusable workflow, thin callers | ~40 copied templates per app |
+| Update path | change `@main`, all 18 apps follow | sync job re-copies templates |
+| Action pinning | tags (`actions/checkout@v4`) | commit SHAs |
+| Trigger | `push` + `pull_request` | `pull_request`, with `dorny/paths-filter` change detection and a `summary` job so branch protection still matches when skipped |
+
+Neither shape is wrong. Ours propagates a fix instantly and gives a single rollup;
+theirs survives the org repo being unavailable and pins its supply chain harder.
+**Action SHA-pinning is the one we should adopt** — it is a supply-chain control,
+not a style preference.
+
+## PHP: where we diverge, and how much
+
+### Formatting — the important one
+
+Nextcloud formats PHP with **php-cs-fixer** via `nextcloud/coding-standard`, whose
+`Config` calls `setIndent("\t")`. Nextcloud core's `.editorconfig` says
+`indent_style = tab`, `indent_size = 4`.
+
+We format PHP with **PHP_CodeSniffer** against a PEAR-derived ruleset that sets
+`indent=4, tabIndent=false`. All 18 apps agree on this.
+
+| Rule | Conduction (PHPCS) | Nextcloud (php-cs-fixer) |
+| --- | --- | --- |
+| Indentation | **4 spaces** | **tabs** |
+| Class / function opening brace | next line (PEAR) | same line (`curly_braces_position`) |
+| Cast spacing | `(int) $x` (`Generic.Formatting.SpaceAfterCast`) | `(int)$x` (`cast_spaces: none`) |
+| Concatenation | `'a'.'b'` (`Squiz.Strings.ConcatenationSpacing`) | `'a' . 'b'` (`concat_space: one`) |
+| Line length | hard limit 150 | not enforced |
+| Yoda conditions | disallowed | disallowed ✅ agree |
+| Named parameters on internal calls | **required** (custom sniff) | no such rule |
+
+These are not reconcilable file-by-file. **A file cannot satisfy both**, so an app
+must wire up exactly one formatter.
+
+:::warning `cs:check` and `cs:fix` do not mean here what they mean upstream
+
+`cs:check` and `cs:fix` are the script names that `nextcloud/coding-standard`
+defines, and they are what Nextcloud's own `lint-php-cs.yml` invokes. In this
+fleet those same two names are **aliases for PHPCS**:
+
+```json
+"cs:check": "./vendor/bin/phpcs --standard=phpcs.xml",
+"cs:fix":   "./vendor/bin/phpcbf --standard=phpcs.xml"
+```
+
+So a contributor who runs the documented Nextcloud command gets our 4-space PEAR
+reformatting, not Nextcloud's tabs. Worse, **17 of 18 apps also list
+`nextcloud/coding-standard:^1.4` in `require-dev`** while shipping no
+`.php-cs-fixer.dist.php` and never invoking php-cs-fixer anywhere in CI. It is a
+dead dependency that pulls `php-cs-fixer/shim` into every `vendor/` tree, and it
+is loaded and ready to reformat the entire codebase the wrong way for anyone who
+finds it.
+
+Either drop the dependency or adopt the standard. Do not keep both.
+:::
+
+### The `.editorconfig` gap
+
+**No fleet app ships an `.editorconfig`.** Nextcloud core does. An editor opening
+one of our PHP files therefore falls back to whatever the user configured — and
+for anyone whose defaults came from Nextcloud work, that is tabs, which PHPCS then
+rejects. This is a one-file fix and it belongs in every app.
+
+### Static analysis and the Nextcloud version it is analysing against
+
+Nextcloud's `psalm.yml` does two things ours does not:
+
+```yaml
+- uses: icewind1991/nextcloud-version-matrix   # reads appinfo/info.xml
+- run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
+- run: composer remove nextcloud/ocp --dev --no-scripts
+- run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }}
+```
+
+The analysed API surface is **derived from what the app declares it supports**, and
+the run fails if `psalm.xml` does not pin the minimum PHP version.
+
+Ours is static, and as of 2026-08-12 it is inconsistent with itself:
+
+| | Declared in `appinfo/info.xml` | Analysed against | Tested against |
+| --- | --- | --- | --- |
+| 16 apps | NC **32–34** | `nextcloud/ocp:^31.0` (15 apps) | `stable32` and/or `stable33` |
+
+Three consequences, in increasing order of seriousness:
+
+1. No app is tested on **NC 34**, which all of them claim to support.
+2. Static analysis runs one major **below** the declared minimum, so nothing added
+   in 32/33/34 is visible to it.
+3. Nothing **removed** in 32/33/34 can be reported either. That is why the removal
+   of `\OC::$server` in NC 34 needed a hand-written PHPCS sniff to catch — the type
+   checker was looking at NC 31 and could not see it.
+
+No app's `psalm.xml` sets `phpVersion`, so our configs would fail Nextcloud's own
+psalm gate outright. Adopting version-matrix derivation removes the whole class of
+problem: the matrix can no longer drift from `info.xml`, because it is computed
+from it.
+
+### What Psalm is actually checking
+
+Every app runs `errorLevel="4"` and suppresses ~34 issue types. The suppression
+list includes `InvalidArgument`, `InvalidReturnType`, `InvalidReturnStatement`,
+`InvalidMethodCall`, `UndefinedInterfaceMethod`, `TypeDoesNotContainType`,
+`InvalidArrayOffset` and `EmptyArrayAccess`, plus `UndefinedClass` for the whole
+`OCP\` namespace. Read a green Psalm leg accordingly.
+
+PHPStan is level 5 fleet-wide, which the older docs state correctly.
+
+### Checks Nextcloud runs that we do not
+
+| Nextcloud check | What it catches | Our coverage |
+| --- | --- | --- |
+| `lint-info-xml.yml` | `appinfo/info.xml` validated against the App Store XSD | **none** — `quality.yml` never reads `info.xml` |
+| `occ app:check-code` | use of private / deprecated server APIs | **partial** — one custom sniff for `\OC::$server` only |
+| `occ integrity:sign-app` | writes `appinfo/signature.json` into the package | **none** — see below |
+| `reuse.yml` | REUSE / SPDX compliance as a CI job | partial — a PHPCS sniff and a hydra gate, not the REUSE tool |
+| PHPUnit on mariadb / mysql / oci / sqlite | database-portability bugs | pgsql only (one app opts into pgsql explicitly; the shared default is pgsql) |
+
+### Release and signing
+
+Both paths build a tarball, attach it to a GitHub release and POST it to the App
+Store. One step differs and it is not cosmetic:
+
+- **Nextcloud** runs `occ integrity:sign-app --privateKey --certificate`, which
+  writes `appinfo/signature.json` **inside** the package, then uploads.
+- **We** sign only the tarball (`openssl dgst -sha512`) for the App Store API.
+  There is no `integrity:sign-app` step in `release.yml`, `release-beta.yml` or
+  `release-stable.yml`.
+
+The upload is accepted either way, but an installed app with no
+`appinfo/signature.json` cannot be verified by Nextcloud's integrity checker.
+
+We also package with `rsync` rather than `krankerl`; no app ships a
+`krankerl.toml`. Nextcloud's template supports both, so this is a free choice.
+
+## Frontend
+
+Here we are much closer to Nextcloud than on the backend — we use their configs
+directly.
+
+| | Conduction | Nextcloud (current apps) |
+| --- | --- | --- |
+| ESLint config | `@nextcloud/eslint-config@^8.4.1` (17/18 apps) | `@nextcloud/eslint-config@^9.0.1` |
+| ESLint | `^8.56` — resolves to 8.57.1, **end of life** | 9.x / 10.x |
+| Stylelint config | `@nextcloud/stylelint-config@^2.4.0` | `@nextcloud/stylelint-config@^3.2.2` |
+| Stylelint | 15.x | 16.x |
+| Unit tests | vitest (11 apps), jest (6), **none (3)** | vitest |
+| E2E | Playwright | Cypress |
+| Node in CI | hardcoded `20` | read from `package.json` `engines`, fallback `^24` |
+
+Four things to fix, in order of how quietly they fail:
+
+1. **Unquoted globs in the `stylelint` script.** Thirteen apps run
+   `stylelint src/**/*.vue src/**/*.scss src/**/*.css` without quotes, so the
+   *shell* expands the glob and — without `globstar` — `src/**/` matches only one
+   directory level. Nested components are silently not linted. The four apps that
+   quote it (`procest`, `pipelinq`, `shillinq`, `doriath`) check strictly more
+   files than the other fourteen. A passing stylelint job does not currently mean
+   the same thing in two apps.
+2. **`npm run lint` is `eslint src` with no `--max-warnings`.** Warnings never fail
+   a build, so they accumulate indefinitely. (ESLint itself *is* running: the flat
+   config loads correctly under 8.57.1 — verified from a live job log, not
+   assumed.)
+3. **Three apps have no unit test script at all** — `scholiq`, `portaliq`,
+   `hermiq`. The shared workflow detects this honestly and records a skip, which
+   renders as a pass in the rollup.
+4. **`.prettierrc` exists in 14 apps and `prettier` is a dependency in none.** No
+   `format` script invokes it either. It is inert in CI but not in editors, where
+   it tells Prettier to use 2-space indentation and double quotes for `.ts` files
+   — both of which `@nextcloud/eslint-config` then flags. Delete it or wire it up.
+
+## Where the configuration lives
+
+As of this change, the PHP quality configuration has **one** home:
+[`quality-config/`](https://github.com/ConductionNL/.github/tree/main/quality-config)
+in this repository, shipped inside the existing `conduction/hydra-gates` composer
+package. An app pulls it with `composer install` and reduces its own files to
+stubs:
+
+```xml
+<ruleset name="myapp">
+    <file>lib</file>
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpcs.xml"/>
+</ruleset>
+```
+
+Same config in CI and on a laptop, which is the point — a config only CI sees
+becomes its own drift source.
+
+The drift this replaces, measured across all 18 core apps on 2026-08-12:
+
+| File | Distinct variants across 18 apps |
+| --- | ---: |
+| `psalm.xml`, `phpstan.neon`, `playwright.config.ts`, `code-quality.yml` | **18 each** |
+| `eslint.config.js` | 17 |
+| `phpmd.xml` | 15 |
+| `vitest.config.js` | 14 |
+| `phpcs.xml`, `stylelint.config.js` | 6 each |
+| `NamedParametersSniff.php` (a *custom rule*) | 6 |
+| `.prettierrc` | 1 |
+
+`psalm.xml` and the frontend configs are not stub-able yet — Psalm has no config
+inheritance and ESLint flat config resolves plugins relative to the config file.
+Both are covered in the [`quality-config/` README](https://github.com/ConductionNL/.github/tree/main/quality-config#not-yet-centralised-and-why).
+
+## Corrections to older pages
+
+- "**Code style — PHPCS (PSR-12)**", in
+  [development-pipeline.md](development-pipeline.md) and
+  [contributing.md](contributing.md), is wrong. The ruleset is PEAR-derived. Four
+  PSR-2/PSR-12 sniffs are pulled in individually; the standard as a whole is not.
+- "**four parallel quality gates**" understates the pipeline by an order of
+  magnitude — see the table at the top of this page.
+- "**Hydra … coming soon**" is stale: `enable-hydra-gates: true` is set in all 18
+  core apps today.
+- "**There are no development builds**", in
+  [release-process.md](release-process.md), is contradicted by
+  `release-development.yml`, which exists in 14 of 18 apps and calls the shared
+  beta release workflow with `channel: dev`.
+
+## Further reading
+
+- [Development Pipeline](development-pipeline.md) — branch flow and release triggers
+- [Contributing](contributing.md) — PR checklist and commit conventions
+- [`quality-config/` README](https://github.com/ConductionNL/.github/tree/main/quality-config) — the mechanism, and the phpcs behaviour it was built on
+- [nextcloud/.github workflow templates](https://github.com/nextcloud/.github/tree/master/workflow-templates)
+- [nextcloud/coding-standard](https://github.com/nextcloud/coding-standard)

--- a/docs/WayOfWork/ci-cd.md
+++ b/docs/WayOfWork/ci-cd.md
@@ -3,16 +3,20 @@ id: ci-cd
 title: CI/CD and Code Standards
 sidebar_label: CI/CD and Code Standards
 sidebar_position: 4
-description: What our pipeline actually runs, where the configuration lives, and exactly where we diverge from Nextcloud's own app CI/CD
+description: What our pipeline runs, where the configuration lives, and how we stay strictly compatible with Nextcloud's own app CI/CD
 ---
 
 # CI/CD and Code Standards
 
-We build Nextcloud apps, and Nextcloud has its own app CI/CD conventions. Ours is
-not the same. Most of the differences are deliberate; a few are accidents worth
-knowing about before they bite you. This page states both, so that a contributor
-arriving from the Nextcloud ecosystem — or an auditor asking why our checks look
-unfamiliar — can see the whole picture in one place.
+We build Nextcloud apps, so we hold ourselves to Nextcloud's rules:
+
+> **Conduction code must pass Nextcloud's own checks unchanged. We may be
+> stricter than Nextcloud; we may not be different from it.**
+
+"Stricter" means adding a rule Nextcloud has no opinion on. It never means giving
+one of their rules a different value — code that satisfies us must still satisfy
+them. Where a difference exists today it is a defect, not a dialect, and this page
+is where each one is tracked.
 
 Two companion pages stay authoritative for what they cover:
 [Development Pipeline](development-pipeline.md) for the branch flow and
@@ -68,58 +72,128 @@ theirs survives the org repo being unavailable and pins its supply chain harder.
 **Action SHA-pinning is the one we should adopt** — it is a supply-chain control,
 not a style preference.
 
-## PHP: where we diverge, and how much
+## PHP
 
-### Formatting — the important one
+### Formatting — one standard, and it is Nextcloud's
 
-Nextcloud formats PHP with **php-cs-fixer** via `nextcloud/coding-standard`, whose
-`Config` calls `setIndent("\t")`. Nextcloud core's `.editorconfig` says
-`indent_style = tab`, `indent_size = 4`.
+**Conduction code must pass `nextcloud/coding-standard` unchanged. We may be
+stricter than Nextcloud; we may not be different from it.**
 
-We format PHP with **PHP_CodeSniffer** against a PEAR-derived ruleset that sets
-`indent=4, tabIndent=false`. All 18 apps agree on this.
+That rule is newer than most of the code. Measured 2026-08-12 against
+openregister's `lib/`, **all 1,427 files failed** Nextcloud's standard:
 
-| Rule | Conduction (PHPCS) | Nextcloud (php-cs-fixer) |
+| php-cs-fixer rule | files affected |
+| --- | ---: |
+| `curly_braces_position` | 1,427 — 100% |
+| `indentation_type` | 1,409 — 98.7% |
+| `phpdoc_align` | 1,221 — 85.6% |
+| `binary_operator_spaces` | 1,104 — 77.4% |
+| `trailing_comma_in_multiline` | 693 — 48.6% |
+| `cast_spaces` | 676 — 47.4% |
+| `concat_space` | 583 — 40.9% |
+
+The fleet had been formatting with a PEAR-derived PHPCS ruleset — four spaces,
+next-line braces, `(int) $x`, `'a'.'b'` — which is not a stricter standard but a
+different dialect. Under the rule above it has to go, and it has.
+
+#### Two tools, disjoint jurisdiction
+
+| Concern | Tool | Where the config lives |
 | --- | --- | --- |
-| Indentation | **4 spaces** | **tabs** |
-| Class / function opening brace | next line (PEAR) | same line (`curly_braces_position`) |
-| Cast spacing | `(int) $x` (`Generic.Formatting.SpaceAfterCast`) | `(int)$x` (`cast_spaces: none`) |
-| Concatenation | `'a'.'b'` (`Squiz.Strings.ConcatenationSpacing`) | `'a' . 'b'` (`concat_space: one`) |
-| Line length | hard limit 150 | not enforced |
-| Yoda conditions | disallowed | disallowed ✅ agree |
-| Named parameters on internal calls | **required** (custom sniff) | no such rule |
+| **Formatting** — whitespace, braces, imports, quotes, casts | php-cs-fixer | [`conduction/coding-standard`](https://github.com/ConductionNL/coding-standard) |
+| **Semantics** — named parameters, `@spec`, banned functions, removed NC APIs, line length | PHP_CodeSniffer | [`quality-config/`](https://github.com/ConductionNL/.github/tree/main/quality-config) |
+| **Types** | Psalm + PHPStan | `quality-config/` |
 
-These are not reconcilable file-by-file. **A file cannot satisfy both**, so an app
-must wire up exactly one formatter.
+`Conduction\CodingStandard\Config` **extends** Nextcloud's and merges a private
+`ADDITIONS` array onto `parent::getRules()`. The package's invariant test fails
+the build if `ADDITIONS` shares a single key with the parent set, if any parent
+rule is dropped, or if any parent rule's *value* changed. The policy is therefore
+enforced by construction, not by review — and each assertion carries a positive
+control, because a suite that cannot fail is indistinguishable from one that
+passes.
 
-:::warning `cs:check` and `cs:fix` do not mean here what they mean upstream
+`ADDITIONS` is currently **empty**, which is a result rather than an omission.
+Every rule this fleet wants beyond Nextcloud's is semantic, not typographic, and
+php-cs-fixer cannot express any of them.
 
-`cs:check` and `cs:fix` are the script names that `nextcloud/coding-standard`
-defines, and they are what Nextcloud's own `lint-php-cs.yml` invokes. In this
-fleet those same two names are **aliases for PHPCS**:
+#### Why PHPCS had to be cut back, not just re-pointed
 
-```json
-"cs:check": "./vendor/bin/phpcs --standard=phpcs.xml",
-"cs:fix":   "./vendor/bin/phpcbf --standard=phpcs.xml"
+Left alone, the two tools contradict each other and the app becomes unfixable —
+`composer cs:fix` and `composer phpcs` demand opposite things and neither can be
+satisfied. That was the fleet's real state. Running the old ruleset over
+php-cs-fixer-formatted code produced **111,932 findings, 111,747 of them
+auto-fixable formatting**:
+
+```
+Generic.WhiteSpace.DisallowTabIndent                62,123
+Generic.WhiteSpace.ScopeIndent                      35,030
+Generic.Arrays.ArrayIndent                           3,726
+PEAR.Commenting.FunctionComment (param spacing)      2,797
+PEAR.Functions.FunctionDeclaration (indent + brace)  2,576
+Generic.Formatting.MultipleStatementAlignment        1,132
+Generic.Formatting.SpaceAfterCast                      909
+Squiz.Strings.ConcatenationSpacing                     534
+Squiz.ControlStructures.ElseIfDeclaration               31
 ```
 
-So a contributor who runs the documented Nextcloud command gets our 4-space PEAR
-reformatting, not Nextcloud's tabs. Worse, **17 of 18 apps also list
-`nextcloud/coding-standard:^1.4` in `require-dev`** while shipping no
-`.php-cs-fixer.dist.php` and never invoking php-cs-fixer anywhere in CI. It is a
-dead dependency that pulls `php-cs-fixer/shim` into every `vendor/` tree, and it
-is loaded and ready to reformat the entire codebase the wrong way for anyone who
-finds it.
+That last line is the shape of the whole problem: Squiz's sniff **forbids** the
+`elseif` keyword Nextcloud's `elseif` fixer **requires**. Two tools cannot both be
+right about one token.
 
-Either drop the dependency or adopt the standard. Do not keep both.
+With every formatting sniff removed, the same measurement yields **185 findings,
+all semantic** — 181 missing `@spec`, 2 over the 150-character line limit, 2 SPDX
+end-char. The named-parameter and legacy-accessor sniffs fire **zero** times,
+which is what stricter-but-compatible looks like when it is true rather than
+assumed.
+
+Docblock *presence* stays; docblock *layout* is `phpdoc_align`'s. The alignment
+codes are excluded individually rather than by dropping the sniff — losing the
+presence requirement would be a real regression.
+
+`quality-config/tests/compatibility.sh` makes this permanent: format a fixture,
+run PHPCS over the result, fail on any formatting sniff.
+
+#### What migrating an app looks like
+
+Proven end-to-end on `nextcloud-app-template`
+([PR #141](https://github.com/ConductionNL/nextcloud-app-template/pull/141)):
+
+```
+php-cs-fixer   Found 0 of 23 files that can be fixed
+phpcs          39 violations, ALL WARNINGS (35 @spec, 4 SPDX). Zero errors.
+```
+
+:::warning `cs:check` and `cs:fix` used to lie
+
+They are the script names `nextcloud/coding-standard` defines, and what
+Nextcloud's own `lint-php-cs.yml` invokes. In this fleet they were **aliases for
+PHPCS** — so a contributor running the documented Nextcloud command got four-space
+PEAR reformatting. Worse, 17 of 18 apps carried `nextcloud/coding-standard` in
+`require-dev` with no `.php-cs-fixer.dist.php` and no invocation anywhere: loaded,
+and ready to reformat the whole codebase for whoever found it.
+
+They now run php-cs-fixer, and the direct dependency is dropped — it arrives
+transitively at a version `conduction/coding-standard` has tested against.
+:::
+
+:::danger A missing autoloader reports as a clean tree
+
+`.php-cs-fixer.dist.php` **must** start with `require_once __DIR__ . '/vendor/autoload.php';`.
+php-cs-fixer includes the config before your autoloader runs, so without it the
+run dies with `Class not found` — and in `--format=json` that fatal is reported as
+**zero files needing changes**. It reads exactly like a pass.
 :::
 
 ### The `.editorconfig` gap
 
-**No fleet app ships an `.editorconfig`.** Nextcloud core does. An editor opening
-one of our PHP files therefore falls back to whatever the user configured — and
-for anyone whose defaults came from Nextcloud work, that is tabs, which PHPCS then
-rejects. This is a one-file fix and it belongs in every app.
+**No fleet app shipped an `.editorconfig`.** Nextcloud core does. An editor
+opening one of our PHP files fell back to whatever the user configured — and for
+anyone whose defaults came from Nextcloud work, that is tabs, which the old PHPCS
+ruleset then rejected.
+
+Nextcloud's `.editorconfig` is now copied **verbatim** into every app
+(`indent_style = tab`, `indent_size = 4`, two-space YAML and `package*.json`). It
+agrees with the formatter instead of fighting it.
 
 ### Static analysis and the Nextcloud version it is analysing against
 

--- a/docs/WayOfWork/ci-cd.md
+++ b/docs/WayOfWork/ci-cd.md
@@ -336,6 +336,98 @@ The drift this replaces, measured across all 18 core apps on 2026-08-12:
 inheritance and ESLint flat config resolves plugins relative to the config file.
 Both are covered in the [`quality-config/` README](https://github.com/ConductionNL/.github/tree/main/quality-config#not-yet-centralised-and-why).
 
+## Package registry
+
+Shared configuration only stops drifting if every app pulls it the same way, so
+the distribution channel is part of the standard, not an implementation detail.
+
+| Package | Registry | Contains | Consumed by |
+| --- | --- | --- | --- |
+| [`conduction/coding-standard`](https://packagist.org/packages/conduction/coding-standard) | Packagist | php-cs-fixer config extending Nextcloud's | every app, `require-dev` |
+| [`conduction/hydra-gates`](https://packagist.org/packages/conduction/hydra-gates) | Packagist | the mechanical gates **and** `quality-config/` (PHPCS, PHPMD, PHPStan base, custom sniffs) | every app, `require-dev` |
+| [`@conduction/nextcloud-vue`](https://www.npmjs.com/package/@conduction/nextcloud-vue) | npm | shared Vue components **and** the ESLint / Stylelint config | every app, `dependencies` |
+
+Both composer packages are built from repositories that also do other things —
+`conduction/hydra-gates` is the root package of `ConductionNL/.github`, which also
+hosts this documentation site. One repository can publish exactly one composer
+package, which is why the coding standard needed a repository of its own.
+
+### Registration is not cosmetic
+
+Before registration, an app consuming `conduction/hydra-gates` needed this in its
+own `composer.json`:
+
+```jsonc
+"repositories": [
+    { "type": "vcs", "url": "https://github.com/ConductionNL/.github.git", "no-api": true }
+]
+```
+
+That block is a per-app file, and per-app files are what drift — it is the same
+failure mode the shared config exists to end. `no-api: true` also made composer
+clone the **entire** `.github` repository, docs site included, on every install.
+Registration deletes the block from all 18 apps.
+
+### Constraints float; they are not pinned
+
+Apps require `^1.0`, not an exact version. A pin is a silent expiry date: 22 repos
+once sat on gate package `v1.0.1` while 16 gates were dead fleet-wide and every one
+of them reported PASS. Hold a package still only for a stated reason, in that app,
+with the reason written next to the constraint.
+
+### Publishing, and how to tell it actually published
+
+Submitting a repository creates a push webhook on it automatically —
+`https://packagist.org/api/github`, `push` events. **That webhook on its own does
+not keep the package up to date.** Measured 2026-08-12 on
+`conduction/coding-standard`: a real push delivered `202 OK`, and ten minutes
+later Packagist's `dev-main` still pointed at the previous commit.
+
+The missing piece is the **Packagist GitHub App**, which was not installed on the
+`ConductionNL` organisation. Install it once, org-wide, at
+[github.com/apps/packagist](https://github.com/apps/packagist) — it is a browser
+flow by design, since GitHub Apps cannot be installed through the API, so there is
+no `gh` command for it and no way to script it.
+
+Until then, publishing is manual: click **Update** on the package page, or
+
+```bash
+curl -XPOST -H'content-type:application/json' \
+  "https://packagist.org/api/update-package?username=<user>&apiToken=<token>" \
+  -d '{"repository":{"url":"https://github.com/ConductionNL/<repo>"}}'
+```
+
+Either way, there is something to **verify**, and it is easy to get wrong in three
+separate ways:
+
+1. **A `ping` delivery is not a `push` delivery.** Packagist sends a ping on
+   install; it proves the endpoint answers a handshake and nothing more.
+2. **HTTP `202` is not "published".** 202 means *accepted for processing* —
+   Packagist queues the crawl — and a queued crawl it never runs still answers
+   202. A green delivery list is consistent with a package that has not moved,
+   which is exactly what was observed here.
+3. **`package.time` is the creation timestamp**, not the last update. It will not
+   change no matter how many times you publish.
+
+The only claim worth making is that the **source reference moved**:
+
+```bash
+curl -s https://packagist.org/packages/<vendor>/<pkg>.json \
+  | jq -r '.package.versions["dev-main"] | "\(.time)  \(.source.reference[0:8])"'
+```
+
+Compare that SHA to `git rev-parse HEAD`. If they differ, the queue has not caught
+up — or the hook is not working, and those two look identical for the first few
+minutes. Wait, then re-read; do not read the delivery log and call it done.
+
+### npm
+
+`@conduction/nextcloud-vue` was already published, so homing the frontend config
+there adds export paths to an existing package rather than creating a new one.
+Note its dist-tags: apps consume **`vue3`**, currently `2.2.0-vue3.x`. The `latest`
+tag is `1.0.0-beta.3`, an old Vue 2 build — installing without a tag or an explicit
+version gets the wrong library.
+
 ## Corrections to older pages
 
 - "**Code style — PHPCS (PSR-12)**", in

--- a/docs/WayOfWork/contributing.md
+++ b/docs/WayOfWork/contributing.md
@@ -111,7 +111,7 @@ Every PR triggers automated quality checks. **All must pass before merge.**
 | Check           | Tool                      |
 | --------------- | ------------------------- |
 | Syntax          | `php -l`                  |
-| Code style      | PHPCS (PSR-12)            |
+| Code style      | PHPCS ([Conduction standard](ci-cd.md#formatting--the-important-one)) |
 | Static analysis | PHPStan (level 5) + Psalm |
 | Mess detection  | PHPMD                     |
 
@@ -128,6 +128,10 @@ Every PR triggers automated quality checks. **All must pass before merge.**
 - Known vulnerability scan (npm audit + composer audit)
 
 **Run locally:**
+
+> **`cs:check` / `cs:fix` are PHPCS here, not php-cs-fixer.** They are the script
+> names `nextcloud/coding-standard` defines, and in this fleet they are aliases for
+> `phpcs` / `phpcbf`. See [CI/CD and Code Standards](ci-cd.md#formatting--the-important-one).
 
 ```bash
 # PHP

--- a/docs/WayOfWork/development-pipeline.md
+++ b/docs/WayOfWork/development-pipeline.md
@@ -28,14 +28,17 @@ All branches are protected. No direct pushes. Every change flows through a pull 
 
 ## Quality Gates
 
-Every PR triggers **four parallel quality gates** — all must pass before merge:
+Every PR triggers the shared quality pipeline — all applicable gates must pass before merge.
+The four groups below are the core of it; the full set is 18 job groups, including PHPUnit,
+Playwright, Newman, axe-core, SBOM and the Hydra gates. See
+[CI/CD and Code Standards](ci-cd.md#one-pipeline-eighteen-thin-callers) for the complete table.
 
 ### PHP Quality
 
 | Check           | Tool            |
 | --------------- | --------------- |
 | Syntax          | `php -l`        |
-| Code style      | PHPCS (PSR-12)  |
+| Code style      | PHPCS ([Conduction standard](ci-cd.md#formatting--the-important-one)) |
 | Static analysis | PHPStan + Psalm |
 | Mess detection  | PHPMD           |
 | Code metrics    | PHPMetrics      |
@@ -79,14 +82,19 @@ Version numbers are calculated from PR labels:
 
 ## Hydra — Agentic Development Pipeline
 
-:::info Coming soon
+:::info
 
-Conduction is developing **Hydra**, an agentic spec-driven development pipeline that builds applications from structured specifications with government-grade traceability, SBOM generation, and audit trails. This section will be updated when Hydra is publicly available.
+**Hydra** is Conduction's agentic spec-driven development pipeline: it builds applications from
+structured specifications with government-grade traceability, SBOM generation, and audit trails.
+Its mechanical quality gates run on every PR in all 18 core apps today (`enable-hydra-gates: true`)
+and are published as the open-source composer package
+[`conduction/hydra-gates`](https://github.com/ConductionNL/.github/tree/main/hydra-gates).
 
 :::
 
 ## Further Reading
 
+- [CI/CD and Code Standards](ci-cd.md) — what the pipeline runs, and where we diverge from Nextcloud's own app CI/CD
 - [Contributing guide](contributing.md) — PR checklist, commit conventions, DCO
 - [Release process](release-process.md) — full versioning and deployment details
 - [Spec-driven development](spec-driven-development.md) — how specs feed the pipeline

--- a/docs/WayOfWork/release-process.md
+++ b/docs/WayOfWork/release-process.md
@@ -98,7 +98,11 @@ The `appinfo/info.xml` in your repository is **never modified** by the release w
 | **Stable** | `main` | `nightly: false` | Production users, default install                       |
 | **Beta**   | `beta` | `nightly: true`  | Testers, early adopters (opt-in via App Store settings) |
 
-There are no development builds. The `development` branch is for integration only — developers test locally or install from the beta channel.
+In addition, 14 of the 18 core apps ship a `release-development.yml` that calls the shared beta
+release workflow with `channel: dev` on every push to `development`. The `dev` channel is a **GitHub
+prerelease only** — it shares the beta packaging path but never POSTs to
+`apps.nextcloud.com`, so it is not an App Store channel. It exists so work on `development` can
+be installed before it reaches beta. Developers otherwise test locally or install from beta.
 
 ## Automatic PR Sync
 

--- a/hydra-gates/scripts/lib/check_coding_standard_adoption.py
+++ b/hydra-gates/scripts/lib/check_coding_standard_adoption.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Conduction
+# SPDX-License-Identifier: EUPL-1.2
+"""
+gate-65: coding-standard-adoption.
+
+Conduction code must pass ``nextcloud/coding-standard`` unchanged. We may be
+stricter than Nextcloud; we may not be different from it. This checker is what
+makes that a rule rather than an intention.
+
+WHY IT EXISTS
+-------------
+Measured 2026-08-12 across the 18 core apps, from canonical
+``<app>@development``. ``psalm.xml``, ``phpstan.neon``, ``playwright.config.ts``
+and ``code-quality.yml`` each existed in EIGHTEEN mutually different versions.
+``NamedParametersSniff.php`` — a custom *rule*, not a setting — existed in six,
+one of which called ``addWarning()`` where the others called ``addError()``.
+
+None of that was anyone's decision. Every one of those files started as a copy
+of something shared, and copies drift. Centralising them does not by itself fix
+that; the 18 variants were copies of something shared too. What stops it
+recurring is a check that fails when an app walks away from the centre.
+
+Each rule below corresponds to a defect that was live in the fleet, not to a
+preference:
+
+  1. NO PHP-CS-FIXER CONFIG — all 1,427 openregister files failed Nextcloud's
+     standard because nothing ever ran it.
+  2. MISSING AUTOLOADER in .php-cs-fixer.dist.php — php-cs-fixer includes that
+     file before the app's autoloader, so the config fatals with "Class not
+     found"; in --format=json that fatal is reported as ZERO FILES NEEDING
+     CHANGES. It reads exactly like a clean tree.
+  3. cs:check / cs:fix WIRED TO PHPCS — those are nextcloud/coding-standard's
+     script names. In this fleet they were aliases for phpcs/phpcbf, so the
+     documented Nextcloud command reformatted code AWAY from Nextcloud.
+  4. nextcloud/coding-standard AS A DIRECT DEPENDENCY — 17 of 18 apps declared
+     it with no config file and no invocation anywhere. It must arrive
+     transitively, at a version conduction/coding-standard has tested against.
+  5. LOCAL FORMATTING SNIFFS — two formatters with overlapping jurisdiction make
+     an app UNFIXABLE: `cs:fix` and `phpcs` demand opposite things and neither
+     can be satisfied. Running the old PEAR ruleset over php-cs-fixer-formatted
+     code produced 111,932 findings, 111,747 of them formatting.
+  6. A LOCAL phpcs-custom-sniffs/ COPY — the six-versions-of-one-rule defect.
+  7. NO .editorconfig — no fleet app had one, so an editor configured by
+     someone's previous Nextcloud work defaulted to tabs, which the old ruleset
+     then rejected. Nextcloud core ships one.
+  8. UNQUOTED STYLELINT GLOB — 13 apps ran `stylelint src/**/*.vue …` unquoted,
+     so the SHELL expanded it and without globstar `src/**/` matched exactly one
+     directory level. Nested components were silently unlinted.
+  9. nextcloud/ocp BELOW info.xml's min-version — 15 apps declared NC 32-34 and
+     analysed against ^31. Nothing ADDED in 32/33/34 was visible, and — the part
+     that bites — nothing REMOVED was reportable either. That is why the NC 34
+     removal of \\OC::$server needed a hand-written PHPCS sniff.
+ 10. A PINNED SHARED STANDARD — the gates, the coding standard and the shared
+     workflow are consumed at the tip, never at a version. A pin is a silent
+     expiry date, and this fleet has paid for it twice in the same year:
+
+       .github#159  22 repos sat on gate package v1.0.1 while 16 gates were
+                    DEAD fleet-wide — and every one of them reported PASS.
+       .github#173  a default flipped at @main then reached those same old
+                    runners and turned them red on gates whose subject matter
+                    they had no code for.
+
+     Both directions of that failure come from the same cause: two halves of one
+     system moving independently. `^1.0` is not a pin — it floats within a major
+     and is correct. An exact version, a `dev-<branch>` constraint, or a
+     `hydra-gates-ref` that is not `main`, is.
+
+USAGE
+    check_coding_standard_adoption.py <app-root>
+
+Prints one `FAIL <rule>: <detail>` line per violation, then a terminal summary
+`checked N rule(s)`. The runner treats a missing summary as a WIRING failure
+rather than a pass, so a crash cannot be mistaken for a clean repo.
+
+Exit code is the violation count (0 = clean, 90 = could not run).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+CENTRAL_RULESET = "quality-config/phpcs.xml"
+
+# Sniff families php-cs-fixer owns. A phpcs.xml that names one locally is
+# re-opening the jurisdiction conflict rule 5 describes. Matched against the
+# `ref=` of a <rule>, so `Generic.WhiteSpace.ScopeIndent` and
+# `Squiz.WhiteSpace.OperatorSpacing` both hit on `WhiteSpace`.
+FORMATTING_TOKENS = (
+    "WhiteSpace",
+    "Whitespace",
+    "ScopeIndent",
+    "ArrayIndent",
+    "Indent",
+    "SpaceAfterCast",
+    "ConcatenationSpacing",
+    "MultipleStatementAlignment",
+    "ClassDeclaration",
+    "FunctionDeclaration",
+    "ElseIfDeclaration",
+    "DocCommentAlignment",
+    "OpeningBrace",
+    "ClosingBrace",
+    "LineEndings",
+    "DisallowTabIndent",
+    "DisallowSpaceIndent",
+)
+
+
+def read(path: str) -> str | None:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def strip_xml_comments(xml: str) -> str:
+    """A commented-out rule is not a rule. Matching one would be the
+    grep-a-string-and-hit-every-comment defect gate-64 was written about."""
+    return re.sub(r"<!--.*?-->", "", xml, flags=re.S)
+
+
+def check(root: str) -> tuple[list[str], int]:
+    fails: list[str] = []
+    checked = 0
+
+    def fail(rule: str, detail: str) -> None:
+        fails.append(f"FAIL {rule}: {detail}")
+
+    def j(name: str):
+        raw = read(os.path.join(root, name))
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            fail("unparseable-json", f"{name} is not valid JSON ({exc}).")
+            return None
+
+    composer = j("composer.json")
+    package = j("package.json")
+
+    # ── 1 + 2. php-cs-fixer config ───────────────────────────────────────
+    checked += 1
+    fixer = read(os.path.join(root, ".php-cs-fixer.dist.php")) or read(
+        os.path.join(root, ".php-cs-fixer.php")
+    )
+    if fixer is None:
+        fail(
+            "no-php-cs-fixer-config",
+            "no .php-cs-fixer.dist.php. Nothing in this repo runs Nextcloud's "
+            "coding standard, so nothing can be said about whether it passes it.",
+        )
+    else:
+        if "Conduction\\CodingStandard\\Config" not in fixer and "CodingStandard\\Config" not in fixer:
+            fail(
+                "wrong-fixer-config",
+                ".php-cs-fixer.dist.php does not instantiate "
+                "Conduction\\CodingStandard\\Config.",
+            )
+        checked += 1
+        if not re.search(r"require(_once)?\s.*autoload\.php", fixer):
+            fail(
+                "fixer-config-missing-autoloader",
+                ".php-cs-fixer.dist.php never requires vendor/autoload.php. "
+                "php-cs-fixer includes this file before the app's autoloader, so "
+                "it fatals with \"Class not found\" — and in --format=json that "
+                "fatal is reported as ZERO FILES NEEDING CHANGES, which reads "
+                "exactly like a clean tree.",
+            )
+
+    # ── 3 + 4. composer wiring ───────────────────────────────────────────
+    if composer is not None:
+        req = {}
+        req.update(composer.get("require") or {})
+        req.update(composer.get("require-dev") or {})
+        scripts = composer.get("scripts") or {}
+
+        checked += 1
+        if "conduction/coding-standard" not in req:
+            fail(
+                "coding-standard-not-required",
+                "composer.json does not require conduction/coding-standard.",
+            )
+
+        checked += 1
+        if "nextcloud/coding-standard" in req:
+            fail(
+                "nextcloud-coding-standard-declared-directly",
+                "nextcloud/coding-standard is a DIRECT dependency. It must arrive "
+                "transitively through conduction/coding-standard, at a version that "
+                "package has tested against. Declared directly it was, in 17 of 18 "
+                "apps, a dead dependency with no config and no invocation — loaded, "
+                "and ready to reformat everything for whoever found it.",
+            )
+
+        checked += 1
+        for name in ("cs:check", "cs:fix"):
+            body = scripts.get(name)
+            if body is None:
+                fail(
+                    "cs-script-missing",
+                    f"composer.json declares no '{name}' script.",
+                )
+                continue
+            body_s = body if isinstance(body, str) else " ".join(body)
+            if "phpcbf" in body_s or re.search(r"\bphpcs\b", body_s):
+                fail(
+                    "cs-script-wired-to-phpcs",
+                    f"'{name}' runs PHPCS, not php-cs-fixer. That is "
+                    "nextcloud/coding-standard's script name, so a contributor "
+                    "running the documented Nextcloud command gets this fleet's "
+                    f"reformatting instead. Body: {body_s!r}",
+                )
+            elif "php-cs-fixer" not in body_s:
+                fail(
+                    "cs-script-runs-neither",
+                    f"'{name}' invokes neither php-cs-fixer nor phpcs: {body_s!r}",
+                )
+
+    # ── 5 + 6. PHPCS keeps to semantics ──────────────────────────────────
+    phpcs_raw = read(os.path.join(root, "phpcs.xml")) or read(
+        os.path.join(root, "phpcs.xml.dist")
+    )
+    if phpcs_raw is not None:
+        body = strip_xml_comments(phpcs_raw)
+
+        checked += 1
+        if CENTRAL_RULESET not in body:
+            fail(
+                "phpcs-not-centralised",
+                f"phpcs.xml does not reference {CENTRAL_RULESET}. Every app that "
+                "kept its own full ruleset is how this fleet reached six variants "
+                "of one file.",
+            )
+
+        checked += 1
+        local_formatting = []
+        for ref in re.findall(r'<rule\s+ref="([^"]+)"', body):
+            if ref.startswith("vendor/") or ref.startswith("./") or ref.startswith("../"):
+                continue
+            if any(tok in ref for tok in FORMATTING_TOKENS):
+                local_formatting.append(ref)
+        if local_formatting:
+            fail(
+                "phpcs-declares-formatting-sniffs",
+                "phpcs.xml names formatting sniffs that php-cs-fixer owns: "
+                + ", ".join(sorted(set(local_formatting)))
+                + ". Two formatters with overlapping jurisdiction make an app "
+                "unfixable — cs:fix and phpcs then demand opposite things and "
+                "neither can be satisfied.",
+            )
+
+    checked += 1
+    if os.path.isdir(os.path.join(root, "phpcs-custom-sniffs")):
+        fail(
+            "local-custom-sniffs",
+            "phpcs-custom-sniffs/ exists locally. The sniffs come from "
+            "vendor/conduction/hydra-gates/. A local copy is how "
+            "NamedParametersSniff.php reached six versions across the fleet, one "
+            "of them calling addWarning() where the rest called addError().",
+        )
+
+    # ── 7. .editorconfig ─────────────────────────────────────────────────
+    checked += 1
+    editorconfig = read(os.path.join(root, ".editorconfig"))
+    if editorconfig is None:
+        fail(
+            "no-editorconfig",
+            "no .editorconfig. Nextcloud core ships one; without it an editor "
+            "falls back to whatever the developer last configured.",
+        )
+    else:
+        # The [*] section's indent_style. A file that sets it to space for PHP
+        # contradicts the formatter it is supposed to agree with.
+        star = re.search(r"^\[\*\]\s*$(.*?)(?=^\[|\Z)", editorconfig, re.M | re.S)
+        style = None
+        if star:
+            m = re.search(r"^\s*indent_style\s*=\s*(\w+)", star.group(1), re.M)
+            style = m.group(1) if m else None
+        if style != "tab":
+            fail(
+                "editorconfig-not-tab",
+                f"[*] indent_style is {style!r}, not 'tab'. Nextcloud's own "
+                ".editorconfig sets tab, and php-cs-fixer enforces it — an "
+                ".editorconfig that disagrees fights the formatter on every save.",
+            )
+
+    # ── 8. stylelint glob ────────────────────────────────────────────────
+    if package is not None:
+        sl = (package.get("scripts") or {}).get("stylelint")
+        if sl:
+            checked += 1
+            # Everything after the binary name. An unquoted glob containing `**`
+            # is expanded by the SHELL, and without globstar `src/**/` matches
+            # exactly one directory level.
+            args = sl.split("stylelint", 1)[1] if "stylelint" in sl else sl
+            for token in args.split():
+                if "**" in token and not (
+                    token.startswith(("'", '"')) or token.endswith(("'", '"'))
+                ):
+                    fail(
+                        "stylelint-glob-unquoted",
+                        f"the stylelint script passes an unquoted glob {token!r}. "
+                        "The shell expands it, and without globstar `src/**/` "
+                        "matches exactly one directory level — nested components "
+                        "are silently not linted. Quote it so stylelint expands it.",
+                    )
+                    break
+
+    # ── 9. ocp major vs info.xml min-version ─────────────────────────────
+    info = read(os.path.join(root, "appinfo", "info.xml"))
+    if info is not None and composer is not None:
+        m = re.search(r'<nextcloud[^>]*min-version="(\d+)"', info)
+        req = {}
+        req.update(composer.get("require") or {})
+        req.update(composer.get("require-dev") or {})
+        ocp = req.get("nextcloud/ocp")
+        if m and ocp:
+            checked += 1
+            declared_min = int(m.group(1))
+            om = re.search(r"(\d+)", ocp)
+            # `dev-master` and friends track the tip; they cannot be below the
+            # declared minimum, so they are not a finding.
+            if om and not ocp.strip().startswith("dev-"):
+                ocp_major = int(om.group(1))
+                if ocp_major < declared_min:
+                    fail(
+                        "ocp-below-declared-minimum",
+                        f"appinfo/info.xml declares min-version=\"{declared_min}\" "
+                        f"but composer pins nextcloud/ocp:{ocp}. Static analysis is "
+                        f"reading the NC {ocp_major} API surface, a major below what "
+                        "this app claims to support — so nothing added in "
+                        f"{declared_min}+ is visible to it, and nothing REMOVED in "
+                        f"{declared_min}+ can be reported. That is why the NC 34 "
+                        "removal of \\OC::$server needed a hand-written sniff.",
+                    )
+
+    # ── 10. nothing shared may be pinned ─────────────────────────────────
+    # An exact version, or a dev-branch constraint, freezes this app against a
+    # standard the rest of the fleet has moved past. `^1.0` floats and is fine.
+    if composer is not None:
+        req = {}
+        req.update(composer.get("require") or {})
+        req.update(composer.get("require-dev") or {})
+        for pkg in ("conduction/coding-standard", "conduction/hydra-gates"):
+            spec = req.get(pkg)
+            if not spec:
+                continue
+            checked += 1
+            s = spec.strip()
+            if s.startswith("dev-"):
+                fail(
+                    "shared-package-pinned",
+                    f"{pkg} is constrained to {s!r} — a branch, not a released "
+                    "range. This app is frozen against whatever that branch "
+                    "happens to contain and will not follow the fleet. Use a "
+                    "floating range such as ^1.0.",
+                )
+            elif re.fullmatch(r"v?\d+(\.\d+){1,2}", s) or s.startswith("=="):
+                fail(
+                    "shared-package-pinned",
+                    f"{pkg} is pinned to the exact version {s!r}. A pin is a "
+                    "silent expiry date: 22 repos once sat on gate package v1.0.1 "
+                    "while 16 gates were dead fleet-wide and every one reported "
+                    "PASS (.github#159). Use ^1.0.",
+                )
+
+    # The shared workflow and the gate package are consumed at the tip. A caller
+    # that names a tag stops receiving fixes AND keeps receiving new defaults
+    # from the half of the system it did not pin — the #173 direction.
+    wf = read(os.path.join(root, ".github", "workflows", "code-quality.yml"))
+    if wf is not None:
+        body = re.sub(r"^\s*#.*$", "", wf, flags=re.M)
+
+        checked += 1
+        m = re.search(r"^\s*hydra-gates-ref:\s*[\"']?([^\s\"'#]+)", body, re.M)
+        if m and m.group(1) != "main":
+            fail(
+                "gates-ref-pinned",
+                f"hydra-gates-ref is set to {m.group(1)!r}. The gate package is "
+                "consumed at main, together with the shared workflow that drives "
+                "it, so a gate fix reaches this repo without a commit in this "
+                "repo. Pinned, the two halves move independently: an old runner "
+                "receives a new default and goes red on gates it has no subject "
+                "matter for (.github#173), or silently stops running gates it "
+                "never learned about (#159). Remove the input.",
+            )
+
+        checked += 1
+        for ref in re.findall(
+            r"uses:\s*ConductionNL/\.github/\.github/workflows/[^@\s]+@([^\s]+)", body
+        ):
+            if ref != "main":
+                fail(
+                    "shared-workflow-pinned",
+                    f"the shared quality workflow is consumed at @{ref}, not @main. "
+                    "A pinned pipeline stops receiving fixes for defects found in "
+                    "other apps — which is the entire reason it is shared.",
+                )
+                break
+
+    return fails, checked
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: check_coding_standard_adoption.py <app-root>", file=sys.stderr)
+        return 90
+
+    root = sys.argv[1]
+    if not os.path.isdir(root):
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 90
+
+    try:
+        fails, checked = check(root)
+    except Exception as exc:  # noqa: BLE001 - a crash must not read as clean
+        print(f"checker crashed: {exc!r}", file=sys.stderr)
+        return 90
+
+    for line in fails:
+        print(line)
+
+    # Terminal summary. The runner treats its absence as a WIRING failure, so a
+    # crash can never be mistaken for a clean repo.
+    print(f"checked {checked} rule(s)")
+    return len(fails)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
+++ b/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# Self-test for check_coding_standard_adoption.py (gate-65).
+#
+# Discovered and run by tests/run-helper-suites.sh — no workflow edit needed.
+#
+# Every assertion is paired: a NEGATIVE control (a compliant fixture must produce
+# zero findings) and a POSITIVE control (a fixture carrying exactly one defect
+# must produce exactly that finding). A checker that reports nothing on a broken
+# repo and a checker that reports nothing on a clean one are the same program
+# from the outside, which is the failure this suite exists to make impossible.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="${HERE}/check_coding_standard_adoption.py"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+ok() { echo "  PASS  $1"; pass=$((pass + 1)); }
+no() { echo "  FAIL  $1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; fail=$((fail + 1)); }
+
+# Build a fully compliant app fixture in $1.
+scaffold() {
+    local d="$1"
+    mkdir -p "$d/appinfo" "$d/lib"
+
+    cat > "$d/.php-cs-fixer.dist.php" <<'PHP'
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+$config = new Conduction\CodingStandard\Config();
+$config->getFinder()->in(__DIR__ . '/lib');
+return $config;
+PHP
+
+    cat > "$d/composer.json" <<'JSON'
+{
+    "name": "conductionnl/fixture",
+    "require-dev": {
+        "conduction/coding-standard": "^1.0",
+        "nextcloud/ocp": "^34.0"
+    },
+    "scripts": {
+        "cs:check": "php-cs-fixer fix --dry-run --diff",
+        "cs:fix": "php-cs-fixer fix"
+    }
+}
+JSON
+
+    cat > "$d/phpcs.xml" <<'XML'
+<?xml version="1.0"?>
+<ruleset name="fixture">
+    <file>lib</file>
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpcs.xml"/>
+</ruleset>
+XML
+
+    cat > "$d/.editorconfig" <<'EC'
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = tab
+
+[*.yml]
+indent_size = 2
+indent_style = space
+EC
+
+    cat > "$d/package.json" <<'JSON'
+{
+    "name": "fixture",
+    "scripts": {
+        "stylelint": "stylelint \"src/**/*.{vue,scss,css}\""
+    }
+}
+JSON
+
+    mkdir -p "$d/.github/workflows"
+    cat > "$d/.github/workflows/code-quality.yml" <<'YML'
+name: Code Quality
+on: [push]
+jobs:
+  quality:
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: fixture
+      enable-hydra-gates: true
+YML
+
+    cat > "$d/appinfo/info.xml" <<'XML'
+<?xml version="1.0"?>
+<info>
+    <id>fixture</id>
+    <version>1.0.0</version>
+    <dependencies>
+        <nextcloud min-version="32" max-version="34"/>
+    </dependencies>
+</info>
+XML
+}
+
+run() { python3 "$CHECKER" "$1" 2>&1; }
+
+echo "check_coding_standard_adoption — self-test"
+echo
+
+# ── NEGATIVE CONTROL ──────────────────────────────────────────────────────
+CLEAN="$WORK/clean"
+scaffold "$CLEAN"
+out="$(run "$CLEAN")"; rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "compliant fixture reports nothing (exit 0)"
+else
+    no "compliant fixture should be clean" "$out"
+fi
+
+if printf '%s' "$out" | grep -q 'checked [0-9]* rule'; then
+    ok "prints its terminal summary line"
+else
+    no "no 'checked N rule(s)' summary — the runner reads its absence as a wiring failure" "$out"
+fi
+
+# ── POSITIVE CONTROLS: one defect at a time ───────────────────────────────
+# Each names the defect it plants, so a broadened rule that starts matching
+# everything is caught by the negative control above rather than hidden here.
+probe() {
+    local name="$1" expect="$2"; shift 2
+    local d="$WORK/$name"
+    rm -rf "$d"; scaffold "$d"
+    ( cd "$d" && eval "$@" )
+    local o; o="$(run "$d")"
+    if printf '%s' "$o" | grep -q "FAIL ${expect}:"; then
+        ok "detects ${name} (${expect})"
+    else
+        no "did not detect ${name}; expected 'FAIL ${expect}:'" "$o"
+    fi
+}
+
+probe no-fixer-config          no-php-cs-fixer-config              'rm .php-cs-fixer.dist.php'
+probe missing-autoloader       fixer-config-missing-autoloader     "sed -i '/autoload.php/d' .php-cs-fixer.dist.php"
+probe cs-wired-to-phpcs        cs-script-wired-to-phpcs            "sed -i 's|php-cs-fixer fix --dry-run --diff|./vendor/bin/phpcs --standard=phpcs.xml|' composer.json"
+probe nc-standard-direct       nextcloud-coding-standard-declared-directly \
+                               "sed -i 's|\"conduction/coding-standard\": \"^1.0\",|\"conduction/coding-standard\": \"^1.0\", \"nextcloud/coding-standard\": \"^1.4\",|' composer.json"
+probe phpcs-not-central        phpcs-not-centralised               "sed -i 's|vendor/conduction/hydra-gates/quality-config/phpcs.xml|PEAR|' phpcs.xml"
+probe local-formatting-sniff   phpcs-declares-formatting-sniffs \
+                               "sed -i 's|</ruleset>|<rule ref=\"Generic.WhiteSpace.ScopeIndent\"/></ruleset>|' phpcs.xml"
+probe local-sniff-dir          local-custom-sniffs                 'mkdir -p phpcs-custom-sniffs/CustomSniffs'
+probe no-editorconfig          no-editorconfig                     'rm .editorconfig'
+probe editorconfig-spaces      editorconfig-not-tab                "sed -i 's|indent_style = tab|indent_style = space|' .editorconfig"
+probe unquoted-glob            stylelint-glob-unquoted             "sed -i 's|stylelint \\\\\"src/\\*\\*/\\*.{vue,scss,css}\\\\\"|stylelint src/**/*.vue src/**/*.css|' package.json"
+probe ocp-below-min            ocp-below-declared-minimum          "sed -i 's|\"nextcloud/ocp\": \"^34.0\"|\"nextcloud/ocp\": \"^31.0\"|' composer.json"
+
+probe gates-ref-pinned         gates-ref-pinned                    "printf '      hydra-gates-ref: v1.3.0\\n' >> .github/workflows/code-quality.yml"
+probe workflow-pinned          shared-workflow-pinned              "sed -i 's|quality.yml@main|quality.yml@v2.0.0|' .github/workflows/code-quality.yml"
+probe package-pinned-exact     shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"1.0.0\"|' composer.json"
+probe package-pinned-branch    shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"dev-some-branch\"|' composer.json"
+
+# ── ^1.0 IS NOT A PIN ─────────────────────────────────────────────────────
+# The rule must distinguish "floats within a major" from "frozen". If it cannot,
+# it fires on every compliant app and gets switched off.
+D="$WORK/caret"
+rm -rf "$D"; scaffold "$D"
+if run "$D" | grep -q 'FAIL shared-package-pinned:'; then
+    no "^1.0 was reported as a pin — the rule cannot tell floating from frozen"
+else
+    ok "treats ^1.0 as floating, not pinned"
+fi
+
+# ── hydra-gates-ref: main is the correct value, not a pin ─────────────────
+D="$WORK/refmain"
+rm -rf "$D"; scaffold "$D"
+printf '      hydra-gates-ref: main\n' >> "$D/.github/workflows/code-quality.yml"
+if run "$D" | grep -q 'FAIL gates-ref-pinned:'; then
+    no "hydra-gates-ref: main was reported as a pin"
+else
+    ok "accepts an explicit hydra-gates-ref: main"
+fi
+
+# ── a COMMENTED-OUT pin is not a pin ──────────────────────────────────────
+D="$WORK/commentedpin"
+rm -rf "$D"; scaffold "$D"
+printf '      # hydra-gates-ref: v1.3.0\n' >> "$D/.github/workflows/code-quality.yml"
+if run "$D" | grep -q 'FAIL gates-ref-pinned:'; then
+    no "a commented-out hydra-gates-ref was reported as a live pin"
+else
+    ok "ignores a commented-out hydra-gates-ref"
+fi
+
+# ── A COMMENTED-OUT RULE IS NOT A RULE ────────────────────────────────────
+# gate-64's defect: grepping for a string matches it inside every comment.
+D="$WORK/commented"
+rm -rf "$D"; scaffold "$D"
+sed -i 's|</ruleset>|<!-- <rule ref="Generic.WhiteSpace.ScopeIndent"/> --></ruleset>|' "$D/phpcs.xml"
+if run "$D" | grep -q 'FAIL phpcs-declares-formatting-sniffs:'; then
+    no "a COMMENTED-OUT formatting sniff was reported as live"
+else
+    ok "ignores a commented-out formatting sniff"
+fi
+
+# ── dev-master ocp is not below anything ──────────────────────────────────
+D="$WORK/devmaster"
+rm -rf "$D"; scaffold "$D"
+sed -i 's|"nextcloud/ocp": "\^34.0"|"nextcloud/ocp": "dev-master"|' "$D/composer.json"
+if run "$D" | grep -q 'FAIL ocp-below-declared-minimum:'; then
+    no "nextcloud/ocp:dev-master reported as below the declared minimum"
+else
+    ok "treats nextcloud/ocp:dev-master as tracking the tip, not as stale"
+fi
+
+# ── a crash must not read as clean ────────────────────────────────────────
+if python3 "$CHECKER" "$WORK/does-not-exist" >/dev/null 2>&1; then
+    no "a missing app root exited 0 — an unrunnable checker read as a clean repo"
+else
+    ok "a missing app root exits non-zero rather than reporting clean"
+fi
+
+echo
+echo "----------------------------------------------------------------"
+printf '%d passed, %d failed\n' "$pass" "$fail"
+echo "----------------------------------------------------------------"
+[ "$fail" -eq 0 ]

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -8166,6 +8166,51 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Gate 65: coding-standard-adoption — the app must still be on the fleet's
+# shared standard, and must not have pinned itself away from it.
+#
+# WHY THIS EXISTS
+# ---------------
+# Centralising configuration does not stop it drifting. The 18 mutually
+# different psalm.xml files measured on 2026-08-12 were all copies of something
+# that had been shared once. What stops recurrence is a check that fails when an
+# app walks away from the centre — including by freezing itself against it.
+#
+# NOT DIFF-SCOPED, deliberately. The subject is the app's standing configuration,
+# not the lines a PR touched: an app that never touches phpcs.xml again must not
+# thereby become exempt from having one. Every rule is a whole-repo property that
+# is either true today or is not.
+#
+# The checker prints one `FAIL <rule>: <detail>` per violation and a terminal
+# `checked N rule(s)`. Its ABSENCE is treated as a wiring failure rather than a
+# pass — a crashed checker and a clean repo are otherwise the same silence.
+# ---------------------------------------------------------------------------
+_csa_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-coding-standard-adoption.log
+: > "${_csa_log}"
+if [ -f composer.json ] || [ -f phpcs.xml ]; then
+    set +e
+    python3 "${SCRIPT_DIR}/lib/check_coding_standard_adoption.py" . > "${_csa_log}" 2>&1
+    _csa_rc=$?
+    set +e
+    grep -E '^FAIL ' "${_csa_log}" || true
+    if ! _helper_finished "${_csa_log}" '^checked [0-9]+ rule\(s\)$'; then
+        # A CRASH IS NOT A FINDING (.github#330).
+        _csa_why=$(head -3 "${_csa_log}" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+        _skip 65 "coding-standard-adoption" wiring "check_coding_standard_adoption.py exited ${_csa_rc} without printing its terminal 'checked N rule(s)' summary, so NO rule was evaluated and this repo's adoption of the shared standard is UNVERIFIED by this run. Checker output: ${_csa_why:-<empty>}. See ${_csa_log}."
+    elif [ "${_csa_rc}" -eq 0 ]; then
+        _pass 65 "coding-standard-adoption"
+    else
+        # Count comes off the checker's own FAIL lines, not off the exit code,
+        # so a future exit-code change cannot silently alter the number.
+        _csa_n=$(grep -cE '^FAIL ' "${_csa_log}" 2>/dev/null || true)
+        case "${_csa_n}" in ''|*[!0-9]*) _csa_n=1 ;; esac
+        _fail 65 "coding-standard-adoption" "${_csa_n} deviation(s) from the shared coding standard; see ${_csa_log}"
+    fi
+else
+    _skip 65 "coding-standard-adoption" na "no composer.json and no phpcs.xml — this repo ships no PHP for a coding standard to apply to."
+fi
+
+# ---------------------------------------------------------------------------
 # Summary + COVERAGE ACCOUNTING
 #
 # The banner used to read "ALL 63 GATES GREEN" whenever the failure count was

--- a/quality-config/README.md
+++ b/quality-config/README.md
@@ -1,0 +1,129 @@
+# quality-config — the fleet's quality configuration, in one place
+
+Every Conduction Nextcloud app runs the same PHP and frontend quality tools. Until
+now every app also carried its **own copy** of every tool's configuration. This
+directory is the single source of truth those copies are replaced by.
+
+## The drift this exists to end
+
+Measured on 2026-08-12 across the 18 core apps, reading canonical
+`ConductionNL/<app>@development` (not local checkouts). "Variants" counts distinct
+file contents after normalising away the app's own name and the `<description>`:
+
+| File | Present in | Distinct variants |
+| --- | ---: | ---: |
+| `psalm.xml` | 18 | **18** |
+| `phpstan.neon` | 18 | **18** |
+| `playwright.config.ts` | 18 | **18** |
+| `.github/workflows/code-quality.yml` | 18 | **18** |
+| `eslint.config.js` | 17 | **17** |
+| `phpmd.xml` | 18 | 15 |
+| `vitest.config.js` | 14 | 14 |
+| `stylelint.config.js` | 18 | 6 |
+| `phpcs.xml` | 18 | 6 |
+| `.prettierrc` | 14 | 1 |
+
+Two of those numbers matter more than the rest.
+
+**`phpcs.xml` has 6 variants but 14 of the 18 differ by nothing except a typo.**
+Group A (8 apps) and group B (6 apps) are byte-identical apart from one word in a
+comment — `openbuild` vs `openbuilt`. The remaining four are real: `doriath` is
+missing the `vendor-bin` exclude, `ignore_warnings_on_exit`, **and both the
+`NoLegacyServerAccessors` and `SpecTag` sniffs**; `zaakafhandelapp` demotes ten
+sniffs to warnings under a tracked debt issue; `decidesk` carries the SPDX
+`InvalidEndChar` downgrade; `openbuild` has the typo comment emptied.
+
+**`NamedParametersSniff.php` has 6 distinct versions.** The same *named* rule
+enforces six different things across the fleet. `launchpad`'s is a strict superset
+(it alone knows about `Entity` magic accessors — 525 lines); `opencatalogi`'s is a
+231-line stub with none of the scoping logic that calls `addWarning()` where every
+other copy calls `addError()`. `doriath` ships two of the three sniffs not at all.
+
+A shared rule that is copied is not a shared rule.
+
+## How an app consumes this
+
+`conduction/hydra-gates` is already a published composer package built from this
+repository, so `composer install` is the pull. No workflow change is required and
+local `composer phpcs` behaves exactly like CI — which matters, because a config
+that only CI sees becomes its own drift source.
+
+```jsonc
+// composer.json
+"require-dev": {
+    "conduction/hydra-gates": "^1.0"
+}
+```
+
+Then the app's config files shrink to the stubs in [`stubs/`](stubs/):
+
+```xml
+<!-- phpcs.xml -->
+<ruleset name="myapp">
+    <file>lib</file>
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpcs.xml"/>
+</ruleset>
+```
+
+### Two mechanics that were measured, not assumed
+
+Both were established with a positive control against phpcs 3.13.6 and 4.0.4 in a
+`php:8.3-cli` container before this directory was written.
+
+1. **Rules and custom sniffs DO inherit through `<rule ref>`, including sniff
+   files referenced by a path relative to the central ruleset.** The first attempt
+   at this fixture registered only 1 sniff instead of 2 and looked like proof that
+   central sniffs cannot work. It was the fixture that was wrong — a custom sniff
+   must live at `<Standard>/Sniffs/<Category>/<Name>Sniff.php` with a matching
+   class name. With the real layout, `phpcs --standard=phpcs.xml -e` through the
+   stub lists the custom sniff and it fires.
+
+2. **`<file>` must stay in the app stub.** phpcs resolves `<file>` relative to the
+   directory of the ruleset that *declares* it, and it propagates through
+   `<rule ref>`. A `<file>lib</file>` in this directory resolves to
+   `quality-config/lib` inside `vendor/` and the run dies with
+   `ERROR: The file "lib" does not exist` (exit 3) in every consuming app.
+
+## What is here
+
+| Path | Replaces, per app |
+| --- | --- |
+| `phpcs.xml` | the whole ruleset |
+| `phpcs-custom-sniffs/` | 3 sniffs, canonically `launchpad`'s NamedParameters + `openregister`'s SpecTag and NoLegacyServerAccessors |
+| `phpmd.xml`, `phpmd-unusedparams.xml` | both PHPMD legs |
+| `phpstan-base.neon` | everything except the app's own baseline and app-only ignores |
+| `frontend/eslint.config.js` | the flat config (see caveat below) |
+| `frontend/stylelint.config.js` | the whole config — 8 of 18 apps already match it byte-for-byte |
+| `stubs/` | what an app's file becomes after adoption |
+
+## Not yet centralised, and why
+
+**`psalm.xml` — Psalm has no config inheritance.** There is no `include`,
+`extends` or `ref` in Psalm's config format, so the 18-way drift cannot be fixed
+by a stub the way phpcs and phpstan can. The two available routes are a generator
+(`composer psalm:sync-config`) or a drift *gate* that diffs the app's file against
+a canonical template and fails on undeclared deviation. The gate is the better
+one: it makes divergence visible without making the file un-editable.
+
+This matters more than the drift count suggests. Every app suppresses the same
+~34 issue types, and the list includes `InvalidArgument`, `InvalidReturnType`,
+`InvalidMethodCall`, `UndefinedInterfaceMethod`, `TypeDoesNotContainType` and
+`InvalidArrayOffset` — the checks that find bugs. `UndefinedClass` is suppressed
+for the entire `OCP\` namespace. At `errorLevel="4"` with those off, a green Psalm
+leg is close to a statement that the file parses.
+
+**`frontend/` is a template, not yet a live import.** ESLint flat config resolves
+plugins relative to the config file, so a config shipped in `vendor/` cannot load
+`@nextcloud/eslint-config` from the app's `node_modules`. The frontend needs an
+**npm** channel, and the right home is `@conduction/nextcloud-vue`, which all 18
+apps already depend on and which already exports `/eslint`. Until that lands,
+these two files are what the rollout copies, and the drift gate is what keeps them
+copied correctly.
+
+## Where the tabs-versus-spaces question is answered
+
+`phpcs.xml` sets `indent=4, tabIndent=false`. Nextcloud core sets `"\t"`. That is
+a deliberate divergence with consequences a contributor needs to know about before
+their first PR; it is written up in
+[Way of Work → CI/CD](https://docs.conduction.nl/WayOfWork/ci-cd/) rather than
+here, because it is a policy, not a setting.

--- a/quality-config/editorconfig
+++ b/quality-config/editorconfig
@@ -1,0 +1,36 @@
+# https://editorconfig.org
+
+# SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.svg]
+insert_final_newline = false
+
+[package*.json]
+indent_size = 2
+indent_style = space
+
+[build/psalm-baseline.xml]
+indent_size = 2
+indent_style = space
+
+[config/*config.php]
+indent_size = 2
+indent_style = space

--- a/quality-config/frontend/eslint.config.js
+++ b/quality-config/frontend/eslint.config.js
@@ -1,0 +1,121 @@
+/**
+ * ESLint flat config for OpenRegister.
+ *
+ * Layered as:
+ *   1. `@nextcloud` (v8 base, via FlatCompat) — the fleet's baseline style rules.
+ *   2. `conductionVue3Fixes` from `@conduction/nextcloud-vue/eslint`, spread
+ *      LAST so it wins.
+ *   3. this app's own overrides (in layer 1's `rules` block).
+ *
+ * ⚠️ Layer 2 is load-bearing, not decoration. Without it not one
+ * `vue/no-deprecated-*` rule is active, and every surviving Vue-2 idiom
+ * (`beforeDestroy`, `.sync`, `$listeners`) lints clean while being silently
+ * ignored at runtime — openconnector finished its Vue 3 migration with four
+ * live `beforeDestroy` memory leaks exactly that way.
+ *
+ * ⚠️ `@nextcloud/eslint-config/vue3` is deliberately NOT extended directly: it
+ * sets `parserOptions.parser` to a bare string, which routes template
+ * expressions through `@typescript-eslint/parser`, drops `v-for` scope, and
+ * manufactures hundreds of bogus `vue/valid-v-for` errors.
+ *
+ * ⚠️ `conductionVue3Fixes` is an ARRAY of configs and must be SPREAD, not
+ * pushed as a single object. It registers no plugins, which is why it layers
+ * cleanly on top of the `@nextcloud` base.
+ */
+const {
+	defineConfig,
+} = require('@eslint/config-helpers')
+
+const js = require('@eslint/js')
+
+const {
+	FlatCompat,
+} = require('@eslint/eslintrc')
+
+const { conductionVue3Fixes } = require('@conduction/nextcloud-vue/eslint')
+
+const compat = new FlatCompat({
+	baseDirectory: __dirname,
+	recommendedConfig: js.configs.recommended,
+	allConfig: js.configs.all,
+})
+
+module.exports = defineConfig([{
+	extends: compat.extends('@nextcloud'),
+
+	settings: {
+		'import/resolver': {
+			alias: {
+				map: [
+					['@', './src'],
+					['@floating-ui/dom-actual', './node_modules/@floating-ui/dom'],
+					['@conduction/nextcloud-vue', '../nextcloud-vue/src'],
+				],
+				extensions: ['.js', '.ts', '.vue', '.json', '.css'],
+			},
+		},
+	},
+
+	rules: {
+		// Allow unused i18n functions (t, n) — imported for future translation wiring
+		'no-unused-vars': ['error', { varsIgnorePattern: '^(t|n)$', argsIgnorePattern: '^_' }],
+		'jsdoc/require-jsdoc': 'off',
+		// `@spec` is the ADR-003 spec-traceability tag (links code to OpenSpec change tasks).
+		// Register it so jsdoc/check-tag-names does not flag it as an unknown tag.
+		'jsdoc/check-tag-names': ['warn', { definedTags: ['spec'] }],
+		'vue/first-attribute-linebreak': 'off',
+		'@typescript-eslint/no-explicit-any': 'off',
+		'n/no-missing-import': 'off',
+		'import/namespace': 'off', // disable namespace checking to avoid parser requirement
+		'import/default': 'off', // disable default import checking to avoid parser requirement
+		'import/no-named-as-default': 'off', // disable named-as-default checking to avoid parser requirement
+		'import/no-named-as-default-member': 'off', // disable named-as-default-member checking to avoid parser requirement
+	},
+},
+// Spread LAST so the Vue 3 rules win over the Vue 2 base.
+...conductionVue3Fixes,
+{
+	name: 'openregister/vue3-base-rule-corrections',
+	files: ['**/*.vue'],
+	rules: {
+		// ⚠️ INVERTED VUE-2 RULE. `vue/no-multiple-template-root` forbids what
+		// Vue 3 requires: fragments. Removing this app's `vue-frag` `<Fragment>`
+		// wrappers (which existed ONLY to fake fragments under Vue 2) legitimately
+		// produces multi-root templates in Modals.vue, ViewSource.vue and
+		// RegisterSideBar.vue.
+		//
+		// It is armed by the `@nextcloud` v8 base and `conductionVue3Fixes` does
+		// NOT disable it, even though it already disables the other two rules of
+		// exactly this class (`vue/no-v-model-argument`,
+		// `vue/no-v-for-template-key`). Reported upstream — remove this override
+		// once the shared preset covers it.
+		'vue/no-multiple-template-root': 'off',
+
+		// `vue/v-on-event-hyphenation` would rewrite `@update:tokenName` to
+		// `@update:token-name`. That only keeps working because Vue 3's `emit()`
+		// falls back to a hyphenated lookup — and that fallback does NOT apply to
+		// components reading `props['onUpdate:x']` directly via `useModel`, which
+		// is why the shared preset already ignores `update:modelValue`.
+		//
+		// Every event below is a `update:*` component event emitted with an exact
+		// camelCase name (verified at each `$emit` site), so the camelCase
+		// listener is the spelling that matches the emit rather than the spelling
+		// that survives a fallback. Same rationale as the preset's own exception,
+		// extended to this app's events.
+		//
+		// The right fix is for the preset to ignore `update:*` generally;
+		// reported upstream.
+		'vue/v-on-event-hyphenation': ['error', 'always', {
+			autofix: false,
+			ignore: [
+				'update:modelValue',
+				'update:showDetails',
+				'update:riskLevel',
+				'update:tokenName',
+				'update:tokenExpires',
+				'update:confirmUsername',
+			],
+		}],
+	},
+},
+])

--- a/quality-config/frontend/stylelint.config.js
+++ b/quality-config/frontend/stylelint.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	extends: '@nextcloud/stylelint-config',
+	rules: {
+		'selector-pseudo-element-no-unknown': [true, {
+			ignorePseudoElements: ['v-deep'],
+		}],
+	},
+}

--- a/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the
+ * requirement the code exists to satisfy:
+ *
+ *     @spec openspec/specs/{capability}/spec.md#requirement-{slug}
+ *
+ * POINT AT THE CANONICAL SPEC, NOT AT A CHANGE DIRECTORY.
+ *
+ * This guidance used to read `openspec/changes/{change-name}/tasks.md#task-N`,
+ * and tags written to it dangle by construction: `openspec/changes/<name>/` is
+ * temporary — archiving moves it to `openspec/changes/archive/<date>-<name>/`,
+ * and renaming or dropping a change removes the target outright. Gate-46
+ * (spec-anchor-existence) then reports the tag, and the developer who wrote it
+ * had followed this sniff's own instruction. Measured on portaliq 2026-08-08:
+ * 100 unresolved targets, with 260 of its 385 live tags pointing into a change
+ * directory. The cross-repo measurement is in ConductionNL/.github#228.
+ *
+ * An `openspec/changes/...` target is still ACCEPTED — this sniff only checks
+ * that a tag is PRESENT, and gate-46 resolves archived paths — but it is no
+ * longer what this sniff tells you to write.
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/specs/{capability}/spec.md#requirement-{slug}, not a change dir';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag — link back to openspec/specs/{capability}/spec.md#requirement-{slug}';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php
+++ b/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php
@@ -1,0 +1,525 @@
+<?php
+/**
+ * Enforce named parameters for all calls to internal (our own) code.
+ *
+ * Requires named arguments for:
+ * - $this->method(name: $value)
+ * - self::method(name: $value) / static::method(name: $value)
+ * - parent::method(name: $value)
+ * - new OurClass(name: $value) — classes from the same app namespace
+ *
+ * Allows positional arguments for external code:
+ * - PHP built-in functions (strlen, array_map, sprintf, etc.)
+ * - Nextcloud/third-party method calls ($variable->method() where $variable !== $this)
+ * - Any call we cannot determine is "our code"
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NamedParametersSniff — enforces named parameters for internal code.
+ */
+class NamedParametersSniff implements Sniff
+{
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_STRING];
+
+    }//end register()
+
+
+    /**
+     * Process a T_STRING token — check if it's a function/method call to our code.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_STRING token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $functionName = $tokens[$stackPtr]['content'];
+
+        // Must be followed by ( to be a function/method call.
+        $openParen = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        // Skip function/method definitions.
+        if ($this->isFunctionDefinition(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        // Only check calls to our own code.
+        if ($this->isInternalCall(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        // Skip Entity magic setter/getter calls. Nextcloud's OCP\AppFramework\Db\Entity
+        // routes set*/get*/is* through __call which uses $args[0] and breaks with named
+        // parameters. Files extending Entity must use positional args for these.
+        if ($this->isEntityMagicAccessor(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        // Get the closing parenthesis.
+        if (isset($tokens[$openParen]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $closeParen = $tokens[$openParen]['parenthesis_closer'];
+
+        // Check if there are any arguments.
+        $firstContent = $phpcsFile->findNext(
+            types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+            start: ($openParen + 1),
+            end: $closeParen,
+            exclude: true
+        );
+        if ($firstContent === false) {
+            return;
+        }
+
+        // Check if all arguments use named parameters.
+        if ($this->hasUnnamedArguments(phpcsFile: $phpcsFile, openParen: $openParen, closeParen: $closeParen) === true) {
+            $error = 'All arguments in calls to internal code must use named parameters: %s(paramName: $value)';
+            $phpcsFile->addError($error, $stackPtr, 'RequireNamedParameters', [$functionName]);
+        }
+
+    }//end process()
+
+
+    /**
+     * Check whether the call at $stackPtr is an Entity magic accessor (setX/getX/isX)
+     * inside a class that extends OCP\AppFramework\Db\Entity.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the method-name T_STRING.
+     *
+     * @return bool True if this is a magic Entity accessor call.
+     */
+    private function isEntityMagicAccessor(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+        $name   = $tokens[$stackPtr]['content'];
+
+        // Only setX/getX/isX names with at least one trailing capital qualify.
+        if (preg_match(pattern: '/^(set|get|is)[A-Z]/', subject: $name) !== 1) {
+            return false;
+        }
+
+        // Must be a $this->name() call (already established by isInternalCall, but
+        // re-check defensively because we also want to ignore self::set*() etc.).
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false || $tokens[$prev]['code'] !== T_OBJECT_OPERATOR) {
+            return false;
+        }
+
+        return $this->classExtendsEntity(phpcsFile: $phpcsFile);
+
+    }//end isEntityMagicAccessor()
+
+
+    /**
+     * Check if the file's primary class extends OCP\AppFramework\Db\Entity.
+     *
+     * Considers both fully-qualified and use-aliased "Entity" parents.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True when the class extends Entity.
+     */
+    private function classExtendsEntity(File $phpcsFile): bool
+    {
+        $tokens   = $phpcsFile->getTokens();
+        $classPtr = $phpcsFile->findNext(types: T_CLASS, start: 0);
+        if ($classPtr === false) {
+            return false;
+        }
+
+        $extendsPtr = $phpcsFile->findNext(
+            types: T_EXTENDS,
+            start: $classPtr,
+            end: ($tokens[$classPtr]['scope_opener'] ?? $phpcsFile->numTokens)
+        );
+        if ($extendsPtr === false) {
+            return false;
+        }
+
+        // Read the parent class identifier (handles namespaced parents like \OCP\…\Entity).
+        $parentName = '';
+        $j          = ($extendsPtr + 1);
+        $end        = ($tokens[$classPtr]['scope_opener'] ?? $phpcsFile->numTokens);
+        while ($j < $end) {
+            $code = $tokens[$j]['code'];
+            if ($code === T_OPEN_CURLY_BRACKET || $code === T_IMPLEMENTS || $code === T_COMMA) {
+                break;
+            }
+
+            if ($code !== T_WHITESPACE && $code !== T_COMMENT && $code !== T_DOC_COMMENT) {
+                $parentName .= $tokens[$j]['content'];
+            }
+
+            $j++;
+        }
+
+        $parentName = trim(string: $parentName);
+        if ($parentName === '') {
+            return false;
+        }
+
+        // Direct fully-qualified match.
+        if ($parentName === '\OCP\AppFramework\Db\Entity'
+            || $parentName === 'OCP\AppFramework\Db\Entity'
+        ) {
+            return true;
+        }
+
+        // Aliased: parent is "Entity" and a use statement imports it from the OCP path.
+        if ($parentName === 'Entity') {
+            for ($i = 0; $i < $classPtr; $i++) {
+                if ($tokens[$i]['code'] !== T_USE) {
+                    continue;
+                }
+
+                $usePath = $this->getUseStatementPath(phpcsFile: $phpcsFile, usePtr: $i);
+                if ($usePath === 'OCP\AppFramework\Db\Entity') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end classExtendsEntity()
+
+
+    /**
+     * Check if the T_STRING at $stackPtr is part of a function/method definition (not a call).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_STRING token.
+     *
+     * @return bool True if this is a definition, false if it's a call.
+     */
+    private function isFunctionDefinition(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+        $prev   = ($stackPtr - 1);
+        while ($prev >= 0) {
+            $code = $tokens[$prev]['code'];
+            if ($code === T_FUNCTION) {
+                return true;
+            }
+
+            // Stop at statement/block boundaries.
+            if ($code === T_SEMICOLON
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+            ) {
+                return false;
+            }
+
+            $prev--;
+        }
+
+        return false;
+
+    }//end isFunctionDefinition()
+
+
+    /**
+     * Determine if the function/method call at $stackPtr is to our own code.
+     *
+     * Matches:
+     * - $this->method()
+     * - self::method() / static::method() / parent::method()
+     * - new OurClass() where OurClass is from the same app namespace
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_STRING (function/method name).
+     *
+     * @return bool True if call is to internal code.
+     */
+    private function isInternalCall(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false) {
+            return false;
+        }
+
+        $prevCode = $tokens[$prev]['code'];
+
+        // Case 1: $this->method().
+        if ($prevCode === T_OBJECT_OPERATOR) {
+            $beforeArrow = $phpcsFile->findPrevious(
+                types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                start: ($prev - 1),
+                end: null,
+                exclude: true
+            );
+            return ($beforeArrow !== false
+                && $tokens[$beforeArrow]['code'] === T_VARIABLE
+                && $tokens[$beforeArrow]['content'] === '$this');
+        }
+
+        // Case 2: self::method() / static::method() / parent::method().
+        if ($prevCode === T_DOUBLE_COLON) {
+            $beforeColon = $phpcsFile->findPrevious(
+                types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                start: ($prev - 1),
+                end: null,
+                exclude: true
+            );
+            return ($beforeColon !== false
+                && in_array($tokens[$beforeColon]['code'], [T_SELF, T_STATIC, T_PARENT], true) === true);
+        }
+
+        // Case 3: new OurClass().
+        if ($prevCode === T_NEW) {
+            return $this->isClassFromOurNamespace(phpcsFile: $phpcsFile, classNamePtr: $stackPtr);
+        }
+
+        return false;
+
+    }//end isInternalCall()
+
+
+    /**
+     * Check if the class at $classNamePtr is from the same app namespace as the current file.
+     *
+     * Compares the class's use-import path against the file's OCA\AppName\ prefix.
+     *
+     * @param File $phpcsFile    The file being scanned.
+     * @param int  $classNamePtr Position of the class name token.
+     *
+     * @return bool True if the class is from our app namespace.
+     */
+    private function isClassFromOurNamespace(File $phpcsFile, int $classNamePtr): bool
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $className = $tokens[$classNamePtr]['content'];
+
+        // Find the file's namespace declaration.
+        $appPrefix = $this->getAppNamespacePrefix(phpcsFile: $phpcsFile);
+        if ($appPrefix === null) {
+            return false;
+        }
+
+        // Scan use-statements for an import matching this class name from our namespace.
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === T_USE) {
+                $usePath = $this->getUseStatementPath(phpcsFile: $phpcsFile, usePtr: $i);
+                if ($usePath === null) {
+                    continue;
+                }
+
+                // Extract the imported short name (last segment).
+                $segments     = explode(separator: '\\', string: $usePath);
+                $importedName = end($segments);
+
+                if ($importedName === $className
+                    && str_starts_with(haystack: $usePath, needle: $appPrefix) === true
+                ) {
+                    return true;
+                }
+            }//end if
+
+            // Stop scanning after the class declaration.
+            if (in_array($tokens[$i]['code'], [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], true) === true) {
+                break;
+            }
+        }//end for
+
+        return false;
+
+    }//end isClassFromOurNamespace()
+
+
+    /**
+     * Get the app namespace prefix (e.g., "OCA\LaunchPad") from the file's namespace declaration.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return string|null The app prefix or null if not found.
+     */
+    private function getAppNamespacePrefix(File $phpcsFile): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === T_NAMESPACE) {
+                $namespace = '';
+                $j         = ($i + 1);
+                while ($j < $phpcsFile->numTokens && $tokens[$j]['code'] !== T_SEMICOLON) {
+                    if ($tokens[$j]['code'] !== T_WHITESPACE) {
+                        $namespace .= $tokens[$j]['content'];
+                    }
+
+                    $j++;
+                }
+
+                // Extract first two segments: OCA\AppName.
+                $parts = explode(separator: '\\', string: $namespace);
+                if (count($parts) >= 2) {
+                    return $parts[0].'\\'.$parts[1];
+                }
+
+                return null;
+            }//end if
+        }//end for
+
+        return null;
+
+    }//end getAppNamespacePrefix()
+
+
+    /**
+     * Extract the full path from a use-statement starting at $usePtr.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $usePtr    Position of the T_USE token.
+     *
+     * @return string|null The use path or null if parsing failed.
+     */
+    private function getUseStatementPath(File $phpcsFile, int $usePtr): ?string
+    {
+        $tokens  = $phpcsFile->getTokens();
+        $usePath = '';
+        $j       = ($usePtr + 1);
+        while ($j < $phpcsFile->numTokens) {
+            $code = $tokens[$j]['code'];
+            if ($code === T_SEMICOLON || $code === T_OPEN_CURLY_BRACKET) {
+                break;
+            }
+
+            // Stop at 'as' keyword (aliases) — use the path before it.
+            if ($code === T_AS) {
+                break;
+            }
+
+            if ($code !== T_WHITESPACE) {
+                $usePath .= $tokens[$j]['content'];
+            }
+
+            $j++;
+        }
+
+        $usePath = trim(string: $usePath);
+        return ($usePath !== '') ? $usePath : null;
+
+    }//end getUseStatementPath()
+
+
+    /**
+     * Check if the arguments between $openParen and $closeParen contain any unnamed arguments.
+     *
+     * An argument is "named" if its first significant token is followed by T_COLON.
+     * Handles nested parentheses, brackets, and braces correctly.
+     *
+     * @param File $phpcsFile  The file being scanned.
+     * @param int  $openParen  Position of the opening parenthesis.
+     * @param int  $closeParen Position of the closing parenthesis.
+     *
+     * @return bool True if any argument is positional (unnamed).
+     */
+    private function hasUnnamedArguments(File $phpcsFile, int $openParen, int $closeParen): bool
+    {
+        $tokens         = $phpcsFile->getTokens();
+        $parenDepth     = 0;
+        $bracketDepth   = 0;
+        $braceDepth     = 0;
+        $atArgumentStart = true;
+
+        for ($i = ($openParen + 1); $i < $closeParen; $i++) {
+            $code = $tokens[$i]['code'];
+
+            // Track nesting depth.
+            if ($code === T_OPEN_PARENTHESIS) {
+                $parenDepth++;
+            } elseif ($code === T_CLOSE_PARENTHESIS) {
+                $parenDepth--;
+            } elseif ($code === T_OPEN_SHORT_ARRAY || $code === T_OPEN_SQUARE_BRACKET) {
+                $bracketDepth++;
+            } elseif ($code === T_CLOSE_SHORT_ARRAY || $code === T_CLOSE_SQUARE_BRACKET) {
+                $bracketDepth--;
+            } elseif ($code === T_OPEN_CURLY_BRACKET) {
+                $braceDepth++;
+            } elseif ($code === T_CLOSE_CURLY_BRACKET) {
+                $braceDepth--;
+            }
+
+            // Only examine tokens at the top level of the argument list.
+            if ($parenDepth > 0 || $bracketDepth > 0 || $braceDepth > 0) {
+                continue;
+            }
+
+            // Comma at top level → next argument starts.
+            if ($code === T_COMMA) {
+                $atArgumentStart = true;
+                continue;
+            }
+
+            // Skip whitespace and comments at argument start.
+            if ($atArgumentStart === true
+                && in_array($code, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true) === true
+            ) {
+                continue;
+            }
+
+            if ($atArgumentStart === true) {
+                $atArgumentStart = false;
+
+                // Skip spread operator (...$args).
+                if ($code === T_ELLIPSIS) {
+                    continue;
+                }
+
+                // Check if this argument is named: token followed by ':'.
+                $nextNonWs = $phpcsFile->findNext(
+                    types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                    start: ($i + 1),
+                    end: $closeParen,
+                    exclude: true
+                );
+
+                $isNamed = ($nextNonWs !== false && $tokens[$nextNonWs]['code'] === T_COLON);
+
+                if ($isNamed === false) {
+                    return true;
+                }
+            }//end if
+        }//end for
+
+        return false;
+
+    }//end hasUnnamedArguments()
+
+
+}//end class

--- a/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/quality-config/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/quality-config/phpcs-custom-sniffs/CustomSniffs/ruleset.xml
+++ b/quality-config/phpcs-custom-sniffs/CustomSniffs/ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="CustomSniffs">
+    <description>Conduction custom PHPCS sniffs, shared by every fleet app.</description>
+
+    <rule ref="CustomSniffs.Functions.NamedParameters"/>
+    <rule ref="CustomSniffs.Commenting.SpecTag"/>
+    <rule ref="CustomSniffs.Nextcloud.NoLegacyServerAccessors"/>
+</ruleset>

--- a/quality-config/phpcs.xml
+++ b/quality-config/phpcs.xml
@@ -36,7 +36,7 @@
 
     <!-- Surface warnings (e.g. SpecTagSniff) in the log without failing the build.
          The shared quality workflow ALSO maps phpcs exit 1 to success, so this is
-         belt and braces; do not add `--warning-severity=0` to the composer script,
+         belt and braces; do not add a `warning-severity=0` flag to the composer script,
          which suppresses the reporting as well and makes the warnings invisible. -->
     <config name="ignore_warnings_on_exit" value="1"/>
 

--- a/quality-config/phpcs.xml
+++ b/quality-config/phpcs.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Conduction" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>
+        The Conduction PHP coding standard. ONE copy, here. Apps consume it through a
+        four-line stub phpcs.xml; nothing below is duplicated into an app repository.
+
+        DELIBERATE DIVERGENCE FROM NEXTCLOUD — read before changing an indentation,
+        brace or spacing rule. Nextcloud core formats PHP with php-cs-fixer and
+        `nextcloud/coding-standard`, which sets TABS (`Config::setIndent("\t")`) and
+        same-line opening braces. This ruleset is PEAR-derived and sets FOUR SPACES
+        with next-line braces for classes and functions. The two cannot both be
+        satisfied by the same file.
+
+        The divergence is a choice, not an accident, and it is documented at
+        https://docs.conduction.nl/WayOfWork/ci-cd/. What matters operationally is
+        that ONLY ONE of the two formatters may be wired up in an app. See the
+        `cs:check` / `cs:fix` note in that page: those two script names belong to
+        nextcloud/coding-standard, and in this fleet they are aliases for PHPCS.
+    </description>
+
+    <!-- NO <file> ELEMENT HERE, AND THAT IS LOAD-BEARING.
+         PHPCS resolves <file> relative to the directory of the ruleset that
+         DECLARES it, not to the working directory, and it DOES propagate through
+         `<rule ref>`. A `<file>lib</file>` here therefore resolves to
+         <package>/quality-config/lib in every consuming app and phpcs exits 3
+         with `The file "lib" does not exist` — measured, phpcs 3.13.6 and 4.0.4.
+         The scanned tree is an app-level fact; the app stub declares it. -->
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/
+         (openbuild) keep it out of lint scope; a no-op everywhere else. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface warnings (e.g. SpecTagSniff) in the log without failing the build.
+         The shared quality workflow ALSO maps phpcs exit 1 to success, so this is
+         belt and braces; do not add `--warning-severity=0` to the composer script,
+         which suppresses the reporting as well and makes the warnings invisible. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="parallel" value="75"/>
+    <arg name="extensions" value="php"/>
+    <arg value="p"/>
+
+    <!-- Don't hide tokenizer exceptions -->
+    <rule ref="Internal.Tokenizer.Exception">
+        <type>error</type>
+    </rule>
+
+    <!-- Include the whole PEAR standard -->
+    <rule ref="PEAR">
+        <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
+        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
+        <exclude name="PEAR.Commenting.ClassComment"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+        <exclude name="PEAR.Commenting.InlineComment"/>
+        <!-- Exclude indentation rules we'll configure separately -->
+        <exclude name="PEAR.WhiteSpace.ScopeIndent"/>
+    </rule>
+
+    <!-- Include some sniffs from other standards that don't conflict with PEAR -->
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+    <rule ref="Squiz.ControlStructures.ControlSignature"/>
+    <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
+    <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
+    <rule ref="Squiz.Commenting.BlockComment"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
+    <rule ref="Squiz.Commenting.InlineComment"/>
+    <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
+    <rule ref="Squiz.Commenting.PostStatementComment"/>
+    <rule ref="Squiz.Commenting.VariableComment"/>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+    <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="spacingAfterLast" value="0"/>
+            <property name="spacingBeforeFirst" value="0"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Commenting.Todo">
+        <exclude name="Generic.Commenting.Todo"/>
+    </rule>
+    <rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="150"/>
+            <property name="absoluteLineLimit" value="150"/>
+        </properties>
+    </rule>
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
+    <rule ref="PSR2.Classes.PropertyDeclaration"/>
+    <rule ref="PSR2.Methods.MethodDeclaration"/>
+    <rule ref="PSR2.Files.EndFileNewline"/>
+    <rule ref="PSR12.Files.OpenTag"/>
+    <rule ref="Zend.Files.ClosingTag"/>
+
+    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure">
+        <properties>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- We use custom indent rules for arrays -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+
+    <!-- Selectively include array rules, excluding alignment rules -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration">
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNewLine"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+    </rule>
+
+    <!-- Check var names, but we don't want leading underscores for private vars -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Only one argument per line in multi-line function calls -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="false"/>
+            <property name="indent" value="8"/>
+            <property name="requiredSpacesAfterOpen" value="0"/>
+            <property name="requiredSpacesBeforeClose" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Disable the indentation rule for multiline function declarations -->
+    <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Disable the opening placement for multiline arrays -->
+    <rule ref="PEAR.Functions.FunctionCallSignature.OpeningIndent">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Set standard indentation but don't apply it to function parameters.
+         FOUR SPACES, tabIndent=false. This is the line that diverges from
+         Nextcloud core; see the <description> above. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="4"/>
+            <property name="tabIndent" value="false"/>
+            <property name="ignoreIndentationTokens" type="array">
+                <element value="T_FUNCTION"/>
+                <element value="T_CLOSURE"/>
+                <element value="T_USE"/>
+                <element value="T_PRIVATE"/>
+                <element value="T_PROTECTED"/>
+                <element value="T_PUBLIC"/>
+                <element value="T_READONLY"/>
+                <element value="T_ARRAY"/>
+                <element value="T_OPEN_SHORT_ARRAY"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Have 12 chars padding maximum and always show as errors -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="12"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Ban some functions -->
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array">
+                <element key="sizeof" value="count"/>
+                <element key="delete" value="unset"/>
+                <element key="print" value="echo"/>
+                <element key="is_null" value="null"/>
+                <element key="create_function" value="null"/>
+                <element key="var_dump" value="null"/>
+                <element key="die" value="null"/>
+                <element key="error_log" value="null"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Private methods MUST not be prefixed with an underscore -->
+    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+        <type>error</type>
+    </rule>
+
+    <!-- Private properties MUST not be prefixed with an underscore -->
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+        <type>error</type>
+    </rule>
+
+    <!--
+        InvalidEndChar demands that every inline comment end in `.`, `!` or `?`.
+        Every occurrence in a fleet lib/ tree is the REUSE-mandated SPDX header
+
+            // SPDX-License-Identifier: EUPL-1.2
+
+        whose value is a machine-parsed SPDX expression: a trailing full stop
+        makes it a DIFFERENT, invalid identifier and breaks REUSE compliance.
+        The two requirements are in direct conflict and REUSE wins.
+
+        Recorded as a WARNING rather than left to be inherited, because the state
+        it preserves used to be accidental. Under php_codesniffer 3.13.5 these
+        findings were warnings, so `composer phpcs` exited 1 and the gate passed.
+        3.13.6 — adopted to clear CVE-2026-67434 — reclassifies them as errors,
+        so the same unchanged code exits 2 and the gate fails. Nothing about the
+        code changed; only the tool's severity mapping did. Declaring the posture
+        here makes it explicit and version-independent.
+
+        Scope is deliberately narrow: only InvalidEndChar is downgraded. Every
+        other Squiz.Commenting.InlineComment sniff (WrongStyle, NotCapital,
+        SpacingBefore, Empty, …) still fails the build as an error.
+
+        First discovered and fixed in decidesk; hoisted here so the other 17 apps
+        do not each rediscover it on their next php_codesniffer bump.
+    -->
+    <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+        <type>warning</type>
+    </rule>
+
+    <!-- Explicitly exclude other rules that might conflict -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PEAR.WhiteSpace.ScopeIndent.Incorrect">
+        <severity>0</severity>
+    </rule>
+
+    <!-- ── Conduction custom sniffs ────────────────────────────────────────
+         Paths are relative to THIS file, so they resolve wherever the package
+         is checked out or vendored. An app stub must not repeat them. -->
+
+    <!-- Enforce named parameters on internal calls. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query(), removed in
+         Nextcloud 34. This sniff exists because static analysis CANNOT see the
+         removal: every app pins nextcloud/ocp to a major below its declared
+         min-version, so psalm has no NC34 API surface to compare against. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag
+         (hydra ADR-003). Warnings, not errors, so CI surfaces the gap without
+         blocking merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
+    </rule>
+
+</ruleset>

--- a/quality-config/phpcs.xml
+++ b/quality-config/phpcs.xml
@@ -1,27 +1,50 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Conduction" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>
-        The Conduction PHP coding standard. ONE copy, here. Apps consume it through a
-        four-line stub phpcs.xml; nothing below is duplicated into an app repository.
+        The Conduction PHP_CodeSniffer ruleset — SEMANTICS ONLY.
 
-        DELIBERATE DIVERGENCE FROM NEXTCLOUD — read before changing an indentation,
-        brace or spacing rule. Nextcloud core formats PHP with php-cs-fixer and
-        `nextcloud/coding-standard`, which sets TABS (`Config::setIndent("\t")`) and
-        same-line opening braces. This ruleset is PEAR-derived and sets FOUR SPACES
-        with next-line braces for classes and functions. The two cannot both be
-        satisfied by the same file.
+        FORMATTING IS NOT THIS FILE'S JOB. php-cs-fixer owns it, via
+        conduction/coding-standard, which extends nextcloud/coding-standard and
+        may only ADD to it. Conduction code must pass Nextcloud's own standard
+        unchanged; we may be stricter, never different.
 
-        The divergence is a choice, not an accident, and it is documented at
-        https://docs.conduction.nl/WayOfWork/ci-cd/. What matters operationally is
-        that ONLY ONE of the two formatters may be wired up in an app. See the
-        `cs:check` / `cs:fix` note in that page: those two script names belong to
-        nextcloud/coding-standard, and in this fleet they are aliases for PHPCS.
+        Every whitespace, brace, indentation and alignment sniff has been
+        removed from this ruleset, and that is load-bearing rather than tidy.
+        Measured 2026-08-12: php-cs-fixer was run over openregister's 1,427
+        files and the previous PEAR-derived version of this ruleset was then
+        run over the RESULT. It produced 111,932 findings — 111,747 of them
+        auto-fixable formatting, i.e. this file arguing with the formatter:
+
+          Generic.WhiteSpace.DisallowTabIndent            62,123
+          Generic.WhiteSpace.ScopeIndent                  35,030
+          Generic.Arrays.ArrayIndent                       3,726
+          Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned 2,259
+          PEAR.Commenting.FunctionComment (param spacing)  2,797
+          PEAR.Functions.FunctionDeclaration (indent+brace) 2,576
+          Generic.Formatting.MultipleStatementAlignment    1,132
+          Generic.Formatting.SpaceAfterCast                  909
+          Squiz.Strings.ConcatenationSpacing                  534
+          PEAR.Classes.ClassDeclaration.OpenBraceNewLine      200
+          Squiz.ControlStructures.ElseIfDeclaration            31
+
+        That last one is the shape of the whole problem: Squiz's sniff FORBIDS
+        the `elseif` keyword that Nextcloud's `elseif` fixer REQUIRES. Two tools
+        cannot both be right about the same token, so only one of them gets an
+        opinion about tokens.
+
+        What survived that run is exactly what stays here: 185 findings, all
+        semantic — the @spec sniff, the 150-character line limit, and the SPDX
+        end-char exception. The named-parameters and legacy-accessor sniffs fired
+        zero times, which is what "stricter but compatible" looks like when it is
+        true.
+
+        See https://docs.conduction.nl/WayOfWork/ci-cd/
     </description>
 
     <!-- NO <file> ELEMENT HERE, AND THAT IS LOAD-BEARING.
          PHPCS resolves <file> relative to the directory of the ruleset that
-         DECLARES it, not to the working directory, and it DOES propagate through
-         `<rule ref>`. A `<file>lib</file>` here therefore resolves to
+         DECLARES it, not to the working directory, and it DOES propagate
+         through `<rule ref>`. A `<file>lib</file>` here resolves to
          <package>/quality-config/lib in every consuming app and phpcs exits 3
          with `The file "lib" does not exist` — measured, phpcs 3.13.6 and 4.0.4.
          The scanned tree is an app-level fact; the app stub declares it. -->
@@ -34,10 +57,11 @@
          (openbuild) keep it out of lint scope; a no-op everywhere else. -->
     <exclude-pattern>lib/Resources/template/*</exclude-pattern>
 
-    <!-- Surface warnings (e.g. SpecTagSniff) in the log without failing the build.
-         The shared quality workflow ALSO maps phpcs exit 1 to success, so this is
-         belt and braces; do not add a `warning-severity=0` flag to the composer script,
-         which suppresses the reporting as well and makes the warnings invisible. -->
+    <!-- Surface warnings (e.g. SpecTagSniff) in the log without failing the
+         build. The shared quality workflow ALSO maps phpcs exit 1 to success,
+         so this is belt and braces; do not add a `warning-severity=0` flag to
+         the composer script, which suppresses the REPORTING as well and makes
+         the warnings invisible. -->
     <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
@@ -46,162 +70,17 @@
     <arg name="extensions" value="php"/>
     <arg value="p"/>
 
-    <!-- Don't hide tokenizer exceptions -->
+    <!-- Don't hide tokenizer exceptions: a file phpcs cannot parse is a finding,
+         not a skip. -->
     <rule ref="Internal.Tokenizer.Exception">
         <type>error</type>
     </rule>
 
-    <!-- Include the whole PEAR standard -->
-    <rule ref="PEAR">
-        <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
-        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
-        <exclude name="PEAR.Commenting.ClassComment"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
-        <exclude name="PEAR.Commenting.InlineComment"/>
-        <!-- Exclude indentation rules we'll configure separately -->
-        <exclude name="PEAR.WhiteSpace.ScopeIndent"/>
-    </rule>
+    <!-- ── Correctness and safety ──────────────────────────────────────────
+         Nextcloud has no opinion on any of these, so they are additive. -->
 
-    <!-- Include some sniffs from other standards that don't conflict with PEAR -->
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-    <rule ref="Squiz.ControlStructures.ControlSignature"/>
-    <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
-    <rule ref="Squiz.Commenting.BlockComment"/>
-    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
-    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
-    <rule ref="Squiz.Commenting.InlineComment"/>
-    <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
-    <rule ref="Squiz.Commenting.PostStatementComment"/>
-    <rule ref="Squiz.Commenting.VariableComment"/>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
-    <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
-    <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
-        <properties>
-            <property name="spacing" value="1"/>
-            <property name="spacingAfterLast" value="0"/>
-            <property name="spacingBeforeFirst" value="0"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-    <rule ref="Generic.Commenting.Todo">
-        <exclude name="Generic.Commenting.Todo"/>
-    </rule>
-    <rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
-    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
-    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
-    <rule ref="Generic.Formatting.SpaceAfterCast"/>
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="150"/>
-            <property name="absoluteLineLimit" value="150"/>
-        </properties>
-    </rule>
-    <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat">
-        <properties>
-            <property name="allowMultiline" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
-    <rule ref="PSR2.Classes.PropertyDeclaration"/>
-    <rule ref="PSR2.Methods.MethodDeclaration"/>
-    <rule ref="PSR2.Files.EndFileNewline"/>
-    <rule ref="PSR12.Files.OpenTag"/>
-    <rule ref="Zend.Files.ClosingTag"/>
 
-    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
-    <rule ref="Generic.ControlStructures.InlineControlStructure">
-        <properties>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
-
-    <!-- We use custom indent rules for arrays -->
-    <rule ref="Generic.Arrays.ArrayIndent"/>
-
-    <!-- Selectively include array rules, excluding alignment rules -->
-    <rule ref="Squiz.Arrays.ArrayDeclaration">
-        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
-        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
-        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
-        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNewLine"/>
-        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
-        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
-    </rule>
-
-    <!-- Check var names, but we don't want leading underscores for private vars -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
-    <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Only one argument per line in multi-line function calls -->
-    <rule ref="PEAR.Functions.FunctionCallSignature">
-        <properties>
-            <property name="allowMultipleArguments" value="false"/>
-            <property name="indent" value="8"/>
-            <property name="requiredSpacesAfterOpen" value="0"/>
-            <property name="requiredSpacesBeforeClose" value="0"/>
-        </properties>
-    </rule>
-
-    <!-- Disable the indentation rule for multiline function declarations -->
-    <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Disable the opening placement for multiline arrays -->
-    <rule ref="PEAR.Functions.FunctionCallSignature.OpeningIndent">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Set standard indentation but don't apply it to function parameters.
-         FOUR SPACES, tabIndent=false. This is the line that diverges from
-         Nextcloud core; see the <description> above. -->
-    <rule ref="Generic.WhiteSpace.ScopeIndent">
-        <properties>
-            <property name="indent" value="4"/>
-            <property name="tabIndent" value="false"/>
-            <property name="ignoreIndentationTokens" type="array">
-                <element value="T_FUNCTION"/>
-                <element value="T_CLOSURE"/>
-                <element value="T_USE"/>
-                <element value="T_PRIVATE"/>
-                <element value="T_PROTECTED"/>
-                <element value="T_PUBLIC"/>
-                <element value="T_READONLY"/>
-                <element value="T_ARRAY"/>
-                <element value="T_OPEN_SHORT_ARRAY"/>
-            </property>
-        </properties>
-    </rule>
-
-    <!-- Have 12 chars padding maximum and always show as errors -->
-    <rule ref="Generic.Formatting.MultipleStatementAlignment">
-        <properties>
-            <property name="maxPadding" value="12"/>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
-
-    <!-- Ban some functions -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array">
@@ -217,15 +96,69 @@
         </properties>
     </rule>
 
-    <!-- Private methods MUST not be prefixed with an underscore -->
+    <!-- `$a == $b` where `$a === $b` was meant is a bug generator. -->
+    <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+
+    <!-- Nested ternaries hide control flow. Nextcloud does not police this. -->
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
+
+    <!-- Every method declares its visibility explicitly. -->
+    <rule ref="Squiz.Scope.MethodScope"/>
+
+    <!-- ── Style that Nextcloud AGREES with, kept as a second line of defence
+         ──────────────────────────────────────────────────────────────────
+         Both of these point the same way as a php-cs-fixer rule
+         (`yoda_style` all-false, `array_syntax` short), so they cannot
+         conflict; they fail faster and with a clearer message. -->
+    <rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+    <!-- ── Naming ──────────────────────────────────────────────────────────
+         Nextcloud's standard is silent on naming; ours is not. -->
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+        <severity>0</severity>
+    </rule>
     <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
         <type>error</type>
     </rule>
-
-    <!-- Private properties MUST not be prefixed with an underscore -->
     <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
         <type>error</type>
     </rule>
+
+    <!-- ── Documentation must EXIST ────────────────────────────────────────
+         Presence is semantic and stays. LAYOUT of a docblock is php-cs-fixer's
+         (`phpdoc_align => left`), so every alignment and spacing code inside
+         these sniffs is switched off individually rather than by dropping the
+         sniff — losing the presence requirement would be a real regression.
+
+         The excluded codes are not guesses; each one was observed firing on
+         php-cs-fixer-formatted code in the 2026-08-12 measurement. -->
+    <rule ref="PEAR.Commenting.FunctionComment">
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamName"/>
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamType"/>
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingBeforeTags"/>
+        <exclude name="PEAR.Commenting.FunctionComment.ParamCommentAlignment"/>
+        <exclude name="PEAR.Commenting.FunctionComment.ParamNameAlignment"/>
+        <exclude name="PEAR.Commenting.FunctionComment.ParamTypeAlignment"/>
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingAfter"/>
+        <exclude name="PEAR.Commenting.FunctionComment.SpacingBefore"/>
+    </rule>
+    <rule ref="Generic.Commenting.DocComment">
+        <exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
+        <exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
+        <exclude name="Generic.Commenting.DocComment.SpacingBeforeTags"/>
+        <exclude name="Generic.Commenting.DocComment.ShortNotCapital"/>
+        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+        <exclude name="Generic.Commenting.DocComment.SpacingAfter"/>
+        <exclude name="Generic.Commenting.DocComment.ContentAfterOpen"/>
+        <exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
+    </rule>
+    <rule ref="Squiz.Commenting.VariableComment">
+        <exclude name="Squiz.Commenting.VariableComment.IncorrectVarType"/>
+    </rule>
+    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
 
     <!--
         InvalidEndChar demands that every inline comment end in `.`, `!` or `?`.
@@ -242,37 +175,41 @@
         findings were warnings, so `composer phpcs` exited 1 and the gate passed.
         3.13.6 — adopted to clear CVE-2026-67434 — reclassifies them as errors,
         so the same unchanged code exits 2 and the gate fails. Nothing about the
-        code changed; only the tool's severity mapping did. Declaring the posture
-        here makes it explicit and version-independent.
+        code changed; only the tool's severity mapping did.
 
-        Scope is deliberately narrow: only InvalidEndChar is downgraded. Every
-        other Squiz.Commenting.InlineComment sniff (WrongStyle, NotCapital,
-        SpacingBefore, Empty, …) still fails the build as an error.
+        Scope is deliberately narrow: only InvalidEndChar. Every other
+        Squiz.Commenting.InlineComment code still fails the build.
 
-        First discovered and fixed in decidesk; hoisted here so the other 17 apps
-        do not each rediscover it on their next php_codesniffer bump.
+        First found in decidesk; hoisted here so the other 17 apps do not each
+        rediscover it on their next php_codesniffer bump.
     -->
+    <rule ref="Squiz.Commenting.InlineComment">
+        <exclude name="Squiz.Commenting.InlineComment.SpacingBefore"/>
+        <exclude name="Squiz.Commenting.InlineComment.SpacingAfter"/>
+    </rule>
     <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
         <type>warning</type>
     </rule>
 
-    <!-- Explicitly exclude other rules that might conflict -->
-    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.WhiteSpace.ScopeIndent.Incorrect">
-        <severity>0</severity>
+    <!-- ── Budget ──────────────────────────────────────────────────────────
+         Nextcloud enforces no line length at all, so 150 is purely additive.
+         Measured on the php-cs-fixer-formatted openregister tree: 2 violations
+         in 200 files. We are already inside this limit. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="150"/>
+            <property name="absoluteLineLimit" value="150"/>
+        </properties>
     </rule>
 
     <!-- ── Conduction custom sniffs ────────────────────────────────────────
          Paths are relative to THIS file, so they resolve wherever the package
-         is checked out or vendored. An app stub must not repeat them. -->
+         is checked out or vendored. An app stub must not repeat them.
+
+         These three are the entire reason PHPCS is still in the toolchain:
+         php-cs-fixer cannot express any of them. All three reported ZERO
+         findings against php-cs-fixer-formatted code, which is the evidence
+         that they are stricter-but-compatible rather than merely untested. -->
 
     <!-- Enforce named parameters on internal calls. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
@@ -281,8 +218,8 @@
 
     <!-- Block calls to \OC::$server->getX() / \OC::$server->query(), removed in
          Nextcloud 34. This sniff exists because static analysis CANNOT see the
-         removal: every app pins nextcloud/ocp to a major below its declared
-         min-version, so psalm has no NC34 API surface to compare against. -->
+         removal when nextcloud/ocp is pinned below the declared min-version —
+         the condition this fleet was in until 2026-08. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
         <type>error</type>
     </rule>

--- a/quality-config/phpmd-unusedparams.xml
+++ b/quality-config/phpmd-unusedparams.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<ruleset name="Unused formal parameters"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
+
+    <description>
+        Second PHPMD leg: UnusedFormalParameter only.
+
+        This rule lives in its own ruleset because PHPMD honours &lt;exclude-pattern&gt;
+        ONLY as a direct child of &lt;ruleset&gt;; nested inside a &lt;rule&gt; it is parsed and
+        discarded (ConductionNL/.github#155). A direct child, however, is applied by
+        PDepend at file-collection time and drops the file from EVERY rule in the
+        ruleset. Isolating UnusedFormalParameter here means the lib/Migration
+        exclusion applies to this rule and this rule ALONE - every other rule still
+        analyses lib/Migration in the main leg.
+
+        Why lib/Migration is excluded from THIS rule: OCP\Migration\IMigrationStep
+        mandates changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+        and preSchemaChange/postSchemaChange with the same three parameters. A step
+        that needs none of them still cannot drop them. The signature cannot change.
+
+        Both legs must always run - see the "phpmd" script in composer.json, which
+        keeps the worst exit code rather than letting the first leg short-circuit
+        the second.
+
+        WHY THE PATTERN IS `*/lib/Migration/*` AND NOT `*/Migration/*`
+        PDepend compiles an exclude-pattern into an UNANCHORED regex - see
+        Input\ExcludePathFilter::__construct, which preg_quote()s the pattern and
+        then turns `\*` into `.*`. `*/Migration/*` therefore matches ANY path with
+        a `/Migration/` segment anywhere in it, not just the app's migration steps:
+        `lib/Service/Migration/`, `lib/Command/Migration/` and any future
+        `lib/*/Migration/` would be silently dropped from this rule too. Those are
+        ordinary classes with no interface-mandated signature, so a genuine unused
+        parameter in one of them would never be reported and the run would still
+        look clean. This is not hypothetical - openconnector carried exactly such a
+        file (lib/Service/Migration/LegacyToRegisterMigrator.php) with a real
+        finding the broad form hid.
+
+        openregister has no `lib/*/Migration/` directory today, so the two patterns
+        currently select the same files. That is precisely why this had to be fixed
+        BEFORE one appears: the broad form fails silently and only on the day
+        someone adds the directory.
+
+        Measured on PHPMD 2.15.0 / PHP 8.4.22 with four probe classes:
+
+          probe                                   `*/Migration/*`   `*/lib/Migration/*`
+          lib/Migration/…            UFP          not reported      not reported  (intended)
+          lib/Migration/…            Else (leg 1) reported          reported      (leg 1 unaffected)
+          lib/Service/…              UFP          reported          reported
+          lib/Service/Migration/…    UFP          NOT REPORTED      reported      (the leak)
+
+        Note this is still a path pattern, not an anchor: a nested
+        `lib/Foo/lib/Migration/` would match. No such path exists here, and the
+        alternative - a top-level anchor - is not something PDepend's filter
+        offers.
+    </description>
+
+    <exclude-pattern>*/lib/Migration/*</exclude-pattern>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+</ruleset>

--- a/quality-config/phpmd.xml
+++ b/quality-config/phpmd.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0"?>
+<ruleset name="Conduction Nextcloud Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                        http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
+
+    <description>
+        The Conduction PHPMD ruleset. ONE copy, here; apps reference it from a stub.
+    </description>
+
+    <!-- NOTE: this ruleset deliberately carries NO top-level <exclude-pattern>.
+
+         It used to carry <exclude-pattern>*/Migration/*</exclude-pattern> here as a
+         runtime optimisation. A top-level exclude-pattern is applied by PDepend at
+         FILE-COLLECTION time, so it does not drop the directory from one rule - it
+         drops it from EVERY rule in this ruleset. Measured on phpmd 2.15.0 /
+         PHP 8.4.22, that single line was silently swallowing 11 real non-
+         UnusedFormalParameter findings in lib/Migration (3 NPathComplexity,
+         3 ElseExpression, 2 StaticAccess, 2 ExcessiveMethodLength,
+         1 CyclomaticComplexity). See ConductionNL/.github#155 and
+         ConductionNL/openregister#2338.
+
+         UnusedFormalParameter - the one rule that genuinely cannot apply to
+         migrations, because OCP\Migration\IMigrationStep mandates the signature -
+         now lives alone in phpmd-unusedparams.xml with its own top-level
+         exclude-pattern, so the exclusion is scoped to that rule and nothing else.
+         Both rulesets are run as separate legs by `composer phpmd`; adding a rule
+         here is enough, but a rule that must skip a path needs its own leg. -->
+
+    <!-- Clean Code Rules -->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
+    <rule ref="rulesets/cleancode.xml/ElseExpression"/>
+    <rule ref="rulesets/cleancode.xml/StaticAccess"/>
+    <rule ref="rulesets/cleancode.xml/IfStatementAssignment"/>
+    <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/>
+    <rule ref="rulesets/cleancode.xml/MissingImport"/>
+    <rule ref="rulesets/cleancode.xml/UndefinedVariable"/>
+    <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/>
+
+    <!-- Code Size Rules -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
+    <rule ref="rulesets/codesize.xml/NPathComplexity"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
+    <rule ref="rulesets/codesize.xml/TooManyFields"/>
+    <rule ref="rulesets/codesize.xml/TooManyMethods"/>
+    <rule ref="rulesets/codesize.xml/TooManyPublicMethods"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity"/>
+
+    <!-- Controversial Rules -->
+    <rule ref="rulesets/controversial.xml/Superglobals"/>
+    <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
+    <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
+    <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
+    <!-- CamelCaseParameterName removed - we allow leading underscores on parameters (convention for unused/config params) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
+    <!-- CamelCaseVariableName removed - we allow leading underscores on variables (convention for unused loop vars) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
+
+    <!-- Design Rules -->
+    <rule ref="rulesets/design.xml/ExitExpression"/>
+    <rule ref="rulesets/design.xml/EvalExpression"/>
+    <rule ref="rulesets/design.xml/GotoStatement"/>
+    <rule ref="rulesets/design.xml/NumberOfChildren"/>
+    <rule ref="rulesets/design.xml/DepthOfInheritance"/>
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects"/>
+    <!-- DevelopmentCodeFragment MUST carry ignore-namespaces=true, or it is dead
+         code in this ruleset. See ConductionNL/openregister#2286.
+
+         PDepend resolves an unqualified call inside a namespaced file to the
+         CURRENT-NAMESPACE-qualified image, so `var_dump($x)` in
+         `namespace OCA\OpenRegister\Service;` reaches the rule as
+         `OCA\OpenRegister\Service\var_dump`, which never matches the
+         `unwanted-functions` list. All of our production PHP is namespaced, so
+         with the default (false) the rule catches nothing anywhere. Measured on
+         phpmd 2.15.0 / PHP 8.3.32: byte-identical probe class, namespaced ->
+         exit 0, non-namespaced -> exit 2. With ignore-namespaces=true the rule
+         strips the enclosing namespace before matching and the namespaced probe
+         is reported (exit 2), while a clean namespaced file stays exit 0.
+
+         Note: hydra gate 2 (forbidden-patterns) independently greps lib/ for
+         var_dump / die / error_log / print_r / dd / dump and is the broader
+         control — it also catches calls outside methods, which this rule (a
+         MethodAware/FunctionAware rule) cannot see. This rule is the
+         `composer check:strict` half of the same guard; keep both. -->
+    <rule ref="rulesets/design.xml/DevelopmentCodeFragment">
+        <properties>
+            <property name="ignore-namespaces" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/design.xml/EmptyCatchBlock"/>
+    <rule ref="rulesets/design.xml/CountInLoopExpression"/>
+
+    <!-- Naming Rules -->
+    <rule ref="rulesets/naming.xml/LongClassName"/>
+    <rule ref="rulesets/naming.xml/ShortClassName"/>
+    <!-- ShortVariable configured with allowlist of idiomatic short names -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="3" />
+            <property name="exceptions" value="id,db,qb,op,ui,io,gc,tz,pk,fk,to,ch,a,b,l,v,c,t,r,f,n,k,e" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable"/>
+    <rule ref="rulesets/naming.xml/ShortMethodName"/>
+    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
+
+    <!-- Unused Code Rules -->
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <!-- UnusedFormalParameter is NOT declared here. It lives alone in
+         phpmd-unusedparams.xml, which carries a top-level (therefore effective)
+         <exclude-pattern>*/Migration/*</exclude-pattern>. The nested
+         <exclude-pattern> that used to sit inside this rule was INERT: PHPMD 2.15
+         parses exclude-patterns only as direct children of <ruleset> and silently
+         discards nested ones. `composer phpmd` runs both rulesets as separate legs
+         and returns the worst exit code. -->
+</ruleset>

--- a/quality-config/phpstan-base.neon
+++ b/quality-config/phpstan-base.neon
@@ -1,0 +1,122 @@
+# The Conduction PHPStan base. ONE copy, here.
+#
+# An app's phpstan.neon is a stub that `includes:` this file, then adds ONLY what
+# is genuinely local to that app: its own baseline, its own excludePaths, and
+# ignores naming symbols that exist nowhere else in the fleet.
+#
+# Everything below was fleet-wide duplicated debt before centralisation: measured
+# 2026-08-12, all 18 core apps shipped a byte-DIFFERENT phpstan.neon (18 distinct
+# SHAs) whose divergence was almost entirely re-typed copies of these same
+# ignoreErrors blocks.
+#
+# ── WHY `scanDirectories: vendor/nextcloud/ocp` IS NOT ENOUGH ────────────────
+# Nextcloud's own psalm/phpstan workflows do NOT pin nextcloud/ocp. They read
+# appinfo/info.xml with icewind1991/nextcloud-version-matrix and then
+#   composer require --dev nextcloud/ocp:dev-<branches-max>
+# so the analysed API surface always matches the app's DECLARED support range.
+#
+# This fleet pins it statically, and as of 2026-08-12 that pin is one major
+# BELOW the declared minimum in 15 of 18 apps: info.xml says
+# min-version="32" max-version="34" while composer says nextcloud/ocp:^31.0.
+# The consequence is not noise, it is blindness — a symbol removed in NC 32/33/34
+# cannot be reported, because the analyser is looking at NC 31. That is why
+# `\OC::$server`, removed in NC 34, needed a hand-written PHPCS sniff to catch:
+# the type checker could not see the removal at all.
+#
+# Do not "fix" the resulting unknown-class noise by adding more ignores here.
+# The fix is to align the pin with info.xml, per
+# https://docs.conduction.nl/WayOfWork/ci-cd/.
+
+parameters:
+    level: 5
+
+    paths:
+        - lib
+
+    bootstrapFiles:
+        - phpstan-bootstrap.php
+
+    excludePaths:
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/
+        # (openbuild). A no-op everywhere else.
+        - lib/Resources/template
+
+    scanDirectories:
+        - vendor/nextcloud/ocp
+
+    reportUnmatchedIgnoredErrors: false
+
+    ignoreErrors:
+        # ── Nextcloud server internals (\OC, OC_App, OC\) ────────────────────
+        # Not stubbed in nextcloud/ocp. Present at runtime, absent to the analyser.
+        - '#Call to an undefined method OC::#'
+        - '#Class OC not found#'
+        - '#Access to static property \$server on an unknown class OC#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs.
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+
+        # ── Optional Nextcloud components, lazy-resolved behind class_exists ──
+        # Ignored rather than baselined on purpose: a baseline entry for one of
+        # these is only correct in the environment that generated it, and goes
+        # stale the moment the component IS present. An absent optional
+        # dependency is a property of the analysis host, not app debt.
+        - '#unknown class OCP\\ContextChat\\#'
+        - '#OCP\\ContextChat\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCP\\ContextChat\\#'
+        - '#has invalid type OCP\\ContextChat\\#'
+        # The RETURN-type variant, which the line above does not cover: phpstan
+        # words a parameter/property as "has invalid type" and a return as
+        # "has invalid return type".
+        - '#has invalid return type OCP\\ContextChat\\#'
+        - '#implements unknown interface OCP\\ContextChat\\#'
+        - '#unknown class OCP\\SystemTag\\Tag(Assigned|Unassigned)Event#'
+        - '#OCP\\SystemTag\\Tag(Assigned|Unassigned)Event not found#'
+        - '#has invalid type OCP\\SystemTag\\Tag(Assigned|Unassigned)Event#'
+
+        # OCA\Bookmarks — optional peer app resolved via \OCP\Server::get()
+        # behind a class_exists guard; not a composer dependency.
+        - '#unknown class OCA\\Bookmarks\\#'
+        - '#OCA\\Bookmarks\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\Bookmarks\\#'
+        - '#has invalid return type OCA\\Bookmarks\\#'
+        - '#Instantiated class OCA\\Bookmarks\\#'
+
+        # ── Cross-app OpenRegister types ─────────────────────────────────────
+        # Every leaf app consumes OpenRegister's ObjectService/ObjectEntity and
+        # resolves them lazily (ADR-022); openregister itself keeps these too,
+        # because its own listeners resolve peers the same way.
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+
+        # ── Libraries the server ships but the app does not require ──────────
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+
+        # ── Known nextcloud/ocp stub gaps (methods that exist at runtime) ────
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'
+
+        # Dynamic HTTP status codes from business-rule validation results.
+        # Matches both `Parameter $statusCode` and `Parameter #N $statusCode`.
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'

--- a/quality-config/stubs/.php-cs-fixer.dist.php
+++ b/quality-config/stubs/.php-cs-fixer.dist.php
@@ -1,0 +1,20 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Conduction
+// SPDX-License-Identifier: EUPL-1.2
+
+// The require_once is NOT optional. php-cs-fixer includes this file before the
+// app's autoloader runs, so without it the run dies with "Class not found" —
+// and in --format=json that fatal is reported as ZERO FILES NEEDING CHANGES,
+// which reads exactly like a clean tree.
+require_once __DIR__ . '/vendor/autoload.php';
+
+$config = new Conduction\CodingStandard\Config();
+$config->getFinder()
+    ->notPath('vendor')
+    ->notPath('node_modules')
+    ->notPath('build')
+    ->in(__DIR__ . '/lib')
+    ->in(__DIR__ . '/tests');
+
+return $config;

--- a/quality-config/stubs/phpcs.xml
+++ b/quality-config/stubs/phpcs.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="APP_NAME" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>APP_NAME — Conduction PHP coding standard (single source: conduction/hydra-gates).</description>
+    <description>
+        APP_NAME — SEMANTICS ONLY. Formatting belongs to php-cs-fixer via
+        conduction/coding-standard; see .php-cs-fixer.dist.php.
+    </description>
 
     <!-- The scanned tree MUST be declared here, not centrally: phpcs resolves
-         <file> relative to the ruleset that declares it. -->
+         the file element relative to the ruleset that declares it. -->
     <file>lib</file>
 
     <rule ref="vendor/conduction/hydra-gates/quality-config/phpcs.xml"/>
 
     <!-- App-specific deviations go BELOW this line, each with a reason and a
-         tracking issue. A deviation with no reason is caught by the
-         quality-config-drift gate. -->
+         tracking issue. A formatting sniff here will be caught by
+         quality-config/tests/compatibility.sh. -->
 </ruleset>

--- a/quality-config/stubs/phpcs.xml
+++ b/quality-config/stubs/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="APP_NAME" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>APP_NAME — Conduction PHP coding standard (single source: conduction/hydra-gates).</description>
+
+    <!-- The scanned tree MUST be declared here, not centrally: phpcs resolves
+         <file> relative to the ruleset that declares it. -->
+    <file>lib</file>
+
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpcs.xml"/>
+
+    <!-- App-specific deviations go BELOW this line, each with a reason and a
+         tracking issue. A deviation with no reason is caught by the
+         quality-config-drift gate. -->
+</ruleset>

--- a/quality-config/stubs/phpmd.xml
+++ b/quality-config/stubs/phpmd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="APP_NAME"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
+    <description>APP_NAME — Conduction PHPMD ruleset (single source: conduction/hydra-gates).</description>
+
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpmd.xml"/>
+</ruleset>

--- a/quality-config/stubs/phpstan.neon
+++ b/quality-config/stubs/phpstan.neon
@@ -1,0 +1,14 @@
+# APP_NAME — Conduction PHPStan config.
+#
+# The shared base is the single source of truth. Everything here is either the
+# app's own tracked debt or an ignore naming a symbol that exists in no other
+# fleet app. Anything you are tempted to add that another app would also need
+# belongs in the base, not here.
+includes:
+    - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+    - phpstan-baseline.neon
+
+parameters:
+    # App-specific only. The base already sets level, paths, bootstrapFiles,
+    # scanDirectories and every fleet-wide ignore.
+    ignoreErrors: []

--- a/quality-config/tests/compatibility.sh
+++ b/quality-config/tests/compatibility.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Does the Conduction PHPCS ruleset argue with the Conduction php-cs-fixer
+# standard?
+#
+# The two tools have overlapping jurisdiction by default, and when they disagree
+# the app is unfixable: `composer cs:fix` and `composer phpcs` demand opposite
+# things and neither can be satisfied. Before the 2026-08 split that was the
+# fleet's actual state — php-cs-fixer's output produced 111,932 PHPCS findings,
+# 111,747 of them auto-fixable formatting.
+#
+# So: format a fixture with php-cs-fixer, then run PHPCS over the result. Any
+# finding from a whitespace, brace, indentation or alignment sniff is a
+# regression — this ruleset has taken back an opinion that belongs to the fixer.
+#
+# Exit code is the number of formatting findings. Semantic findings (@spec,
+# line length, SPDX end-char) are expected and are NOT failures.
+#
+# POSITIVE CONTROL: the run also asserts that php-cs-fixer CHANGED the fixture.
+# tests/fixtures/Messy.php is deliberately written in the old PEAR dialect —
+# four spaces, next-line braces, `(int) $a`, `'a'.'b'`, `else if`. If the fixer
+# reports nothing to fix, it did not run (a missing `require vendor/autoload.php`
+# in .php-cs-fixer.dist.php fatals and reports ZERO FILES in --format=json), and
+# a clean PHPCS pass afterwards would prove nothing at all.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/lib"
+cp "$HERE"/fixtures/*.php "$WORK/lib/"
+
+cat > "$WORK/.php-cs-fixer.dist.php" <<'PHP'
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+$config = new Conduction\CodingStandard\Config();
+$config->getFinder()->in(__DIR__ . '/lib');
+return $config;
+PHP
+
+cat > "$WORK/phpcs.xml" <<PHP
+<?xml version="1.0"?>
+<ruleset name="compat"><file>lib</file><rule ref="$ROOT/phpcs.xml"/></ruleset>
+PHP
+
+cd "$WORK" || exit 2
+
+# `composer require` has no --repository flag; the source has to be registered
+# in composer.json first, and `composer config` needs that file to already
+# exist. Drop this block once the package is on Packagist.
+echo '{"name":"conduction/compat-fixture","description":"throwaway","license":"EUPL-1.2"}' > composer.json
+
+composer config --no-interaction repositories.conduction-coding-standard \
+  vcs https://github.com/ConductionNL/coding-standard.git \
+  || { echo "FAIL: could not register the VCS repository"; exit 2; }
+
+composer require --quiet --no-interaction --dev conduction/coding-standard:^1.0 \
+  || { echo "FAIL: could not install conduction/coding-standard"; exit 2; }
+
+# ── positive control ──────────────────────────────────────────────────────
+BEFORE=$(vendor/bin/php-cs-fixer fix --dry-run --format=json 2>/dev/null \
+         | php -r 'echo count((json_decode(stream_get_contents(STDIN),true)["files"]??[]));')
+if [ "${BEFORE:-0}" -eq 0 ]; then
+  echo "FAIL (positive control): php-cs-fixer found nothing to fix in a fixture"
+  echo "  written specifically to violate it. The fixer did not run — most often"
+  echo "  a missing 'require vendor/autoload.php' in .php-cs-fixer.dist.php, which"
+  echo "  fatals and is reported as zero files."
+  exit 2
+fi
+echo "positive control: php-cs-fixer reformats $BEFORE fixture file(s)  OK"
+
+vendor/bin/php-cs-fixer fix -q 2>/dev/null
+
+# ── the assertion ─────────────────────────────────────────────────────────
+SRC=$(phpcs --standard=phpcs.xml --report=source -q --no-colors 2>/dev/null || true)
+echo "$SRC"
+
+FORMATTING=$(printf '%s\n' "$SRC" | grep -ciE \
+  'white ?space|indent|brace|alignment|spacing|blank line|else if declaration' || true)
+
+if [ "$FORMATTING" -gt 0 ]; then
+  echo
+  echo "FAIL: $FORMATTING formatting sniff(s) fired on php-cs-fixer-formatted code."
+  echo "  PHPCS has taken back an opinion that belongs to the fixer. Remove the"
+  echo "  sniff from quality-config/phpcs.xml — formatting is php-cs-fixer's job."
+  exit "$FORMATTING"
+fi
+
+echo
+echo "PASS: no formatting sniff fired on php-cs-fixer-formatted code."
+exit 0

--- a/quality-config/tests/fixtures/Messy.php
+++ b/quality-config/tests/fixtures/Messy.php
@@ -1,0 +1,13 @@
+<?php
+namespace OCA\Fixture\Service;
+class Messy
+{
+    public function go( $a,$b )
+    {
+        $x = (int) $a;
+        $y = 'a'.'b';
+        if ($a == 1) { return $x; }
+        else if ($b) { return $y; }
+        return null;
+    }
+}


### PR DESCRIPTION
> **Rewritten 2026-08-12.** The first version of this PR argued that four-space PEAR formatting was a deliberate divergence worth documenting. The policy is the opposite — *stricter than Nextcloud, never different from it* — so the divergence is a defect, and this PR now removes it.

## The policy

> Conduction code must pass Nextcloud's own checks unchanged. We may be **stricter** than Nextcloud; we may not be **different** from it.

"Stricter" means adding a rule Nextcloud has no opinion on. It never means giving one of their rules a different value.

## We failed it completely

Measured 2026-08-12, `nextcloud/coding-standard` (php-cs-fixer 3.95) over openregister's `lib/`: **1,427 of 1,427 files fail.**

| fixer | files |
| --- | ---: |
| `curly_braces_position` | 1,427 — 100% |
| `indentation_type` | 1,409 — 98.7% |
| `phpdoc_align` | 1,221 — 85.6% |
| `binary_operator_spaces` | 1,104 — 77.4% |
| `cast_spaces` | 676 — 47.4% |
| `concat_space` | 583 — 40.9% |

Not "stricter" — a different dialect.

## The split

| Concern | Tool | Config |
| --- | --- | --- |
| Formatting | php-cs-fixer | **[`conduction/coding-standard`](https://github.com/ConductionNL/coding-standard)** — new repo, `v1.0.0` |
| Semantics | PHP_CodeSniffer | `quality-config/` — **this PR** |
| Types | Psalm + PHPStan | `quality-config/` |

`Conduction\CodingStandard\Config` **extends** Nextcloud's and merges a private `ADDITIONS` onto `parent::getRules()`. Its invariant suite fails the build if `ADDITIONS` shares one key with the parent set, if a parent rule is dropped, or if a parent rule's *value* changed. **The policy is enforced by inheritance, not by review.** 13/13 pass, each with a positive control.

`ADDITIONS` is empty — a result, not an omission. Every rule we want beyond Nextcloud's is semantic, and php-cs-fixer cannot express any of them.

## Why PHPCS had to be cut back

Two formatters with overlapping jurisdiction make an app **unfixable**: `cs:fix` and `phpcs` demand opposite things. Running the old ruleset over php-cs-fixer-formatted code gave **111,932 findings, 111,747 auto-fixable formatting**:

```
Generic.WhiteSpace.DisallowTabIndent                62,123
Generic.WhiteSpace.ScopeIndent                      35,030
Generic.Arrays.ArrayIndent                           3,726
PEAR.Commenting.FunctionComment (param spacing)      2,797
PEAR.Functions.FunctionDeclaration (indent + brace)  2,576
Generic.Formatting.MultipleStatementAlignment        1,132
Generic.Formatting.SpaceAfterCast                      909
Squiz.Strings.ConcatenationSpacing                     534
Squiz.ControlStructures.ElseIfDeclaration               31
```

That last line is the whole problem in miniature: Squiz **forbids** the `elseif` keyword Nextcloud's `elseif` fixer **requires**.

**After stripping every formatting sniff, the same measurement yields 185 findings, all semantic** — 181 `@spec`, 2 line-length, 2 SPDX. The named-parameter and legacy-accessor sniffs fire **zero** times: stricter-but-compatible, demonstrated rather than assumed.

Docblock *presence* stays, docblock *layout* goes to `phpdoc_align` — alignment codes excluded individually rather than by dropping the sniff, since losing the presence requirement would be a real regression. Each excluded code was **observed firing**, not guessed.

## Proven end-to-end

[nextcloud-app-template#141](https://github.com/ConductionNL/nextcloud-app-template/pull/141), in `php:8.3-cli`, installing from `vendor/`:

```
php-cs-fixer   Found 0 of 23 files that can be fixed
phpcs          39 violations, ALL WARNINGS (35 @spec, 4 SPDX). Zero errors.
```

Three custom sniffs register and fire from the vendored package. That PR is the recipe the other 18 apps follow.

## What's in this PR

- `quality-config/phpcs.xml` — semantic-only ruleset
- `quality-config/phpcs-custom-sniffs/` — three sniffs, canonically `launchpad`'s NamedParameters (a 525-line superset; `opencatalogi`'s 231-line copy calls `addWarning()` where the rest call `addError()`) + `openregister`'s SpecTag and NoLegacyServerAccessors
- `quality-config/phpmd.xml`, `phpmd-unusedparams.xml`, `phpstan-base.neon`
- `quality-config/editorconfig` — Nextcloud's, verbatim. **No fleet app had one**, so editors defaulted to whatever the developer last worked in
- `quality-config/tests/compatibility.sh` — format a fixture, run PHPCS over the result, fail on any formatting sniff. Its positive control asserts the fixer actually changed the fixture first, because otherwise a clean PHPCS pass proves nothing
- `quality-config/stubs/` — what an app's files become
- `docs/WayOfWork/ci-cd.md` + four corrections to existing pages

## Mechanics measured, not assumed

Against phpcs 3.13.6 and 4.0.4:

1. Rules and custom sniffs **do** inherit through `<rule ref>`, including sniff paths relative to the central ruleset. The first fixture registered 1 sniff instead of 2 and looked like proof this cannot work — the fixture was wrong (a sniff must sit at `<Standard>/Sniffs/<Category>/<Name>Sniff.php`).
2. `<file>` **must** stay in the app stub — phpcs resolves it relative to the declaring ruleset, so a central one becomes `quality-config/lib` inside `vendor/` and every consumer exits 3.
3. A `--` inside an XML comment makes a ruleset unparseable, before any sniff registers. Caught by running it; it would have turned 18 apps red on a comment.
4. `.php-cs-fixer.dist.php` without `require vendor/autoload.php` fatals, and in `--format=json` that fatal is reported as **zero files needing changes**. It reads exactly like a clean tree.

## Blast radius

**Zero until an app adopts it.** `quality.yml` is unchanged; no app's files change in this PR.

## Deliberately not here

- **`psalm.xml`** — Psalm has no config inheritance. Needs a generator or a drift gate.
- **`quality-config/frontend/`** — templates only. ESLint flat config resolves plugins relative to the config file, so a config in `vendor/` cannot reach `node_modules`. Frontend is being homed in `@conduction/nextcloud-vue`, which all 18 apps already depend on.

## Follow-ups

Roll to 18 apps · `quality-config-drift` gate · frontend homing · NC 34 for `ocp` + PHPUnit + `psalm.xml phpVersion` · Psalm to strictest level · quote the stylelint globs (13 apps lint one directory deep) · wire Prettier · align frontend versions · adopt the five Nextcloud checks we lack (info.xml XSD, `app:check-code`, `integrity:sign-app`, REUSE, multi-DB PHPUnit) · chain Nextcloud's release template · register both packages on Packagist.
