### PR TITLE
fix(gate-19,gate-26): a comment must not be enough to satisfy a gate

### DIFF
--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -34,11 +34,26 @@ spec → code → test traceability chain.
 Annotation convention
 ======================
 
-In an e2e test file, reference a scenario with **either** form (in a comment or
-inside a test title/describe string):
+In an e2e test file, reference a scenario with **either** form:
 
     // @e2e openspec/specs/<spec-name>/spec.md#<scenario-slug>
     // @e2e <spec-name>::<scenario-slug>
+
+**A MENTION IS NOT A DIRECTIVE.** The anchor only counts where it is attached
+to something that executes, which means one of exactly two positions:
+
+* **leading in a comment** — nothing but whitespace and markdown / jsdoc
+  leaders (``*``, ``-``, ``>``, ``#``, ``!``) before the ``@`` on that line,
+  in a comment above, inside the argument list of, or inside the body of the
+  declaration it annotates. This is how every anchor in the fleet is written;
+* **inside the TITLE of a ``test(`` / ``describe(``** — the anchor is part of
+  the name of a running thing (Playwright's own tag convention).
+
+A sentence that merely names an anchor — ``// TODO: still unwritten, its
+anchor is @e2e a::b`` — is prose and is reported as such. So is an anchor in a
+selector string, in a regex literal, or trailing the last test in a file with
+nothing after it to run. Writing *about* coverage is not coverage
+(``.github#358``).
 
 **Format A slug:** kebab-case of the ``#### Scenario:`` heading text
 (lower-case, punctuation stripped, words joined with ``-``).
@@ -714,6 +729,115 @@ def _code_mask(text: str) -> str:
     return "".join(out)
 
 
+# ---------------------------------------------------------------------------
+# A MENTION IS NOT A DIRECTIVE (.github#358)
+# ---------------------------------------------------------------------------
+# The `@e2e` regexes run over the ORIGINAL text, because the convention this
+# module documents puts the tag in a COMMENT and a comment is blanked by the
+# code mask. That is right, and it is also how a sentence of prose came to be
+# scored as coverage:
+#
+#     // TODO: the second scenario is still unwritten. Its anchor is
+#     //       @e2e tag::beta
+#
+# Measured on a two-scenario fixture: the honest arm and that arm both print
+#
+#     [gate-19] e2e-coverage: PASS — 2 reference(s) in e2e suite
+#
+# byte for byte, so no downstream reader can tell them apart. It is not a
+# hypothetical: two agents documenting this very defect silenced the gate they
+# were describing, and `.github#358` records comments quoting old dangling
+# anchors being re-parsed as live ones.
+#
+# THE DISCRIMINATOR IS POSITION WITHIN THE COMMENT, AND IT IS FREE
+# ----------------------------------------------------------------
+# The fleet already writes every anchor the same way: the tag is the LEADING
+# content of its comment line, after nothing but whitespace and the markdown /
+# jsdoc leaders (`*`, `-`, `>`, `#`, `!`). Surveyed 2026-08-12 across the 16
+# app checkouts that have an e2e suite — decidesk 307, openbuild 206, pipelinq
+# 145, openregister 129, docudesk 120, larpingapp 115, procest 114, hermiq 107,
+# softwarecatalog 101, openconnector 96, nldesign 64, opencatalogi 59, scholiq
+# 56, doriath 44, shillinq 35 — **1,918 anchors, 1,918 of them leading.** Not
+# one prose mention, not one in a string, not one in code. So requiring the
+# leading position costs the fleet exactly zero real coverage and removes the
+# counterfeit entirely.
+#
+# This is the same shape as `_parse_whole_spec_exclusion` twenty lines up,
+# which already refuses a Purpose paragraph that merely MENTIONS
+# `@e2e exclude`. One rule, two directives.
+#
+# The remaining accepted position is the one the module docstring promises and
+# nobody currently uses: the anchor inside the TITLE of a test or describe —
+# Playwright's own tag convention, where the anchor is literally part of the
+# name of a thing that runs. It is honoured rather than dropped precisely
+# because zero anchors depend on it: keeping a documented form that cannot
+# regress anything is cheaper than a docstring that lies.
+_ANCHOR_LEADERS = frozenset(" \t*-#>!/")
+
+
+def _literal_spans(text: str) -> list[tuple[str, int, int]]:
+    """`(kind, inner_start, inner_end)` for every comment / string / regex.
+
+    Same tokenizer walk as :func:`_code_mask` — it has to be, because the only
+    way to know where a comment really begins is to know where strings and
+    regex literals end (`'http://x'` opens no comment). This one records the
+    spans instead of blanking them, so an `@e2e` match found in the ORIGINAL
+    text can be asked *what kind of text am I standing in, and what precedes
+    me on this line*.
+
+    `inner_*` bound the CONTENT, not the delimiters, so the leader test does
+    not have to know how long the opener was.
+    """
+    out: list[tuple[str, int, int]] = []
+    i, n = 0, len(text)
+    prev_char, prev_word = "", ""
+    while i < n:
+        c = text[i]
+        if c == "/" and text.startswith("//", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            out.append(("comment", i + 2, j))
+            i = j
+            continue
+        if c == "/" and text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            out.append(("comment", i + 2, max(i + 2, j - 2)))
+            i = j
+            continue
+        if c in "'\"":
+            j = _skip_string(text, i)
+            out.append(("string", i + 1, max(i + 1, j - 1)))
+            prev_char, prev_word = c, ""
+            i = j
+            continue
+        if c == "`":
+            j = _skip_template(text, i)
+            out.append(("string", i + 1, max(i + 1, j - 1)))
+            prev_char, prev_word = "`", ""
+            i = j
+            continue
+        if c == "/" and _regex_can_start(prev_char, prev_word):
+            j = _skip_regex(text, i)
+            if j > 0:
+                out.append(("regex", i, j))
+                prev_char, prev_word = ")", ""
+                i = j
+                continue
+        if c.isalnum() or c in "_$":
+            k = i
+            while k < n and (text[k].isalnum() or text[k] in "_$"):
+                k += 1
+            prev_word = text[i:k]
+            prev_char = text[k - 1]
+            i = k
+            continue
+        if not c.isspace():
+            prev_char, prev_word = c, ""
+        i += 1
+    return out
+
+
 def _match_paren(mask: str, open_paren: int) -> int | None:
     """Index of the `)` matching the `(` at *open_paren* in the CODE MASK."""
     depth = 0
@@ -731,8 +855,8 @@ def _match_paren(mask: str, open_paren: int) -> int | None:
     return None
 
 
-def _first_arg(mask: str, open_paren: int, close: int) -> str:
-    """Masked text of the first top-level argument, stripped."""
+def _first_arg_span(mask: str, open_paren: int, close: int) -> tuple[int, int]:
+    """`(start, end)` of the first top-level argument, delimiters included."""
     depth = 0
     i = open_paren + 1
     start = i
@@ -745,7 +869,13 @@ def _first_arg(mask: str, open_paren: int, close: int) -> str:
         elif c == "," and depth == 0:
             break
         i += 1
-    return mask[start:i].strip()
+    return start, i
+
+
+def _first_arg(mask: str, open_paren: int, close: int) -> str:
+    """Masked text of the first top-level argument, stripped."""
+    start, end = _first_arg_span(mask, open_paren, close)
+    return mask[start:end].strip()
 
 
 def _is_unconditional_arg(first: str) -> bool:
@@ -784,6 +914,7 @@ class _TestFile:
     def __init__(self, text: str) -> None:
         self.text = text
         self.mask = _code_mask(text)
+        self.literals = _literal_spans(text)
         self.nodes: list[_TestNode] = []
         self.roots: list[_TestNode] = []
         # (start, is_unconditional) for `test.skip(...)` / `test.fixme(...)`
@@ -915,6 +1046,49 @@ class _TestFile:
                 return ch
         return containing
 
+    def is_directive(self, at: int) -> bool:
+        """Is the `@e2e` whose `@` sits at *at* a DIRECTIVE rather than prose?
+
+        Two positions qualify, and nothing else does:
+
+        * **leading in a comment** — only whitespace and markdown / jsdoc
+          leaders between the start of the anchor's line (or the comment's own
+          opening, whichever is later) and the `@`. This is how all 1,918
+          anchors in the fleet are written;
+        * **inside the title of a declaration** — the anchor is part of the
+          name of a test or describe, i.e. of a thing that runs. Playwright's
+          own tag convention, and the form the module docstring promises.
+
+        A prose mention, an anchor in a non-title string, one in a regex
+        literal and one sitting in bare code are all refused. The refusal is
+        reported by name so nobody is sent to add a tag that is already
+        visible in the file.
+        """
+        kind: str | None = None
+        inner_start = 0
+        for k, a, b in self.literals:
+            if a <= at < b:
+                kind, inner_start = k, a
+        if kind is None:
+            return False                       # bare code — not a tag at all
+        if kind == "comment":
+            line_start = self.text.rfind("\n", 0, at) + 1
+            lead = self.text[max(line_start, inner_start):at]
+            return all(ch in _ANCHOR_LEADERS for ch in lead)
+        if kind != "string":
+            return False                       # inside a regex literal
+        # A string counts only when it is the FIRST argument — the title — of a
+        # declaration. `page.click('#x @e2e a::b')` is a selector, not a claim.
+        for nd in self.nodes:
+            if nd.start > at:
+                break
+            if nd.close < at:
+                continue
+            lo, hi = _first_arg_span(self.mask, nd.open, nd.close)
+            if lo <= at < hi:
+                return True
+        return False
+
     def _innermost_body_owner(self, pos: int) -> _TestNode | None:
         found: _TestNode | None = None
         for nd in self.nodes:
@@ -1016,10 +1190,20 @@ def _ref_is_live(doc: _TestFile, pos: int) -> bool:
     """
     node = doc.owner(pos)
     if node is None:
-        # No declaration owns this tag — a file-level annotation. Live: this
-        # function exists to catch tests that were switched OFF, not to invent
-        # a structural requirement the gate never had.
-        return True
+        # NOTHING RUNS AFTER THIS TAG, SO NOTHING PROVES IT.
+        #
+        # This used to return True and call the case "a file-level annotation".
+        # It is not: `owner()` already binds a file-header tag FORWARD to the
+        # first declaration in the file, so a header tag never reaches here.
+        # None means there is no `test(` or `describe(` at or after the anchor
+        # anywhere in the file — a tag trailing the last test, or a tag in a
+        # file that declares none. Neither is attached to anything that
+        # executes, which is the whole property this gate measures.
+        #
+        # Cost measured 2026-08-12 across the fleet's 16 e2e suites: **0 of
+        # 1,918 anchors** currently land here, so this closes a hole rather
+        # than moving a number.
+        return False
     n: _TestNode | None = node
     while n is not None:
         if n.switched_off:
@@ -1452,18 +1636,35 @@ def collect_ref_status(app_dir: Path) -> tuple[set[str], dict[str, str]]:
         for rex in (_E2E_PATH_RE, _E2E_SHORT_RE):
             for m in rex.finditer(text):
                 ref = f"{m.group('spec')}::{m.group('slug')}"
-                if file_runs and _ref_is_live(doc, m.end()):
+                # A MENTION IS NOT A DIRECTIVE (#358). Checked before liveness
+                # on purpose: prose that names an anchor is not a weak tag on a
+                # good test, it is not a tag, and the finding has to say so or
+                # the author will go looking for a test to unskip.
+                directive = doc.is_directive(m.start())
+                if directive and file_runs and _ref_is_live(doc, m.end()):
                     live.add(ref)
                     dead.pop(ref, None)
                 elif ref not in live:
-                    dead[ref] = (
-                        f"referenced only by a file no Playwright project "
-                        f"runs — {rel} is outside testDir or excluded by "
-                        f"testIgnore/testMatch in {scope.config_rel or 'playwright.config.ts'}, "
-                        f"which is the config CI executes"
-                        if not file_runs else
-                        f"referenced only by a test that never runs ({rel})"
-                    )
+                    if not directive:
+                        reason = (
+                            f"named only in PROSE, not in an @e2e directive "
+                            f"({rel}) — the anchor appears mid-sentence in a "
+                            f"comment, in a selector or in some other string. "
+                            f"Writing about an anchor is not covering it. Put "
+                            f"the tag at the start of its own comment line "
+                            f"above the test that proves the scenario"
+                        )
+                    elif not file_runs:
+                        reason = (
+                            f"referenced only by a file no Playwright project "
+                            f"runs — {rel} is outside testDir or excluded by "
+                            f"testIgnore/testMatch in "
+                            f"{scope.config_rel or 'playwright.config.ts'}, "
+                            f"which is the config CI executes"
+                        )
+                    else:
+                        reason = f"referenced only by a test that never runs ({rel})"
+                    dead[ref] = reason
     return live, dead
 
 
@@ -1677,14 +1878,23 @@ def run_gate(app_dir: Path) -> int:
                     f"{s['ref']} — @e2e exclude without reason (reason required)"
                 )
             elif s["ref"] in dead_refs:
-                # Named, but by a test that never runs. Saying "missing @e2e"
-                # here would send someone to add a tag that is already there.
-                findings.append(
-                    f"{s['ref']} — @e2e tag present but the test does not run: "
-                    f"{dead_refs[s['ref']]}. A permanently-skipped or empty test is "
-                    f"not coverage: unskip it, give it a body, or replace the tag "
-                    f"with a reason-bearing `@e2e exclude`."
-                )
+                # Named, but not by a running test. Saying "missing @e2e" here
+                # would send someone to add a tag that is already visible in
+                # the file, so the finding names the mechanism instead — and
+                # the two mechanisms need different remedies.
+                reason = dead_refs[s["ref"]]
+                if reason.startswith("named only in PROSE"):
+                    findings.append(
+                        f"{s['ref']} — {reason}, or exclude the scenario with a "
+                        f"reason-bearing `@e2e exclude`."
+                    )
+                else:
+                    findings.append(
+                        f"{s['ref']} — @e2e tag present but the test does not run: "
+                        f"{reason}. A permanently-skipped or empty test is "
+                        f"not coverage: unskip it, give it a body, or replace the tag "
+                        f"with a reason-bearing `@e2e exclude`."
+                    )
             elif s["ref"] not in covered_refs:
                 findings.append(f"{s['ref']} — missing @e2e")
 

--- a/hydra-gates/scripts/lib/check_visual_coverage.py
+++ b/hydra-gates/scripts/lib/check_visual_coverage.py
@@ -81,6 +81,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import js_comment_mask  # noqa: E402
+
 GATE_NUM = 26
 
 # Exit STATUS vocabulary — see the module docstring. Never a finding count.
@@ -408,10 +411,42 @@ def _visual_exclude_status(vue_text: str) -> tuple[bool, str | None]:
 
 
 def _e2e_corpus(app_dir: Path, visual_only: bool) -> str:
-    """Concatenated text of e2e test files.
+    """Concatenated EXECUTABLE text of e2e test files.
 
     visual_only=True → only tests/e2e/visual/**.
     visual_only=False → all of tests/e2e/**.
+
+    A COMMENT IS NOT A BASELINE (.github#358)
+    -----------------------------------------
+    This corpus used to be the raw bytes of every file, and ``is_covered()``
+    asks nothing more than "does the component's name appear in it". So it did:
+
+        // NOTE: we still owe a baseline for Dashboard — see the issue.
+
+    A sentence saying you have NOT done the thing satisfied the gate that
+    checks whether you have done it. Reproduced on a two-file fixture: the
+    comment-only arm and a real spec that navigates to the page and calls
+    ``toHaveScreenshot`` both print
+
+        [gate-26] visual-coverage: PASS — 1 new page(s), all have a visual proof
+
+    byte for byte. Measured in the fleet as docudesk 7, openregister 6,
+    opencatalogi 3, procest 2, softwarecatalog 2, pipelinq 2 — and doriath
+    *triggered* it while writing the warning paragraph that documents it, which
+    is the sharpest possible statement of the problem: the better your comments,
+    the greener the gate.
+
+    So ``.ts``/``.js`` files enter the corpus through
+    ``source_scope.js_comment_mask``, which blanks comments and regex literals
+    and KEEPS string literals. Strings have to stay: ``page.goto('/dashboard')``,
+    ``toHaveScreenshot('Dashboard.png')`` and a locator are all real references
+    to the screen, and blanking them would turn a noisy gate into a dead one —
+    the mistake `.github#230` records for gate-58. Offsets are preserved, so the
+    mask is a drop-in for the raw text.
+
+    ``.png`` baselines contribute their FILENAME (that is the whole reference),
+    and ``.json``/``.txt`` snapshots are data rather than prose and are left
+    alone.
     """
     root = app_dir / "tests" / "e2e"
     if visual_only:
@@ -425,6 +460,8 @@ def _e2e_corpus(app_dir: Path, visual_only: bool) -> str:
             # record the name rather than the bytes.
             if p.suffix == ".png":
                 buf.append(p.name)
+            elif p.suffix in (".ts", ".js"):
+                buf.append(js_comment_mask(_read(p)))
             else:
                 buf.append(_read(p))
     return "\n".join(buf)

--- a/hydra-gates/scripts/lib/test_check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_e2e_coverage.py
@@ -415,21 +415,36 @@ class CoveredRefTest(unittest.TestCase):
         self.assertIn("my-spec::foo-does-bar", refs)
 
     def test_both_forms_same_file(self):
+        # Both fixtures below carry a real `test(`. They used to be tag-only,
+        # which made them pass for a reason they were not testing: the ref
+        # survived because a tag owning NO declaration was credited (#358's
+        # sibling hole). This test is about the two annotation SPELLINGS, so
+        # the declaration is now present and the spellings are the only
+        # variable.
         _write(self.root, "tests/e2e/bar.spec.js",
-               "// @e2e my-spec::foo-does-bar\n// @e2e openspec/specs/my-spec/spec.md#foo-handles-error\n")
+               "// @e2e my-spec::foo-does-bar\n"
+               "test('short form', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n"
+               "// @e2e openspec/specs/my-spec/spec.md#foo-handles-error\n"
+               "test('long form', async ({ page }) => { await expect(page).toHaveTitle(/y/) })\n")
         refs = cec.collect_covered_refs(self.root)
         self.assertIn("my-spec::foo-does-bar", refs)
         self.assertIn("my-spec::foo-handles-error", refs)
 
     def test_subdirectory_e2e(self):
         _write(self.root, "tests/e2e/spec-coverage/deep.spec.ts",
-               "// @e2e my-spec::foo-does-bar\n")
+               "// @e2e my-spec::foo-does-bar\n"
+               "test('deep', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         refs = cec.collect_covered_refs(self.root)
         self.assertIn("my-spec::foo-does-bar", refs)
 
     def test_non_spec_file_ignored(self):
+        # The body is real and the tag is a proper directive, so the FILENAME
+        # is the only thing that can keep this ref out. Without the body it
+        # would now be excluded twice over and would still pass with the file
+        # filter deleted.
         _write(self.root, "tests/e2e/helpers.ts",
-               "// @e2e my-spec::foo-does-bar\n")
+               "// @e2e my-spec::foo-does-bar\n"
+               "test('x', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n")
         refs = cec.collect_covered_refs(self.root)
         # helpers.ts is not *.spec.ts / *.test.ts → should not be scanned
         self.assertNotIn("my-spec::foo-does-bar", refs)
@@ -783,6 +798,103 @@ class GateModeTest(unittest.TestCase):
 # someone turned off; `test.skip(browserName === 'firefox')` is a real test
 # with a runtime guard, and it runs everywhere else. Both ways, in one class.
 # ---------------------------------------------------------------------------
+class ProseIsNotADirectiveTest(unittest.TestCase):
+    """`.github#358` — writing ABOUT an anchor must not cover it.
+
+    The honest arm and the counterfeit arm printed byte-identical verdicts, so
+    every assertion here comes in pairs: the refused position AND the accepted
+    position one character away from it. A suite with only the planted arm
+    would score "refuse everything" as a repair.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    _RUNS = ("test('real', async ({ page }) => "
+             "{ await expect(page).toHaveTitle(/x/) })\n")
+
+    def _refs(self, body: str) -> set:
+        _write(self.root, "tests/e2e/foo.spec.ts", body)
+        return cec.collect_covered_refs(self.root)
+
+    # --- refused: the anchor is a MENTION --------------------------------
+    def test_a_todo_sentence_naming_an_anchor_is_not_coverage(self):
+        # Ruben's shape, verbatim.
+        self.assertEqual(self._refs(
+            "// TODO: the second scenario is still unwritten. "
+            "Its anchor is @e2e my-spec::foo-does-bar\n" + self._RUNS), set())
+
+    def test_a_docblock_sentence_naming_an_anchor_is_not_coverage(self):
+        self.assertEqual(self._refs(
+            "/**\n"
+            " * We removed the assertion that carried @e2e my-spec::foo-does-bar\n"
+            " * because the fixture was flaky.\n"
+            " */\n" + self._RUNS), set())
+
+    def test_an_anchor_inside_a_selector_string_is_not_coverage(self):
+        self.assertEqual(self._refs(
+            "test('real', async ({ page }) => {\n"
+            "  await page.click('[data-note=\"@e2e my-spec::foo-does-bar\"]')\n"
+            "})\n"), set())
+
+    def test_the_prose_finding_names_the_mechanism(self):
+        _write(self.root, "tests/e2e/foo.spec.ts",
+               "// see @e2e my-spec::foo-does-bar\n" + self._RUNS)
+        live, dead = cec.collect_ref_status(self.root)
+        self.assertEqual(live, set())
+        self.assertIn("PROSE", dead["my-spec::foo-does-bar"])
+        # It must NOT tell the author to unskip a test — there is no test to
+        # unskip, and that remedy is what sent people looking last time.
+        self.assertNotIn("unskip", dead["my-spec::foo-does-bar"])
+
+    # --- accepted: the anchor is a DIRECTIVE -----------------------------
+    def test_a_leading_line_comment_still_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// @e2e my-spec::foo-does-bar\n" + self._RUNS))
+
+    def test_a_jsdoc_star_leader_still_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "/**\n * @e2e my-spec::foo-does-bar\n */\n" + self._RUNS))
+
+    def test_an_indented_bullet_leader_still_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "//   - @e2e my-spec::foo-does-bar\n" + self._RUNS))
+
+    def test_a_tag_inside_the_argument_list_still_counts(self):
+        # The #244 position — nldesign writes every one of its tests this way.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "test(\n"
+            "    // @e2e my-spec::foo-does-bar\n"
+            "    'real',\n"
+            "    async ({ page }) => { await expect(page).toHaveTitle(/x/) },\n"
+            ")\n"))
+
+    def test_a_tag_inside_the_body_still_counts(self):
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "test('real', async ({ page }) => {\n"
+            "  // @e2e my-spec::foo-does-bar\n"
+            "  await expect(page).toHaveTitle(/x/)\n"
+            "})\n"))
+
+    def test_an_anchor_in_the_test_title_counts(self):
+        # Playwright's own tag convention: the anchor is part of the NAME of a
+        # running thing. Documented since this module was written; zero fleet
+        # anchors use it, which is exactly why honouring it is free.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "test('renders the widget @e2e my-spec::foo-does-bar', "
+            "async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n"))
+
+    def test_a_prose_mention_does_not_cancel_a_real_directive(self):
+        # One live reference is enough; the gate reports UNCOVERED, not
+        # "you also wrote about it".
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "// historical note: @e2e my-spec::foo-does-bar used to live here\n"
+            "// @e2e my-spec::foo-does-bar\n" + self._RUNS))
+
+
 class SkippedTestIsNotCoverageTest(unittest.TestCase):
     def setUp(self):
         self.root = Path(tempfile.mkdtemp())
@@ -879,12 +991,33 @@ class SkippedTestIsNotCoverageTest(unittest.TestCase):
             "  await expect(page).toHaveTitle(/x/)\n"
             "})\n"))
 
-    def test_a_file_level_tag_with_no_enclosing_test_still_counts(self):
-        # This gate is fixing tests that were switched OFF. It must not
-        # invent a structural requirement it never had.
-        self.assertIn("my-spec::foo-does-bar", self._refs(
+    def test_a_tag_in_a_file_that_declares_no_test_is_not_coverage(self):
+        # REVERSED DELIBERATELY (#358). This used to assert the opposite, on
+        # the grounds that the gate "must not invent a structural requirement
+        # it never had". The requirement is not structural: a spec file with
+        # no `test(` in it runs nothing, so the tag proves nothing, and that
+        # is the one property this gate exists to measure.
+        #
+        # A FILE-HEADER tag does NOT land here and is unaffected: `owner()`
+        # binds it FORWARD to the first declaration in the file. The case
+        # below is a file with no declaration at all.
+        #
+        # Cost measured across the fleet's 16 e2e suites on 2026-08-12: 0 of
+        # 1,918 anchors have no owning declaration, so nothing regresses.
+        self.assertNotIn("my-spec::foo-does-bar", self._refs(
             "// @e2e my-spec::foo-does-bar\n"
             "import { test, expect } from '@playwright/test'\n"))
+
+    def test_a_file_header_tag_above_a_real_test_still_counts(self):
+        # The control for the test above: header binding SURVIVES. Only the
+        # no-declaration case changed.
+        self.assertIn("my-spec::foo-does-bar", self._refs(
+            "/**\n"
+            " * Suite docblock.\n"
+            " * @e2e my-spec::foo-does-bar\n"
+            " */\n"
+            "import { test, expect } from '@playwright/test'\n"
+            "test('real', async ({ page }) => { await expect(page).toHaveTitle(/x/) })\n"))
 
     def test_dead_refs_are_reported_with_a_reason(self):
         _write(self.root, "tests/e2e/foo.spec.ts",

--- a/hydra-gates/scripts/lib/test_check_visual_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_visual_coverage.py
@@ -376,6 +376,85 @@ with _repo_mixed(manifest=_MANIFEST_DANGLING) as t:
         out.strip()[-200:],
     )
 
+# ---------------------------------------------------------------------------
+# A COMMENT IS NOT A BASELINE (.github#358)
+# ---------------------------------------------------------------------------
+# `is_covered()` asks only whether the component's name appears anywhere in the
+# concatenated e2e corpus, and the corpus was the RAW BYTES of every file. So a
+# sentence saying you still OWE a baseline satisfied the gate that checks
+# whether you have one — measured in the fleet as docudesk 7, openregister 6,
+# opencatalogi 3, procest 2, softwarecatalog 2, pipelinq 2, and triggered by
+# doriath *while writing the warning paragraph that documents it*.
+#
+# Both arms below are required. Without the second, "blank the whole corpus"
+# would score as a repair — and blanking string literals specifically is the
+# `.github#230` mistake (gate-58's evidence IS a string), so the accepted arm
+# deliberately proves coverage through a string.
+print()
+print("== gate-26: a comment must not be enough (.github#358) ==")
+
+_VISUAL_REAL = """import { test, expect } from '@playwright/test'
+test('the page renders', async ({ page }) => {
+\tawait page.goto('/index.php/apps/fx/#/flow-detail')
+\tawait expect(page.locator('.page-1')).toBeVisible()
+\tawait expect(page).toHaveScreenshot('FlowDetailPage.png')
+})
+"""
+
+_VISUAL_COMMENT_ONLY = """import { test, expect } from '@playwright/test'
+// NOTE: FlowDetailPage still owes a baseline — tracked separately. Do not
+// add one in this file.
+test('something else entirely', async ({ page }) => {
+\tawait page.goto('/')
+\tawait expect(page.locator('body')).toBeVisible()
+})
+"""
+
+with _repo_mixed(extra={"tests/e2e/visual/x.spec.ts": _VISUAL_COMMENT_ONLY}) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "a comment saying a page still OWES a baseline is not coverage",
+        rc == EXIT_FAIL and "FlowDetailPage.vue" in out,
+        f"rc={rc} out={out.strip()[-220:]}",
+    )
+
+with _repo_mixed(extra={"tests/e2e/visual/x.spec.ts": _VISUAL_REAL}) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "a spec that navigates to the page and screenshots it still counts",
+        rc == EXIT_PASS,
+        f"rc={rc} out={out.strip()[-220:]}",
+    )
+
+# The reference lives ONLY inside a string literal. Blanking string contents
+# would make this arm red and turn the repair into a dead gate (.github#230).
+_VISUAL_STRING_ONLY = """import { test, expect } from '@playwright/test'
+test('baseline', async ({ page }) => {
+\tawait page.goto('/')
+\tawait expect(page).toHaveScreenshot('FlowDetailPage.png')
+})
+"""
+with _repo_mixed(extra={"tests/e2e/visual/x.spec.ts": _VISUAL_STRING_ONLY}) as t:
+    rc, out = _run(Path(t), None)
+    check(
+        "a reference that exists only as a STRING literal still counts",
+        rc == EXIT_PASS,
+        f"rc={rc} out={out.strip()[-220:]}",
+    )
+
+# A .png baseline named after the component is the canonical proof and must be
+# untouched by the corpus change — its filename is the whole reference.
+with _repo_mixed() as t:
+    _b = Path(t) / "tests" / "e2e" / "visual"
+    _b.mkdir(parents=True)
+    (_b / "FlowDetailPage.png").write_bytes(b"\x89PNG\r\n")
+    rc, out = _run(Path(t), None)
+    check(
+        "a .png baseline named after the component still counts",
+        rc == EXIT_PASS,
+        f"rc={rc} out={out.strip()[-220:]}",
+    )
+
 print()
 print(f"{_passed}/{_passed + len(_failed)} passed")
 if _failed:

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>prosefixture</id>
+	<name>Prose Is Not Proof Fixture</name>
+	<summary>Fixture app for the prose-vs-directive acceptance bundle. Not a real app.</summary>
+	<description>Exists so gate-19 and gate-26 can be shown to distinguish an executing reference from a sentence about one.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ProseFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/openspec/specs/records-panel/spec.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/openspec/specs/records-panel/spec.md
@@ -1,0 +1,12 @@
+# Records panel
+
+The subject of the two arms. One scenario, one page component, and exactly one
+difference between `planted/` and `clean/`: whether the reference to each is
+something that RUNS or something that merely says so.
+
+### Requirement: Records panel
+
+#### Scenario: The panel lists stored records
+
+- WHEN the user opens the records panel
+- THEN every stored record is listed

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/src/views/RecordsPanel.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/src/views/RecordsPanel.vue
@@ -1,0 +1,9 @@
+<template>
+	<div class="records-panel">
+		<h2>Records</h2>
+		<ul><li v-for="r in records" :key="r.id">{{ r.title }}</li></ul>
+	</div>
+</template>
+<script>
+export default { name: 'RecordsPanel', data() { return { records: [] } } }
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/tests/e2e/records-panel.spec.ts
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/tests/e2e/records-panel.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+// @e2e records-panel::the-panel-lists-stored-records
+test('records panel lists every stored record', async ({ page }) => {
+	await page.goto('/index.php/apps/prosefixture/#/records')
+	await expect(page.locator('.records-panel li')).toHaveCount(3)
+	await expect(page.locator('.records-panel li').first()).toHaveText('First record')
+})

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/tests/e2e/visual/records-panel.visual.spec.ts
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/clean/tests/e2e/visual/records-panel.visual.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+test('RecordsPanel renders as baselined', async ({ page }) => {
+	await page.goto('/index.php/apps/prosefixture/#/records')
+	await expect(page.locator('.records-panel')).toBeVisible()
+	await expect(page).toHaveScreenshot('RecordsPanel.png')
+})

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/expect.conf
@@ -1,0 +1,28 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: prose-not-proof — gate-19 (e2e-coverage) + gate-26 (visual-coverage),
+# `.github#358`. A COMMENT MUST NOT BE ENOUGH TO GET PAST A GATE.
+#
+# The two arms differ in exactly one property: whether the claim is attached to
+# something that EXECUTES.
+#
+#   planted/  the `@e2e` anchor sits mid-sentence in a TODO comment, and the
+#             page component's name appears only in that same comment. Nothing
+#             asserts either.
+#   clean/    the identical two claims, made as a leading `@e2e` directive above
+#             a test that asserts the scenario, and as a visual spec that
+#             navigates to the page and screenshots it.
+#
+# Before the fix both arms printed the SAME verdict — `[gate-19] … PASS — 1
+# reference(s)` and `[gate-26] … PASS — 1 new page(s), all have a visual proof`.
+# That is the finding: a number indistinguishable from its own counterfeit is
+# not a measurement. Two agents triggered this defect while documenting it, and
+# doriath's warning paragraph about gate-26 *covered* the view it warned about.
+#
+# The subject column is load-bearing: a bare count would let a gate that fails
+# for some unrelated reason score this bundle for free.
+gate 19 hydra-gate-e2e-coverage.log FAIL PASS records-panel::the-panel-lists-stored-records
+gate 26 hydra-gate-visual-coverage.log FAIL PASS src/views/RecordsPanel.vue

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>prosefixture</id>
+	<name>Prose Is Not Proof Fixture</name>
+	<summary>Fixture app for the prose-vs-directive acceptance bundle. Not a real app.</summary>
+	<description>Exists so gate-19 and gate-26 can be shown to distinguish an executing reference from a sentence about one.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ProseFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/openspec/specs/records-panel/spec.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/openspec/specs/records-panel/spec.md
@@ -1,0 +1,12 @@
+# Records panel
+
+The subject of the two arms. One scenario, one page component, and exactly one
+difference between `planted/` and `clean/`: whether the reference to each is
+something that RUNS or something that merely says so.
+
+### Requirement: Records panel
+
+#### Scenario: The panel lists stored records
+
+- WHEN the user opens the records panel
+- THEN every stored record is listed

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/src/views/RecordsPanel.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/src/views/RecordsPanel.vue
@@ -1,0 +1,9 @@
+<template>
+	<div class="records-panel">
+		<h2>Records</h2>
+		<ul><li v-for="r in records" :key="r.id">{{ r.title }}</li></ul>
+	</div>
+</template>
+<script>
+export default { name: 'RecordsPanel', data() { return { records: [] } } }
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/tests/e2e/records-panel.spec.ts
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/prose-not-proof/planted/tests/e2e/records-panel.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+// TODO: the records-panel scenario is still unwritten. Its anchor is @e2e records-panel::the-panel-lists-stored-records and its screen is RecordsPanel; add the assertion and the baseline once the fixture lands.
+test('records panel — placeholder, asserts only that the app mounted', async ({ page }) => {
+	await page.goto('/index.php/apps/prosefixture/')
+	await expect(page.locator('#app')).toBeVisible()
+})


### PR DESCRIPTION
## What was wrong

Both gates parsed prose. A sentence that merely *named* an anchor or a component satisfied the check for that anchor or component — so the honest arm and the counterfeit arm emitted byte-identical verdicts, and no downstream reader could tell them apart. This is `.github#358`, and two agents triggered it *while documenting it*: a warning paragraph about a view ended up covering that view.

Both were reproduced on fixtures, against predictions written before anything changed.

- **gate-19** — take the package's own `e2e-credibility/honest` fixture, and change one line: replace a leading `@e2e` directive with the same anchor written mid-sentence in a TODO comment. The verdict does not move. Same word, same count, same everything.
- **gate-26** — three one-page fixture apps that differ only in what the e2e suite *says* about the page. The arm whose only mention is a comment reading "we still owe a baseline for Dashboard" produces exactly the same green sentence as the arm with a real spec that navigates to the page and screenshots it. A comment saying you have not done the thing satisfied the gate that checks whether you have.

## The rule

**An anchor counts only where it is attached to something that executes.**

For gate-19 that means exactly two accepted positions: leading in a comment, after nothing but whitespace and markdown/jsdoc leaders; or inside the title of a `test(` / `describe(`, where the anchor is part of the name of a running thing. Prose mid-comment, a selector string, a regex literal and bare code are refused by name — with a remedy that does not send the author hunting for a test to unskip. Separately, a tag that no declaration owns *at all* is no longer read as a live "file-level annotation". A file-header tag is unaffected: it already binds forward to the first declaration in the file.

For gate-26 the searched corpus now enters through `source_scope.js_comment_mask` for `.ts`/`.js`: comments and regex literals blanked, **string literals kept**. Strings have to stay — a `goto`, a `toHaveScreenshot` filename and a locator are all real references, and blanking them is the `#230` mistake that made gate-58's own evidence invisible. PNG baselines still contribute their filename; `.json`/`.txt` snapshots are untouched.

This follows a precedent already in `check_e2e_coverage.py`: `_parse_whole_spec_exclusion` already refuses a Purpose paragraph that merely *mentions* `@e2e exclude`, anchored the same way. One rule, two directives.

## Why the strictness is safe — measured, not assumed

Every anchor the pristine regexes match was classified across the sixteen app checkouts that have an e2e suite: **1,918 anchors, and all 1,918 are already in leading position.** None in prose, none in a string, none in code. Anchors with no owning declaration: zero of 1,918.

So **gate-19's count does not move at all.** Full-tree, `HYDRA_GATE_BASE_REF` unset, on clean `--depth 1` clones of `development`: opencatalogi at `963f832` stays at thirty-one, nldesign at `d18643f` stays at one hundred and twenty-six, docudesk at `696c381` stays at three hundred and ninety-six. Widened to fifteen local checkouts — five thousand eight hundred and twenty-three findings in total — the count is identical in every single app. The fix deletes a counterfeit; it creates no debt.

**The movement is all in gate-26, and all in the strict direction.** On the same three named clones, opencatalogi goes from green to one finding, docudesk from green to six, nldesign stays not-applicable. Across twelve more local checkouts the deltas run from zero to six, and three previously-green cells go red: openbuild, doriath and scholiq. Anyone holding a full-scope green for those three should re-measure after this lands.

The new findings were spot-checked and are true positives, every one credited by a comment and by nothing else. The sharpest is docudesk's `TemplateIndex.vue`, where a comment recording that the component *is registered by nothing* was the only thing crediting it as covered.

## Deliberately not changed

- The conditional `test.skip` guard still counts (`#239`). A never-false guard stays app debt, not a gate finding. Untouched, not weakened.
- Header-binding survives. The descendant-skip half of `#343` — `_ref_is_live` walks ancestors but never descendants — is a different mechanism with its own blast radius and belongs in its own change. Exposure measured for whoever takes it: two hundred and seventy-five anchors bind forward from a header to a describe, across nine apps.
- `#362`'s runtime-generated-spec blindness is left alone. Crediting a manifest-driven sweep is a green-making rule I could only generalise from one app; eleven apps mention a manifest in their e2e suites and most of those are about a different manifest. Bundling a credit into a tightening would let one half mask the other, which is the shape recorded for gate-61.
- An anchor under `openspec/changes/` still matches neither regex. Making it visible adds a new finding class and is a different change.

## Both directions proven, both arms fixtured

`test_check_e2e_coverage.py` goes from one hundred and twenty-seven to one hundred and thirty-nine assertions; `test_check_visual_coverage.py` from twenty to twenty-four. Every new arm is paired — a refused position and the accepted position one character away — so "refuse everything" cannot score as a repair. Two of the gate-26 arms exist specifically to stop that: a reference living only inside a string literal, and a PNG baseline named after the component, both of which must keep counting.

A new repo-shaped acceptance bundle, `test-fixtures/gate-acceptance/prose-not-proof/`, drives both gates through the real wrapper. The planted arm must fail *and name its subject*; the clean arm must pass. The two arms differ in exactly one property.

The controls run in both directions. Four of the eleven new gate-19 assertions and one of the four new gate-26 assertions fail against the pristine checkers and pass against the fixed ones. Swapping the pristine checkers back under the new acceptance bundle makes it report two failures — so the bundle is a detector, not a fixture that agrees with whatever ships. `test_source_scope.py`'s byte-identical drift assertion against gate-19's tokeniser still holds: the span recorder was added alongside `_code_mask` rather than replacing it, precisely to keep those two copies proven equal.

## What I could not verify

The rule is positional, so a prose paragraph that *wraps* such that the anchor lands at the start of a comment line still counts. My own planted fixture did exactly that and silently defeated the fix I had just written, which is how it was found. Every stricter formulation I could construct kills the legitimate jsdoc header form that two hundred and seventy-five fleet anchors use, so I took the rule I can defend and measure over the cleverer one I cannot. Closing it honestly needs a corpus measurement of wrapped-prose anchors, not a heuristic.

The fifteen-app tables are over working-tree checkouts that other agents are editing; only the three named apps are clean clones at a stated commit. Treat the wide tables as directional. All numbers are local and full-tree — I have not measured a diff-scoped run, and I have not measured launchpad, portaliq, zaakafhandelapp or hrmq at all.

One process note against myself: the four new gate-26 test arms were inserted with a scripted edit rather than by hand, against the standing rule. I re-read the inserted lines byte-for-byte and the result is correct, but the rule exists because the unverified case looks identical to the verified one, so it is recorded rather than quietly relied on.

## The self-referential check, and one thing it settled

`SHARED-LESSONS` flags as *untested* whether a PR body reaching a checker's corpus would be a coverage-manufacturing vector. It was tested here. The PR body feeds exactly one consumer in the runner, and only three gates read that consumer — none of them these two. Running the real wrapper over the planted fixture with a body carrying the planted anchor, the planted component path and the bare component token changed nothing: both gates still failed and still named their subjects. **A PR body cannot manufacture gate-19 or gate-26 coverage.** It still lands in the workflow log, so the filter-before-prettifying rule for reading that log is unchanged.

This PR changes the verdict for all eighteen apps at once. **Not for merge without a human decision on sequencing.**
