### PR TITLE
fix(gates 2, 21, 35, 36): three false positives and one blind spot, both arms fixtured

### DIFF
--- a/hydra-gates/scripts/lib/check_forbidden_patterns.py
+++ b/hydra-gates/scripts/lib/check_forbidden_patterns.py
@@ -48,6 +48,30 @@ this change is already widening in the other direction. One direction at a time.
 never when preceded by `$`, `->`, `::` or a word character, so `$exit`,
 `$this->exit(` and `exit_code` are not findings.
 
+A DECLARATION IS NOT A CALL
+---------------------------
+`die` and `exit` are SEMI-RESERVED in PHP: they are illegal as a free function
+name and perfectly legal as a METHOD name, so this parses and ships::
+
+    private function exit(): void
+    {
+        $this->exitCode = 1;
+    }
+
+The construct pattern saw `exit` followed by `(` — the parameter list — and
+reported the DECLARATION as a call. Measured 2026-08-12 on a purpose-built
+fixture: three findings where two were real (`var_dump (`, `die;`) and the
+third was that method header. The call sites `$this->exit()` and `self::exit()`
+were already silent via the `->` / `::` lookbehinds, and `$exitCode` via
+`(?<![\w$])` — so the gate flagged the one place the name is definitionally not
+a call and stayed quiet everywhere it might have been one.
+
+The fix is a discriminator, not a relaxation: the offsets of the NAME group of
+every `function` header are computed and a construct match starting exactly
+there is skipped. Nothing else moves. `exit;` inside that method's body is
+still a finding, and so is `exit(0)` in a method that merely happens to be
+called `exitEarly()` — only the identifier in the header position is exempt.
+
 ANTI-WIDENING: `: never` EXEMPTS, AND IT IS A TYPE, NOT A COMMENT
 ------------------------------------------------------------------
 Adding `exit` produced exactly ONE new finding across fourteen fleet repos, and
@@ -150,6 +174,19 @@ def _never_spans(masked: str) -> list[tuple[int, int]]:
     return spans
 
 
+def _declared_name_offsets(masked: str) -> set[int]:
+    """Start offsets of the NAME identifier in every `function` header.
+
+    `die` and `exit` are semi-reserved: illegal as a free function name, legal
+    as a method name. `private function exit(): void` therefore presents to the
+    construct pattern as `exit` followed by `(`, and was reported as a call.
+    An offset set is used rather than a lookbehind because Python's `re`
+    requires lookbehinds to be fixed width, and `function`, `&` and the
+    whitespace between them are not.
+    """
+    return {m.start(1) for m in _FUNC_RX.finditer(masked) if m.group(1)}
+
+
 def scan_file(path: str) -> list[str]:
     try:
         src = read_text(path)
@@ -158,6 +195,7 @@ def scan_file(path: str) -> list[str]:
     masked = php_mask(src, blank_strings=True)
     lines = src.splitlines()
     never = _never_spans(masked)
+    declared = _declared_name_offsets(masked)
 
     def in_never(off: int) -> bool:
         return any(a <= off <= b for a, b in never)
@@ -167,6 +205,8 @@ def scan_file(path: str) -> list[str]:
         line = masked.count("\n", 0, m.start()) + 1
         hits.append((line, m.group(1)))
     for m in _CONSTRUCT_RX.finditer(masked):
+        if m.start() in declared:
+            continue  # `function exit(` — the header, not a call.
         if in_never(m.start()):
             continue
         line = masked.count("\n", 0, m.start()) + 1

--- a/hydra-gates/scripts/lib/check_markup_a11y.py
+++ b/hydra-gates/scripts/lib/check_markup_a11y.py
@@ -38,9 +38,48 @@ are all carried over verbatim from the bash blocks. This changes WHERE the
 gate looks, not what it asks, so before/after counts stay comparable and a
 drop in findings is attributable to prose leaving the scope.
 
+GATE-35 AND GATE-36 JOINED THEM (2026-08-12)
+--------------------------------------------
+They were the last two raw greps in the 31–36 family and each failed in one
+direction, measured on a purpose-built fixture through the real wrapper.
+
+gate-35 (img-alt-empty-only) was BLIND. Its noun list was `\\b`-anchored::
+
+    grep -qiE '\\b(avatar|photo|thumbnail|picture|...)\\b'
+
+`\\b` is a WORD-character boundary, and `U` is a word character, so
+`avatarUrl`, `thumbnailUrl`, `photoUrl` and `pictureUrl` — the four commonest
+spellings in a Vue codebase — could not match. A seven-image probe in which
+every image was a violation reported **3**. Underscore is a word character
+too, so `avatar_url` was invisible for the same reason. The fix TOKENISES the
+src expression on camelCase / `_` / `-` / `.` / `/` boundaries and asks for
+token EQUALITY. Equality, not substring: `photograph` and `pictures` stay out,
+so recall is not bought with noise — which is what an over-broad `<noun>Url`
+substring match would have done to code that is fine.
+
+gate-36 (tabindex-positive) was NOISY. `grep -rnE` over raw bytes reported
+
+    <!-- never write tabindex="5" here; positive values break focus order -->
+
+as a positive tabindex. That is the gate-32 shape exactly (#236): a comment
+documenting the defect scored AS the defect, so the better a team documents
+its focus-order rule the redder its repo gets. The fix masks COMMENTS ONLY —
+not the markup scope — because a positive tabindex is a property of the
+rendered DOM wherever it is emitted from, including `<script>` and PHP code.
+Blanking those regions would have narrowed the gate while removing the noise,
+which is not a repair.
+
+⚠️ Live fleet exposure of BOTH was zero on 2026-08-12, positive-controlled
+across all 18 apps: zero positive tabindex values, and 17 `<img` occurrences
+in total (14 real tags; the other 3 are JSDoc prose in openbuild), exactly one
+of which carries `alt=""` — docudesk's `uploadIcon`, correctly silent under
+both the old rule and the new one. So neither fix closes a live defect. Both
+exist because a gate that cries wolf gets its silences believed, and gate-7
+spent months reporting 0 IDORs across 18 apps for precisely that reason.
+
 Usage::
 
-    check_markup_a11y.py --rule img-alt|semantic-controls <file> [<file>...]
+    check_markup_a11y.py --rule img-alt|semantic-controls|img-alt-empty-only|tabindex-positive <file> [<file>...]
 
 Prints one finding per line in the shape the bash gates emitted, so the
 runner still counts lines. Exits 0 always; the count is the answer and the
@@ -54,7 +93,13 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from source_scope import iter_open_tags, markup_mask, read_text  # noqa: E402
+from source_scope import (  # noqa: E402
+    html_markup_mask,
+    iter_open_tags,
+    js_comment_mask,
+    markup_mask,
+    read_text,
+)
 
 # --- gate-31 ---------------------------------------------------------------
 # `alt=`, `:alt=`, `v-bind:alt=`, `alt-text=` (some Conduction components
@@ -108,20 +153,104 @@ def _semantic_controls(path: str, masked: str) -> list[str]:
     return out
 
 
+# --- gate-35 ---------------------------------------------------------------
+# A LITERAL empty alt. A BOUND `:alt="x"` is out of scope on purpose (carried
+# over from the bash gate): the developer there went through a prop pipeline
+# and the value is a reviewer judgement, not a lie told to gate-31.
+EMPTY_ALT = re.compile(r'(^|\s)alt\s*=\s*(""|\'\')')
+# `:src` / `v-bind:src` carry the noun in a Vue expression; a plain `src`
+# carries it in a literal attribute value (`src="/img/avatar.png"`, or a PHP
+# template's `src="<?php p($avatarUrl) ?>"`). Both mean the same thing.
+SRC_ATTR = re.compile(r'(^|\s)(:src|v-bind:src|src)\s*=\s*("([^"]*)"|\'([^\']*)\')')
+# Content nouns. An image the author NAMED after a person or a picture and then
+# declared decorative with alt="" is the "I made gate-31 green by lying" shape.
+SEMANTIC_NOUNS = frozenset(
+    {"avatar", "photo", "thumbnail", "picture", "headshot", "portrait"}
+)
+# camelCase / PascalCase / SCREAMING_CASE splitting, then every non-alphanumeric
+# run is a separator. `avatarUrl` -> {avatar, url}; `AVATAR_URL` -> {avatar,
+# url}; `/img/avatar.png` -> {img, avatar, png}; `profilePicture` -> {profile,
+# picture}. The `\b`-anchored predicate this replaces could see NONE of the
+# camelCase forms and none of the underscore ones either.
+_CAMEL_1 = re.compile(r"([a-z0-9])([A-Z])")
+_CAMEL_2 = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _tokens(text: str) -> set[str]:
+    """Lowercased identifier tokens of *text*, split on case and punctuation."""
+    spaced = _CAMEL_2.sub(r"\1 \2", _CAMEL_1.sub(r"\1 \2", text))
+    return {t for t in _NON_ALNUM.sub(" ", spaced).lower().split() if t}
+
+
+def _img_alt_empty_only(path: str, masked: str) -> list[str]:
+    out = []
+    for tag in iter_open_tags(masked, {"img"}):
+        if not EMPTY_ALT.search(tag.attrs):
+            continue
+        m = SRC_ATTR.search(tag.attrs)
+        if m is None:
+            continue
+        value = m.group(4) if m.group(4) is not None else (m.group(5) or "")
+        if _tokens(value) & SEMANTIC_NOUNS:
+            out.append(f"{path}:{tag.line}: {tag.flat} rule=empty-alt-on-semantic-bound-src")
+    return out
+
+
+# --- gate-36 ---------------------------------------------------------------
+# A QUOTED positive integer. A bound `:tabindex="n"` is reviewer judgement and
+# stays out, exactly as the bash gate had it.
+TABINDEX_POSITIVE = re.compile(r'(^|[\s>"\'])tabindex\s*=\s*["\']\s*[1-9][0-9]*\s*["\']')
+_JS_EXTS = (".js", ".ts", ".mjs", ".cjs", ".jsx", ".tsx")
+
+
+def _comment_mask(src: str, path: str) -> str:
+    """Comments blanked, EVERYTHING ELSE KEPT — offsets preserved.
+
+    Deliberately NOT `markup_mask`. That returns the markup scope, which blanks
+    `<script>`, `<style>` and PHP code wholesale; a positive tabindex emitted
+    from a render function or from `echo '<div tabindex="5">'` would stop being
+    a finding. Removing the false positive must not cost a true one, so only
+    comments go: HTML `<!-- -->` plus JS comments inside `<script>` bodies for
+    markup files, and JS comments for `.js`/`.ts`. String CONTENTS are kept,
+    because for this gate the string IS the evidence (gate-34's lesson).
+    """
+    if os.path.splitext(path)[1].lower() in _JS_EXTS:
+        return js_comment_mask(src)
+    return html_markup_mask(src)
+
+
+def _tabindex_positive(path: str, masked: str) -> list[str]:
+    out = []
+    for n, line in enumerate(masked.splitlines(), start=1):
+        if TABINDEX_POSITIVE.search(line):
+            out.append(f"{path}:{n}:{line.rstrip()[:200]}")
+    return out
+
+
 RULES = {
     "img-alt": _img_alt,
     "semantic-controls": _semantic_controls,
+    "img-alt-empty-only": _img_alt_empty_only,
+    "tabindex-positive": _tabindex_positive,
 }
+
+# Rules whose mask is "comments only", not "the markup scope". See _comment_mask.
+_COMMENT_SCOPE_RULES = {"tabindex-positive"}
 
 
 def scan_source(rule: str, path: str, src: str) -> list[str]:
+    if rule in _COMMENT_SCOPE_RULES:
+        return RULES[rule](path, _comment_mask(src, path))
     return RULES[rule](path, markup_mask(src, path))
 
 
 def main(argv: list[str]) -> int:
     if len(argv) < 4 or argv[1] != "--rule" or argv[2] not in RULES:
         print(
-            "usage: check_markup_a11y.py --rule img-alt|semantic-controls <file>...",
+            "usage: check_markup_a11y.py --rule "
+            + "|".join(sorted(RULES))
+            + " <file>...",
             file=sys.stderr,
         )
         return 2

--- a/hydra-gates/scripts/lib/test_check_forbidden_patterns.py
+++ b/hydra-gates/scripts/lib/test_check_forbidden_patterns.py
@@ -94,6 +94,42 @@ check("a METHOD call ->exit() is NOT reported", f == [], repr(f))
 f = run("    public function a(): void { $exit_code = 1; }")
 check("an identifier `exit_code` is NOT reported", f == [], repr(f))
 
+# --- A DECLARATION IS NOT A CALL (2026-08-12) ------------------------------
+# `die`/`exit` are SEMI-RESERVED in PHP: illegal as a free function name, legal
+# as a method name. The construct pattern saw the parameter list's `(` and
+# reported the method HEADER as a call. Both arms below, so a fix that removes
+# the false positive by dropping the construct rule fails the second one.
+f = run("    private function exit(): void { $this->exitCode = 1; }")
+check("a method DECLARATION `function exit()` is NOT reported", f == [], repr(f))
+
+f = run("    private function die(): void { $this->done = true; }")
+check("a method DECLARATION `function die()` is NOT reported", f == [], repr(f))
+
+f = run("    private function &exit(): array { return []; }")
+check("a by-reference declaration `function &exit()` is NOT reported", f == [], repr(f))
+
+f = run("    abstract protected function exit(): void;")
+check("a BODILESS declaration `function exit();` is NOT reported", f == [], repr(f))
+
+f = run("    public function a(): void { self::exit(); }")
+check("a STATIC call ::exit() is NOT reported", f == [], repr(f))
+
+# The true-positive half. Exempting the header must not exempt the body, nor a
+# construct in a method whose NAME merely starts with the word.
+f = run("    private function exit(): void { exit; }")
+check(
+    "`exit;` INSIDE a method named exit() is STILL reported (header only is exempt)",
+    len(f) == 1,
+    repr(f),
+)
+
+f = run("    public function exitEarly(): void { exit(0); }")
+check(
+    "`exit(0)` in a method named exitEarly() is STILL reported",
+    len(f) == 1,
+    repr(f),
+)
+
 # --- MUTATION CHECK: assert the guards exist before trusting the negatives --
 _SRC = open(
     os.path.join(
@@ -103,6 +139,7 @@ _SRC = open(
 check("the `: never` exemption is in the source", "_never_spans" in _SRC)
 check("string blanking is requested", "blank_strings=True" in _SRC)
 check("die/exit are matched as constructs", "_CONSTRUCT_RX" in _SRC)
+check("the declaration discriminator is in the source", "_declared_name_offsets" in _SRC)
 
 print()
 if _FAILED:

--- a/hydra-gates/scripts/lib/test_check_markup_a11y.py
+++ b/hydra-gates/scripts/lib/test_check_markup_a11y.py
@@ -212,6 +212,107 @@ class TestSemanticControls(unittest.TestCase):
         self.assertEqual(scan("semantic-controls", src), [])
 
 
+class TestImgAltEmptyOnly(unittest.TestCase):
+    """gate-35. The defect was BLINDNESS, so the fire-cases come first."""
+
+    def _img(self, attrs: str) -> str:
+        return f"<template><div><img {attrs}></div></template>"
+
+    def test_the_four_camelcase_spellings_the_word_boundary_could_not_match(self):
+        # `\\b` is a WORD-character boundary and `U` is a word character, so the
+        # old `\\b(avatar|photo|thumbnail|picture)\\b` matched NONE of these.
+        for expr in ("user.avatarUrl", "user.thumbnailUrl",
+                     "user.photoUrl", "user.pictureUrl"):
+            with self.subTest(expr=expr):
+                self.assertEqual(len(scan("img-alt-empty-only",
+                                          self._img(f':src="{expr}" alt=""'))), 1)
+
+    def test_underscore_is_a_word_character_too(self):
+        self.assertEqual(len(scan("img-alt-empty-only",
+                                  self._img(':src="user.avatar_url" alt=""'))), 1)
+
+    def test_the_spellings_the_old_rule_already_caught_still_fire(self):
+        for expr in ("user.avatar", "user.photo", "user.thumbnail",
+                     "/img/headshot.png", "profilePicture"):
+            with self.subTest(expr=expr):
+                self.assertEqual(len(scan("img-alt-empty-only",
+                                          self._img(f':src="{expr}" alt=""'))), 1)
+
+    def test_single_quoted_alt_and_src(self):
+        self.assertEqual(len(scan("img-alt-empty-only",
+                                  self._img("src='/img/avatar.png' alt=''"))), 1)
+
+    # --- ANTI-WIDENING. Recall must not be bought with noise. ---------------
+    def test_a_noun_that_is_only_a_SUBSTRING_does_not_fire(self):
+        # The tempting repair — relax `\\b` to a substring match — lights all
+        # three of these up. Token EQUALITY after camel/underscore splitting
+        # keeps them out.
+        for expr in ("user.photographerBio", "gallery.pictures", "thumbnails"):
+            with self.subTest(expr=expr):
+                self.assertEqual(scan("img-alt-empty-only",
+                                      self._img(f':src="{expr}" alt=""')), [])
+
+    def test_a_real_alt_is_not_a_finding(self):
+        self.assertEqual(scan("img-alt-empty-only",
+                              self._img(':src="user.avatarUrl" alt="Photo of Ada"')), [])
+        self.assertEqual(scan("img-alt-empty-only",
+                              self._img(':src="user.avatarUrl" :alt="label"')), [])
+
+    def test_decorative_by_name_and_by_shape_stay_silent(self):
+        self.assertEqual(scan("img-alt-empty-only",
+                              self._img(':src="uploadIcon" alt=""')), [])
+        self.assertEqual(scan("img-alt-empty-only",
+                              self._img('src="/img/decoration.svg" alt=""')), [])
+
+    def test_prose_in_script_is_not_a_tag(self):
+        src = ('<template><div /></template>\n<script>\n'
+               '// <img :src="user.avatarUrl" alt=""> in a docblock\n</script>')
+        self.assertEqual(scan("img-alt-empty-only", src), [])
+
+
+class TestTabindexPositive(unittest.TestCase):
+    """gate-36. The defect was NOISE, so the silence-cases come first."""
+
+    def test_a_positive_tabindex_in_an_HTML_COMMENT_is_not_a_finding(self):
+        src = ('<template><div>\n'
+               '<!-- never write tabindex="5"; it breaks focus order -->\n'
+               '<button tabindex="0">ok</button>\n</div></template>')
+        self.assertEqual(scan("tabindex-positive", src), [])
+
+    def test_a_positive_tabindex_in_a_JS_COMMENT_is_not_a_finding(self):
+        src = ('<template><div /></template>\n<script>\n'
+               '// forbidden: tabindex="9"\nexport default {}\n</script>')
+        self.assertEqual(scan("tabindex-positive", src), [])
+
+    def test_zero_and_minus_one_and_bound_values_are_correct_code(self):
+        for attr in ('tabindex="0"', 'tabindex="-1"', ':tabindex="n"'):
+            with self.subTest(attr=attr):
+                self.assertEqual(
+                    scan("tabindex-positive", f"<template><b {attr}>x</b></template>"), [])
+
+    # --- the true positives the noise fix must not cost ---------------------
+    def test_a_real_positive_tabindex_still_fires(self):
+        self.assertEqual(
+            len(scan("tabindex-positive", '<template><b tabindex="5">x</b></template>')), 1)
+
+    def test_single_quotes_render_the_same_DOM(self):
+        self.assertEqual(
+            len(scan("tabindex-positive", "<template><b tabindex='12'>x</b></template>")), 1)
+
+    def test_a_tabindex_EMITTED_FROM_SCRIPT_still_fires(self):
+        # `markup_mask` would blank `<script>` wholesale and lose this. The mask
+        # here is comments-only for exactly that reason.
+        src = ('<template><div /></template>\n<script>\n'
+               'el.innerHTML = \'<button tabindex="4">x</button>\'\n</script>')
+        self.assertEqual(len(scan("tabindex-positive", src)), 1)
+
+    def test_a_js_file_keeps_both_behaviours(self):
+        fire = 'export const h = \'<b tabindex="3">x</b>\'\n'
+        self.assertEqual(len(scan("tabindex-positive", fire, "src/h.js")), 1)
+        quiet = '// tabindex="3" is forbidden\nexport const h = 1\n'
+        self.assertEqual(scan("tabindex-positive", quiet, "src/h.js"), [])
+
+
 class TestCli(unittest.TestCase):
     def test_unknown_rule_is_an_error_not_an_empty_answer(self):
         buf = io.StringIO()

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -3589,6 +3589,44 @@ fi
 # --scope-to-diff is on). The marker pattern is anchored to start-of-
 # line + at least 7 chars + space, which is git's canonical conflict
 # marker shape and unlikely to collide with prose / code.
+#
+# ⚠️ A BARE `=======` IS ALSO A MARKDOWN SETEXT H1 UNDERLINE (2026-08-12).
+# `^={7}$` is git's separator AND, at exactly seven characters, a legal
+# Markdown heading underline:
+#
+#     Release
+#     =======
+#
+# Reproduced on a purpose-built fixture: one conflicted `.php` plus one
+# perfectly ordinary `openspec/notes.md` reported as `2 file(s) with
+# unresolved conflict markers`. Measured live pressure at the same time:
+# pipelinq carries two setext underlines inside this gate's own find scope
+# (`openspec/specs/admin-settings/spec.md:732` and its archived twin), both 26
+# characters — so the fleet is TWO KEYSTROKES from a false red, and the gate's
+# quiet today is luck, not correctness.
+#
+# The discriminator is structural, not a relaxation of the pattern: git cannot
+# emit a `=======` separator without a `<<<<<<< ` above it and a `>>>>>>> `
+# below, so in a Markdown file a bare `=======` with NEITHER companion marker
+# anywhere in the file is a heading. Non-Markdown files are untouched — a lone
+# `=======` in `.php`/`.json` is still a finding, which is where every incident
+# this gate was built for actually happened (DSOIntakeController.php,
+# appinfo/routes.php, package.json, l10n/*.json).
+#
+# ENUMERATION: `find`, NOT `_enum_tracked` — DELIBERATE, and here is why.
+# This is the only gate in 1–21 that does not enumerate via `git ls-files`, and
+# that asymmetry was reviewed rather than removed. An untracked file carrying
+# conflict markers is a real state on this fleet's shared checkouts (several
+# agents write into one work tree), and the cost of the wider corpus is one
+# grep per file. `git ls-files` would also make the gate blind to exactly the
+# file a developer has not staged yet — which is the moment this gate is
+# supposed to speak. Switching it would NARROW the true-positive class to buy
+# tidiness, so it stays.
+# ⚠️ What WAS wrong in the enumeration: `appinfo` was named TWICE, so `find`
+# walked it twice and every file under it was inspected twice. A conflicted
+# `appinfo/routes.php` — incident #12, one of the three this gate was written
+# for — was therefore reported as `2 file(s)`. Verified: `find lib appinfo src
+# tests openspec l10n appinfo -name '*.xml'` prints `appinfo/info.xml` twice.
 # ---------------------------------------------------------------------------
 _cm_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-conflict-markers.log
 : > "${_cm_log}"
@@ -3603,10 +3641,18 @@ while IFS= read -r _file; do
     # grep -l would short-circuit but we want a line count for the log.
     _matches=$(grep -nE '^(<{7}[[:space:]]|>{7}[[:space:]]|={7}$)' "${_file}" 2>/dev/null || true)
     [ -z "${_matches}" ] && continue
+    # Markdown only: a bare `=======` with no `<<<<<<< ` or `>>>>>>> ` anywhere
+    # in the same file is a setext H1 underline, not half a conflict.
+    case "${_file}" in
+        *.md|*.markdown)
+            printf '%s\n' "${_matches}" \
+                | grep -qE '^[0-9]+:(<{7}|>{7})[[:space:]]' || continue
+            ;;
+    esac
     echo "${_file}:" >> "${_cm_log}"
     echo "${_matches}" | head -5 | sed 's/^/  /' >> "${_cm_log}"
     _cm_hits=$((_cm_hits + 1))
-done < <(find lib appinfo src tests openspec l10n appinfo \
+done < <(find lib appinfo src tests openspec l10n \
             \( -name '*.php' -o -name '*.js' -o -name '*.ts' \
              -o -name '*.vue' -o -name '*.json' -o -name '*.md' \
              -o -name '*.yaml' -o -name '*.yml' -o -name '*.xml' \) \
@@ -5141,6 +5187,29 @@ fi
 # `<img src="img/decoration.svg" alt="">`). The gate only fires when the
 # bound src name explicitly signals dynamic user content.
 #
+# ⚠️ THE NOUN LIST WAS `\b`-ANCHORED AND THEREFORE BLIND (2026-08-12).
+# `grep -qiE '\b(avatar|photo|thumbnail|picture|…)\b'` cannot match
+# `avatarUrl`: `\b` is a WORD-character boundary and `U` is a word character.
+# Nor `avatar_url`, for the same reason — `_` is a word character too. So the
+# four commonest spellings in a Vue codebase were invisible. Measured on a
+# seven-image probe in which EVERY image was a violation: the gate reported
+# THREE. `avatarUrl`, `thumbnailUrl`, `photoUrl`, `pictureUrl` all passed.
+#
+# Extraction moved to scripts/lib/check_markup_a11y.py — the same helper
+# gates 31 and 32 already use — which reads the markup scope only and
+# tokenises the src expression on camelCase / `_` / `-` / `.` / `/` boundaries,
+# then asks for token EQUALITY against the noun set. Equality is the part that
+# matters: a substring match on `<noun>Url` would also light up
+# `photographerBio` and `pictures`, and buying recall with noise is how a gate
+# earns the reputation that makes its silences believed.
+#
+# ⚠️ Live fleet exposure was ZERO when this was fixed, positive-controlled
+# across all 18 apps: 17 `<img` occurrences fleet-wide, of which 3 are JSDoc
+# prose in openbuild and exactly ONE carries `alt=""` — docudesk's
+# `uploadIcon`, correctly silent before and after. This repair buys
+# trustworthiness, not a closed defect. Sizing note for whoever reads the
+# number next: do not infer urgency from it.
+#
 # References:
 #   - ADR-010 (NL Design — WCAG 2.2 AA)
 #   - openspec/architecture/wcag-coverage.md SC 1.1.1 (Non-text Content)
@@ -5148,39 +5217,42 @@ fi
 if _a11y_has_markup_dir; then
     _iae_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt-empty-only.log
     : > "${_iae_log}"
+    _iae_ran=1
+    _iae_helper="${SCRIPT_DIR}/lib/check_markup_a11y.py"
+    _iae_files=()
     while IFS= read -r vue; do
+        [ -f "${vue}" ] || continue
         _in_scope "${vue}" || continue
-        _flat=$(tr '\n' ' ' < "${vue}")
-        echo "${_flat}" \
-            | grep -oE '<img\b[^>]*>' 2>/dev/null \
-            | while IFS= read -r tag; do
-                [ -z "${tag}" ] && continue
-                # Must have literal alt="" (not bound `:alt=""` — bound expressions
-                # with computed-default-empty are out of scope; the developer there
-                # at least went through a prop pipeline).
-                # Both quote styles: `alt=''` renders identically to `alt=""`
-                # and was invisible here. Measured as a PASS on a planted
-                # `<img src='/img/avatar.png' alt=''> in both a .vue app and a
-                # PHP-template app.
-                echo "${tag}" | grep -qE 'alt[[:space:]]*=[[:space:]]*("[[:space:]]*"|'"'"'[[:space:]]*'"'"')' || continue
-                # Must have a src that names a semantic noun. A BOUND :src /
-                # v-bind:src carries the noun in its expression; a PHP template
-                # or plain HTML carries it in the literal attribute value
-                # (`src="<?php p($avatarUrl) ?>"`, `src="/img/avatar.png"`).
-                # Both mean the same thing — the author knew the image was a
-                # person or a picture and still gave it an empty alt (#225).
-                _src_expr=$(echo "${tag}" | grep -oE '(:src|v-bind:src|src)[[:space:]]*=[[:space:]]*("[^"]*"|'"'"'[^'"'"']*'"'"')' | head -1 || true)
-                [ -z "${_src_expr}" ] && continue
-                if echo "${_src_expr}" | grep -qiE '\b(avatar|photo|thumbnail|picture|headshot|portrait|profilePicture)\b'; then
-                    echo "${vue}: ${tag} rule=empty-alt-on-semantic-bound-src" >> "${_iae_log}"
-                fi
-            done
+        _iae_files+=("${vue}")
     done < <(_a11y_markup_files)
-    _iae_fail=$(wc -l < "${_iae_log}" 2>/dev/null || echo 0)
-    if [ "${_iae_fail}" -eq 0 ]; then
-        _pass 35 "img-alt-empty-only"
+    if [ "${#_iae_files[@]}" -eq 0 ]; then
+        # AN EMPTY SCOPE IS NOT A PASS (#147) — the shape the whole a11y band
+        # was falsely green in on nldesign.
+        _iae_ran=0
+        _skip 35 "img-alt-empty-only" na "no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No <img alt=\"\"> was inspected and none could be."
+    elif [ ! -f "${_iae_helper}" ]; then
+        _iae_ran=0
+        _skip 35 "img-alt-empty-only" wiring "check_markup_a11y.py not found at ${_iae_helper} — ${#_iae_files[@]} markup file(s) were in scope and NONE were inspected; content images silenced with alt=\"\" (WCAG 1.1.1) are UNVERIFIED by this run."
     else
-        _fail 35 "img-alt-empty-only" "${_iae_fail} <img alt=\"\"> on semantic-bound src — see ${_iae_log}"
+        set +e
+        _iae_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-img-alt-empty-only.err"
+        python3 "${_iae_helper}" --rule img-alt-empty-only "${_iae_files[@]}" >> "${_iae_log}" 2>"${_iae_err}"
+        _iae_rc=$?
+        if [ "${_iae_rc}" -ne 0 ]; then
+            # A CRASHED CHECKER IS NOT A CLEAN FILE (#245, #249).
+            _iae_ran=0
+            _skip 35 "img-alt-empty-only" wiring "check_markup_a11y.py exited ${_iae_rc} — ${#_iae_files[@]} markup file(s) were in scope and NONE were judged. See ${_iae_err}."
+        fi
+    fi
+    _iae_fail=$(wc -l < "${_iae_log}" 2>/dev/null || echo 0)
+    [ -z "${_iae_fail}" ] && _iae_fail=0
+    if [ "${_iae_ran}" -eq 1 ]; then
+        if [ "${_iae_fail}" -eq 0 ]; then
+            echo "[hydra-gates] gate-35 img-alt-empty-only: ${#_iae_files[@]} markup file(s) inspected, 0 content image silenced with alt=\"\"."
+            _pass 35 "img-alt-empty-only"
+        else
+            _fail 35 "img-alt-empty-only" "${_iae_fail} <img alt=\"\"> on semantic-bound src — see ${_iae_log}"
+        fi
     fi
 fi
 
@@ -5197,28 +5269,77 @@ fi
 #   - WHATWG / W3C: "Authors should generally use `tabindex='0'` or
 #     `tabindex='-1'`. Positive integer values are very rarely useful."
 # ---------------------------------------------------------------------------
+# ⚠️ THE LAST RAW GREP IN THE 31–36 FAMILY, AND IT READ COMMENTS (2026-08-12).
+# `grep -rnE` over raw bytes reported
+#
+#     <!-- never write tabindex="5" here; positive values break focus order -->
+#
+# as a positive tabindex. That is gate-32's #236 defect exactly: the comment
+# written to document the rule scores AS a violation of it, so the better a
+# team documents its focus order the redder its repo goes — and a gate a
+# comment can redden is a gate whose findings reviewers learn to discard.
+#
+# Extraction moved to scripts/lib/check_markup_a11y.py. The VALUE rule is
+# carried over character for character (quoted positive integer, both quote
+# styles, whitespace inside the quotes allowed, bound `:tabindex` still out of
+# scope), so before/after counts stay comparable.
+#
+# ⚠️ THE MASK IS COMMENTS-ONLY, NOT THE MARKUP SCOPE — deliberately. gates 31,
+# 32 and 35 use `markup_mask`, which blanks `<script>`, `<style>` and PHP code
+# wholesale. That is right for `<img>`, which only a template renders, and
+# WRONG here: a positive tabindex is a property of the rendered DOM whoever
+# emitted it, including a render function and `echo '<div tabindex="5">'`.
+# Blanking those would have removed the noise by removing detection, which is
+# not a repair. `.js`/`.ts` stay in scope for the same reason.
+#
+# ⚠️ Live fleet exposure was ZERO when this was fixed — positive-controlled,
+# all 18 apps, zero positive tabindex values anywhere. As with gate-35 this
+# buys trustworthiness rather than closing a defect; do not read urgency into
+# the number.
 if _a11y_has_markup_dir; then
     _tp_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-tabindex-positive.log
     : > "${_tp_log}"
-    # Match tabindex with quoted positive integer. Allow whitespace
-    # inside the quotes. Excludes tabindex="0", tabindex="-1", and any
-    # form where the value is bound (`:tabindex="..."` is reviewer-judgment).
-    # templates/ too (#225): focus order is a property of the rendered DOM, not
-    # of the language that emitted it.
-    #
-    # BOTH QUOTE STYLES. The pattern read `"` only, so `tabindex='5'` — the
-    # same rendered DOM, the same defect — reported PASS in both a .vue app
-    # and a PHP-template app when it was planted there. Zero occurrences in
-    # the fleet today, which is precisely why it could sit here unnoticed.
-    grep -rnE 'tabindex[[:space:]]*=[[:space:]]*["'"'"'][[:space:]]*[1-9][0-9]*[[:space:]]*["'"'"']' src/ templates/ appinfo/templates/ \
-        --include='*.vue' --include='*.js' --include='*.ts' \
-        --include='*.php' --include='*.html' --include='*.htm' 2>/dev/null \
-        | _filter_grep_by_scope >> "${_tp_log}" || true
-    _tp_fail=$(wc -l < "${_tp_log}" 2>/dev/null || echo 0)
-    if [ "${_tp_fail}" -eq 0 ]; then
-        _pass 36 "tabindex-positive"
+    _tp_ran=1
+    _tp_helper="${SCRIPT_DIR}/lib/check_markup_a11y.py"
+    # Same three roots and same six extensions the grep used — `.js`/`.ts`
+    # included, which `_a11y_markup_files` does not carry. Generated trees are
+    # pruned as everywhere else in this family.
+    _tp_files=()
+    while IFS= read -r _tpf; do
+        [ -f "${_tpf}" ] || continue
+        _in_scope "${_tpf}" || continue
+        _tp_files+=("${_tpf}")
+    done < <(find src templates appinfo/templates -type f \
+                \( -name '*.vue' -o -name '*.js' -o -name '*.ts' \
+                 -o -name '*.php' -o -name '*.html' -o -name '*.htm' \) \
+                2>/dev/null \
+                | grep -vE '(^|/)(node_modules|vendor|dist|build|coverage|phpmetrics|\.git)/' \
+                || true)
+    if [ "${#_tp_files[@]}" -eq 0 ]; then
+        _tp_ran=0
+        _skip 36 "tabindex-positive" na "no markup or script file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No tabindex value was inspected and none could be."
+    elif [ ! -f "${_tp_helper}" ]; then
+        _tp_ran=0
+        _skip 36 "tabindex-positive" wiring "check_markup_a11y.py not found at ${_tp_helper} — ${#_tp_files[@]} file(s) were in scope and NONE were inspected; positive tabindex values (WCAG 2.4.3) are UNVERIFIED by this run."
     else
-        _fail 36 "tabindex-positive" "${_tp_fail} positive tabindex value(s) — use \"0\" or \"-1\" — see ${_tp_log}"
+        set +e
+        _tp_err="${HYDRA_GATE_LOG_DIR}/hydra-gate-tabindex-positive.err"
+        python3 "${_tp_helper}" --rule tabindex-positive "${_tp_files[@]}" >> "${_tp_log}" 2>"${_tp_err}"
+        _tp_rc=$?
+        if [ "${_tp_rc}" -ne 0 ]; then
+            _tp_ran=0
+            _skip 36 "tabindex-positive" wiring "check_markup_a11y.py exited ${_tp_rc} — ${#_tp_files[@]} file(s) were in scope and NONE were judged. See ${_tp_err}."
+        fi
+    fi
+    _tp_fail=$(wc -l < "${_tp_log}" 2>/dev/null || echo 0)
+    [ -z "${_tp_fail}" ] && _tp_fail=0
+    if [ "${_tp_ran}" -eq 1 ]; then
+        if [ "${_tp_fail}" -eq 0 ]; then
+            echo "[hydra-gates] gate-36 tabindex-positive: ${#_tp_files[@]} file(s) inspected, 0 positive tabindex."
+            _pass 36 "tabindex-positive"
+        else
+            _fail 36 "tabindex-positive" "${_tp_fail} positive tabindex value(s) — use \"0\" or \"-1\" — see ${_tp_log}"
+        fi
     fi
 fi
 

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
@@ -17,6 +17,10 @@ number, so the first column cell of every row must literally start with
 * a declared gate that appears in neither place — a gate cannot be added to the
   runner and left untested in silence.
 
+Gates already covered by a bundle in THIS directory are deliberately absent
+too: **7** (`auth-guards/`), **2** and **21** (`debug-and-conflict/`), **35**
+and **36** (`a11y-noise/`).
+
 Gates already covered by a repo-shaped bundle are deliberately absent from this
 table: **23, 24, 26, 27, 29, 30, 31, 32, 33** (`scripts/test-fixtures/gates-23-33/`
 via `scripts/lib/test_gates_23_33_never_green_over_nothing.sh`), **61**
@@ -40,9 +44,15 @@ A reason is a testable claim, so each row states which of four kinds it is.
 
 Two notes on authoring, both measured rather than assumed:
 
-1. `scripts/test-fixtures/gate-acceptance/auth-guards/` exists but carries no
-   `expect.conf` and no source files beyond `appinfo/info.xml`, so it currently
-   contributes **zero** covered gates. It is a stub, not coverage.
+1. ⚠️ **CORRECTED 2026-08-12.** This note used to read *"`auth-guards/` exists
+   but carries no `expect.conf` and no source files beyond `appinfo/info.xml`,
+   so it contributes zero covered gates."* That has not been true since the
+   bundle was finished: it has an `expect.conf` and a controller/service pair
+   in both arms, and it covers gate-7. The general point it was making stands
+   and is worth keeping — **a fixture directory with no `expect.conf` is not
+   coverage, and the ratchet counts directories, so an empty bundle would
+   otherwise read as progress.** The driver enforces this directly: a bundle
+   without an `expect.conf`, or missing either arm, is a hard failure.
 2. `_enum_tracked` prefers `git ls-files`, and a fixture directory sits inside
    this repository's own work tree — so a planted file must be **committed** to
    be enumerated at all. An untracked plant reproduces the very silence these
@@ -53,7 +63,6 @@ Two notes on authoring, both measured rather than assumed:
 | gate | name | category | reason |
 |---|---|---|---|
 | gate-1 | spdx-headers | no-fixture-yet | A planted `lib/Service/Unlicensed.php` with no `@license`/`@copyright` docblock tags would trip it; the clean arm is the same file carrying both. Nothing blocks authoring this. |
-| gate-2 | forbidden-patterns | no-fixture-yet | A planted `lib/Service/Debug.php` containing `var_dump($x);` (and the `die;` language-construct form, which the pre-`check_forbidden_patterns.py` grep missed) would trip it; the clean arm keeps the file and drops the calls. |
 | gate-3 | stub-scan | no-fixture-yet | A planted `lib/BackgroundJob/EmptyJob.php` whose `run()` body does no non-logger call, plus a `lib/Service/` method taking `$userId` and never referencing it, would trip both arms of the checker. Nothing blocks it. |
 | gate-4 | composer-audit | needs-external | Requires the `composer` binary on PATH **and** a network round-trip to the Packagist security-advisories API, since `composer audit --locked` resolves advisories remotely. A planted arm would additionally need a lock pinning a package with a live published CVE, which rots as advisories are superseded. |
 | gate-5 | route-auth | no-fixture-yet | `scripts/test-fixtures/route-auth/` and `fq-route-names/` already exercise this gate, but through `scripts/lib/test_gate_route_auth.sh`, which drives the checker's helper level rather than a planted/clean pair through the real wrapper. A planted `appinfo/routes.php` entry whose controller method carries no auth attribute would give it wrapper-level coverage. |
@@ -69,13 +78,10 @@ Two notes on authoring, both measured rather than assumed:
 | gate-17 | redundant-controller | no-fixture-yet | A planted `lib/Controller/MeetingController.php::index()` whose body is a literal pass-through to OpenRegister's `ObjectService` would trip it; the clean arm deletes the wrapper. Runs full-tree when unscoped, so no diff is required. |
 | gate-18 | notification-dialect | no-fixture-yet | A planted `lib/Settings/register.json` whose `x-openregister-notifications` block uses the obsolete singular `channel`/`recipient` + `lifecycleEnter` dialect would trip the blocking half (a); the clean arm uses plural `channels`/`recipients` + `trigger.type`. Half (b) is advisory and never decides the verdict. |
 | gate-20 | or-objectservice-api | no-fixture-yet | A planted `lib/Service/Thing.php` calling `$this->objectService->findObjects(...)` would trip it; the clean arm calls `findAll()`. A second clean file with the same call **commented out** would pin the `source_scope.py --mask php` behaviour. Nothing blocks it. |
-| gate-21 | conflict-markers | no-fixture-yet | A planted tracked file under `lib/` carrying git's canonical `<<<<<<< `/`=======`/`>>>>>>> ` marker shapes at start-of-line would trip it; the clean arm is the resolved file. Nothing blocks it. |
 | gate-22 | manifest-validation | needs-external | `scripts/test-fixtures/manifest-validation/` exists but feeds `check_manifest.js` directly via `test_check_manifest.sh` rather than driving the wrapper. Wrapper-level coverage additionally needs `node` on PATH **and** `ajv/dist/2020` resolvable: no `node_modules` ships anywhere in this package, so today the validator exits 3 and the clean arm cannot go green. |
 | gate-25 | contract-coverage | no-fixture-yet | A planted `appinfo/routes.php` entry plus a `#[PublicPage]` controller method with no Postman collection assertion, no PHPUnit controller test and no `@contract exclude <reason>` would trip it. The helper audits the full tree when unscoped, so no diff is required. |
 | gate-28 | license-triangle | no-fixture-yet | A planted `composer.json` declaring `"license": "EUPL-1.2"` alongside a `lib/` PHP file whose docblock says `@license MIT` would trip it; the clean arm makes the two agree. Nothing blocks it. |
 | gate-34 | window-confirm | no-fixture-yet | A planted `src/components/Thing.vue` calling `window.confirm(...)` — and the bracket form `window['confirm'](...)`, which the old regex missed — would trip it; the clean arm uses `NcDialog`. Nothing blocks it. |
-| gate-35 | img-alt-empty-only | no-fixture-yet | A planted `<img :src="user.avatarUrl" alt="">` (and the single-quoted `alt=''` spelling, which was invisible until recently) would trip it; the clean arm gives the image a real text alternative. Nothing blocks it. |
-| gate-36 | tabindex-positive | no-fixture-yet | A planted markup file with `tabindex="5"` — plus the single-quoted `tabindex='5'` form, for which the fleet has zero occurrences and therefore no live regression pressure — would trip it; the clean arm uses `"0"`. Nothing blocks it. |
 | gate-37 | aria-hidden-focusable | no-fixture-yet | A planted element with `aria-hidden="true"` and `tabindex="0"` would trip it; the clean arm must include the canonical `aria-hidden` + `tabindex="-1"` hidden file input, which is correct code this gate previously reported. Nothing blocks it. |
 | gate-38 | skip-link | no-fixture-yet | `scripts/test-fixtures/monitoring-skiplink/` exists but is driven by `scripts/lib/test_gate_monitoring_and_skiplink.sh` at helper level, not as a planted/clean pair through the wrapper. A planted `src/App.vue` that is neither an `<NcContent>` nor a `<CnAppRoot>` and carries no skip-link anchor would give it wrapper-level coverage. |
 | gate-39 | button-name | no-fixture-yet | A planted `<button><CloseIcon /></button>` with no accessible name would trip it; the clean arm must include a `:title="t('app', 'Remove tab')"` bound name, which is the shape that produced all 22 of openbuild's false positives. Nothing blocks it. |

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/appinfo/info.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<info>
+	<id>gateaccept</id>
+	<name>Gate acceptance fixture</name>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/components/Faces.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/components/Faces.vue
@@ -1,0 +1,23 @@
+<template>
+	<div>
+		<!-- A real text alternative on a semantic src is the CORRECT code
+		     gate-35 exists to steer people toward. -->
+		<img :src="user.avatarUrl" :alt="t('app', 'Profile picture of {name}', { name: user.name })">
+
+		<!-- Decorative BY NAME: neither token is a content noun, so an empty
+		     alt is honest here. `uploadIcon` is docudesk's live shape and is
+		     the only `alt=""` anywhere in the fleet. -->
+		<img :src="uploadIcon" alt="" class="upload-icon">
+
+		<!-- Decorative BY SHAPE: a static asset path. -->
+		<img src="/img/decoration.svg" alt="">
+
+		<!-- THE ANTI-WIDENING ARM. A substring matcher taught to see
+		     `avatarUrl` would also fire on these. The rule asks for token
+		     EQUALITY after camelCase/underscore splitting, so `photographer`
+		     is not `photo` and `pictures` is not `picture`. -->
+		<img :src="user.photographerBio" alt="">
+		<img :src="gallery.pictures" alt="">
+		<img :src="thumbnails" alt="">
+	</div>
+</template>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/components/Focus.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/components/Focus.vue
@@ -1,0 +1,27 @@
+<template>
+	<div>
+		<!-- gate-36 NEAR-MISS: a comment documenting the rule. Reported as a
+		     violation of it before 2026-08-12, which is the #236 shape — the
+		     better a team documents its focus order, the redder its repo. -->
+		<!-- never write tabindex="5"; positive values pull the element out of
+		     natural document order -->
+		<button tabindex="0">in natural order</button>
+		<div tabindex="-1">programmatically focusable only</div>
+		<span :tabindex="computedIndex">bound values are reviewer judgement</span>
+	</div>
+</template>
+
+<script>
+// A JS comment mentioning tabindex="9" is prose too, and lives in the SFC
+// block markup_mask would have blanked wholesale. This gate masks COMMENTS
+// only, so `<script>` stays in scope and this line still has to be exempted
+// on its own merits rather than by being in the wrong block.
+export default {
+	name: 'Focus',
+	computed: {
+		computedIndex() {
+			return 0
+		},
+	},
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/render-helpers.js
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/clean/src/render-helpers.js
@@ -1,0 +1,6 @@
+// gate-36 keeps `.js`/`.ts` in scope: a positive tabindex is a property of the
+// rendered DOM whoever emitted it. This comment mentions tabindex="3" and must
+// not fire; the planted arm proves the executable form still does.
+export function attrs() {
+	return { tabindex: '0' }
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/expect.conf
@@ -1,0 +1,67 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: a11y-noise — gate-35 (img-alt-empty-only) and gate-36
+# (tabindex-positive), the last two raw greps in the 31–36 family. Repaired
+# 2026-08-12 in opposite directions, which is why both arms carry weight.
+#
+# gate-35 was BLIND. Its noun list was `\b`-anchored, and `\b` is a
+# WORD-character boundary, so `avatarUrl` / `thumbnailUrl` / `photoUrl` /
+# `pictureUrl` — and `avatar_url`, since `_` is a word character — could not
+# match. A seven-image probe in which every image was a violation reported 3.
+#   planted/  nine violations, including the five the old rule could not see
+#             and the three it could, so a repair cannot trade one set for the
+#             other.
+#   clean/    THE ANTI-WIDENING ARM, and the reason this bundle exists rather
+#             than a unit test. `photographerBio`, `gallery.pictures` and
+#             `thumbnails` all CONTAIN a content noun as a substring and are
+#             all fine. A matcher taught to see `<noun>Url` by relaxing to a
+#             substring would light up every one of them and start the cycle
+#             this repair exists to avoid. Also here: a real `:alt`, a
+#             decorative-by-name `uploadIcon` (docudesk's live shape, the only
+#             `alt=""` in the fleet) and a decorative-by-shape static asset.
+#
+# gate-36 was NOISY. A raw `grep -rnE` reported
+#   <!-- never write tabindex="5" ... -->
+# as a positive tabindex — gate-32's #236 shape, where the comment documenting
+# the rule scores as a violation of it.
+#   clean/    the HTML-comment form, a JS-comment form inside `<script>`, a
+#             `.js` comment, plus `tabindex="0"`, `tabindex="-1"` and a bound
+#             `:tabindex`.
+#   planted/  `tabindex="5"` in a template, `tabindex='12'` single-quoted, and
+#             `tabindex="4"` inside a `.js` string. That last one is the
+#             assertion that the noise was removed by masking COMMENTS and not
+#             by narrowing to the markup scope: `markup_mask` would blank
+#             `<script>` and PHP wholesale and take the true positive with it.
+#
+# ⚠️ WHY THERE ARE TWO ROWS PER GATE — the driver grades a VERDICT plus a
+# NAMED SUBJECT, never a count. A single planted file holding every mechanism
+# is blind to any regression that leaves one finding standing, and gate-35 is
+# the worst case: reverting to the `\b` noun list still produces `FAIL` naming
+# a file with `user.avatar` in it. Verified while authoring this bundle — the
+# suite stayed green over the exact defect it exists to pin.
+#
+# So each row names a file holding exactly ONE mechanism:
+#   FacesCamel.vue     ONLY `avatarUrl` / `thumbnailUrl` / `photoUrl` /
+#                      `pictureUrl` / `avatar_url` — the five spellings `\b`
+#                      cannot match. A revert to `\b` empties this file's
+#                      findings and the subject assertion fires.
+#   Faces.vue          ONLY the three the old rule already caught, so a repair
+#                      cannot trade the old set for the new one.
+#   Focus.vue          the TEMPLATE forms, `tabindex="5"` and `tabindex='12'`.
+#   render-helpers.js  a `tabindex="4"` inside a `.js` string, so `.js` cannot
+#                      silently leave gate-36's scope.
+#
+# ⚠️ Measured, and NOT what was predicted: substituting `markup_mask` for the
+# comments-only mask — the tempting shortcut, since gates 31/32/35 all use it —
+# turns the CLEAN arm red, not this planted row. `markup_mask` dispatches on
+# extension and sends `.js` to `html_markup_mask`, which does not understand
+# `//`, so the clean arm's `.js` COMMENT starts firing while both planted files
+# keep firing. The suite catches the shortcut either way; the prediction about
+# WHICH arm goes red was wrong and is recorded here rather than tidied away.
+gate 35 hydra-gate-img-alt-empty-only.log FAIL PASS src/components/FacesCamel.vue
+gate 35 hydra-gate-img-alt-empty-only.log FAIL PASS src/components/Faces.vue
+gate 36 hydra-gate-tabindex-positive.log FAIL PASS src/components/Focus.vue
+gate 36 hydra-gate-tabindex-positive.log FAIL PASS src/render-helpers.js

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/appinfo/info.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<info>
+	<id>gateaccept</id>
+	<name>Gate acceptance fixture</name>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/Faces.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/Faces.vue
@@ -1,0 +1,12 @@
+<template>
+	<div>
+		<!-- The three the OLD rule already caught, kept in their own file so a
+		     repair cannot trade them for the camelCase ones. -->
+		<img :src="user.avatar" alt="">
+		<img :src="user.photo" alt="">
+		<img :src="user.thumbnail" alt="">
+
+		<!-- Both quote styles, and a literal src in place of a bound one. -->
+		<img src='/img/headshot.png' alt=''>
+	</div>
+</template>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/FacesCamel.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/FacesCamel.vue
@@ -1,0 +1,13 @@
+<template>
+	<div>
+		<!-- ONLY the forms the `\b`-anchored noun list could NOT see. This
+		     file is named as gate-35's subject in expect.conf precisely so a
+		     regression to `\b` drops it out of the log: the OTHER planted file
+		     would still fire, so the verdict alone would not notice. -->
+		<img :src="user.avatarUrl" alt="">
+		<img :src="user.thumbnailUrl" alt="">
+		<img :src="user.photoUrl" alt="">
+		<img :src="user.pictureUrl" alt="">
+		<img :src="user.avatar_url" alt="">
+	</div>
+</template>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/Focus.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/components/Focus.vue
@@ -1,0 +1,7 @@
+<template>
+	<div>
+		<!-- The comment form is in the CLEAN arm; this is the executable one. -->
+		<button tabindex="5">pulled out of natural document order</button>
+		<a href="#x" tabindex='12'>single quotes render the same DOM</a>
+	</div>
+</template>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/render-helpers.js
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/a11y-noise/planted/src/render-helpers.js
@@ -1,0 +1,7 @@
+// `.js` stays in scope: focus order is a property of the rendered DOM, not of
+// the language that emitted it. Blanking script regions would have removed the
+// gate-36 noise by removing detection, which is not a repair — this file is the
+// assertion that it was not done that way.
+export function render(el) {
+	el.innerHTML = '<button tabindex="4">emitted from script</button>'
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/appinfo/info.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<info>
+	<id>gateaccept</id>
+	<name>Gate acceptance fixture</name>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/appinfo/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	"routes" => [],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/lib/Service/EmitAndExit.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/lib/Service/EmitAndExit.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * The `: never` exemption, kept alongside the declaration exemption so a fix
+ * that removes one cannot quietly remove the other.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\GateAccept\Service;
+
+class EmitAndExit
+{
+	// A COMMENT warning against var_dump( must not count as a use of it,
+	// and the string literal below must not either.
+	public function emit(): never
+	{
+		$sql = "select dd(x)";
+		unset($sql);
+		exit;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/lib/Service/ExitAware.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/lib/Service/ExitAware.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * gate-2 NEAR-MISSES. Every construct below is correct PHP that the gate
+ * reported as a shipped debug helper before 2026-08-12.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\GateAccept\Service;
+
+class ExitAware
+{
+	private int $exitCode = 0;
+
+	/**
+	 * `exit` is SEMI-RESERVED in PHP: illegal as a free function name, legal
+	 * as a method name. The construct pattern saw the parameter list's `(`
+	 * and reported this DECLARATION as a call to the language construct.
+	 */
+	private function exit(): void
+	{
+		$this->exitCode = 1;
+	}
+
+	private function &die(): array
+	{
+		return [];
+	}
+
+	public function run(): void
+	{
+		// A call through `->` or `::` was already silent; the header was not.
+		$this->exit();
+		self::exit();
+	}
+
+	public function code(): int
+	{
+		return $this->exitCode;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/openspec/notes.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/openspec/notes.md
@@ -1,0 +1,13 @@
+Release
+=======
+
+A Markdown SETEXT H1 underline of exactly seven `=` characters is
+byte-identical to git's conflict separator, and `^={7}$` matched it. This file
+is the gate-21 near-miss: it must NOT be reported, because there is no
+`<<<<<<< ` or `>>>>>>> ` anywhere in it.
+
+Subheading
+==========
+
+A longer underline never matched and is here only so the discriminator is not
+accidentally satisfied by length.

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/src/index.js
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/clean/src/index.js
@@ -1,0 +1,2 @@
+// gate-21 clean arm: no markers of any kind.
+export const ok = true;

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/expect.conf
@@ -1,0 +1,57 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# <subject-substring> is the LOAD-BEARING part. The driver requires the planted
+# arm's finding to NAME it. A gate that fails with a bare count, or that fails
+# for some unrelated reason, does not prove this fixture triggered it.
+#
+# Bundle: debug-and-conflict — gate-2 (forbidden-patterns) and gate-21
+# (conflict-markers). Both were repaired on 2026-08-12 for a FALSE POSITIVE,
+# which is why the clean/ arm is the interesting one here: it carries the exact
+# near-misses each gate used to report, so a regression to the old matcher
+# turns clean/ red rather than turning planted/ green.
+#
+# clean/ near-misses, each measured as a live finding before the fix:
+#   gate-2   `private function exit(): void` — `exit` is SEMI-RESERVED in PHP,
+#            illegal as a free function name and legal as a method name, so
+#            this DECLARATION is not a call. `$this->exit()`, `self::exit()`
+#            and `$exitCode` were already silent; only the header was not.
+#            Also here: the `: never` exemption, a comment mentioning
+#            `var_dump(` and a string literal containing `dd(` — three older
+#            exemptions kept in the same arm so a fix cannot remove one of
+#            them unnoticed.
+#   gate-21  a Markdown SETEXT H1 underline of exactly seven `=` characters,
+#            byte-identical to git's conflict separator under `^={7}$`.
+#
+# planted/ true positives, which must survive every repair:
+#   gate-2   `var_dump ($payload);` (with the space PHP permits) and a bare
+#            `die;` in lib/Service/Debugger.php. lib/Service/ExitAware.php is
+#            present in BOTH arms and must stay silent in both, so a fix that
+#            removes the false positive by disabling the construct rule fails
+#            here on the count rather than passing both arms.
+#   gate-21  lib/Controller/Conflicted.php, plus openspec/conflicted.md — a
+#            Markdown file that carries a setext underline AND real markers,
+#            which must still be reported. Without that second file, "exempt
+#            every `=======` in Markdown" would pass this suite.
+#
+# ⚠️ WHY THERE ARE TWO ROWS PER GATE — the driver grades a VERDICT plus a
+# NAMED SUBJECT, never a count, and a one-row bundle is therefore blind to any
+# regression that leaves ONE finding standing. Measured while authoring this:
+# with all of gate-2's true positives in a single Debugger.php, dropping the
+# `die`/`exit` construct rule entirely still produced `FAIL` naming
+# Debugger.php, and the suite stayed green. Each row below names a file that
+# holds exactly ONE mechanism, so losing that mechanism drops its file out of
+# the log and the subject assertion fires.
+#
+#   Debugger.php    only `var_dump (` — the whitespace-tolerant call form
+#   Terminator.php  only `die;` — the LANGUAGE-CONSTRUCT form
+#   Conflicted.php  a conflict in PHP — the shape every real incident took
+#   conflicted.md   a conflict in MARKDOWN — so "exempt every `=======` in
+#                   Markdown", the over-correction this repair could have
+#                   shipped, turns the planted arm red instead of green
+gate 2 hydra-gate-forbidden-patterns.log FAIL PASS lib/Service/Debugger.php
+gate 2 hydra-gate-forbidden-patterns.log FAIL PASS lib/Service/Terminator.php
+gate 21 hydra-gate-conflict-markers.log FAIL PASS lib/Controller/Conflicted.php
+gate 21 hydra-gate-conflict-markers.log FAIL PASS openspec/conflicted.md

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/appinfo/info.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<info>
+	<id>gateaccept</id>
+	<name>Gate acceptance fixture</name>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/appinfo/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	"routes" => [],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Controller/Conflicted.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Controller/Conflicted.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+<<<<<<< HEAD
+$version = 1;
+=======
+$version = 2;
+>>>>>>> feature/bump

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/Debugger.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/Debugger.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * gate-2 TRUE POSITIVE: `var_dump (` with the space PHP permits between the
+ * name and the argument list, which `\bvar_dump\(` required to be absent.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\GateAccept\Service;
+
+class Debugger
+{
+	public function trace(array $payload): void
+	{
+		var_dump ($payload);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/ExitAware.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/ExitAware.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Present in BOTH arms on purpose. Here it must stay silent while Debugger.php
+ * fires, so the planted arm's finding count distinguishes "the rule works" from
+ * "the rule was switched off".
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\GateAccept\Service;
+
+class ExitAware
+{
+	private int $exitCode = 0;
+
+	private function exit(): void
+	{
+		$this->exitCode = 1;
+	}
+
+	public function code(): int
+	{
+		return $this->exitCode;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/Terminator.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/lib/Service/Terminator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * `die` is a LANGUAGE CONSTRUCT, not a function, so the pre-2026-08-08 grep
+ * `\bdie\(` never saw `die;`. It has its own file because it is named as a
+ * gate-2 subject in expect.conf: if the construct rule is ever dropped to
+ * silence the `function exit()` false positive, Debugger.php would still fire
+ * on `var_dump (` and the verdict alone would not notice.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\GateAccept\Service;
+
+class Terminator
+{
+	public function halt(): void
+	{
+		die;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/openspec/conflicted.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/openspec/conflicted.md
@@ -1,0 +1,11 @@
+Release
+=======
+
+A setext underline in a file that ALSO carries real markers is a true
+positive: the whole file is unresolved.
+
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> feature/bump

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/src/index.js
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/debug-and-conflict/planted/src/index.js
@@ -1,0 +1,2 @@
+// gate-21 planted arm.
+export const ok = true;


### PR DESCRIPTION
Fixes three false positives and one blind spot found by the gate audit. **Do not merge without Ruben** — a gate change moves the verdict for all eighteen apps at once.

## Why this is security work

A gate that cries wolf gets its silences believed. That is not a slogan: gate-7 reported zero IDORs in all eighteen apps for months because its known failure mode was false *positives*, so every agent who met it learned to distrust its findings and therefore to trust its quiet. One hundred and sixty-seven real ones sat in the tree. Three of the four repairs here remove a false positive, and that is the route by which they matter.

## The four

**gate-2 forbidden-patterns** flagged `private function exit()`. `die` and `exit` are semi-reserved in PHP — illegal as free function names, legal as method names — so the construct pattern saw the parameter list's opening bracket and reported the one position where the identifier is definitionally not a call. The call sites `$this->exit()` and `self::exit()` and the property `$exitCode` were already silent, so the gate was quiet everywhere it might have been right and loud in the one place it could not be. Fixed by computing the name offsets of every `function` header and skipping a construct match that starts exactly there. A construct in that method's *body* still fires, and so does one in a method merely named `exitEarly()`.

**gate-21 conflict-markers** flagged a seven-character Markdown setext H1 underline, which is byte-identical to git's separator under the anchored pattern. In Markdown only, a bare separator with no angle-bracket marker anywhere in the same file is now read as a heading. Every other file type is untouched, which is where all three incidents this gate was written for actually happened. A second, independent defect in the same block: the enumeration named `appinfo` twice, so `find` walked it twice and a conflicted `appinfo/routes.php` — one of those three incidents — was reported as two files.

The brief asked whether this gate's use of `find` rather than `git ls-files`, unique in gates one to twenty-one, is intended. **Decision: keep it, and say so in the code.** An unstaged conflicted file is a real state on shared checkouts, and switching to the tracked-file enumeration would narrow the true-positive class to buy consistency. The reason is now written into the block rather than left as an unexplained asymmetry.

**gate-35 img-alt-empty-only** was blind. The noun list was word-boundary anchored, and `U` is a word character, so `avatarUrl`, `thumbnailUrl`, `photoUrl` and `pictureUrl` could not match; underscore is a word character too, so `avatar_url` was invisible for the same reason. On a seven-image probe in which every image was a violation, the gate found three. The source expression is now tokenised on camelCase and punctuation boundaries and compared for token equality. **Equality rather than substring is the load-bearing choice** — a relaxed substring match lights up `photographerBio`, `gallery.pictures` and `thumbnails`, all of which are correct code, and that is exactly how the next gate earns the reputation this PR exists to undo.

**gate-36 tabindex-positive**, the last raw grep in its family, reported a comment warning against positive tabindex as a positive tabindex — the gate-32 shape, where the better a team documents a rule the redder its repository goes. Comments are now masked. Deliberately comments only, not the markup scope: focus order is a property of the rendered DOM whoever emitted it, so script blocks, PHP code and `.js` files all stay in scope. Removing the noise by removing detection would not be a repair.

gates 35 and 36 move into `check_markup_a11y.py`, joining 31 and 32 for the reason those moved.

## Measurement

On one fixture tree with only the gate package changed, gate-2 goes from three findings to two, gate-21 from five to three, gate-35 from three to seven, gate-36 from three to one.

On **openregister** and **pipelinq**, both at their `development` tips, all four gates are clean before and after the change — so the before/after on real repositories is zero to zero, and a repair that had silently narrowed detection would be invisible in that number alone. The load-bearing measurement is therefore the planted one: with true positives committed into both repositories, the pre-repair package misses the planted image entirely and reports the planted comment, while the repaired package names the real subject in each of the four gates, identically in both apps.

**Live exposure is zero for all four defects**, positive-controlled across all eighteen fleet apps. No method is named after a language construct; there is no seven-character setext underline; there is no positive tabindex value anywhere; and there are seventeen image-tag occurrences fleet-wide, of which three are documentation prose and exactly one carries an empty alt, correctly silent both before and after. **These repairs buy trustworthiness, not a closed defect. Please do not read urgency into them.**

## Acceptance coverage

Two new repo-shaped bundles under `gate-acceptance/`. The ratchet moves from thirteen fixtured gates to seventeen and the four rows leave `UNCOVERED.md`.

There are **two `expect.conf` rows per gate**, because the driver grades a verdict plus a named subject and never a count. With all of a gate's true positives in a single file, switching a whole rule off still produces a failure naming that file and the suite stays green — measured while authoring these bundles, not assumed. Each row now names a file holding exactly one mechanism.

Eight deliberate breakages were run, each verified to have landed before its result was believed, and each turns the suite red. They include both over-corrections a reviewer should worry about: exempting every Markdown separator, and widening the noun match to a substring. One prediction was wrong — substituting the markup scope for the comments-only mask reddens the clean arm rather than the planted one, because the extension dispatch sends `.js` somewhere that does not understand `//` — and that correction is recorded in the fixture rather than tidied away.

The full helper-suite runner reports seventy-four passing, two quarantined, and one failing. The one failure is `test_gate_45_to_55_acceptance.sh`, which fails **identically on the unmodified base** with `ajv is not resolvable`; the two logs differ only in the absolute path. It is the known `needs-external` dependency, not this change.
