### PR TITLE
feat(quality): validate appinfo/info.xml against the App Store schema (Nextcloud's lint-info-xml)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -559,6 +559,93 @@ jobs:
           name: result-php-quality-${{ matrix.tool }}
           path: quality-results/
 
+  # ── appinfo/info.xml, validated against the App Store's own schema ─────
+  #
+  # Nextcloud ships `lint-info-xml.yml` as a workflow template and every
+  # upstream app runs it. This fleet ran no equivalent: `quality.yml` did not
+  # reference appinfo/info.xml anywhere, so a malformed manifest was discovered
+  # at App Store upload time — after the release had been built, tagged and
+  # published to GitHub.
+  #
+  # That matters more now than it did last week. The release path reads
+  # info.xml for two things it cannot get wrong: the version the tag must match,
+  # and the Nextcloud version whose `occ` signs the package. A file that does
+  # not validate can still parse well enough for a grep to return something
+  # plausible — which is exactly how an unanchored min-version pattern resolved
+  # `8` from `<php min-version="8.3"/>` in 13 apps.
+  #
+  # The schema is fetched from nextcloud/appstore rather than vendored, because
+  # a vendored copy is a claim about what the App Store accepts that goes stale
+  # silently. If the fetch fails the job FAILS — a validator that cannot get its
+  # schema has validated nothing, and saying so is the whole point.
+  info-xml:
+    if: ${{ inputs.enable-php }}
+    runs-on: ubuntu-latest
+    name: "info.xml lint"
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: appinfo/
+
+      - name: Is there an info.xml to lint?
+        id: detect
+        run: |
+          if [ -f appinfo/info.xml ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No appinfo/info.xml — this repo is not a Nextcloud app."
+          fi
+
+      - name: Install xmllint
+        if: steps.detect.outputs.run == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils
+
+      - name: Fetch the App Store schema
+        if: steps.detect.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          curl -sSfL -o info.xsd \
+            https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd
+          # A 200 that returned an error page is not a schema. Assert the shape
+          # before trusting a validation result produced with it.
+          head -1 info.xsd | grep -q '<?xml' || { echo "::error::The fetched info.xsd is not XML — validating against it would prove nothing."; exit 1; }
+          grep -q 'schema' info.xsd || { echo "::error::The fetched info.xsd contains no schema element."; exit 1; }
+
+      - name: Validate appinfo/info.xml
+        if: steps.detect.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          xmllint --noout --schema info.xsd appinfo/info.xml
+
+      # The two values the release path reads out of this file. Validity alone
+      # does not mean they are present, and their absence surfaces at release
+      # time — long after this PR merged.
+      - name: Assert the release-critical fields exist
+        if: steps.detect.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          grep -qoP '<version>[^<]+</version>' appinfo/info.xml \
+            || { echo "::error::appinfo/info.xml declares no <version>. The release tag has nothing to match against."; exit 1; }
+          grep -qoP '<nextcloud[^>]*min-version="[0-9]+"' appinfo/info.xml \
+            || { echo "::error::appinfo/info.xml declares no <nextcloud min-version>. The release cannot resolve which server to sign with."; exit 1; }
+          echo "version:     $(grep -oP '(?<=<version>)[^<]+' appinfo/info.xml | head -1)"
+          echo "nextcloud:   $(grep -oP '<nextcloud[^>]*' appinfo/info.xml | head -1)"
+
+      - name: Record result
+        if: always()
+        run: |
+          mkdir -p quality-results
+          echo "${{ job.status }}" > quality-results/info-xml.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-info-xml
+          path: quality-results/
+
   # ── Group 2: Vue Quality ────────────────────────
   vue-quality:
     if: ${{ inputs.enable-frontend }}


### PR DESCRIPTION
Adopts the first of the five checks Nextcloud runs and we did not. `quality.yml` never referenced `appinfo/info.xml` at all, so a malformed manifest was discovered at **App Store upload time** — after the release was built, tagged and published.

It matters more now: the release path reads `info.xml` for the version the tag must match and the Nextcloud version whose `occ` signs the package. A file that doesn't validate can still parse well enough for a grep to return something *plausible* — which is how an unanchored pattern resolved `8` from `<php min-version="8.3"/>` in 13 apps earlier today.

## Measured before merging — 5 pass, 13 fail

| apps | violation |
| --- | --- |
| doriath, opencatalogi | `<background-jobs>` out of sequence |
| hermiq, portaliq, softwarecatalog | `<php>` out of sequence |
| larpingapp, openbuild, scholiq | `<app>` out of sequence |
| launchpad | `<types>` out of sequence |
| nldesign | `<repair-steps>` out of sequence |
| openconnector | `<category>` out of sequence |
| openregister | `<documentation>` out of sequence |
| zaakafhandelapp | `<summary>` is 136 chars; the schema caps it |

Twelve are element **order** — the schema is an `xs:sequence`. The thirteenth is a real content violation. All pre-existing, all would fail Nextcloud's own `lint-info-xml`, all a reorder away from passing.

## Design notes

- **Schema fetched, not vendored.** A vendored copy is a claim about what the App Store accepts that goes stale silently.
- **The fetch is asserted** to have returned XML containing a schema element before any result is trusted. A validator that couldn't get its schema has validated nothing and must say so rather than pass.
- **Two extra assertions** cover what validity alone does not: that `<version>` and `<nextcloud min-version>` exist. Their absence otherwise surfaces at release time.

---

## Correction to the table above (2026-08-12)

**"Twelve are element order" was wrong.** Only **seven** were. The other six carried elements that **do not exist in the App Store XSD at any position** and could never be reordered into validity:

| element | apps | why it was invisible at runtime |
| --- | --- | --- |
| `<dependencies><app>` | larpingapp, openbuild, scholiq ×2, openconnector | `DependencyAnalyzer::analyze()` handles only architecture, php, database, command, lib, os and server version. It never reads `app`. |
| `<groups>` | larpingapp | `OC_App` sets `$info['groups']` unconditionally from the `enabled` appconfig, overwriting whatever info.xml parsed. |
| `<notification>` | openregister | NC's `InfoParser` has no handling for it; the notifier is registered in PHP via `registerNotifierService()`. |
| `<types><search/>` | launchpad | Not a valid app type; search is wired via `registerSearchProvider()`. |

**The measurement was at fault, not the schema.** `xmllint` stops reporting once an earlier error appears, so the "first error" column I built the table from masked everything behind it. A one-line-per-app summary of a validator that short-circuits is not an inventory of that app's problems — it is an inventory of each app's *first* problem.

Also hidden that way: **`<install>` had to move after `<post-migration>` in six apps** — the single most common violation in the fleet, absent from the original table entirely.

**One real behaviour change** came out of it. launchpad's `<activity><provider>` was an invalid direct child, and NC reads providers from `activity.providers.provider` — so `OCA\LaunchPad\Activity\Extension` had **never been registered**. Wrapping it in `<providers>` satisfies the schema and makes that feature work for the first time. Every other removal was verified inert against the Nextcloud server source before being touched.

All 13 now validate, verified by re-downloading each file **from its remote branch** and re-running `xmllint`. The fixes are commits on the existing `chore/nextcloud-coding-standard` PRs.
