### PR TITLE
fix(gate-14): brace style is not supposed to be an input to route reachability

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_route_registration.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_registration.sh
@@ -126,7 +126,7 @@ for _f in routes-standard routes-standard-missing-update \
           psr4-namespaced-controller psr4-namespaced-controller-missing-method \
           delegated-registrar delegated-registrar-absent \
           monitoring-capitalised monitoring-per-object monitoring-per-object-only \
-          monitoring-none; do
+          monitoring-none knr-braces; do
     [ -d "${FIXTURES}/${_f}" ] || _bad "fixture ${FIXTURES}/${_f} does not exist — this suite would be green on nothing"
 done
 
@@ -296,6 +296,46 @@ if _run "${FIXTURES}/monitoring-none"; then
         "zero candidates: gate-30 states that no route name is monitoring-shaped"
     _expect_log "${_OUT}" "\[gate-30\].*declares no route whose name contains" \
         "zero candidates: the verdict line names the reason"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. K&R BRACES — brace style must not be an input to gate-14
+#
+# Invariant 1 decides "does this method return a Response?" by buffering the
+# signature and up to twelve following lines and grepping the buffer for
+# `: …Response`. Both of its stop conditions were tested against the lines it
+# READ AHEAD and never against the signature line itself, so a K&R signature —
+# which opens the body on its own line — never stopped the buffer. It ran on
+# into the NEXT method's docblock and signature, and the first method
+# inherited the second one's return type.
+#
+# MEASURED on openconnector#1229, mid-migration to Nextcloud's coding standard:
+#
+#   lib/Controller/UiController.php method=__construct
+#     expected_route='ui#__construct' rule=missing-route
+#
+# — a constructor reported as an unrouted endpoint, with the `TemplateResponse`
+# it "returns" belonging to `makeSpaResponse()` eleven lines below. The same
+# awk over the same file in Allman braces printed nothing, so the reformat
+# looked like it had introduced a routing defect. Nextcloud's standard IS K&R
+# and the whole fleet is adopting it, which turns this into a finding every
+# migrated app receives on its first reformat.
+#
+# The anti-widening half is in the same fixture: `gadget#run` is K&R, returns
+# a JSONResponse and is routed nowhere, so it MUST still be reported. The fix
+# had to stop reading ahead past a completed signature, not stop looking at
+# K&R files.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/knr-braces"; then
+    _expect_gate 14 "FAIL" "knr-braces: the genuinely unrouted K&R method is still a finding"
+    _expect_log "${_RRLOG}" "GadgetController\.php method=run .*rule=missing-route" \
+        "knr-braces: gadget#run — K&R, Response-returning, routed nowhere — IS reported"
+    _expect_not_log "${_RRLOG}" "method=__construct" \
+        "knr-braces: ui#__construct is NOT reported — a constructor returns no Response and no route names one"
+    _expect_not_log "${_RRLOG}" "method=dashboard" \
+        "knr-braces: ui#dashboard is routed and resolves, so it is NOT reported"
+    _expect_lines "${_RRLOG}" 1 \
+        "knr-braces: exactly ONE finding — brace style changed nothing but the phantom"
 fi
 
 echo

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2800,6 +2800,32 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
         # opening `{`, and grep that buffer for any `): ...Response` return
         # type. Done in plain awk for portability (no pcregrep dependency).
         # Helper-prefixed names are excluded by the gate convention.
+        #
+        # ⚠️ THE BUFFER MUST END AT THE SIGNATURE LINE WHEN THAT LINE ALREADY
+        # OPENS THE BODY (K&R braces). Both stop conditions below are tested
+        # against `nxt` — the lines READ AHEAD — and never against `$0`, so
+        # under Allman the buffer stopped at the very next line (`{` alone) and
+        # under K&R it did not stop at all: it ran on through the body, the
+        # closing brace and the NEXT method's docblock until it hit that
+        # method's signature. The buffer then contained a `: SomeResponse` that
+        # belongs to a DIFFERENT method, and the gate reported the first one as
+        # an unrouted endpoint.
+        #
+        # That is not a corner case now. Nextcloud's coding standard is K&R,
+        # and the fleet is migrating to it: every `__construct` immediately
+        # followed by a Response-returning action becomes a phantom finding the
+        # moment an app reformats. MEASURED on openconnector#1229 —
+        # `lib/Controller/UiController.php method=__construct
+        # expected_route='ui#__construct' rule=missing-route`, where the
+        # inherited return type came from `makeSpaResponse(): TemplateResponse`
+        # eleven lines below. The SAME awk over the SAME file in Allman braces
+        # prints nothing. Brace style is not supposed to be an input to this
+        # gate, and while it was, the reformat looked like the defect.
+        #
+        # Reading nothing ahead is correct rather than merely quieter: if the
+        # signature line ends in `{`, the whole signature — parameters, return
+        # type and all — is ON that line, so there is nothing further to find.
+        # A K&R method that DOES return a Response still matches on `$0`.
         _methods=$(awk -v RESPONSE_RX='Response[ |\\{]' '
             /^[[:space:]]*public[[:space:]]+function[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\(/ {
                 method = $0
@@ -2808,7 +2834,7 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
                 if (method ~ /^(helper|assert|validate|guard|ensure|prepare|format|render)/) next
                 buf = $0
                 n = 0
-                while (n < 12) {
+                while (n < 12 && $0 !~ /\{[[:space:]]*$/) {
                     if ((getline nxt) <= 0) break
                     buf = buf "\n" nxt
                     n++

--- a/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/appinfo/routes.php
@@ -1,0 +1,10 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+//
+// Every Response-returning method in this fixture IS routed, except
+// `gadget#run` — which is the anti-widening half. See the controllers.
+return [
+    'routes' => [
+        ['name' => 'ui#dashboard', 'url' => '/', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/lib/Controller/GadgetController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/lib/Controller/GadgetController.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * THE ANTI-WIDENING HALF of this fixture.
+ *
+ * `gadget#run` returns a `JSONResponse`, is written in the SAME K&R braces,
+ * and appears in no route table — so it is a genuine 404 and gate-14
+ * invariant 1 MUST still report it.
+ *
+ * Without this half, "stop reading ahead when the signature line already opens
+ * the body" could have been implemented as "skip K&R files", and the gate
+ * would have gone silent for every app that adopts Nextcloud's coding
+ * standard — which is the entire fleet. The two controllers here differ by
+ * exactly one thing: whether a route names the method.
+ */
+class GadgetController extends Controller {
+	#[NoAdminRequired]
+	public function run(): JSONResponse {
+		return new JSONResponse([]);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/lib/Controller/UiController.php
+++ b/hydra-gates/scripts/test-fixtures/route-registration/knr-braces/lib/Controller/UiController.php
@@ -1,0 +1,35 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+declare(strict_types=1);
+
+namespace OCA\Fixture\Controller;
+
+/**
+ * K&R BRACES — Nextcloud's coding standard, and the shape the whole fleet is
+ * migrating to.
+ *
+ * The layout is the one that broke the gate, reproduced from openconnector's
+ * real UiController: a `__construct` that returns NOTHING, immediately
+ * followed — inside the twelve-line read-ahead window — by a method that
+ * returns a `TemplateResponse`. The signature line itself opens the body, so
+ * the scanner's stop conditions (which only ever looked at the lines it read
+ * AHEAD) never fired on it, and `__construct` inherited the return type of the
+ * method below it.
+ *
+ * `ui#__construct` MUST NOT be reported. A constructor is not an endpoint and
+ * no route table in the fleet names one.
+ */
+class UiController extends Controller {
+	public function __construct(string $appName, IRequest $request) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * The method whose return type leaked upward.
+	 *
+	 * @return TemplateResponse
+	 */
+	public function dashboard(): TemplateResponse {
+		return new TemplateResponse('fixture', 'index');
+	}
+}


### PR DESCRIPTION
## What

gate-14 invariant 1 buffers a method signature plus up to twelve following lines and greps the buffer for `: ...Response`. Both loop stop conditions are tested against the lines it reads **ahead** and never against the signature line itself.

Under Allman that was harmless — the next line is a lone `{`. Under **K&R the signature line already opens the body**, so nothing stops the buffer: it runs through the body, the closing brace and the next method's docblock until it hits that method's signature, and the first method inherits the **second one's** return type.

## Measured

openconnector#1229, mid-migration to Nextcloud's coding standard:

```
lib/Controller/UiController.php method=__construct
  expected_route='ui#__construct' rule=missing-route
```

A constructor reported as an unrouted endpoint. The `TemplateResponse` it was credited with belongs to `makeSpaResponse()` eleven lines below. The identical awk over the identical file **in Allman braces prints nothing** — the finding was a property of brace style, and the reformat looked like it had broken routing.

Nextcloud's standard *is* K&R and the fleet is adopting it app by app, so every app with a `__construct` followed within twelve lines by a Response-returning action gets this phantom on its first reformat — roughly two dozen PRs each re-diagnosing the same thing.

## The fix

Read nothing ahead once the signature line ends in `{`. Correct rather than merely quieter: if the body opens on the signature line then the whole signature — parameters, return type and all — is on that line. A K&R method that genuinely returns a Response still matches, on `$0`.

## Both arms, because "stop reading ahead" could have been "skip K&R files"

New fixture `route-registration/knr-braces/`:

| | |
|---|---|
| `UiController` | K&R, `__construct` then a routed `dashboard(): TemplateResponse` → `ui#__construct` MUST NOT be reported |
| `GadgetController` | K&R, `run(): JSONResponse`, routed nowhere → `gadget#run` MUST still be reported |

The suite asserts **exactly one** finding, so the fix cannot pass by going silent.

## Mutation check (`HYDRA_GATES_RUNNER_UNDER_TEST`)

```
pre-fix runner   45 passed, 2 FAILED — 2 findings, ui#__construct among them
fixed runner     47 passed, 0 failed — 1 finding, gadget#run
```

shellcheck clean on both changed files.
