### PR TITLE
fix(ci): the default Nextcloud test matrix must be a configuration that can exist

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,10 +18,25 @@ on:
         type: string
         default: '["8.3", "8.4"]'
       nextcloud-test-refs:
-        description: "JSON array of Nextcloud server branches for PHPUnit matrix"
+        # A caller SHOULD pass the whole range its own appinfo/info.xml declares.
+        # This default exists for callers that do not, and it has to be a
+        # configuration that can actually exist.
+        #
+        # It was '["stable31", "stable32"]', which no longer could. Every app in
+        # the fleet installs openregister as a fixture dependency, openregister
+        # declares min-version="32", and `occ app:enable openregister` on NC31
+        # fails with only a ::warning:: — so the run continued with no data layer
+        # and every /apps/openregister/... call returned Nextcloud's HTML 404
+        # page. A stable31 leg's red said nothing, and its green said less.
+        #
+        # The order is load-bearing, not cosmetic. `fromJSON(...)[0]` is read
+        # below as THE single server for newman, playwright, journeydoc-capture
+        # and the coverage guard, so entry 0 must be a version the fixture can
+        # load — and is the one version those jobs actually exercise.
+        description: "JSON array of Nextcloud server branches for the PHPUnit matrix. Entry [0] is also THE single server used by newman, playwright, journeydoc-capture and the coverage guard, so it must be a version the app and its fixture dependencies can install. Pass every major inside the range your appinfo/info.xml declares."
         required: false
         type: string
-        default: '["stable31", "stable32"]'
+        default: '["stable34", "stable32", "stable33"]'
       enable-php:
         description: "Master switch for the PHP toolchain (php-quality, PHPUnit, composer security/license legs, SBOM). Set false for JS-only repos without composer.json."
         required: false


### PR DESCRIPTION
## The defect

`nextcloud-test-refs` defaulted to `'["stable31", "stable32"]'`.

**stable31 is a version no app in this fleet can run on.** Every app installs
openregister as a fixture dependency, openregister declares `min-version="32"`,
and `occ app:enable openregister` on NC31 fails with only a `::warning::` — so
the run continues with no data layer and every `/apps/openregister/...` call
returns Nextcloud's HTML 404 page. That leg's red said nothing, and its green
said less.

## Who this reaches

Measured, not assumed — three callers pass no `nextcloud-test-refs` at all and
therefore inherit this default:

| caller | today |
| --- | --- |
| `openklant` | inherits — 1 impossible leg, nothing on 33/34 |
| `opentalk` | inherits — 1 impossible leg, nothing on 33/34 |
| `openzaak` | inherits — 1 impossible leg, nothing on 33/34 |

Two more repos pin the same stale list explicitly and are **not** fixed by this
PR (they need their own change): `app-versions` and `petstore`, both
`'["stable31", "stable32", "stable33"]'`.

## The change

Default becomes `'["stable34", "stable32", "stable33"]'` — every major inside the
range the fleet declares (`min-version="32" max-version="34"`).

`stable34` is **first** deliberately. `fromJSON(inputs.nextcloud-test-refs)[0]`
is read at six places below as *the* single server for newman, playwright,
journeydoc-capture and the coverage guard, so entry 0 must be a version the
fixture can install — and it is the only version those jobs ever exercise. The
input's `description` now says so, because that was not discoverable from the
name.

## Evidence

Verified green on all three refs against `nextcloud/ocp ^34` on portaliq — run
31599055849, six PHPUnit legs (32/33/34 × PHP 8.3/8.4) all `success`.

The edited file was re-read back from the branch and parsed with a YAML parser;
the default it resolves to is asserted, not grepped.

## Related

The same defect in the opposite direction — apps testing **only** the ceiling
because the coding-standard rollout *replaced* the ref list instead of extending
it — is fixed across all 18 core apps in a matching PR per app.
