### PR TITLE
docs(hydra): link the CI/CD standard from the Hydra pages

### DIFF
--- a/docs/hydra/README.md
+++ b/docs/hydra/README.md
@@ -69,6 +69,31 @@ Each repo has its own `docs/` directory, and that's not a duplication: **Hydra's
 
 Most developers only need `.github`. You only need the Hydra clone when you're working *on* the pipeline (skills, agents, container images) rather than *with* it (triggering it on your PR via labels).
 
+## The standard Hydra enforces
+
+Hydra's mechanical gates are only half the answer to "will this merge?". The
+other half is the coding standard the gates check against, and that standard is
+**Nextcloud's**:
+
+> Conduction code must pass Nextcloud's own checks unchanged. We may be stricter
+> than Nextcloud; we may not be different from it.
+
+Formatting is owned by php-cs-fixer via
+[`conduction/coding-standard`](https://github.com/ConductionNL/coding-standard),
+which *extends* `nextcloud/coding-standard` and can only add to it — enforced by
+that package's invariant test rather than by review. PHP_CodeSniffer keeps only
+the semantic rules (named parameters, `@spec`, banned debug functions, removed
+Nextcloud APIs), with every whitespace and brace sniff removed so the two tools
+cannot contradict each other.
+
+**gate-65 `coding-standard-adoption`** is what holds it in place. It fails an app
+that keeps a local ruleset, ships no `.editorconfig`, wires `cs:fix` to PHPCS,
+analyses against a `nextcloud/ocp` below its declared `min-version` — or **pins**
+the gates, the coding standard or the shared workflow instead of tracking the tip.
+
+The full comparison against Nextcloud's own app CI/CD, including what we do not
+yet run, is in [Way of Work → CI/CD and Code Standards](../WayOfWork/ci-cd.md).
+
 ## Where to learn more
 
 For a narrative introduction, the Academy's **[Hydra tutorial series](https://conduction.nl/academy/?series=hydra-tutorial)** walks through what Hydra is, the three pipelines, the quality gates, the skill catalogue, and how to start a real run — six short modules. Read it first if you're new to Hydra; come back here for the reference detail.

--- a/docs/hydra/pipeline-overview.md
+++ b/docs/hydra/pipeline-overview.md
@@ -60,6 +60,14 @@ The pipeline is driven entirely by GitHub issue labels. The supervisor polls eve
 
 Every failure path terminates in `needs-input`; there is no retry and no fix-iteration loop.
 
+## Code standards
+
+The gates check code against a standard defined outside this document:
+Nextcloud's, extended but never contradicted. See
+[Way of Work → CI/CD and Code Standards](../WayOfWork/ci-cd.md) for the rules,
+the tool split (php-cs-fixer owns formatting, PHP_CodeSniffer owns semantics),
+and gate-65, which fails any app that drifts from it or pins itself against it.
+
 ## Labels
 
 | Label                                                     | On       | Meaning                                                                                                                                      | Set by                                | Removed by                        |


### PR DESCRIPTION
The Hydra docs described the machinery — states, labels, gates — but never said which **standard** a gate measures against. `docs/WayOfWork/ci-cd.md` had no inbound link from anywhere in `docs/hydra/`.

Adds a *The standard Hydra enforces* section to the Hydra one-pager: the rule (pass Nextcloud's checks unchanged; stricter allowed, different not), the tool split (php-cs-fixer owns formatting, PHPCS owns semantics), and **gate-65**, including that it fails an app for pinning the gates, the coding standard or the shared workflow. `pipeline-overview.md` gets the same cross-link.