### PR TITLE
fix(quality-config): phpstan-base.neon resolved every path against itself, not the app

### DIFF
--- a/quality-config/phpstan-base.neon
+++ b/quality-config/phpstan-base.neon
@@ -27,24 +27,44 @@
 # The fix is to align the pin with info.xml, per
 # https://docs.conduction.nl/WayOfWork/ci-cd/.
 
+# ── WHY EVERY PATH BELOW IS %currentWorkingDirectory%-PREFIXED ───────────────
+# PHPStan resolves a relative path against the directory of the config file that
+# DECLARES it, not against the app root. This file is consumed from
+#   vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+# so a bare `lib` here means `vendor/conduction/hydra-gates/quality-config/lib`.
+#
+# That is not a soft failure. Measured on larpingapp 2026-08-12 with hydra-gates
+# v1.7.0 and the stub in quality-config/stubs/phpstan.neon, `composer phpstan`
+# aborted before analysing anything:
+#   In FileFinder.php line 47:
+#     Path /app/vendor/conduction/hydra-gates/quality-config/vendor/nextcloud/ocp
+#     does not exist
+# — exit 1, zero files analysed. v1.7.0 shipped this file but no app had adopted
+# it yet, so nothing was red and the breakage was invisible.
+#
+# %currentWorkingDirectory% is the directory phpstan was INVOKED from, which for
+# every consumer is the app root (`composer phpstan` runs there). With the
+# prefix, `phpstan dump-parameters` on larpingapp resolved paths, excludePaths,
+# bootstrapFiles and scanDirectories to byte-identical values to the hand-rolled
+# per-app config it replaces, and the findings were unchanged.
 parameters:
     level: 5
 
     paths:
-        - lib
+        - %currentWorkingDirectory%/lib
 
     bootstrapFiles:
-        - phpstan-bootstrap.php
+        - %currentWorkingDirectory%/phpstan-bootstrap.php
 
     excludePaths:
-        - vendor
-        - vendor-bin
+        - %currentWorkingDirectory%/vendor
+        - %currentWorkingDirectory%/vendor-bin
         # Apps that ship a verbatim template snapshot under lib/Resources/template/
         # (openbuild). A no-op everywhere else.
-        - lib/Resources/template
+        - %currentWorkingDirectory%/lib/Resources/template
 
     scanDirectories:
-        - vendor/nextcloud/ocp
+        - %currentWorkingDirectory%/vendor/nextcloud/ocp
 
     reportUnmatchedIgnoredErrors: false
 


### PR DESCRIPTION
## The bug

`quality-config/phpstan-base.neon` (new in v1.7.0) declares its paths relative:

```neon
paths:
    - lib
scanDirectories:
    - vendor/nextcloud/ocp
```

PHPStan resolves a relative path against **the directory of the config file that
declares it**, not against the app root. This file is consumed from
`vendor/conduction/hydra-gates/quality-config/`, so `lib` means
`vendor/conduction/hydra-gates/quality-config/lib`.

## How it was found

Adopting `quality-config/stubs/phpstan.neon` verbatim on **larpingapp** (fleet
job: finish the PHP centralisation the phpcs migration left half-done). Before
the change, `composer phpstan` → `[OK] No errors`, exit 0. After:

```
In FileFinder.php line 47:

  Path /app/vendor/conduction/hydra-gates/quality-config/vendor/nextcloud/ocp
   does not exist

EXIT=1
```

Zero files analysed. Every one of the 18 core apps would have gone red on the
first PR that adopted the stub. v1.7.0 shipped the base but **no app had adopted
it yet**, so nothing was red and the defect was invisible.

## The fix

Prefix every path-bearing key with `%currentWorkingDirectory%` — the directory
phpstan was invoked from, which for every consumer is the app root, because
`composer phpstan` runs there.

## Verification

Not "it looks right". On larpingapp, `phpstan dump-parameters` before (local
hand-rolled `phpstan.neon`) vs after (stub + fixed base):

- `level`, `paths`, `excludePaths`, `bootstrapFiles`, `scanDirectories` —
  **byte-identical resolved values**
- the only diff in the whole parameter dump is `ignoreErrors`: the base adds the
  ContextChat / SystemTag / Bookmarks entries larpingapp did not carry, and
  reorders one entry
- `composer phpstan` findings before vs after: **identical** (`[OK] No errors`)
- `composer phpmd` effective ruleset dumped rule-by-rule (class, name, priority,
  every property): **43 rules before, the same 43 after**

## Follow-up worth noting

`quality-config/tests/compatibility.sh` is not referenced by any workflow in
`.github/workflows/` — it is a test that never runs. Same failure mode that hid
this one. Not fixed here to keep this PR to the defect.
