### PR TITLE
fix(gates 50/57/60/62): the exemption list was the defect in all four

### DIFF
--- a/hydra-gates/scripts/lib/check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/check_icon_vocabulary.py
@@ -80,6 +80,10 @@ EXIT_TOOLING_MISSING = 5
 # raw SVG path. All three stay legal per ADR-077 rule 1.
 _URLISH = ('/', 'http://', 'https://', 'data:')
 
+# Sentinel in the label slot of a _menu_entries() tuple, marking a caption that
+# carries keys the renderer ignores. Not a label any manifest can produce.
+_CAPTION_DEAD_KEYS = '\x00caption-dead-keys'
+
 
 def _is_svg_path(value: str) -> bool:
     """Whether the value looks like a raw SVG path payload rather than a name."""
@@ -142,7 +146,8 @@ def _registered_icon_names(repo: str) -> tuple[set[str] | None, str | None]:
     if not os.path.isfile(main_js):
         return None, None
 
-    src_main = open(main_js, encoding='utf-8').read()
+    with open(main_js, encoding='utf-8') as fh:
+        src_main = fh.read()
     # Ignore comments so a `registerIcons()` mentioned in prose is not read as a call.
     code = '\n'.join(l for l in src_main.splitlines()
                      if not l.lstrip().startswith(('//', '*', '/*')))
@@ -158,7 +163,8 @@ def _registered_icon_names(repo: str) -> tuple[set[str] | None, str | None]:
     for f in (icons_js, main_js):
         if not os.path.isfile(f):
             continue
-        text = open(f, encoding='utf-8').read()
+        with open(f, encoding='utf-8') as fh:
+            text = fh.read()
         for m in re.finditer(r"import\s+(\w+)\s+from\s+'vue-material-design-icons/([\w-]+)\.vue'", text):
             names.add(m.group(1))
             names.add(m.group(2))
@@ -188,6 +194,53 @@ def _menu_entries(path: str):
     def walk(node, label_ctx, in_widget=False):
         if isinstance(node, dict):
             if node.get('type') == 'caption':
+                # THE CAPTION EXEMPTION, AND WHY IT IS THE CORRECT ONE.
+                #
+                # gate-60 and gate-62 DISAGREED about this node until
+                # 2026-08-12: gate-60 skipped it, gate-62 failed it twice (once
+                # for "names the STORE concept but renders X", once for "one
+                # glyph, two meanings"). Two gates in one package, opposite
+                # verdicts on the same three lines of JSON. Somebody had to
+                # decide, so it was decided against the RENDERER rather than by
+                # aligning whichever was easier to change.
+                #
+                # `CnAppNav.vue` renders a caption as
+                #
+                #     <NcAppNavigationCaption v-if="isCaption(item)"
+                #         :name="resolveLabel(item)"
+                #         :data-testid="`cn-nav-caption-${item.id}`" />
+                #
+                # — `:name` and a test id, and NOTHING ELSE. No `#icon` slot is
+                # passed, no `:to`, no children loop. Its own docblock states
+                # the contract: "Caption entries ignore `route`, `href`,
+                # `action`, `icon`, `count`, `children`, and `pinned`." The
+                # manifest schema says the same thing independently:
+                # "'caption' renders an NcAppNavigationCaption section divider —
+                # only label, id, order, and section are honoured."
+                #
+                # So a caption's `icon` DRAWS NOTHING. Every rule this gate
+                # enforces is a claim about a rendered glyph, and there is no
+                # glyph. Failing it — as gate-62 did — is an unclosable finding
+                # about dead metadata, and the "fix" it demands changes no
+                # pixel. gate-62 has been aligned to this decision, not the
+                # other way round. See check_store_and_settings_surface.py.
+                #
+                # The `return` (rather than `continue`) is deliberate and is
+                # part of the same decision: the renderer does not walk a
+                # caption's `children` either, so nothing under it is drawn.
+                #
+                # WHAT IS *NOT* EXEMPT: the keys themselves. Dead metadata on a
+                # caption is a mistake worth telling the author about — it
+                # usually means they expected an icon and got none — so it is
+                # reported as a WARN below, which does not fail the gate. An
+                # exemption that produces silence is how a gate's quiet gets
+                # believed; this one produces a sentence.
+                dead = sorted(k for k in ('icon', 'route', 'children', 'href',
+                                          'action', 'count', 'pinned')
+                              if node.get(k))
+                if dead:
+                    label = str(node.get('label') or node.get('id') or '?')
+                    yield (_CAPTION_DEAD_KEYS, ', '.join(dead), label, False)
                 return
             label = (node.get('title') or node.get('label') or node.get('name')
                      or node.get('id') or label_ctx)
@@ -209,27 +262,67 @@ def _menu_entries(path: str):
 
 # Label -> concept. Only unambiguous namings; an app's own domain wording is
 # never guessed at. Matched against the lowercased, stripped label.
+#
+# THIS MAP IS THE *SYNONYM* LAYER, NOT THE VOCABULARY.
+# ---------------------------------------------------
+# It holds the spellings that are NOT recoverable from a concept's own name:
+# Dutch synonyms, plurals, and abbreviations. The concept names themselves are
+# derived from semantic-icons.json by `_concept_labels()` below, so adding a
+# concept to the vocabulary makes it enforceable without editing this file.
+#
+# WHY THAT MATTERS (.github, 2026-08-12). Every value in this map is a **Tier
+# A** key, and the vocabulary ships **140 Tier B concepts**. So the
+# `warns.append(... Tier B — SHOULD)` branch below was UNREACHABLE CODE: no
+# label could ever resolve to a Tier B concept, and a green gate-60 said
+# nothing whatsoever about 140 of the 153 concepts it claims to govern.
+# Measured before the fix, with node_modules installed, across 14 fleet repos
+# and 417 manifests: **0 warnings, everywhere, always.** A planted
+# `{"label": "Invoice", "icon": "FileDocumentOutline"}` — an exact Tier B
+# concept name carrying the wrong glyph — produced nothing at all.
+#
+# Three TIER A concepts were unreachable too — `activity`, `admin`,
+# `tutorial` — and those are MUSTs, not SHOULDs.
 CONCEPT_LABELS = {
-    'dashboard': 'dashboard',
-    'documentation': 'documentation',
     'docs': 'documentation',
     'features & roadmap': 'features-roadmap',
     'features and roadmap': 'features-roadmap',
-    'settings': 'settings',
     'instellingen': 'settings',
     'configuratie': 'settings',
     'configuration': 'settings',
-    'search': 'search',
     'zoeken': 'search',
-    'store': 'store',
-    'about': 'about',
-    'notifications': 'notifications',
     'notificaties': 'notifications',
-    'audit trail': 'audit-trail',
     'audit log': 'audit-trail',
-    'my work': 'my-work',
     'mijn werk': 'my-work',
+    'beheer': 'admin',
+    'activiteit': 'activity',
 }
+
+
+def _concept_labels(all_concepts: dict) -> dict:
+    """Label -> concept, derived from the vocabulary plus the synonym map.
+
+    A concept's own NAME is an exact, unambiguous label for it — `Invoice`
+    means the `invoice` concept in any app, in the same way `Dashboard` means
+    `dashboard`. This is NOT the label-count heuristic ADR-077 rule 5 forbids:
+    nothing is inferred from how many entries share a glyph, and nothing is
+    matched as a substring. The comparison is equality against the concept's
+    own name, which is exactly the strength the hand-written map already had —
+    the map was simply missing 143 of the 153 concepts.
+
+    Hyphenated concepts (`audit-trail`, `bank-transaction`, `open-external`)
+    additionally accept the space-separated spelling, because that is how a
+    menu label is written.
+
+    The synonym map WINS on a collision, so `configuration` keeps resolving to
+    `settings` rather than being shadowed.
+    """
+    labels: dict[str, str] = {}
+    for concept in all_concepts:
+        labels[concept] = concept
+        if '-' in concept:
+            labels[concept.replace('-', ' ')] = concept
+    labels.update(CONCEPT_LABELS)
+    return labels
 
 
 def main() -> int:
@@ -244,6 +337,7 @@ def main() -> int:
     tier_a: dict = vocab['tierA']
     tier_b: dict = vocab['tierB']
     all_concepts = {**tier_a, **tier_b}
+    concept_labels = _concept_labels(all_concepts)
     canonical_icons = set(all_concepts.values())
     bridged = set(vocab['bridgedCssIcons'])
     content_block_icons = set((vocab.get('contentBlockIcons') or {}).get('names') or [])
@@ -262,10 +356,25 @@ def main() -> int:
     fails: list[str] = []
     warns: list[str] = []
     used_mdi: set[str] = set()
+    # Non-vocabulary icon names this run could not check for existence because
+    # vue-material-design-icons is not installed. EMPTY means the run is fully
+    # verified and the missing library changed no answer.
+    unverifiable: set[str] = set()
 
     for path in paths:
         rel = os.path.relpath(path, repo)
         for label, icon, entry_id, in_widget in _menu_entries(path):
+            if label == _CAPTION_DEAD_KEYS:
+                # Not a rendered icon — dead metadata on a section divider.
+                # WARN, never FAIL: there is no glyph to be wrong about, so
+                # this cannot block a PR, but it is not silent either.
+                warns.append(
+                    f'{rel}: caption entry "{entry_id}" declares {icon} — a '
+                    f'type:"caption" renders NcAppNavigationCaption, which '
+                    f'honours only label/id/order/section. These keys draw '
+                    f'nothing; drop them, or drop type:"caption" if the entry '
+                    f'was meant to be clickable.')
+                continue
             where = f'{rel}: {label or entry_id or "?"}'
             if not icon:
                 continue
@@ -308,12 +417,31 @@ def main() -> int:
                 continue
 
             # An MDI-style name from here on.
-            if available is not None and icon not in available and icon not in canonical_icons:
-                fails.append(
-                    f'{where}: icon "{icon}" does not exist in '
-                    f'vue-material-design-icons and is not a vocabulary icon — '
-                    f'it renders blank wherever it is not aliased locally.')
-                continue
+            if icon not in canonical_icons:
+                if available is None:
+                    # UNVERIFIABLE, AND ONLY THIS NAME IS.
+                    #
+                    # The existence rule used to be switched off wholesale the
+                    # moment node_modules was absent, and the whole RUN then
+                    # reported SKIPPED — including runs where every icon in the
+                    # app came straight out of the vocabulary and nothing
+                    # needed the library at all. That is why this gate "went
+                    # unrun" in apps whose manifests were in fact clean: one
+                    # missing `npm ci` erased a verdict the gate already had.
+                    #
+                    # A vocabulary icon needs no library to be verified. The
+                    # vocabulary is curated, and nextcloud-vue's own
+                    # tests/components/semanticIcons.spec.js asserts every name
+                    # in it resolves. So the library is needed for exactly one
+                    # question — "is this NON-vocabulary name real?" — and only
+                    # a manifest that asks that question is unverifiable.
+                    unverifiable.add(icon)
+                elif icon not in available:
+                    fails.append(
+                        f'{where}: icon "{icon}" does not exist in '
+                        f'vue-material-design-icons and is not a vocabulary icon — '
+                        f'it renders blank wherever it is not aliased locally.')
+                    continue
 
             used_mdi.add(icon)
 
@@ -344,15 +472,22 @@ def main() -> int:
             # Tier A glyphs to widgetIcons.js), after which this exemption can
             # go. Until then it is the difference between a gate that is strict
             # and one that is impossible.
-            concept = CONCEPT_LABELS.get(label.strip().lower())
+            concept = concept_labels.get(label.strip().lower())
             if concept and in_widget is True:
                 concept = None
 
             if concept:
                 expected = all_concepts.get(concept)
                 if expected and icon != expected:
-                    msg = (f'{where}: concept "{concept}" must use "{expected}", '
-                           f'found "{icon}"')
+                    # Name the ENTRY ID as well as the label. One manifest can
+                    # carry the same label at several ids, and without the id
+                    # the findings are byte-identical — 14 warnings collapsing
+                    # to 8 distinct strings in pipelinq, none of them telling
+                    # you WHICH entry to edit. A count you cannot act on is not
+                    # a finished measurement.
+                    ident = f' [id={entry_id}]' if entry_id else ''
+                    msg = (f'{where}{ident}: concept "{concept}" must use '
+                           f'"{expected}", found "{icon}"')
                     if concept in tier_a:
                         fails.append(msg + ' (ADR-077 Tier A — MUST).')
                     else:
@@ -382,10 +517,13 @@ def main() -> int:
                 f'manifests are NOT registered — they render with no icon at all, '
                 f'not a fallback: {shown}{more} (ADR-077 rule 3).')
 
-    if available is None:
-        # No silent caps: say what could not be checked.
-        print('NOTE: vue-material-design-icons is not installed — could not verify '
-              'that icon names exist upstream. Install dependencies for full coverage.')
+    if available is None and unverifiable:
+        # No silent caps: say what could not be checked, and NAME it. A NOTE
+        # that lists the actual names is auditable; "could not verify" is not.
+        print('NOTE: vue-material-design-icons is not installed and this app uses '
+              f'{len(unverifiable)} icon name(s) from OUTSIDE the ADR-077 vocabulary, '
+              'whose existence therefore could not be verified: '
+              f'{", ".join(sorted(unverifiable))}. Install dependencies for full coverage.')
         # ...and do not let the caller read that NOTE as a clean bill of health.
         #
         # This gate once reported 43 confident FAILs when node_modules was
@@ -407,11 +545,18 @@ def main() -> int:
           f'{len(warns)} warning(s)')
     if fails:
         return 1
-    if available is None:
+    if available is None and unverifiable:
         # Clean on every rule that COULD run, but the invented-name rule could
-        # not. The runner reports this as SKIPPED (wiring), which is visible to
-        # --require-full-coverage. Returning 0 here would claim the icon names
-        # were verified against the library when the library was not there.
+        # not be answered FOR THESE NAMES. The runner reports this as SKIPPED
+        # (wiring), which is visible to --require-full-coverage. Returning 0
+        # here would claim those names were verified against the library when
+        # the library was not there.
+        #
+        # Note the condition is `unverifiable`, not `available is None`: an app
+        # whose every icon comes from the vocabulary has nothing left to ask
+        # the library, so it gets a real PASS with no toolchain. That is not a
+        # loosening — it is the difference between "I could not check" and "I
+        # did not need to".
         return EXIT_TOOLING_MISSING
     return 0
 

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -86,7 +86,41 @@ _PRUNE_DIRS = {"custom_apps", "vendor", "node_modules", "tests", ".git"}
 # is*/has*/get*/find*/list*/validate*/check*/ensure*/require*/authorize* —
 # those read-or-guard shapes are gate-6's (orphan-auth) territory, not
 # this gate's.
+#
+# THE VERB LIST *IS* THE DETECTOR (.github, 2026-08-12).
+# ------------------------------------------------------
+# Everything else in this module — four indirect seams, a cross-app caller
+# index, comment blanking — only ever REMOVES findings. Nothing is examined
+# at all unless its name starts with one of these words, so a verb that is
+# missing is not a weaker check, it is NO check.
+#
+# Measured on a controlled probe: four orphaned write methods on one service,
+# `postJournalEntry` / `updateLedgerBalance` / `sendRemittanceAdvice` /
+# `deleteJournalEntry`, all with zero callers and no seam. The gate reported
+# exactly ONE — `post*`. The other three were invisible, and `delete*`'s
+# absence was already load-bearing enough that the fleet board had to warn
+# agents to "plant with `post*`" or they would wrongly record the gate as
+# blind.
+#
+# The original seventeen skew heavily to LEDGER vocabulary (`post`, `settle`,
+# `reconcile`, `issue`, `record`, `seed`) because the gate was written from a
+# shillinq bookkeeping sweep. The additions below are the ordinary write verbs
+# any app uses.
+#
+# WIDENING A VOCABULARY LIST IS HOW A GATE STARTS CRYING WOLF, so each verb
+# below was measured on twelve fleet repos BEFORE being added, and every
+# finding it produced was read. The set adds 35 findings to a baseline of 41.
+# Deliberately REJECTED after measurement, with their costs:
+#
+#   apply    (6)  applyFilters/applyDefaults are pure transforms
+#   process  (7)  processResponse/processRow are frequently pure
+#   register (4)  collides with OpenRegister's core NOUN, and with this
+#                 gate's own "registered seam" concept
+#   set/add  (--) never measured and never will be: every PHP setter matches
+#
+# One measured false positive drove _PREFIX_ONLY_VERBS below.
 WRITE_VERB_PREFIXES = (
+    # --- ledger/accounting vocabulary (original seventeen) ---
     "post",
     "create",
     "save",
@@ -104,7 +138,54 @@ WRITE_VERB_PREFIXES = (
     "seed",
     "publish",
     "issue",
+    # --- ordinary persistence writes ---
+    "update",
+    "delete",
+    "remove",
+    "persist",
+    "store",
+    "insert",
+    "upsert",
+    "patch",
+    "replace",
+    "purge",
+    "flush",
+    # --- outward side effects ---
+    "send",
+    "upload",
+    "import",
+    "sync",
+    "transfer",
+    # --- state transitions ---
+    "archive",
+    "cancel",
+    "approve",
+    "assign",
+    "mark",
+    "finalize",
+    "sign",
+    "revoke",
+    "grant",
+    # --- deferred work ---
+    "schedule",
+    "enqueue",
+    "trigger",
 )
+
+# Verbs that are ALSO ordinary English NOUNS, and so may name a pure accessor
+# when used as a whole method name. For these, only the PREFIX form counts
+# (`scheduleReminder` yes, `schedule` no).
+#
+# Measured, not guessed: `KapitaallastenCalculator::schedule()` in shillinq is
+# a PURE function returning a depreciation table — no side effect anywhere in
+# its body — and it was the single false positive among the 35 findings the
+# widening added. `flush()` and `sync()`, the only other bare-name matches in
+# the fleet, are genuine writes and are deliberately NOT listed here.
+#
+# The original seventeen are left alone on purpose: changing their exact-match
+# behaviour would drop existing findings, which is a different change from the
+# one being measured here.
+_PREFIX_ONLY_VERBS = frozenset({"schedule"})
 
 _METHOD_RE = re.compile(
     r"^\s*public\s+function\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\("
@@ -194,7 +275,15 @@ _EXCLUDE_RE = re.compile(
 
 
 def _is_write_method(name: str) -> bool:
-    return any(name.startswith(v) and len(name) > len(v) and name[len(v)].isupper() for v in WRITE_VERB_PREFIXES) or name in WRITE_VERB_PREFIXES
+    if any(
+        name.startswith(v) and len(name) > len(v) and name[len(v)].isupper()
+        for v in WRITE_VERB_PREFIXES
+    ):
+        return True
+    # Exact-name match, except for the noun-shaped verbs (see
+    # _PREFIX_ONLY_VERBS): `schedule()` is as likely to RETURN a schedule as to
+    # write one, and in the fleet it does exactly that.
+    return name in WRITE_VERB_PREFIXES and name not in _PREFIX_ONLY_VERBS
 
 
 def _class_short_name(src: str) -> str | None:

--- a/hydra-gates/scripts/lib/check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/check_store_and_settings_surface.py
@@ -88,11 +88,20 @@ def _load(path: Path) -> dict | None:
         return None
 
 
-def _walk_menu(items, out):
+def _walk_menu(items, out, skip_captions: bool = False):
+    """Flatten a menu tree into *out*.
+
+    ``skip_captions`` drops ``type: "caption"`` nodes AND their subtrees. See
+    :func:`check_store` for the decision and its evidence; gate 63 keeps
+    walking them, because the rule it applies to a caption (its LABEL) is a
+    property the renderer does honour.
+    """
     for item in items or []:
         if isinstance(item, dict):
+            if skip_captions and item.get("type") == "caption":
+                continue
             out.append(item)
-            _walk_menu(item.get("children"), out)
+            _walk_menu(item.get("children"), out, skip_captions)
 
 
 def _pages_by_id(manifests: list[tuple[Path, dict]]) -> dict[str, dict]:
@@ -105,12 +114,53 @@ def _pages_by_id(manifests: list[tuple[Path, dict]]) -> dict[str, dict]:
 
 
 def check_store(root: Path, manifests, findings, changed: set[str] | None = None) -> None:
-    """ADR-080: store / templates / catalogue are three distinct concepts."""
+    """ADR-080: store / templates / catalogue are three distinct concepts.
+
+    A ``type: "caption"`` entry is NOT a menu entry for this gate's purposes.
+    -----------------------------------------------------------------------
+    Until 2026-08-12 this gate and gate 60 (icon-vocabulary) DISAGREED about
+    that node, in the same package, on the same three lines of JSON: gate 60
+    exempted it, and this gate failed it TWICE — once for "names the STORE
+    concept but renders X", once for "one glyph, two meanings". Reproduced on
+    a fixture carrying `{"type":"caption","label":"Store","icon":
+    "ViewGridOutline"}`: gate-60 → 0 findings, gate-62 → 2 FAILs.
+
+    The disagreement was decided against the RENDERER, not by aligning
+    whichever gate was easier to edit. ``CnAppNav.vue`` renders a caption as
+
+        <NcAppNavigationCaption v-if="isCaption(item)"
+            :name="resolveLabel(item)"
+            :data-testid="`cn-nav-caption-${item.id}`" />
+
+    — the label and a test id, and nothing else. No ``#icon`` slot, no ``:to``,
+    no children loop. Its own docblock states the contract ("Caption entries
+    ignore `route`, `href`, `action`, `icon`, `count`, `children`, and
+    `pinned`"), and the manifest schema states it independently ("'caption'
+    renders an NcAppNavigationCaption section divider — only label, id, order,
+    and section are honoured").
+
+    EVERY rule below is a claim about a rendered ICON or a resolved ROUTE, and
+    a caption has neither. So gate 60 was right and this gate was wrong: it was
+    emitting unclosable findings about dead metadata, whose only "fix" changes
+    no pixel. This gate is therefore aligned to gate 60, and gate 60 now emits
+    a WARN naming the dead keys so the information is not merely dropped.
+
+    ⚠️ SCOPE OF THE DECISION. It covers the ICON and ROUTE rules only. A
+    caption's LABEL *is* honoured by the renderer, so a label rule on a caption
+    would still be legitimate — gate 63 (settings-surface) keeps walking
+    captions for exactly that reason, and its ADR-079 D4 rule is about the
+    label. Nothing here exempts a caption from a future naming rule.
+
+    Fleet exposure, measured before the change across 14 repos and 145
+    manifests: **1** caption node exists and **0** carry any dead key, so this
+    corrects a latent contradiction, not a live count. The census was
+    positive-controlled (it found the 1 caption, so a 0 is a result).
+    """
     pages = _pages_by_id(manifests)
 
     for path, data in manifests:
         entries: list[dict] = []
-        _walk_menu(data.get("menu"), entries)
+        _walk_menu(data.get("menu"), entries, skip_captions=True)
         rel = path.relative_to(root)
 
         for entry in entries:

--- a/hydra-gates/scripts/lib/test_check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/test_check_icon_vocabulary.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_icon_vocabulary (gate 60). Run with:
+
+    python3 scripts/lib/test_check_icon_vocabulary.py
+
+WHY THIS SUITE EXISTS
+---------------------
+Gate 60 had NO tests at all, and half of it was unreachable code.
+
+`CONCEPT_LABELS` mapped ten labels, and all ten resolved to **Tier A**
+concepts, while `semantic-icons.json` ships **140 Tier B** concepts. So the
+`warns.append(... Tier B — SHOULD)` branch could never execute — not for a
+badly-chosen glyph, not for any input at all. Measured across 14 fleet repos
+and 417 manifests with node_modules installed: **0 warnings, everywhere**. A
+green gate-60 said nothing whatsoever about 140 of the 153 concepts it claims
+to govern, and three TIER A concepts (`activity`, `admin`, `tutorial`) were
+unreachable too — those are MUSTs.
+
+Every class below plants a defect and asserts the gate names it, then plants
+the correct code and asserts it stays silent. An arm that only ever sees clean
+input proves nothing: a checker widened until it catches nothing passes it
+identically.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_icon_vocabulary as iv  # noqa: E402
+
+
+# Icons the fake node_modules below "ships". Deliberately a SMALL set: the
+# existence rule must be able to fail, or the arms testing it prove nothing.
+INSTALLED = (
+    "FileDocumentOutline ViewDashboardOutline ReceiptTextOutline CurrencyEur "
+    "StoreOutline ViewGridOutline Cog CogOutline History Eye EyeOutline "
+    "ClipboardTextClockOutline"
+).split()
+
+
+def _app(tmp: Path, menu, *, with_node_modules=True, registered=None, pages=None):
+    """Build a minimal repo-shaped app tree and return its root."""
+    (tmp / "src").mkdir(parents=True, exist_ok=True)
+    (tmp / "src" / "manifest.json").write_text(
+        json.dumps({"version": "0.1.0", "menu": menu, "pages": pages or []}),
+        encoding="utf-8")
+
+    # Register every icon the manifest uses unless the caller overrides it, so
+    # the registry-completeness rule never contaminates an arm about concepts.
+    if registered is None:
+        registered = sorted({
+            v for v in _icons_in(menu)
+            if v and v[:1].isupper() and not v.startswith("icon-")
+        })
+    (tmp / "src" / "main.js").write_text(
+        "import icons from './icons.js'\nregisterIcons(icons)\n", encoding="utf-8")
+    (tmp / "src" / "icons.js").write_text(
+        "".join(f"import {n} from 'vue-material-design-icons/{n}.vue'\n"
+                for n in registered)
+        + "export default { " + ", ".join(registered) + " }\n",
+        encoding="utf-8")
+
+    if with_node_modules:
+        nm = tmp / "node_modules" / "vue-material-design-icons"
+        nm.mkdir(parents=True, exist_ok=True)
+        for n in INSTALLED:
+            (nm / f"{n}.vue").write_text("", encoding="utf-8")
+    return tmp
+
+
+def _icons_in(node):
+    if isinstance(node, dict):
+        if node.get("icon"):
+            yield node["icon"]
+        for v in node.values():
+            yield from _icons_in(v)
+    elif isinstance(node, list):
+        for i in node:
+            yield from _icons_in(i)
+
+
+def _run(root: Path):
+    """(exit_code, stdout) for a full check of *root*."""
+    buf = io.StringIO()
+    argv = sys.argv
+    sys.argv = ["check_icon_vocabulary.py", str(root)]
+    try:
+        with redirect_stdout(buf):
+            rc = iv.main()
+    finally:
+        sys.argv = argv
+    return rc, buf.getvalue()
+
+
+class _TmpCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TierBIsReachable(_TmpCase):
+    """The half of the gate that was unreachable code."""
+
+    def test_a_tier_b_concept_with_the_wrong_glyph_warns(self):
+        # `invoice` is a Tier B concept. Before the fix this produced NOTHING —
+        # no warning, no failure — because no label could resolve to Tier B.
+        root = _app(self.tmp, [
+            {"id": "inv", "label": "Invoice", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertIn("Tier B — SHOULD", out)
+        self.assertIn('concept "invoice"', out)
+        self.assertIn("ReceiptTextOutline", out)
+
+    def test_a_tier_b_warning_does_not_fail_the_gate(self):
+        # SHOULD, not MUST. Widening Tier B must not turn 140 concepts into
+        # 140 new ways to block a PR — that is how a gate starts crying wolf.
+        root = _app(self.tmp, [
+            {"id": "inv", "label": "Invoice", "icon": "FileDocumentOutline"}])
+        rc, _ = _run(root)
+        self.assertEqual(rc, 0)
+
+    def test_the_correct_tier_b_glyph_is_silent(self):
+        # ANTI-WIDENING. The same label with the canonical icon must produce
+        # nothing at all.
+        root = _app(self.tmp, [
+            {"id": "inv", "label": "Invoice", "icon": "ReceiptTextOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("Tier B", out)
+        self.assertNotIn("FAIL", out)
+
+    def test_every_vocabulary_concept_is_reachable_by_its_own_name(self):
+        # The structural assertion behind all of the above: the label table is
+        # DERIVED from the vocabulary, so adding a concept makes it
+        # enforceable. Before the fix this was 10 of 153.
+        vocab = iv._load_vocab()
+        concepts = {**vocab["tierA"], **vocab["tierB"]}
+        labels = iv._concept_labels(concepts)
+        unreachable = sorted(c for c in concepts if c not in set(labels.values()))
+        self.assertEqual(unreachable, [])
+        self.assertGreater(len(vocab["tierB"]), 100)
+
+    def test_a_tier_a_concept_still_fails(self):
+        # No regression: Tier A stays a MUST.
+        root = _app(self.tmp, [
+            {"id": "d", "label": "Dashboard", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("Tier A — MUST", out)
+
+    def test_a_newly_reachable_tier_a_concept_fails(self):
+        # `admin` was in Tier A and had no label mapping, so it was as dead as
+        # Tier B despite being a MUST.
+        vocab = iv._load_vocab()
+        self.assertIn("admin", vocab["tierA"])
+        root = _app(self.tmp, [
+            {"id": "a", "label": "Admin", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn('concept "admin"', out)
+
+    def test_a_dutch_synonym_still_resolves(self):
+        # The synonym layer must survive being merged with the derived one.
+        root = _app(self.tmp, [
+            {"id": "s", "label": "Instellingen", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertIn('concept "settings"', out)
+
+    def test_a_domain_label_is_never_guessed_at(self):
+        # ANTI-WIDENING, and the thing ADR-077 rule 5 actually forbids. An
+        # app's own wording resolves to no concept and is left alone.
+        root = _app(self.tmp, [
+            {"id": "z", "label": "Zaakdossiers", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("concept", out)
+
+    def test_a_finding_names_the_entry_id(self):
+        # One manifest can carry the same label at several ids; without the id
+        # the findings are byte-identical and name nothing to edit.
+        root = _app(self.tmp, [
+            {"id": "inv-a", "label": "Invoice", "icon": "FileDocumentOutline"},
+            {"id": "inv-b", "label": "Invoice", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertIn("id=inv-a", out)
+        self.assertIn("id=inv-b", out)
+
+
+class CaptionsAreNotRenderedIcons(_TmpCase):
+    """The gate-60 / gate-62 divergence, decided against the renderer.
+
+    `CnAppNav.vue` renders a caption as `<NcAppNavigationCaption :name=... />`
+    — no `#icon` slot, no `:to`, no children loop — and its docblock says
+    "Caption entries ignore `route`, `href`, `action`, `icon`, `count`,
+    `children`, and `pinned`". The manifest schema agrees independently. So a
+    caption's icon draws nothing and cannot be wrong; gate 62 used to fail it
+    twice and has been aligned to this.
+    """
+
+    def test_a_caption_icon_is_not_judged_as_a_glyph(self):
+        root = _app(self.tmp, [
+            {"id": "cap", "type": "caption", "label": "Dashboard",
+             "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("Tier A", out)
+        self.assertNotIn("FAIL", out)
+
+    def test_a_caption_carrying_dead_keys_still_says_so(self):
+        # The exemption must not be a SILENCE — it produces a sentence.
+        root = _app(self.tmp, [
+            {"id": "cap", "type": "caption", "label": "Dashboard",
+             "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertIn("caption entry", out)
+        self.assertIn("icon", out)
+        self.assertTrue(out.lstrip().startswith("WARN"), out)
+
+    def test_a_clean_caption_is_completely_silent(self):
+        # ANTI-WIDENING: a caption with only the honoured keys says nothing.
+        root = _app(self.tmp, [
+            {"id": "cap", "type": "caption", "label": "Dashboard", "order": 1}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("caption entry", out)
+
+    def test_the_identical_node_without_type_caption_still_fails(self):
+        # The decisive pair. Same label, same icon; only `type` differs.
+        root = _app(self.tmp, [
+            {"id": "cap", "label": "Dashboard", "icon": "FileDocumentOutline"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("Tier A — MUST", out)
+
+
+class ToolingMissingIsNarrowedToWhatItActuallyBlocks(_TmpCase):
+    """A missing npm install must not erase a verdict the gate already has."""
+
+    def test_an_all_vocabulary_app_passes_with_no_node_modules(self):
+        # Every icon here is a vocabulary icon, whose existence is asserted by
+        # nextcloud-vue's own semanticIcons.spec.js. The library answers no
+        # question this manifest asks, so the run is fully verified. This used
+        # to report SKIPPED, which is how the gate "went unrun" in apps whose
+        # manifests were clean.
+        root = _app(self.tmp,
+                    [{"id": "d", "label": "Dashboard",
+                      "icon": "ViewDashboardOutline"}],
+                    with_node_modules=False)
+        rc, out = _run(root)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("NOTE", out)
+
+    def test_a_non_vocabulary_name_without_node_modules_is_still_unverifiable(self):
+        # ANTI-WIDENING. The third state survives exactly where it is earned:
+        # this name is not in the vocabulary, so only the library could confirm
+        # it, and the library is absent. Neither a finding nor a pass.
+        root = _app(self.tmp,
+                    [{"id": "x", "label": "Widgets", "icon": "SomeInventedName"}],
+                    with_node_modules=False)
+        rc, out = _run(root)
+        self.assertEqual(rc, iv.EXIT_TOOLING_MISSING)
+        self.assertIn("SomeInventedName", out)
+
+    def test_an_invented_name_with_node_modules_present_fails(self):
+        # And with the library there, the same name is a hard failure.
+        root = _app(self.tmp,
+                    [{"id": "x", "label": "Widgets", "icon": "SomeInventedName"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("does not exist in", out)
+
+
+class RegressionGuards(_TmpCase):
+    """Rules that existed before and must keep working."""
+
+    def test_an_unbridged_legacy_css_icon_fails(self):
+        root = _app(self.tmp, [
+            {"id": "x", "label": "Widgets", "icon": "icon-not-a-real-bridge"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("unbridged legacy icon", out)
+
+    def test_an_unregistered_mdi_name_fails(self):
+        root = _app(self.tmp,
+                    [{"id": "x", "label": "Widgets", "icon": "Eye"}],
+                    registered=[])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("NOT registered", out)
+
+    def test_a_lowercase_non_contentblock_name_fails(self):
+        # The blanket lowercase skip is what hid shillinq's `calendar-sync`.
+        root = _app(self.tmp, [
+            {"id": "x", "label": "Widgets", "icon": "calendar-sync"}])
+        rc, out = _run(root)
+        self.assertEqual(rc, 1)
+        self.assertIn("ContentBlocks", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
@@ -1075,5 +1075,122 @@ class McpSeamSpellingTest(unittest.TestCase):
         self.assertIn("createInvoice", self._fully_qualified().methods())
 
 
+class WriteVerbVocabularyTest(unittest.TestCase):
+    """The verb list IS the detector — everything else only removes findings.
+
+    Nothing in this module is examined at all unless the method name starts
+    with a `WRITE_VERB_PREFIXES` entry, so a missing verb is not a weaker
+    check, it is NO check. Measured on a controlled probe before the fix: four
+    orphaned write methods on one service — `postJournalEntry`,
+    `updateLedgerBalance`, `sendRemittanceAdvice`, `deleteJournalEntry`, all
+    zero-caller, no seam — and the gate reported exactly ONE. `delete*`'s
+    absence was load-bearing enough that the fleet board had to warn agents to
+    "plant with `post*`" or they would wrongly record the gate as blind.
+    """
+
+    _FOUR = (
+        "<?php\nnamespace OCA\\Fixture\\Service;\nclass LedgerService {\n"
+        "    public function postJournalEntry(array $e): void { $this->x = $e; }\n"
+        "    public function updateLedgerBalance(array $e): void { $this->x = $e; }\n"
+        "    public function sendRemittanceAdvice(array $e): void { $this->x = $e; }\n"
+        "    public function deleteJournalEntry(string $i): void { $this->x = $i; }\n"
+        "}\n"
+    )
+
+    def _write(self, root, rel, content):
+        full = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        return full
+
+    def test_all_four_orphaned_write_shapes_are_reported(self):
+        with _AppFixture() as root:
+            path = self._write(root, "lib/Service/LedgerService.php", self._FOUR)
+            out = _run_main(path)
+            self.assertEqual(len(out), 4, out)
+            for name in ("postJournalEntry", "updateLedgerBalance",
+                         "sendRemittanceAdvice", "deleteJournalEntry"):
+                self.assertTrue(any(f"method={name}" in ln for ln in out), (name, out))
+
+    def test_the_same_four_with_callers_are_silent(self):
+        """ANTI-WIDENING. Widening a vocabulary list is exactly how a gate
+        starts crying wolf, so every added verb must be proven NOT to fire on
+        correct code."""
+        with _AppFixture() as root:
+            body = self._FOUR.replace(
+                "}\n",
+                "    public function run(): void {\n"
+                "        $this->postJournalEntry([]);\n"
+                "        $this->updateLedgerBalance([]);\n"
+                "        $this->sendRemittanceAdvice([]);\n"
+                "        $this->deleteJournalEntry('x');\n"
+                "    }\n}\n",
+            )
+            path = self._write(root, "lib/Service/LedgerService.php", body)
+            self.assertEqual(_run_main(path), [])
+
+    def test_each_added_verb_family_fires_on_an_orphan(self):
+        """One representative per family, so a verb cannot be dropped silently."""
+        families = [
+            "persistLoonStrook", "storeInbound", "insertRow", "upsertRecord",
+            "patchDocument", "replaceAttachment", "purgeExpired", "flushQueue",
+            "removeFromQueue", "uploadMedia", "importContact", "syncAbonnement",
+            "transferToIncasso", "archiveAndDelete", "cancelRedemption",
+            "approveRequest", "assignReviewer", "markOptedOut", "finalizeInvoice",
+            "signDocument", "revokeGrant", "grantAccess", "scheduleReminder",
+            "enqueueDispatch", "triggerTerugvordering",
+        ]
+        with _AppFixture() as root:
+            body = ("<?php\nnamespace OCA\\Fixture\\Service;\nclass WideService {\n"
+                    + "".join(f"    public function {n}(): void {{ $this->x = 1; }}\n"
+                              for n in families)
+                    + "}\n")
+            path = self._write(root, "lib/Service/WideService.php", body)
+            out = _run_main(path)
+            missed = [n for n in families
+                      if not any(f"method={n}" in ln for ln in out)]
+            self.assertEqual(missed, [], f"verbs the gate cannot see: {missed}")
+
+    def test_noun_shaped_verbs_are_prefix_only(self):
+        """A MEASURED false positive, not a hypothetical one.
+
+        `KapitaallastenCalculator::schedule()` in shillinq is a PURE function
+        returning a depreciation table. It was the single false positive among
+        the 35 findings the widening added across 12 repos, and it is why
+        `_PREFIX_ONLY_VERBS` exists: `scheduleReminder` counts, bare
+        `schedule` does not.
+        """
+        self.assertFalse(owc._is_write_method("schedule"))
+        self.assertTrue(owc._is_write_method("scheduleReminder"))
+        with _AppFixture() as root:
+            path = self._write(
+                root, "lib/Service/CalculatorService.php",
+                "<?php\nnamespace OCA\\Fixture\\Service;\nclass CalculatorService {\n"
+                "    public function schedule(float $b, int $n): array\n"
+                "    { return array_fill(0, $n, $b / $n); }\n"
+                "}\n")
+            self.assertEqual(_run_main(path), [])
+
+    def test_bare_verbs_that_are_genuine_writes_still_count(self):
+        """ANTI-WIDENING for the arm above: the prefix-only rule must apply to
+        `schedule` and to nothing else. `flush()` and `sync()` are the only
+        other bare-name matches in the fleet and both are real writes."""
+        self.assertTrue(owc._is_write_method("flush"))
+        self.assertTrue(owc._is_write_method("sync"))
+        self.assertTrue(owc._is_write_method("post"))
+
+    def test_read_and_guard_shapes_are_still_gate_6s_territory(self):
+        """The exclusions the gate declares in its own docstring must hold —
+        and `apply*` / `process*` / `register*` were measured and REJECTED
+        (6, 7 and 4 findings, all pure transforms or noun collisions)."""
+        for name in ("isReady", "hasAccess", "getBalance", "findAll",
+                     "listItems", "validateInput", "checkQuorum",
+                     "ensureSchema", "requireAdmin", "authorizeUser",
+                     "applyFilters", "processResponse", "registerHooks",
+                     "setRegister", "addRow"):
+            self.assertFalse(owc._is_write_method(name), name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
@@ -158,5 +158,78 @@ class GateIsNotBlind(unittest.TestCase):
             shutil.rmtree(root, ignore_errors=True)
 
 
+class CaptionsAreNotMenuEntriesForThisGate(unittest.TestCase):
+    """The gate-60 / gate-62 divergence, and the decision that resolved it.
+
+    Until 2026-08-12 these two gates disagreed about one node, in the same
+    package: gate 60 exempted a `type: "caption"` entry, and gate 62 failed it
+    TWICE. Reproduced on a fixture carrying
+    `{"type":"caption","label":"Store","icon":"ViewGridOutline"}` —
+    gate-60 → 0 findings, gate-62 → 2 FAILs.
+
+    Decided against the RENDERER, not by aligning whichever was easier to
+    change. `CnAppNav.vue` renders a caption as
+    `<NcAppNavigationCaption :name=... :data-testid=... />` — no `#icon` slot,
+    no `:to`, no children loop — and its docblock states "Caption entries
+    ignore `route`, `href`, `action`, `icon`, `count`, `children`, and
+    `pinned`". The manifest schema says the same independently. Every rule in
+    `check_store` is a claim about a rendered icon or a resolved route, and a
+    caption has neither, so gate 62 was emitting unclosable findings about
+    dead metadata. Gate 62 was aligned to gate 60; gate 60 now WARNs about the
+    dead keys so the information is not merely dropped.
+    """
+
+    def _findings(self, entry, gate="store"):
+        root = Path(tempfile.mkdtemp())
+        try:
+            data = {"id": "app", "menu": [entry], "pages": []}
+            findings: list[str] = []
+            fn = css.check_store if gate == "store" else css.check_settings
+            fn(root, [(root / "src" / "manifest.json", data)], findings)
+            return findings
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_a_caption_claiming_the_store_concept_is_not_failed(self):
+        findings = self._findings({
+            "id": "cap", "type": "caption", "label": "Store",
+            "icon": "ViewGridOutline"})
+        self.assertEqual(findings, [])
+
+    def test_the_identical_node_without_type_caption_still_fails_twice(self):
+        # THE DECISIVE PAIR. Same label, same icon; only `type` differs. If
+        # this arm ever goes green the exemption has become a hole.
+        findings = self._findings({
+            "id": "cap", "label": "Store", "icon": "ViewGridOutline"})
+        self.assertEqual(len(findings), 2, findings)
+        self.assertTrue(all(f.startswith("FAIL") for f in findings))
+
+    def test_a_child_of_a_caption_is_not_judged_either(self):
+        # The renderer does not walk a caption's children, so nothing under it
+        # is drawn. gate 60 skips the subtree for the same reason.
+        findings = self._findings({
+            "id": "cap", "type": "caption", "label": "Section",
+            "children": [{"id": "s", "label": "Store", "icon": "ViewGridOutline"}]})
+        self.assertEqual(findings, [])
+
+    def test_a_non_caption_parent_still_has_its_children_judged(self):
+        # ANTI-WIDENING for the arm above: the subtree skip must be caused by
+        # `type: "caption"` and by nothing else.
+        findings = self._findings({
+            "id": "grp", "label": "Section",
+            "children": [{"id": "s", "label": "Store", "icon": "ViewGridOutline"}]})
+        self.assertEqual(len(findings), 2, findings)
+
+    def test_gate_63_still_walks_captions_because_labels_ARE_rendered(self):
+        # SCOPE OF THE DECISION. It covers icon and route rules only. A
+        # caption's LABEL is honoured by the renderer, so ADR-079 D4 — which is
+        # a rule about the label — must keep applying to one.
+        findings = self._findings(
+            {"id": "cap", "type": "caption", "label": "Settings",
+             "section": "settings"},
+            gate="settings")
+        self.assertTrue(any("ADR-079 D4" in f for f in findings), findings)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -374,23 +374,37 @@ _outC8="${_tmp}/c8.txt"
 _run "${_appC}" "${_outC8}"
 _expect "${_outC8}" 50 "FAIL" "still fails a multi-line read with no guard anywhere"
 
-# C9 — A DELIBERATE, MEASURED BLIND SPOT, PINNED SO IT CANNOT DRIFT SILENTLY.
+# C9 — THE BOUNDARY, MOVED DELIBERATELY AND WITH THE NUMBER IN FRONT OF US.
 #
-# The first draft of the app-id fix accepted ANY expression up to the comma,
-# which also takes `$app` and `$this->appName`. A 12-repo before/after sweep
-# priced that: softwarecatalog went 23 -> 64 findings and 47 of the new ones
-# are entries in an array literal that assembles the admin settings payload —
+# The previous revision of C9/C10 encoded the boundary as the APP ID'S
+# SPELLING: a variable app id was a measured blind spot (PASS), a class
+# constant was caught (FAIL). C10's own comment named the condition for
+# changing it — "if someone later teaches this gate to tell a scope decision
+# from a read-out, this is the arm to change" — and that is what happened on
+# 2026-08-12.
 #
-#     'sendgridApiKey' => $this->config->getValueString($app, 'email_sendgrid_api_key', ''),
+# The old boundary was in the wrong place. Measured over 12 repos, accepting a
+# variable app id adds:
 #
-# There is no defense being deactivated in a settings read-out and nothing to
-# guard, so the finding has no legitimate end state (#252). The accepted app-id
-# shapes are therefore the ones actually measured as blind: a quoted literal
-# and a class constant.
+#     softwarecatalog  +47 new, 47 of 47 in `'key' => ...` position
+#     docudesk         + 1 new,  1 of  1 in `'key' => ...` position
+#     opencatalogi     +16 new,  0 of 16 in `'key' => ...` position
 #
-# This arm asserts the CURRENT boundary rather than an ideal one. If someone
-# later teaches this gate to tell a scope decision from a read-out, this is the
-# arm to change — deliberately, with the number in front of them.
+# The noise is not caused by the app id being a variable — it is caused by the
+# read sitting in an ARRAY-LITERAL VALUE POSITION, and the two populations
+# separate perfectly on that one syntactic fact. Meanwhile the 16 that are NOT
+# read-outs are `listing_register` / `listing_schema` / `catalog_register` /
+# `publication_schema` read unguarded via `$this->appName` — the exact
+# opencatalogi#86 defect this gate was BUILT for, in opencatalogi, reported
+# PASS for its whole life.
+#
+# So the discriminator is now the POSITION, not the spelling, and it applies
+# uniformly to every app-id form. C9 and C10 below assert that uniformity;
+# C11 asserts the defect the old boundary was hiding.
+#
+# ⚠️ PRICE OF THIS CHANGE, STATED: 21 findings the fleet reports today stop
+# failing (softwarecatalog 17, pipelinq 4). All 21 are `'key' => ...` reads.
+# They are not deleted — they are written to <log>.notes, and C10 asserts that.
 _write_service '    public function readouts(): array
     {
         $app = '"'"'fx'"'"';
@@ -402,20 +416,85 @@ _write_service '    public function readouts(): array
 _commit "${_appC}" "settings read-outs with a variable app id"
 _outC9="${_tmp}/c9.txt"
 _run "${_appC}" "${_outC9}"
-_expect "${_outC9}" 50 "PASS" "does not report settings read-outs whose app id is a plain variable (measured blind spot, not a safe shape)"
+_expect "${_outC9}" 50 "PASS" "does not fail settings read-outs in array-literal value position (no guard can be written there)"
 
-# C10 — and the constant form of the SAME read is still caught, so C9 is a
-# boundary and not a hole the gate fell through.
+# C10 — THE EXEMPTION MUST NOT BE A SILENCE, and it must not depend on how the
+# app id is spelled. Same read-out written with a CLASS CONSTANT: also demoted
+# (uniformity), and BOTH forms must appear in the .notes sidecar by name.
+#
+# An exemption that produces silence is how a gate's quiet gets believed —
+# gate-7 reported 0 IDORs across 18 apps while 167 sat in the tree. So the
+# demotion is asserted to be *legible*: file, line and key, in a file a
+# reviewer can read.
+_g50notes="${_tmp}/g50notes"
+mkdir -p "${_g50notes}"
 _write_service '    public function readouts(): array
     {
         return [
             '"'"'sendgridApiKey'"'"' => $this->config->getValueString(Application::APP_ID, '"'"'email_sendgrid_api_key'"'"', '"'"''"'"'),
+            '"'"'mailgunApiKey'"'"'  => $this->config->getValueString($this->appName, '"'"'email_mailgun_api_key'"'"', '"'"''"'"'),
         ];
     }'
-_commit "${_appC}" "same read-out with a class-constant app id"
+_commit "${_appC}" "same read-out, constant and variable app id side by side"
 _outC10="${_tmp}/c10.txt"
-_run "${_appC}" "${_outC10}"
-_expect "${_outC10}" 50 "FAIL" "still catches the same read written with a class-constant app id"
+(
+    cd "${_appC}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_g50notes}" bash "${_runner}" . > "${_outC10}" 2>&1
+)
+_expect "${_outC10}" 50 "PASS" "demotes the read-out identically whether the app id is a constant or a variable"
+if [ -s "${_g50notes}/hydra-gate-security-config-fail-mode.log.notes" ] \
+   && grep -qF 'email_sendgrid_api_key' "${_g50notes}/hydra-gate-security-config-fail-mode.log.notes" \
+   && grep -qF 'email_mailgun_api_key' "${_g50notes}/hydra-gate-security-config-fail-mode.log.notes"; then
+    _ok "gate-50 RECORDS both demoted read-outs by key in .notes — demoted, not silent"
+else
+    _bad "gate-50 demoted the read-outs but left no note: $(wc -c < "${_g50notes}/hydra-gate-security-config-fail-mode.log.notes" 2>/dev/null || echo 'no file')"
+fi
+
+# C11 — THE DEFECT THE OLD BOUNDARY HID. Verbatim shape from opencatalogi
+# CatalogiService / DirectoryService / PublicationService: the app id is
+# `$this->appName`, the value lands in a LOCAL VARIABLE, and nothing guards it.
+# Sixteen of these live in opencatalogi today and every one reported PASS.
+# This is the arm that must fail, or the whole change bought nothing.
+_write_service '    public function scope(): array
+    {
+        $listingRegister = $this->config->getValueString($this->appName, '"'"'listing_register'"'"', '"'"''"'"');
+        $listingSchema   = $this->config->getValueString($this->appName, '"'"'listing_schema'"'"', '"'"''"'"');
+        return [$listingRegister, $listingSchema];
+    }'
+_commit "${_appC}" "opencatalogi#86 shape with a variable app id"
+_outC11="${_tmp}/c11.txt"
+_run "${_appC}" "${_outC11}"
+_expect "${_outC11}" 50 "FAIL" "sees the opencatalogi#86 defect written with a \$this->appName app id"
+
+# C12 — ANTI-WIDENING for C11. The SAME variable-app-id reads, correctly
+# guarded, must go green. Widening a matcher is how a gate starts crying wolf;
+# this arm proves the new shape does not fire on correct code.
+_write_service '    public function scope(): array
+    {
+        $listingRegister = $this->config->getValueString($this->appName, '"'"'listing_register'"'"', '"'"''"'"');
+        $listingSchema   = $this->config->getValueString($this->appName, '"'"'listing_schema'"'"', '"'"''"'"');
+        if ($listingRegister === '"'"''"'"' || $listingSchema === '"'"''"'"') {
+            return [];
+        }
+        return [$listingRegister, $listingSchema];
+    }'
+_commit "${_appC}" "variable app id, correctly guarded"
+_outC12="${_tmp}/c12.txt"
+_run "${_appC}" "${_outC12}"
+_expect "${_outC12}" 50 "PASS" "accepts a correctly-guarded read whose app id is a variable"
+
+# C13 — the exemption is about an ARRAY KEY, not about the `=>` token. A
+# single-expression arrow closure has `)` before its `=>`, so it is NOT a
+# read-out and stays reported. Pins the exemption's edge so it cannot quietly
+# widen into "anything after a fat arrow".
+_write_service '    public function lazyScope(): callable
+    {
+        return fn() => $this->config->getValueString($this->appName, '"'"'listing_register'"'"', '"'"''"'"');
+    }'
+_commit "${_appC}" "arrow closure returning an unguarded read"
+_outC13="${_tmp}/c13.txt"
+_run "${_appC}" "${_outC13}"
+_expect "${_outC13}" 50 "FAIL" "does not mistake an arrow closure's => for an array key"
 
 # ===========================================================================
 # FAMILY D — gate-53 must block the PR that CREATES larpingapp#286.

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -6771,13 +6771,44 @@ SEC_KEY = re.compile(
     # `self::APP_ID`, `static::APP_ID`) — which is exactly the blind spot that
     # was measured: 7 security-relevant reads across 5 repos.
     #
-    # KNOWN BLIND SPOT, STATED RATHER THAN QUIETLY ENFORCED: a read whose app
-    # id is a plain variable is still invisible to this gate. It is not a safe
-    # shape, it is an unmeasured one — separating the settings read-outs from
-    # the real scope decisions among them needs a data-flow question this
-    # regex cannot ask.
+    # THE BLIND SPOT IS NOW CLOSED, AND THE SEPARATION IT NEEDED IS SYNTACTIC.
+    #
+    # The paragraph above used to end here, saying a variable app id "is not a
+    # safe shape, it is an unmeasured one". It has now been measured, and it
+    # was hiding the gate's own founding defect IN THE APP THE GATE WAS BUILT
+    # FOR. opencatalogi reads
+    #
+    #     $this->config->getValueString($this->appName, 'listing_register', '')
+    #     $this->config->getValueString($this->appName, 'listing_schema',   '')
+    #
+    # unguarded, and 14 more of exactly that shape across CatalogiService,
+    # DirectoryService, PublicationService and SetupController — `catalog_
+    # register`, `catalog_schema`, `publication_register`, `publication_schema`.
+    # Sixteen reads of the opencatalogi#86 keys, in opencatalogi, reported
+    # PASS, because the app id is spelled `$this->appName` rather than
+    # `'opencatalogi'`. Same family as #184 and as the class-constant fix
+    # above: a matcher that only handles the spellings someone thought of is a
+    # floor, not a count. (The fleet has ~30 `method_exists($x, $variable)`
+    # sites invisible to literal greps for the same reason.)
+    #
+    # WHAT THE FIRST ATTEMPT GOT WRONG, AND WHY THIS ONE IS DIFFERENT.
+    # The rejected draft accepted `[^,()]+` and softwarecatalog went 23 -> 64,
+    # with 47 of the new findings being SETTINGS READ-OUTS. That cost is real
+    # and it is why the widening was backed out. But the diagnosis was wrong:
+    # the noise does not come from the app id being a variable, it comes from
+    # the read sitting in an ARRAY-LITERAL VALUE POSITION, where the gate's own
+    # remedy cannot be written. Measured over 12 repos, the two populations
+    # separate perfectly on that one syntactic fact:
+    #
+    #     softwarecatalog  +47 new, 47 of 47 in `'key' => ...` position
+    #     docudesk         + 1 new,  1 of  1 in `'key' => ...` position
+    #     opencatalogi     +16 new,  0 of 16 in `'key' => ...` position
+    #
+    # So the app id is widened to include a variable, and the array-literal
+    # value position is exempted instead — see _ARRAY_VALUE below.
     r"getValue(?:String|Bool|Int)\s*\(\s*"
-    r"(?:['\"][^'\"]*['\"]|(?:self|static|parent|[A-Z]\w*)(?:\\\w+)*::\w+)"
+    r"(?:['\"][^'\"]*['\"]|(?:self|static|parent|[A-Z]\w*)(?:\\\w+)*::\w+"
+    r"|\$this\s*->\s*\w+|\$\w+)"
     r"\s*,\s*['\"]"
     r"(?P<key>[^'\"]*"
     r"(?:register|schema|allow[_-]?list|allow_?list|whitelist|blocklist|"
@@ -6794,6 +6825,42 @@ SEC_KEY = re.compile(
     r"['\"]",
     re.IGNORECASE,
 )
+
+# THE ONE EXEMPTION THIS GATE GRANTS, AND THE CLAIM THAT JUSTIFIES IT.
+#
+# Shape:   'someLabel' => $this->config->getValueString($app, 'x_key', ''),
+#
+# CLAIM (testable): at this syntactic position NONE of the six remedies the
+# gate's own guard vocabulary recognises — an empty-compare, `empty()`, a
+# logger->warning, a `throw`, or an early Response return — can be written
+# without restructuring the surrounding expression. There is no local variable
+# to test and no statement slot to put a test in. A finding here names a line
+# at which no closing action exists, which is the unclosable-gate shape
+# (#252) that gate 59 exists to forbid, and 47 of them in one repo is how a
+# gate teaches people to stop reading it.
+#
+# TEST OF THE CLAIM: read the sites. softwarecatalog
+# ArchiMateImportService::getAmefConfiguration() builds `$decoded` as one array
+# literal of eight such reads; the only place a guard can go is the consumer of
+# `$decoded`, in a different function. The near-miss arm in
+# test_gate_45_to_55_acceptance.sh plants the SAME key read into a local
+# variable and asserts the gate still FAILS, so the exemption is about the
+# position and not about the key.
+#
+# NOT SILENT. An exemption that produces silence is how a gate's quiet gets
+# believed. Every demoted read is written to <log>.notes with its file, line
+# and key, so "the gate saw it and demoted it" is checkable rather than
+# indistinguishable from "the gate never looked".
+#
+# DELIBERATELY NOT EXEMPTED: `fn() => $this->config->getValueString(...)`. The
+# pattern requires an array KEY before the `=>`, and an arrow function has `)`
+# there, so a single-expression closure is still reported.
+_ARRAY_VALUE = re.compile(
+    r"(?:['\"][^'\"]*['\"]|\w+)\s*=>\s*"
+    r"(?:[\w\$]+(?:\s*(?:->|::)\s*[\w\$]+)*\s*(?:->|::)\s*)?$"
+)
+notes_path = log_path + '.notes'
+open(notes_path, 'w', encoding='utf-8').close()
 for fp in files:
     try:
         with open(fp, encoding='utf-8', errors='replace') as f:
@@ -6889,6 +6956,14 @@ for fp in files:
             window,
         )
         if not has_guard:
+            if _ARRAY_VALUE.search(src[max(0, m.start() - 200):m.start()]):
+                with open(notes_path, 'a', encoding='utf-8') as g:
+                    g.write(f"{fp}:{lineno}: NOTE security-relevant config read of "
+                            f"\"{m.group('key')}\" is unguarded but sits in an "
+                            f"array-literal value position, where no guard can be "
+                            f"written — demoted, not ignored. Guard it at the "
+                            f"consumer of the assembled array.\n")
+                continue
             with open(log_path, 'a', encoding='utf-8') as g:
                 g.write(f"{fp}:{lineno}: security-relevant config read of \"{m.group('key')}\" has no fail-mode guard within 10 lines\n")
 PY


### PR DESCRIPTION
## The pattern

Four gates, one shape: **the detection logic was sound in every case and the vocabulary or exemption list was what made the gate quiet.** Each defect below was reproduced on a repo-shaped fixture with the prediction written down first, and each fix was measured on real repos against `origin/main` at `57bcb2b`.

Note on reading the numbers: they are written as prose and plain tables on purpose. This PR's description is echoed into the gates log via the workflow `env:` block, so pasting verdict-shaped lines here would plant them inside the artefact meant to prove the fix.

## gate-60 icon-vocabulary — half the gate was unreachable code

All ten entries in `CONCEPT_LABELS` resolved to Tier A concepts, while the vocabulary ships 140 Tier B ones. The Tier B warning branch could not execute for any input at all. Across fourteen repos and 417 manifests it had produced zero warnings, ever, so a green verdict said nothing about 140 of 153 concepts. Three Tier A concepts were dead the same way, and those are MUSTs.

The label table is now derived from the vocabulary itself, so a concept is reachable by its own name and adding one to the schema makes it enforceable. The hand-written map survives as a synonym layer for Dutch spellings and abbreviations. Fleet effect: warnings nought to sixty-two, and one new failure which is a true positive (a schema labelled Audit-trail drawing the wrong glyph).

Also narrows the missing-toolchain skip. Only a non-vocabulary icon name actually needs the library, so an all-vocabulary app now gets a real verdict with no `npm ci` — which is the part of "this gate went unrun" that lives in the checker rather than the workflow.

## gate-57 orphaned-write-capability — the verb list is the whole detector

Everything else in that module only removes findings, so a missing verb is not a weaker check but no check. Measured on a controlled probe: four zero-caller write methods on one service, one reported.

Every candidate verb was measured across twelve repos before inclusion and every finding it produced was read. Three were measured and rejected — `apply`, `process` and `register` — with their costs recorded in the code. One measured false positive, a pure `schedule()` accessor returning a depreciation table, drove a prefix-only rule for noun-shaped verbs. Fleet effect: forty-one to seventy-five, matching the prediction exactly.

## gate-50 security-config-fail-mode — blind in the app it was built for

The accepted app-id shapes let it pass over sixteen unguarded reads of the `opencatalogi#86` keys, in opencatalogi, because the app id is spelled `$this->appName` rather than a literal.

The earlier attempt at this widening was backed out for noise, and the code carried a comment blaming the app-id shape. That diagnosis was wrong. The noise comes from the read sitting in an array-literal value position, where none of the six remedies this gate recognises can be written — no local variable, no statement slot. The two populations separate perfectly on that one syntactic fact: every one of the forty-eight noisy new findings is in that position and none of the sixteen real ones is.

So the app id is widened and the position is exempted instead. Demoted reads are written to a notes sidecar with file, line and key, so "the gate saw it and demoted it" stays checkable rather than becoming a silence. This does stop twenty-one currently-failing findings from failing; all twenty-one were read and all sit inside single `return [...]` config-assembly literals.

## gate-62 store-plane — an undeclared divergence, now decided

gate-60 and gate-62 disagreed about whether a `type: "caption"` node is a menu entry. On one fixture, gate-60 found nothing and gate-62 failed twice.

Decided against the renderer rather than by aligning whichever was easier to change. `CnAppNav.vue` passes a caption only its label and a test id — no icon slot, no route, no children loop — its docblock states that captions ignore icon, route and children, and the manifest schema says the same independently. Every rule in `check_store` is a claim about a rendered icon or a resolved route, so gate-60 was right. gate-62 is aligned to it, and gate-60 now warns about the dead keys so the information is not merely dropped.

Scoped deliberately: the decision covers icon and route rules only. A caption's label **is** rendered, so gate-63 keeps walking captions and there is an arm pinning that.

Live exposure is zero — a positive-controlled census of 145 manifests found one caption node and none carrying a dead key. This corrects a latent contradiction, not a live count.

## Acceptance arms

`test_check_icon_vocabulary.py` is new — gate-60 had no test suite at all — and is auto-discovered by `run-helper-suites.sh`. New classes were also added to the gate-57 and gate-62 suites, and the gate-50 boundary arms in `test_gate_45_to_55_acceptance.sh` were rewritten with the measurement in the comment, which is what the old arm's own comment asked for.

**Every new arm was verified able to fail** by running it against the pristine `57bcb2b` checkers: seven of nineteen red for gate-60, four for gate-57, two for gate-62, and exactly the arms that should be. The anti-widening and regression arms stay green on both sides. The full package suite and the 45–55 acceptance suite are green on the final state.

## Reviewer notes

- **Merge conflict expected in `run-hydra-gates.sh`.** gate-50's checker is a heredoc inside that file, which another agent is editing this session. I touched only the gate-50 heredoc — no scope resolution, no verdict wiring, no other gate. Please resolve in favour of both changes rather than taking a side.
- Worth doing later: extract gate-50's checker into `scripts/lib/` like every other gate, so it can be unit-tested directly.
- Full findings, including everything I could not verify: `fleet-board/findings/gates-exemption-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
