### PR TITLE
fix(gate-48): a re-indented #[NoCSRFRequired] is not a dropped one

### DIFF
--- a/hydra-gates/scripts/lib/check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/check_csrf_removal.py
@@ -94,8 +94,38 @@ def removals(diff: str) -> list[str]:
     from one controller and added to another is a real change of posture for
     the first one; by multiset because a diff that removes a tag twice and
     restores it once has removed it once.
+
+    A RE-INDENTED LINE IS THE SAME LINE (the coding-standard migration).
+    ------------------------------------------------------------------
+    Cancellation used to compare RAW BYTES, on the stated reasoning that
+    "treating a re-indented line as a move would let a reformat swallow a
+    genuine deletion". Measured on the fleet-wide move to Nextcloud's coding
+    standard (`chore/nextcloud-coding-standard`, larpingapp#313 and 17
+    siblings), that reasoning cost more than it bought: php-cs-fixer re-indents
+    every controller from 4 spaces to a tab, so
+
+        -    #[NoCSRFRequired]
+        +\t#[NoCSRFRequired]
+
+    is emitted for EVERY attribute in the app. On launchpad the helper reported
+    25 "removals" against a tree whose `NoCSRFRequired` count is 43 before and
+    43 after — the annotation was never dropped, only moved one indent level.
+    gate-48 went red on 8 of the 18 migrating apps for that reason alone.
+
+    The fear behind byte-exactness does not survive MULTISET accounting, which
+    is what makes the relaxation safe: a re-indentation contributes exactly one
+    addition for each removal it causes, so the net count is unchanged and
+    nothing cancels that was not restored. Delete one annotation inside an
+    otherwise fully re-indented file and the removals outnumber the additions
+    by one, so exactly one finding survives — pinned by
+    `test_a_genuine_deletion_inside_a_full_reindent_still_reports`, which is
+    the positive control for this relaxation and fails if it is over-applied.
+
+    Only leading/trailing whitespace is normalised. The attribute list itself
+    is still compared verbatim, so `#[NoAdminRequired, NoCSRFRequired]` can
+    never cancel a removed `#[NoCSRFRequired]`.
     """
-    # {path: [raw content of each added line]} and the removals in file order.
+    # {path: [normalised content of each added line]}, removals in file order.
     added: dict[str | None, list[str]] = {}
     found: list[tuple[str | None, str]] = []
     path: str | None = None
@@ -106,7 +136,7 @@ def removals(diff: str) -> list[str]:
             path = header.group('path')
             continue
         if line.startswith('+'):
-            added.setdefault(path, []).append(line[1:])
+            added.setdefault(path, []).append(line[1:].strip())
             continue
         if not line.startswith('-') or DIFF_HEADER.match(line):
             continue
@@ -116,9 +146,10 @@ def removals(diff: str) -> list[str]:
     out: list[str] = []
     for file_path, line in found:
         pool = added.get(file_path)
-        if pool is not None and line[1:] in pool:
+        key = line[1:].strip()
+        if pool is not None and key in pool:
             # Consume the pairing so a second identical removal still reports.
-            pool.remove(line[1:])
+            pool.remove(key)
             continue
         out.append(line)
     return out

--- a/hydra-gates/scripts/lib/test_check_csrf_removal.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_removal.py
@@ -160,13 +160,79 @@ class TestANetZeroMoveIsNotARemoval(unittest.TestCase):
         ])
         self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
 
-    def test_whitespace_is_not_normalised_away(self):
-        """A re-indented line is NOT the same line. Treating it as a move would
-        let a reformat swallow a genuine deletion."""
+    def test_a_reindented_line_is_the_same_line(self):
+        """REVERSED, deliberately (fleet coding-standard migration).
+
+        This assertion used to read the other way, on the reasoning that
+        "treating a re-indented line as a move would let a reformat swallow a
+        genuine deletion". php-cs-fixer re-indents every controller from four
+        spaces to a tab, so the byte-exact rule emitted a finding for EVERY
+        attribute in the app: launchpad reported 25 removals against a tree
+        whose `NoCSRFRequired` count is 43 before and 43 after. gate-48 was red
+        on 8 of the 18 migrating apps over indentation alone.
+
+        What makes the reversal safe is MULTISET accounting, not optimism —
+        see `test_a_genuine_deletion_inside_a_full_reindent_still_reports`
+        immediately below, which is the arm that proves the gate was relaxed
+        and not disabled.
+        """
         diff = "\n".join([
             "+++ b/lib/Controller/X.php",
             "-    #[NoCSRFRequired]",
-            "+        #[NoCSRFRequired]",
+            "+\t#[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), [])
+
+    def test_a_genuine_deletion_inside_a_full_reindent_still_reports(self):
+        """THE POSITIVE CONTROL for whitespace-insensitive cancellation.
+
+        Three attributes re-indented, one of them genuinely deleted: four
+        removals, three additions. Multiset cancellation consumes three and
+        leaves exactly one finding. If this ever returns [] the relaxation has
+        been over-applied and the gate is fail-open on precisely the change
+        shape it was relaxed for.
+        """
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+            "-    #[NoCSRFRequired]",
+            "-    #[NoCSRFRequired]",
+            "-    #[NoCSRFRequired]",
+            "+\t#[NoCSRFRequired]",
+            "+\t#[NoCSRFRequired]",
+            "+\t#[NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_a_reindented_docblock_tag_cancels_too(self):
+        """The docblock form re-indents as well: ` * @NoCSRFRequired` gains a
+        leading tab. Same mechanism, same cancellation."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-     * @NoCSRFRequired",
+            "+\t * @NoCSRFRequired",
+        ])
+        self.assertEqual(gate.removals(diff), [])
+
+    def test_reindentation_cannot_cancel_a_DIFFERENT_attribute_list(self):
+        """Normalisation is leading/trailing whitespace ONLY. Re-indenting
+        `#[NoAdminRequired, NoCSRFRequired]` must not absorb the deletion of a
+        standalone `#[NoCSRFRequired]` — they are different postures."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/X.php",
+            "-    #[NoCSRFRequired]",
+            "+\t#[NoAdminRequired, NoCSRFRequired]",
+        ])
+        self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
+
+    def test_a_reindented_move_ACROSS_files_is_still_a_removal(self):
+        """Whitespace insensitivity must not leak across the per-file
+        boundary — A genuinely lost the annotation."""
+        diff = "\n".join([
+            "+++ b/lib/Controller/A.php",
+            "-    #[NoCSRFRequired]",
+            "+++ b/lib/Controller/B.php",
+            "+\t#[NoCSRFRequired]",
         ])
         self.assertEqual(gate.removals(diff), ["-    #[NoCSRFRequired]"])
 


### PR DESCRIPTION
## The finding

gate-48's move-cancellation compared removed and added lines by **raw bytes**. `php-cs-fixer` re-indents every controller from four spaces to a tab, so the fleet-wide move to Nextcloud's coding standard emits

```
-    #[NoCSRFRequired]
+	#[NoCSRFRequired]
```

for **every** attribute in the app, and the helper read all of them as deletions.

Measured on `ConductionNL/launchpad#106`: the helper reports **25 "removals"** against a tree whose `NoCSRFRequired` count is **43 before the PR and 43 after** — nothing was dropped, everything moved one indent level. gate-48 is red for this reason alone on **8 of the 18 apps currently migrating**, and the cheapest way out would have been a `[hydra-gate-csrf-cochange exclude]` waiver on each: a security gate waived fleet-wide over an indentation artefact.

## Why the old rule is safe to reverse

The byte-exact rule carried a stated reason, pinned by `test_whitespace_is_not_normalised_away`:

> A re-indented line is NOT the same line. Treating it as a move would let a reformat swallow a genuine deletion.

That reason does not survive **multiset** accounting, which is what the cancellation already does. A re-indentation contributes exactly one addition for each removal it causes, so the net count is unchanged. Delete one annotation inside an otherwise fully re-indented file and the removals outnumber the additions by one, leaving exactly one finding.

Cancellation now keys on the line content with leading/trailing whitespace stripped. **Nothing else is normalised**: the attribute list is still compared verbatim, so `#[NoAdminRequired, NoCSRFRequired]` cannot absorb a removed `#[NoCSRFRequired]`, and cancellation is still per **file**.

## Measurement (real launchpad diff)

| | findings | tree count before → after |
|---|---|---|
| pre-fix | 25 (all false) | 43 → 43 |
| post-fix | 0 | 43 → 43 |
| post-fix, one added attribute line deleted from the diff so the head genuinely loses it | **1** | — |

The third row is the one that matters: the gate still catches a real removal.

## Tests

The old assertion is **reversed**, with the reason recorded at the assertion rather than in a changelog. Four arms added; the load-bearing one is `test_a_genuine_deletion_inside_a_full_reindent_still_reports` — four removals, three additions, expects exactly one finding. That is the arm that proves the gate was **relaxed and not disabled**, and it is the arm to read first if this is ever revisited.

The new arms **fail against the pre-fix helper (3 failures)** and pass against the fixed one (25 tests, OK), so they discriminate rather than merely agreeing with whatever the code does.
