### PR TITLE
fix(gate-65, shellcheck): restore the required check — a whole-repo gate fires inside every fixture

### DIFF
--- a/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
+++ b/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
@@ -132,7 +132,10 @@ probe() {
     local name="$1" expect="$2"; shift 2
     local d="$WORK/$name"
     rm -rf "$d"; scaffold "$d"
-    ( cd "$d" && eval "$@" )
+    # Every probe below passes its defect as ONE shell string (quoted sed/rm
+    # commands), so the string form is what this has always meant. eval "$@"
+    # only looked array-shaped — SC2294.
+    ( cd "$d" && eval "$*" )
     local o; o="$(run "$d")"
     if printf '%s' "$o" | grep -q "FAIL ${expect}:"; then
         ok "detects ${name} (${expect})"

--- a/hydra-gates/scripts/lib/test_gate_license_triangle_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_license_triangle_scope.sh
@@ -105,7 +105,17 @@ _mkrepo() {
         # So the fixture adopts it, mirroring the compliant scaffold in
         # test_check_coding_standard_adoption.sh.
         printf '{\n  "name": "conduction/fixture",\n  "license": "EUPL-1.2",\n  "require-dev": {\n    "conduction/coding-standard": "^1.0"\n  },\n  "scripts": {\n    "cs:check": "php-cs-fixer fix --dry-run --diff",\n    "cs:fix": "php-cs-fixer fix"\n  }\n}\n' > composer.json
-        printf '<?php\nrequire_once __DIR__ . %s/vendor/autoload.php%s;\n$config = new Conduction\\CodingStandard\\Config();\n$config->getFinder()->in(__DIR__ . %s/lib%s);\nreturn $config;\n' "'" "'" "'" "'" > .php-cs-fixer.dist.php
+        # Quoted heredoc, not printf: the body is PHP and contains `$config`,
+        # which printf-with-single-quotes makes ShellCheck read as a shell
+        # expansion that will not expand (SC2016). <<'PHP' says "verbatim" to
+        # the shell and to the reader at once.
+        cat > .php-cs-fixer.dist.php <<'PHP'
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+$config = new Conduction\CodingStandard\Config();
+$config->getFinder()->in(__DIR__ . '/lib');
+return $config;
+PHP
         printf 'root = true\n\n[*]\nindent_style = tab\n' > .editorconfig
         printf 'name: ci\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo base\n' > .github/workflows/ci.yml
         if [ "${_withlib}" = "yes" ]; then

--- a/hydra-gates/scripts/lib/test_gate_license_triangle_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_license_triangle_scope.sh
@@ -97,7 +97,16 @@ _mkrepo() {
         git config user.email "ci@example.invalid"
         git config user.name "gate28 test"
         printf '<?xml version="1.0"?>\n<info><id>fixture</id><version>1.0.0</version></info>\n' > appinfo/info.xml
-        printf '{\n  "name": "conduction/fixture",\n  "license": "EUPL-1.2"\n}\n' > composer.json
+        # gate-65 (coding-standard-adoption) is deliberately NOT diff-scoped:
+        # it judges the repo's standing configuration, so it fires on this
+        # fixture too. Two assertions below require the whole run to end
+        # GREEN, and a fixture that has not adopted the shared standard cannot
+        # produce that — the arm would be measuring gate-65 instead of gate-28.
+        # So the fixture adopts it, mirroring the compliant scaffold in
+        # test_check_coding_standard_adoption.sh.
+        printf '{\n  "name": "conduction/fixture",\n  "license": "EUPL-1.2",\n  "require-dev": {\n    "conduction/coding-standard": "^1.0"\n  },\n  "scripts": {\n    "cs:check": "php-cs-fixer fix --dry-run --diff",\n    "cs:fix": "php-cs-fixer fix"\n  }\n}\n' > composer.json
+        printf '<?php\nrequire_once __DIR__ . %s/vendor/autoload.php%s;\n$config = new Conduction\\CodingStandard\\Config();\n$config->getFinder()->in(__DIR__ . %s/lib%s);\nreturn $config;\n' "'" "'" "'" "'" > .php-cs-fixer.dist.php
+        printf 'root = true\n\n[*]\nindent_style = tab\n' > .editorconfig
         printf 'name: ci\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo base\n' > .github/workflows/ci.yml
         if [ "${_withlib}" = "yes" ]; then
             mkdir -p lib
@@ -379,8 +388,14 @@ fi
 #        (composer-audit) applicable, and it fails on a fixture with no vendor
 #        tree — `_FAILED` becomes 1 and the coverage sentence is unreachable
 #        again. The diff must contain the lib PHP file and nothing else.
+#        For the same reason the rewrite below drops ONLY the licence field and
+#        keeps the coding-standard wiring: rewriting composer.json down to a
+#        bare name also un-adopts the shared standard, gate-65 fails, `_FAILED`
+#        is 1 again and the coverage sentence this control reads is never
+#        reached — the control would report the coverage requirement inert when
+#        it is simply never consulted.
 _mkrepo scope-nolicense-fullcov yes
-printf '{\n  "name": "conduction/fixture"\n}\n' > "${_REPO}/composer.json"
+printf '{\n  "name": "conduction/fixture",\n  "require-dev": {\n    "conduction/coding-standard": "^1.0"\n  },\n  "scripts": {\n    "cs:check": "php-cs-fixer fix --dry-run --diff",\n    "cs:fix": "php-cs-fixer fix"\n  }\n}\n' > "${_REPO}/composer.json"
 git -C "${_REPO}" add -A >/dev/null 2>&1
 git -C "${_REPO}" commit -qm "drop the composer license field" >/dev/null 2>&1
 _BASE="$(git -C "${_REPO}" rev-parse HEAD)"

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
@@ -32,3 +32,4 @@ identically to `UNCOVERED.md`.
 | gate-32 | semantic-controls | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
 | gate-33 | axe-core | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
 | gate-61 | listener-work-placement | `test_gate_scope_matrix.sh` | `test-fixtures/scope-matrix/app` — push / full / diff matrix, `.github#347` |
+| gate-65 | coding-standard-adoption | `test_check_coding_standard_adoption.sh` | scaffolded in-suite — 15 planted single-defect probes (one rule each) plus a negative control that fails if a broadened rule starts matching the compliant scaffold, and a wiring assertion that the checker printed its terminal `checked N rule(s)` summary |


### PR DESCRIPTION
## Why this is urgent

**`Package invariants` — one of the three REQUIRED checks on `main` — has been red
since 09:38 today.** Six queued gate PRs (#373, #376, #377, #378, #379, #380) cannot
merge, and none of them caused it.

Two independent things were red. Only one was blocking, and it was not the one that
looks scarier in the checks list.

| check | red since | required? |
|---|---|---|
| ShellCheck | 2026-08-03 | **no** — worth fixing, never blocked anything |
| **Package invariants** | today 09:38 | **yes** |

## 1. gate-65 fires inside every other suite's fixture (the blocker)

`gate-65 coding-standard-adoption` (#382) is **deliberately not diff-scoped** — it judges
the repo's standing configuration, which is right for its purpose. But its only
NOT-APPLICABLE path is *"no composer.json and no phpcs.xml"*, and **every synthetic
fixture in the corpus has a composer.json**, because the gate under test needs one.

So it fires inside other suites' fixtures and fails runs those suites require to end
green:

- `test_gate_license_triangle_scope.sh` — 2 assertions, one of them **the control that
  makes assertion 5 mean anything**, died on `status 1`
- `test_gate_acceptance_matrix.sh` — gate-65 declared with neither fixture nor reasoned row

The general lesson, worth writing down: **a whole-repo gate is a global mutation of every
other gate's test environment.** Diff-scoped gates decline inside fixtures they do not
concern; a whole-repo gate cannot, so it quietly becomes a precondition of every "and the
run ends green" assertion in the corpus.

### Fixes

**Fixture adopts the standard** — mirroring the compliant scaffold already in
`test_check_coding_standard_adoption.sh`: `require-dev`, `cs:check`/`cs:fix`,
`.php-cs-fixer.dist.php`, and an `.editorconfig` with `indent_style = tab`.

**Arm 6 needed the same fix separately.** It rewrites `composer.json` down to a bare name
to drop the licence field — which also un-adopts the standard. That arm is the *control*
for assertion 5, so it silently proving nothing was the worse of the two failures.

**gate-65 gets its `COVERED-ELSEWHERE.md` row.** It is not uncovered:
`test_check_coding_standard_adoption.sh` plants **15 single-defect probes, one per rule**,
plus a negative control and a wiring assertion. That is precisely what the ELSEWHERE list
exists for — not an exemption.

## 2. ShellCheck SC2294 (not required, but red for 9 days)

`eval "$@"` → `eval "$*"` in the `probe()` helper. All 15 callers pass their planted
defect as **one quoted shell string**, so there was never an array to preserve;
ShellCheck names the string form explicitly. Checked all 15 call sites — none passes more
than one argument, so `$*`'s IFS join cannot change any of them.

## Verification

| suite | result |
|---|---|
| `test_gate_license_triangle_scope.sh` | **11 PASS / 0 FAIL** (was 2 FAIL) |
| `test_gate_acceptance_matrix.sh` | green — **13** gates counted as covered elsewhere (was 12) |
| `test_check_coding_standard_adoption.sh` | 23 passed / 0 failed, before and after |
| **full helper suite on this branch** | **76 passed · 2 quarantined · 0 failed** |
| full helper suite on `origin/main` | 73 passed · 2 quarantined · **3 failed** |

⚠️ **On the 76 vs 73:** one of that difference is *not* a fix. `test_gate_45_to_55_acceptance.sh`
refuses to run without `ajv` (exit 2) rather than emit a false verdict, and `require('ajv')`
**resolves upward** — so it runs from an in-tree checkout and refuses from a `/tmp`
worktree. The main-branch run above was made in a `/tmp` worktree and this one had
`NODE_PATH` set. Real defects fixed: **2**, which is exactly what CI reported.
