### PR TITLE
fix(quality): quality.yml resolved to ZERO jobs — and the three Nextcloud legs could not block a merge

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -98,10 +98,48 @@ on:
         type: string
         default: "[]"
       enable-check-code:
-        description: "Run `occ app:check-code` against the Nextcloud version the app declares in info.xml. Nextcloud's own tool for private and deprecated API usage; the general form of the hand-written \\OC::$server sniff. Reports without blocking unless check-code-blocking is also set."
+        # DEFAULT FLIPPED true -> false, because the command this job runs DOES
+        # NOT EXIST any more and the job therefore cannot pass in any repo here.
+        #
+        # `occ app:check-code` was removed from Nextcloud server after v20.
+        # Measured, extracting the registered App-namespace commands from
+        # `core/register_command.php` at each tag — same expression, same file,
+        # only the tag varying:
+        #
+        #   v20.0.0  Disable Enable GetPath Install ListApps Remove Update
+        #            + CheckCode                       <- the control: it CAN appear
+        #   v34.0.0  Disable Enable GetPath Install ListApps Remove Update
+        #                                              <- CheckCode is gone
+        #
+        # Corroborated independently: `core/Command/App/CheckCode.php` answers
+        # 200 at v20 and v21 and 404 at v25, v31, v32, v33 and v34, while
+        # `core/Command/App/ListApps.php` answers 200 at every one of those tags
+        # — so the 404s are a removal, not a bad path.
+        #
+        # Every app in this fleet declares <nextcloud min-version> of 31, 32 or
+        # 34, and this job fetches the server at the version the app DECLARES.
+        # So `occ` would be asked for a command roughly eleven majors dead. It
+        # would print no recognisable verdict, the job's own positive control
+        # would fire, and that control's `exit 1` is UNCONDITIONAL — it sits
+        # above the `check-code-blocking` branch and is not covered by it. The
+        # result would be a hard failure in every PHP repo in the fleet, on a
+        # check that can never pass.
+        #
+        # The positive control is doing its job here, exactly as designed: it
+        # refuses to report "no private API usage" from a run that inspected
+        # nothing. The job is what is wrong, not the control.
+        #
+        # LEFT WIRED, NOT DELETED, and still listed in the Quality Report's
+        # `needs:`. A skipped job's result is `skipped`, not `failure`, so this
+        # blocks nothing while it is off — and when someone rebuilds the check on
+        # something that exists (Psalm/PHPStan over the private surface, or
+        # nextcloud/app-api's linter), the wiring is already correct and one
+        # input turns it on. Deleting it would lose that and quietly re-open the
+        # gap #385 was written to close.
+        description: "Run `occ app:check-code` against the Nextcloud version the app declares in info.xml. OFF BY DEFAULT AND CURRENTLY UNUSABLE: `app:check-code` was removed from Nextcloud server after v20 (verified against core/register_command.php and core/Command/App/CheckCode.php from v20 through v34), and every app here declares min-version 31 or later, so the command cannot be found and the job's positive control fails the run. Do not set this true until the check is rebuilt on tooling that still exists."
         required: false
         type: boolean
-        default: true
+        default: false
       check-code-blocking:
         description: "Turn app:check-code findings into a build failure. OFF by default on purpose: every app in this fleet reaches into server internals somewhere, and a gate that is red on arrival is a gate nobody turns on. Flip it per app once the findings are worked down."
         required: false

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -608,30 +608,6 @@ jobs:
     runs-on: ubuntu-latest
     name: "Nextcloud API check (app:check-code)"
     timeout-minutes: 20
-  # ── appinfo/info.xml, validated against the App Store's own schema ─────
-  #
-  # Nextcloud ships `lint-info-xml.yml` as a workflow template and every
-  # upstream app runs it. This fleet ran no equivalent: `quality.yml` did not
-  # reference appinfo/info.xml anywhere, so a malformed manifest was discovered
-  # at App Store upload time — after the release had been built, tagged and
-  # published to GitHub.
-  #
-  # That matters more now than it did last week. The release path reads
-  # info.xml for two things it cannot get wrong: the version the tag must match,
-  # and the Nextcloud version whose `occ` signs the package. A file that does
-  # not validate can still parse well enough for a grep to return something
-  # plausible — which is exactly how an unanchored min-version pattern resolved
-  # `8` from `<php min-version="8.3"/>` in 13 apps.
-  #
-  # The schema is fetched from nextcloud/appstore rather than vendored, because
-  # a vendored copy is a claim about what the App Store accepts that goes stale
-  # silently. If the fetch fails the job FAILS — a validator that cannot get its
-  # schema has validated nothing, and saying so is the whole point.
-  info-xml:
-    if: ${{ inputs.enable-php }}
-    runs-on: ubuntu-latest
-    name: "info.xml lint"
-    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -738,6 +714,47 @@ jobs:
         if: steps.lint.outcome == 'failure' && !inputs.reuse-blocking
         run: |
           echo "::warning::REUSE reported findings. Not blocking yet — set reuse-blocking: true once this app ships a REUSE.toml and a LICENSES/ directory."
+
+      - name: Record result
+        if: always()
+        run: |
+          mkdir -p quality-results
+          echo "${{ steps.lint.outcome }}" > quality-results/reuse.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-reuse
+          path: quality-results/
+
+  # ── appinfo/info.xml, validated against the App Store's own schema ─────
+  #
+  # Nextcloud ships `lint-info-xml.yml` as a workflow template and every
+  # upstream app runs it. This fleet ran no equivalent: `quality.yml` did not
+  # reference appinfo/info.xml anywhere, so a malformed manifest was discovered
+  # at App Store upload time — after the release had been built, tagged and
+  # published to GitHub.
+  #
+  # That matters more now than it did last week. The release path reads
+  # info.xml for two things it cannot get wrong: the version the tag must match,
+  # and the Nextcloud version whose `occ` signs the package. A file that does
+  # not validate can still parse well enough for a grep to return something
+  # plausible — which is exactly how an unanchored min-version pattern resolved
+  # `8` from `<php min-version="8.3"/>` in 13 apps.
+  #
+  # The schema is fetched from nextcloud/appstore rather than vendored, because
+  # a vendored copy is a claim about what the App Store accepts that goes stale
+  # silently. If the fetch fails the job FAILS — a validator that cannot get its
+  # schema has validated nothing, and saying so is the whole point.
+  info-xml:
+    if: ${{ inputs.enable-php }}
+    runs-on: ubuntu-latest
+    name: "info.xml lint"
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
           sparse-checkout: appinfo/
 
       - name: Is there an info.xml to lint?
@@ -789,13 +806,11 @@ jobs:
         if: always()
         run: |
           mkdir -p quality-results
-          echo "${{ steps.lint.outcome }}" > quality-results/reuse.txt
           echo "${{ job.status }}" > quality-results/info-xml.txt
       - name: Upload result
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: result-reuse
           name: result-info-xml
           path: quality-results/
 
@@ -4879,7 +4894,34 @@ jobs:
     # been waved through yet. A gate that would not catch a failure is still a
     # dead gate, and `scripts/assert-quality-report-gates-every-leg.py` now
     # keeps the list complete.
-    needs: [php-quality, vue-quality, frontend-build, frontend-checks, frontend-tests, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection, sbom, features-check, features-extract, hydra-gates]
+    #
+    # THE THREE NEXTCLOUD LEGS (#383, #385) ARE ON THIS LIST DELIBERATELY, and
+    # what that does per leg is not the same thing:
+    #
+    #   app-check-code  internally non-blocking by default. The step swallows a
+    #                   non-zero `occ` exit and warns unless `check-code-blocking`
+    #                   is set, so the job concludes `success` with findings and
+    #                   listing it changes nothing today. It becomes a real gate
+    #                   the moment an app flips its own input — which is the
+    #                   point: the wiring must already be there, or flipping the
+    #                   input would be a no-op nobody notices.
+    #   reuse           same shape, via `continue-on-error: ${{ !inputs.reuse-blocking }}`.
+    #   info-xml        HAS NO SUCH FLAG AND IS BLOCKING ON ARRIVAL. Measured in
+    #                   #383 across all 18 core apps: 5 pass, 13 fail, twelve of
+    #                   those on xs:sequence element ORDER and one on a summary
+    #                   over the schema's length cap. Live-confirmed on
+    #                   openregister run 31591669849 — `Element 'documentation':
+    #                   This element is not expected`. So listing it here turns
+    #                   13 of 18 apps red until their manifests are reordered,
+    #                   and that is the authorised trade: the App Store rejects
+    #                   the same files at upload time, after the release has been
+    #                   built, tagged and published.
+    #
+    # The two remaining Nextcloud checks are NOT missing from this list. Multi
+    # database PHPUnit is a matrix dimension of `phpunit`, which is already
+    # here, and `occ integrity:sign-app` lives in release.yml, which has no
+    # Quality Report to gate.
+    needs: [php-quality, vue-quality, frontend-build, frontend-checks, frontend-tests, security, license, phpunit, newman, playwright, journeydoc-capture, baseline-protection, sbom, features-check, features-extract, hydra-gates, app-check-code, info-xml, reuse]
     if: always()
     # Observed across 266 executions: median 0.6 min — but 2% of runs sit at
     # ~30 min because the `Install PDF tools` apt-get step stalls on the Ubuntu
@@ -5030,6 +5072,31 @@ jobs:
             # npm: security + license in one row
             sec_npm=$(read_result "results/result-security-npm/npm.txt")
             echo "| npm | | | $(icon "$sec_npm") | $(license_info "npm") | |"
+
+            # The three Nextcloud legs. They are in `needs:` above, so their
+            # failure reds this job — but a leg the report never mentions is the
+            # exact silence the Hydra-gates row below exists to correct, and it
+            # would have been reintroduced the day these three landed.
+            #
+            # READ THESE THREE CELLS DIFFERENTLY, because the artefacts behind
+            # them hold different things:
+            #
+            #   REUSE           records `steps.lint.outcome` — the RAW step
+            #                   outcome, before `continue-on-error` rewrites it.
+            #                   So this cell goes ❌ on findings even while the
+            #                   job concludes success. That is the useful shape.
+            #   app:check-code  records `job.status`, and the step exits 0 on
+            #                   findings unless `check-code-blocking` is set. So
+            #                   ✅ here means "the run produced a recognisable
+            #                   verdict", NOT "no private API usage" — the
+            #                   findings are in that job's `::warning::` only.
+            #                   Worth narrowing to the step's own finding count;
+            #                   deliberately not done in this commit.
+            #   info.xml        records `job.status` and has no non-blocking
+            #                   flag, so its cell and its gate agree.
+            echo "| app:check-code | $(icon "$(read_result "results/result-app-check-code/app-check-code.txt")") | | | | |"
+            echo "| info.xml | $(icon "$(read_result "results/result-info-xml/info-xml.txt")") | | | | |"
+            echo "| REUSE | $(icon "$(read_result "results/result-reuse/reuse.txt")") | | | | |"
 
             # Test rows. `test_icon` rather than `icon`: see its definition —
             # an enabled-but-skipped test job is the absence of a verdict and

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4906,16 +4906,29 @@ jobs:
     #                   point: the wiring must already be there, or flipping the
     #                   input would be a no-op nobody notices.
     #   reuse           same shape, via `continue-on-error: ${{ !inputs.reuse-blocking }}`.
-    #   info-xml        HAS NO SUCH FLAG AND IS BLOCKING ON ARRIVAL. Measured in
-    #                   #383 across all 18 core apps: 5 pass, 13 fail, twelve of
-    #                   those on xs:sequence element ORDER and one on a summary
-    #                   over the schema's length cap. Live-confirmed on
-    #                   openregister run 31591669849 — `Element 'documentation':
-    #                   This element is not expected`. So listing it here turns
-    #                   13 of 18 apps red until their manifests are reordered,
-    #                   and that is the authorised trade: the App Store rejects
-    #                   the same files at upload time, after the release has been
-    #                   built, tagged and published.
+    #   info-xml        HAS NO SUCH FLAG AND IS BLOCKING ON ARRIVAL. #383
+    #                   measured 5 pass / 13 fail before it merged. RE-MEASURED
+    #                   2026-08-12 14:20Z against every repo's live `development`
+    #                   tip, same App Store XSD: 6 PASS / 12 FAIL. Eleven of the
+    #                   twelve are xs:sequence element ORDER; the twelfth
+    #                   (zaakafhandelapp) is a <summary> over the schema's length
+    #                   cap. The one-app difference is not drift in the
+    #                   instrument — larpingapp's manifest was reordered by
+    #                   efa6aead at 11:28:48Z, and validating that one file at
+    #                   both refs gives FAIL then PASS.
+    #
+    #                   Live-confirmed against CI, not only locally: openregister
+    #                   run 31591669849 emitted `Element 'documentation': This
+    #                   element is not expected` — the same message, byte for
+    #                   byte, as the local validator.
+    #
+    #                   So listing it here turns 12 of 18 apps red until their
+    #                   manifests are reordered, and that is the authorised
+    #                   trade: the App Store rejects the same files at upload
+    #                   time, after the release has been built, tagged and
+    #                   published. TREAT THE 12 AS DECAYING — it is a count over
+    #                   files several agents edit daily, so re-measure before
+    #                   quoting it.
     #
     # The two remaining Nextcloud checks are NOT missing from this list. Multi
     # database PHPUnit is a matrix dimension of `phpunit`, which is already


### PR DESCRIPTION
## Two defects. The second is what was asked for; the first is what makes the second matter.

### 1. `quality.yml` has produced ZERO jobs since 11:26Z, fleet-wide

`#383` (info-xml) merged at 11:19:40Z. `#385` (app:check-code + REUSE) merged at 11:26:16Z from a branch written against a tree that did not yet contain info-xml. Its hunks anchored on `- name: Checkout` / `uses: actions/checkout@v4` / `with:` — context lines that by then belonged to **info-xml's** checkout. Git merged it textually and cleanly, and spliced two jobs into a third:

- `app-check-code` lost its `steps:` entirely — the job header ran straight into the info.xml comment block.
- info-xml's body became app-check-code's steps.
- `reuse` swallowed info-xml's steps, and a stray `sparse-checkout: appinfo/` landed *inside* a `run: |` block, where it would have executed as a shell command.
- the final `upload-artifact` ended up with **two `name:` keys**, which is what actually makes the file unparseable.

Every core app consumes this file at `@main`. Both apps that pushed after 11:26 produced a run with **zero jobs** — openconnector `31592994170` and larpingapp `31592027242`. The other sixteen have not pushed since; their green describes a workflow that no longer exists. The next push in any of them gets zero jobs.

An unresolvable reusable workflow **never goes red on its own**. The only thing that noticed was this repo's own `Quality resolve probe`, which said so in words.

> Worth recording for whoever lints this file next: **PyYAML's `safe_load` parses the broken version happily** — last duplicate key wins — and reports twenty jobs. A generic YAML lint would have called it clean. Proven both ways with a duplicate-rejecting loader on one tree: before, a duplicate `name` at line 799; after, none.

### 2. The three Nextcloud legs could not block a merge in any of the 18 apps

Neither `#383` nor `#385` added its job to the Quality Report's `needs:` list, and that job is the only meaningful required check on `main` and `beta` across the fleet. `scripts/assert-quality-report-gates-every-leg.py` named all three. It fails on the parent commit and passes on this branch, and **its own positive control passes in both states**, so the clean pass is a verdict rather than an instrument that cannot fail.

---

## Five checks, three jobs

`#385`'s message names five Nextcloud checks. Only three of them are jobs in this file:

| Nextcloud check | job id | governed by | added to `needs:` |
|---|---|---|---|
| info.xml vs App Store XSD | `info-xml` | `enable-php` — **no dedicated flag** | yes |
| `occ app:check-code` | `app-check-code` | `enable-php` && `enable-check-code` | yes |
| REUSE / SPDX | `reuse` | `enable-reuse` | yes |
| multi-database PHPUnit | *not a job* — a matrix dimension of `phpunit` | `database-test-matrix` | already covered via `phpunit` |
| `occ integrity:sign-app` | *not in this file* — `release.yml` | — | cannot be; no Quality Report there |

So `needs:` goes 16 → 19, not 16 → 21.

## What listing them actually does, per leg

`app-check-code` and `reuse` are **internally non-blocking by default** — the first swallows a non-zero `occ` exit and warns, the second carries `continue-on-error: ${{ !inputs.reuse-blocking }}`. Both conclude `success` with findings, so listing them changes nothing today. That is the point: the wiring has to exist first, or flipping the per-app input later would be a no-op nobody notices. **Their `*-blocking` inputs are deliberately not flipped here** — that is a separate decision.

**`info-xml` has no such flag and is blocking on arrival.** `#383` measured it before merging across all 18 core apps: **five pass, thirteen fail** — twelve on `xs:sequence` element order, one on a summary over the schema's length cap. Confirmed live in the six-minute window in which this job both existed and resolved (openregister run `31591669849`, complaining that a `documentation` element is not expected in that position).

**So merging this reds thirteen apps and blocks their merges until their manifests are reordered.** That is the authorised trade: the App Store rejects the same files at upload time, after the release has been built, tagged and published. Every one of the thirteen is a reorder away from passing, and none of them needs a code change.

## The report was silent about all three

They upload result artifacts nobody reads — the same silence the Hydra-gates row three lines below exists to correct, reintroduced the day these landed. Three rows added, with a comment saying to read them differently: `reuse.txt` records the raw step outcome (so it goes red on findings while the job is green), while `app-check-code.txt` records `job.status` (so it reads green with findings — its cell means *a verdict was produced*, not *no private API usage*). Narrowing that one to its own finding count is left as a separate change rather than smuggled in here.

## Verification

- `assert-quality-report-gates-every-leg.py` — fails on `main` naming exactly the three jobs, passes here over nineteen legs; positive control clean in both states.
- Duplicate-key YAML load — before/after on one tree, only the fix varying.
- `assert-run-steps-resolvable.py` over all sixteen workflows, with its `--limit 1` positive control.
- `assert-no-producer-deletes-a-verdict.py`, `test-spec-coverage-gate.py`, `assert-seed-step-fails-loudly.py` — all clean, controls clean.
- All twenty jobs re-parsed and confirmed well-formed: `app-check-code` six steps, `reuse` five, `info-xml` eight.

The one assertion that cannot be run locally is `quality.yml resolves (job count > 0)`, which dispatches a real run and counts its jobs. That is the assertion that caught the outage, and only this PR's own `Quality resolve probe` can close it.
