### PR TITLE
feat(gate-65): fail when the test matrix disagrees with info.xml

### DIFF
--- a/hydra-gates/scripts/lib/check_coding_standard_adoption.py
+++ b/hydra-gates/scripts/lib/check_coding_standard_adoption.py
@@ -65,6 +65,20 @@ preference:
      system moving independently. `^1.0` is not a pin — it floats within a major
      and is correct. An exact version, a `dev-<branch>` constraint, or a
      `hydra-gates-ref` that is not `main`, is.
+ 11. A TEST MATRIX THAT DISAGREES WITH info.xml — the range in info.xml is a
+     promise to the App Store, and `nextcloud-test-refs` is the only thing that
+     can redeem it. This fleet broke that promise in BOTH directions inside one
+     programme: first 18 apps declared 32-34 and tested 31/32, so nothing ran on
+     the version being adopted; then the migration that fixed it REPLACED the
+     list with `'["stable34"]'` instead of extending it, and 16 apps stopped
+     testing their own declared floor. The second defect was introduced by the
+     change that fixed the first, and no check noticed either.
+
+     The out-of-range half is not merely wasteful. A stable31 leg survived long
+     after openregister raised its floor to 32, so `occ app:enable openregister`
+     failed with only a ::warning::, the run continued with no data layer, and
+     every /apps/openregister/... call returned Nextcloud's HTML 404 page. That
+     leg's red said nothing and its green said less.
 
 USAGE
     check_coding_standard_adoption.py <app-root>
@@ -315,7 +329,13 @@ def check(root: str) -> tuple[list[str], int]:
     # ── 9. ocp major vs info.xml min-version ─────────────────────────────
     info = read(os.path.join(root, "appinfo", "info.xml"))
     if info is not None and composer is not None:
-        m = re.search(r'<nextcloud[^>]*min-version="(\d+)"', info)
+        # Comments FIRST. procest's info.xml carries an explanatory comment
+        # containing a literal `<nextcloud min-version="28" .../>` describing an
+        # older declaration, and it sits ABOVE the live element — so a search of
+        # the raw text returns 28 where the app declares 32. That does not fail
+        # loudly; it silently RAISES the bar this rule will accept, which is the
+        # worst direction for a check to be wrong in.
+        m = re.search(r'<nextcloud[^>]*min-version="(\d+)"', strip_xml_comments(info))
         req = {}
         req.update(composer.get("require") or {})
         req.update(composer.get("require-dev") or {})
@@ -403,6 +423,85 @@ def check(root: str) -> tuple[list[str], int]:
                     "other apps — which is the entire reason it is shared.",
                 )
                 break
+
+        # ── 11. the tested matrix covers the declared range ──────────────
+        # An app's appinfo/info.xml is a PROMISE to the App Store: these server
+        # majors work. `nextcloud-test-refs` is the only thing that can redeem
+        # it. When they disagree, the promise is the part users act on and the
+        # matrix is the part that would have caught it being wrong.
+        #
+        # This fleet has now made that mistake in BOTH directions inside one
+        # programme. First every app declared 32-34 and tested 31/32, so nothing
+        # was ever exercised on the version being adopted. Then the migration
+        # that fixed it REPLACED the list with '["stable34"]' instead of
+        # extending it, and 16 apps stopped testing their own declared floor.
+        # Same defect, opposite end, and the second one was introduced by the
+        # change that fixed the first.
+        #
+        # A leg OUTSIDE the range is the other half of the rule, and it is not
+        # merely wasteful: the fleet ran a stable31 leg long after openregister
+        # raised its floor to 32, so `occ app:enable openregister` failed with
+        # only a ::warning::, the run continued with no data layer, and every
+        # /apps/openregister/... call returned Nextcloud's HTML 404 page. That
+        # leg's red said nothing, and its green said less.
+        if info is not None:
+            info_body = strip_xml_comments(info)
+            lo = re.search(r'<nextcloud[^>]*\bmin-version="(\d+)"', info_body)
+            hi = re.search(r'<nextcloud[^>]*\bmax-version="(\d+)"', info_body)
+            if lo and hi:
+                checked += 1
+                declared = set(range(int(lo.group(1)), int(hi.group(1)) + 1))
+                rm = re.search(
+                    r"^\s*nextcloud-test-refs:\s*'(\[[^']*\])'", body, re.M
+                )
+                if rm is None:
+                    fail(
+                        "test-matrix-not-declared",
+                        f"appinfo/info.xml declares NC "
+                        f"{lo.group(1)}-{hi.group(1)} but code-quality.yml passes "
+                        "no nextcloud-test-refs, so the matrix is whatever the "
+                        "shared workflow currently defaults to. A default cannot "
+                        "know this app's declared range; state the range here.",
+                    )
+                else:
+                    try:
+                        refs = json.loads(rm.group(1))
+                    except json.JSONDecodeError as exc:
+                        fail(
+                            "test-matrix-unparseable",
+                            f"nextcloud-test-refs is not valid JSON ({exc}): "
+                            f"{rm.group(1)!r}. The workflow calls fromJSON() on "
+                            "it, so this fails at matrix expansion.",
+                        )
+                        refs = []
+                    tested = {
+                        int(r[len("stable") :])
+                        for r in refs
+                        if isinstance(r, str) and re.fullmatch(r"stable\d+", r)
+                    }
+                    missing = sorted(declared - tested)
+                    outside = sorted(tested - declared)
+                    if missing:
+                        fail(
+                            "test-matrix-misses-declared-versions",
+                            f"appinfo/info.xml declares NC "
+                            f"{lo.group(1)}-{hi.group(1)}, but no job runs on "
+                            + ", ".join(f"stable{v}" for v in missing)
+                            + f". The matrix is {refs!r}. Those majors are "
+                            "advertised to the App Store and exercised by "
+                            "nothing — not known-broken, unmeasured. Either add "
+                            "the legs or narrow what info.xml claims.",
+                        )
+                    if outside:
+                        fail(
+                            "test-matrix-tests-unsupported-version",
+                            "the matrix runs on "
+                            + ", ".join(f"stable{v}" for v in outside)
+                            + f", outside the declared range {lo.group(1)}-"
+                            f"{hi.group(1)}. A leg on a version the app does not "
+                            "support cannot pass for the right reason, and this "
+                            "fleet has had one pass for the wrong one.",
+                        )
 
     return fails, checked
 

--- a/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
+++ b/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
@@ -89,6 +89,7 @@ jobs:
     uses: ConductionNL/.github/.github/workflows/quality.yml@main
     with:
       app-name: fixture
+      nextcloud-test-refs: '["stable34", "stable32", "stable33"]'
       enable-hydra-gates: true
 YML
 
@@ -162,6 +163,79 @@ probe gates-ref-pinned         gates-ref-pinned                    "printf '    
 probe workflow-pinned          shared-workflow-pinned              "sed -i 's|quality.yml@main|quality.yml@v2.0.0|' .github/workflows/code-quality.yml"
 probe package-pinned-exact     shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"1.0.0\"|' composer.json"
 probe package-pinned-branch    shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"dev-some-branch\"|' composer.json"
+
+probe matrix-absent            test-matrix-not-declared \
+                               "sed -i '/nextcloud-test-refs/d' .github/workflows/code-quality.yml"
+probe matrix-misses-floor      test-matrix-misses-declared-versions \
+                               "sed -i 's|\\[\\\"stable34\\\", \\\"stable32\\\", \\\"stable33\\\"\\]|[\\\"stable34\\\"]|' .github/workflows/code-quality.yml"
+probe matrix-outside-range     test-matrix-tests-unsupported-version \
+                               "sed -i 's|\\[\\\"stable34\\\", \\\"stable32\\\", \\\"stable33\\\"\\]|[\\\"stable31\\\", \\\"stable32\\\", \\\"stable33\\\", \\\"stable34\\\"]|' .github/workflows/code-quality.yml"
+
+# ── A COMMENTED-OUT MATRIX IS NOT A MATRIX ────────────────────────────────
+# The rule must not accept a declaration that only exists inside a comment.
+D="$WORK/matrixcommented"
+rm -rf "$D"; scaffold "$D"
+sed -i "s|      nextcloud-test-refs: .*|      # nextcloud-test-refs: '[\"stable34\", \"stable32\", \"stable33\"]'|" "$D/.github/workflows/code-quality.yml"
+# NOTE: capture first, then grep. `set -o pipefail` is on, and the checker exits
+# with its VIOLATION COUNT — so `run | grep -q` returns non-zero on a successful
+# match whenever the fixture is dirty, which is every positive control here.
+out="$(run "$D")"
+if printf '%s' "$out" | grep -q 'FAIL test-matrix-not-declared:'; then
+    ok "a commented-out nextcloud-test-refs does not count as declared"
+else
+    no "a COMMENTED-OUT matrix was accepted as the declared matrix" "$out"
+fi
+
+# ── info.xml's RANGE MUST COME FROM THE ELEMENT, NOT A COMMENT ────────────
+# procest's info.xml carries an explanatory comment containing a literal
+# `<nextcloud min-version="28" .../>` ABOVE the live element. Reading the raw
+# text returns 28 where the app declares 32 — which silently LOWERS the bar
+# rules 9 and 11 enforce, the worst direction for a check to be wrong in.
+D="$WORK/infocomment"
+rm -rf "$D"; scaffold "$D"
+cat > "$D/appinfo/info.xml" <<'XML'
+<?xml version="1.0"?>
+<info>
+    <id>fixture</id>
+    <version>1.0.0</version>
+    <dependencies>
+        <!-- History: this app once declared
+             <nextcloud min-version="28" max-version="30"/>. It was true when
+             written and is not any more. -->
+        <nextcloud min-version="32" max-version="34"/>
+    </dependencies>
+</info>
+XML
+out="$(run "$D")"
+if printf '%s' "$out" | grep -qE 'FAIL test-matrix-(misses-declared-versions|tests-unsupported-version):'; then
+    no "the range was read from a COMMENT, not the live <nextcloud> element" "$out"
+else
+    ok "reads the declared range from the element, ignoring a commented-out one"
+fi
+
+# ...and the positive control for that same fixture: with the comment ignored,
+# a matrix that covers 28-30 instead of 32-34 must still be caught. Without
+# this, the assertion above would also pass on a checker that reads nothing.
+D="$WORK/infocomment2"
+rm -rf "$D"; scaffold "$D"
+cat > "$D/appinfo/info.xml" <<'XML'
+<?xml version="1.0"?>
+<info>
+    <id>fixture</id>
+    <version>1.0.0</version>
+    <dependencies>
+        <!-- <nextcloud min-version="28" max-version="30"/> -->
+        <nextcloud min-version="32" max-version="34"/>
+    </dependencies>
+</info>
+XML
+sed -i "s|      nextcloud-test-refs: .*|      nextcloud-test-refs: '[\"stable28\", \"stable29\", \"stable30\"]'|" "$D/.github/workflows/code-quality.yml"
+out="$(run "$D")"
+if printf '%s' "$out" | grep -q 'FAIL test-matrix-misses-declared-versions:'; then
+    ok "a matrix matching only the commented-out range is still a finding"
+else
+    no "matrix covering the commented range was accepted" "$out"
+fi
 
 # ── ^1.0 IS NOT A PIN ─────────────────────────────────────────────────────
 # The rule must distinguish "floats within a major" from "frozen". If it cannot,


### PR DESCRIPTION
## The rule

`appinfo/info.xml`'s Nextcloud range is a **promise to the App Store**: these
server majors work. `nextcloud-test-refs` is the only thing that can redeem it.
When they disagree, the promise is the part users act on and the matrix is the
part that would have caught it being wrong.

## Why now

This fleet broke that promise in **both directions inside one programme**:

1. Every app declared `32–34` and tested `["stable31","stable32"]`, so nothing
   ever ran on the version being adopted.
2. The migration that fixed that **replaced** the ref list with `'["stable34"]'`
   instead of extending it — and 16 apps stopped testing their own declared
   floor.

The second defect was introduced by the change that fixed the first, and no
check noticed either one. That is what this rule is for.

## What it reports

| finding | meaning |
| --- | --- |
| `test-matrix-not-declared` | no `nextcloud-test-refs` at all, so the matrix is whatever the shared default happens to be — and a default cannot know this app's declared range |
| `test-matrix-misses-declared-versions` | a major is advertised to the App Store and exercised by nothing |
| `test-matrix-tests-unsupported-version` | a leg runs outside the declared range |

The out-of-range half is not merely wasteful. A `stable31` leg survived long
after openregister raised its floor to 32, so `occ app:enable openregister`
failed with only a `::warning::`, the run continued **with no data layer**, and
every `/apps/openregister/...` call returned Nextcloud's HTML 404 page. That
leg's red said nothing, and its green said less.

## A latent defect in rule 9, fixed here too

Rule 9 searched the **raw** `info.xml` for `min-version`. procest's `info.xml`
carries an explanatory comment containing a literal
`<nextcloud min-version="28" .../>` **above** the live element, so the search
returned `28` where the app declares `32`. That does not fail loudly — it
silently **lowers** the bar the rule enforces, which is the worst direction for
a check to be wrong in. I hit this by hand today before the checker did.

Both rules now read comment-stripped XML, with a fixture for exactly that shape.

## Evidence

Verified against **real fleet data**, not only fixtures:

```
larpingapp@development                 FAIL — misses stable32, stable33
larpingapp@fix/test-declared-nc-range  clean
nldesign@development                   FAIL — misses stable33
nldesign@fix/test-declared-nc-range    clean
app-versions@development               FAIL — declares 31-34, no stable34 leg
petstore@development                   FAIL — declares 28-34, tests 31/32/33
```

The two `clean` rows are the point: the rule distinguishes fixed from broken on
the same app, so it is not simply reporting everything.

## Self-test

`lib/test_check_coding_standard_adoption.sh` — **29 passed, 0 failed**,
auto-discovered by `tests/run-helper-suites.sh`.

Every new rule has a paired negative control (the compliant fixture stays clean;
its matrix input had to be added to the scaffold) plus positive controls for
each of the three findings, a commented-out `nextcloud-test-refs` (must not
count as declared), and a commented-out `<nextcloud>` element — that last one
with its **own** positive control, because an assertion that a comment is
ignored also passes on a checker that reads nothing at all.

One bug found while writing the suite, worth recording: `set -o pipefail` is on
and the checker exits with its **violation count**, so `run "$D" | grep -q` returns
non-zero on a *successful* match whenever the fixture is dirty. The existing
tests capture output first and grep the variable; the new ones now do the same.
