### PR TITLE
fix(gate-16): a coding-standard reformat is not a set of changed methods (#395)

### DIFF
--- a/hydra-gates/README.md
+++ b/hydra-gates/README.md
@@ -219,6 +219,18 @@ Gates **16, 29, 47, 48 and 61** ask what a *change* did and cannot be answered b
 checkout. With a base they run at any file scope; with none they report
 `NOT APPLICABLE` **by name, with a reason** — never `PASS`, and never counted as one.
 
+A delta gate also has to decide what *counts* as a change, and a plain `git diff`
+answers "a line moved". gate-16 therefore compares each changed file against its
+own base version with layout normalised away on both sides: brace style (K&R vs
+Allman), indentation and intra-line spacing, a PHP trailing comma, two spellings
+of one string, and a PHP statement re-wrapped across lines. Adopting
+`nextcloud/coding-standard` consequently reports nothing, while a changed value,
+a new parameter or an edited string still reports (`.github#395` — measured
+1071 → 0 findings across the fleet's seven adoption PRs, with a positive control
+per rule). The narrowing intersects git's own answer, so it can only ever shrink
+the scope. `git diff -w` does **not** express this: a brace is a token that moved
+lines, not whitespace that changed width.
+
 To get the old behaviour explicitly:
 
 ```bash

--- a/hydra-gates/scripts/lib/check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/check_spec_coverage.py
@@ -19,6 +19,13 @@ those added lines. A method that exists in the diff's context but was not
 itself touched is never flagged — so untouched legacy methods stay green even
 when a neighbouring method changes.
 
+That added-line set is then narrowed to the lines whose CONTENT changed, not
+merely their layout (``.github#395``): brace style, indentation, intra-line
+spacing and a PHP trailing comma are normalised away on both sides before a
+line counts as added. Only a line the normalisation still shows as different
+puts a method in scope — and the narrowing is an intersection with git's own
+answer, so it can never widen the scope.
+
 This runs against the CURRENT working directory's git repo (the script is
 repo-agnostic — it lives in hydra but operates on whatever app is checked out
 at cwd).
@@ -66,6 +73,7 @@ import os
 import re
 import subprocess
 import sys
+from difflib import SequenceMatcher
 from pathlib import Path
 
 SPEC_RE = re.compile(r"@spec\s+openspec/")
@@ -133,6 +141,191 @@ VUE_METHOD_RE = re.compile(
     r"\([^)]*\)\s*\{",
 )
 
+# ---- cosmetic-reformat normalisation (.github#395) --------------------------
+#
+# A line whose only difference from its base version is LAYOUT is not a changed
+# method. `git diff -w` cannot express that: the brace of Nextcloud's K&R style
+# is a TOKEN THAT MOVED LINES, not whitespace that changed width, so
+# `public function foo()` and `public function foo() {` differ under `-w` and
+# every method in a reformatted app reads as modified.
+#
+# Each rule below is narrow enough that the two forms it equates are the same
+# program. Nothing here is a heuristic about intent.
+
+# `foo() {` -> `foo()`. The brace still has to be SOMEWHERE — Allman puts it on
+# its own line, which normalises to the empty string and is dropped — so no
+# information is lost, only its position.
+_NORM_TRAILING_BRACE_RE = re.compile(r"\s*\{$")
+_NORM_WS_RE = re.compile(r"\s+")
+# A complete single- or double-quoted literal, escapes included. Whitespace
+# INSIDE one is content and is left exactly as it is: `'a b'` -> `'ab'` is a
+# change to what a user sees and must stay visible to this gate.
+_NORM_STRING_RE = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
+
+
+def _unify_quote_style(literal: str) -> str:
+    """``"abc"`` -> ``'abc'`` when the two forms denote the SAME string.
+
+    Only a double-quoted literal is rewritten, and only when its body has no
+    ``$`` or ``{`` (interpolation, in both simple and complex syntax), no ``'``
+    (which would need escaping on the other side), and no backslash other than
+    the ones spelling ``\\"``. Those exclusions are the whole safety argument:
+    they are exactly what makes a double-quoted string mean something a
+    single-quoted one does not. ``"\\n"`` is a newline and ``'\\n'`` is two
+    characters, so a literal carrying any other escape is left alone; ``"a\\"b"``
+    and ``'a"b'`` are the same three characters in PHP and in JS alike, so that
+    one is unescaped and equated. This equates two spellings of one value, never
+    two values.
+    """
+    if not literal.startswith('"'):
+        return literal
+    body = literal[1:-1]
+    if any(c in body for c in ("$", "{", "'")):
+        return literal
+    if "\\" in body.replace('\\"', ""):
+        return literal
+    return "'" + body.replace('\\"', '"') + "'"
+
+
+def _normalise_code_line(line: str) -> str | None:
+    """A layout-independent key for ``line``, or ``None`` if the line carries no
+    code identity at all (blank, or a bare docblock ``*``, or a lone brace).
+
+    Applied to BOTH sides of the comparison, so the only question it answers is
+    "are these two lines the same program". What it deliberately equates:
+
+    * brace placement — K&R vs Allman (``.github#395``, and gate-14's ``#391``);
+    * indentation and intra-line spacing, including operator and cast spacing
+      (``(array) $x`` / ``(array)$x``) and docblock column alignment;
+    * quote style, under the narrow rule in ``_unify_quote_style``.
+
+    What it deliberately does NOT equate: anything INSIDE a string literal.
+    ``'a b'`` -> ``'ab'`` changes what a user reads and stays visible to this
+    gate, which is why literals are lifted out before whitespace is touched.
+
+    Whitespace outside a literal is REMOVED rather than collapsed because
+    php-cs-fixer both adds it (``'a'.$b`` -> ``'a' . $b``) and removes it
+    (``(array) $x`` -> ``(array)$x``); collapsing to a single space leaves the
+    second form differing, and was measured on procest#819 to recover 71 of the
+    185 false findings against 183 for removal. Removal can in principle weld
+    two tokens together (``else if`` -> ``elseif``, which procest's diff
+    actually contains), but each pair it can weld is either the same program —
+    that one is — or one half of it does not parse, so it cannot equate two
+    different WORKING programs.
+    """
+    s = line.strip()
+    if s == "" or s == "*":
+        return None
+    s = _NORM_TRAILING_BRACE_RE.sub("", s)
+    if s == "":
+        return None
+    out: list[str] = []
+    pos = 0
+    for m in _NORM_STRING_RE.finditer(s):
+        out.append(_NORM_WS_RE.sub("", s[pos:m.start()]))
+        out.append(_unify_quote_style(m.group(0)))
+        pos = m.end()
+    out.append(_NORM_WS_RE.sub("", s[pos:]))
+    return "".join(out)
+
+
+def _comparison_keys(text: str, is_php: bool) -> tuple[list[int], list[str], list[str]]:
+    """``(line_numbers, keys, keys_with_trailing_comma_kept)`` for ``text``.
+
+    Two variants of the same key, index-aligned, because the two comparisons
+    below want different things from a trailing comma. Line-vs-line, a PHP
+    trailing comma is a no-op and must be ignored — php-cs-fixer adds one to
+    every multi-line parameter list, which is 2 of procest's 185 findings on its
+    own. Region-vs-region (the re-wrap rule) has to keep it, because there the
+    commas are load-bearing punctuation of the joined statement.
+    """
+    numbers: list[int] = []
+    keys: list[str] = []
+    keys_full: list[str] = []
+    for i, raw in enumerate(text.splitlines()):
+        k = _normalise_code_line(raw)
+        if k is None:
+            continue
+        numbers.append(i + 1)
+        keys_full.append(k)
+        keys.append(k[:-1] if is_php and k.endswith(",") else k)
+    return numbers, keys, keys_full
+
+
+def _is_pure_rewrap(base_region: list[str], head_region: list[str], is_php: bool) -> bool:
+    """True if the two regions are the SAME CHARACTERS, distributed differently
+    across lines — a line-length reflow such as ``'a '.`` + ``'b'`` becoming
+    ``'a '`` + ``.'b'``, or a long call broken after an argument.
+
+    PHP ONLY, and never across a line comment. Both restrictions are about the
+    one thing a line break can do besides layout: END something. JavaScript has
+    automatic semicolon insertion, so joining ``return`` and ``x`` changes what
+    the function returns; PHP has no ASI. And in either language a ``//`` runs
+    to the end of the line, so inserting a break after one UNCOMMENTS whatever
+    followed — the same characters, a different program. Refusing the rule
+    whenever the region contains a comment introducer costs only precision.
+    """
+    if not is_php or not base_region or not head_region:
+        return False
+    joined_base = "".join(base_region)
+    if joined_base != "".join(head_region):
+        return False
+    return "//" not in joined_base and "#" not in joined_base
+
+
+def _substantively_changed_lines(base_text: str, head_text: str, is_php: bool) -> set[int]:
+    """1-based line numbers in ``head_text`` that are not present, unchanged, in
+    ``base_text`` once both sides are normalised by ``_normalise_code_line``."""
+    _, base_keys, base_full = _comparison_keys(base_text, is_php)
+    head_numbers, head_keys, head_full = _comparison_keys(head_text, is_php)
+    matcher = SequenceMatcher(None, base_keys, head_keys, autojunk=False)
+    changed: set[int] = set()
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag not in ("replace", "insert"):
+            continue
+        if _is_pure_rewrap(base_full[i1:i2], head_full[j1:j2], is_php):
+            continue
+        for j in range(j1, j2):
+            changed.add(head_numbers[j])
+    return changed
+
+
+def _is_in_gate_scope(rel: str) -> bool:
+    """True if this path is one gate-16 would evaluate at all."""
+    if rel.endswith(".php"):
+        return rel.startswith(BACKEND_DIRS) and not rel.startswith(BACKEND_EXEMPT_DIRS)
+    return _is_frontend_in_scope(rel)
+
+
+def _drop_cosmetic_only(
+    changed: dict[str, set[int]], base_commit: str, cwd: Path,
+) -> dict[str, set[int]]:
+    """Narrow each file's added-line set to the lines that are not pure layout.
+
+    INTERSECTS with git's own set — it can only ever REMOVE lines, never add
+    one. A file that is new at HEAD (no base blob) or that cannot be read keeps
+    git's answer untouched, so the failure mode of every lookup here is the
+    PRE-EXISTING behaviour, not silence.
+    """
+    out: dict[str, set[int]] = {}
+    for rel, added in changed.items():
+        if not added or not _is_in_gate_scope(rel):
+            out[rel] = added
+            continue
+        base_text = _git(["show", f"{base_commit}:{rel}"], cwd)
+        if not base_text:
+            # Added by this branch, or unreadable at the base: every line of it
+            # is genuinely new.
+            out[rel] = added
+            continue
+        try:
+            head_text = (cwd / rel).read_text(encoding="utf-8")
+        except OSError:
+            out[rel] = added
+            continue
+        out[rel] = added & _substantively_changed_lines(base_text, head_text, rel.endswith(".php"))
+    return out
+
 
 def _git(args: list[str], cwd: Path) -> str:
     try:
@@ -153,10 +346,21 @@ def changed_lines(base_ref: str, cwd: Path) -> dict[str, set[int]]:
 
     Falls back from ``BASE...HEAD`` to ``BASE`` (working-tree diff) so the
     gate works both on a PR branch and on an uncommitted local checkout.
+
+    A LINE THAT ONLY MOVED IS NOT A CHANGED METHOD (.github#395). git's answer
+    is then narrowed by ``_drop_cosmetic_only``: each in-scope file is compared
+    against its own base version with layout normalised away, and any added line
+    that survives normalisation as identical is dropped from the scope. Measured
+    on ConductionNL/procest#819, a `conduction/coding-standard` adoption PR of
+    921 PHP files: 185 findings before, 0 after, and PHP's own tokeniser agrees
+    — the 54 files those findings named are token-identical to their base once
+    whitespace, comments, trailing commas and quote style are set aside.
     """
     diff = _git(["diff", "-U0", "--diff-filter=ACMR", f"{base_ref}...HEAD"], cwd)
+    three_dot = True
     if not diff.strip():
         diff = _git(["diff", "-U0", "--diff-filter=ACMR", base_ref], cwd)
+        three_dot = False
     result: dict[str, set[int]] = {}
     current: str | None = None
     hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
@@ -173,7 +377,14 @@ def changed_lines(base_ref: str, cwd: Path) -> dict[str, set[int]]:
                 count = int(m.group(2)) if m.group(2) is not None else 1
                 for n in range(start, start + count):
                     result[current].add(n)
-    return result
+    # `A...B` diffs against the MERGE BASE, so that — not `base_ref` itself — is
+    # the version each file has to be compared with. Getting this wrong would
+    # compare against a commit the branch never saw and silently stop
+    # suppressing anything, which is why it is resolved rather than assumed.
+    base_commit = base_ref
+    if three_dot:
+        base_commit = _git(["merge-base", base_ref, "HEAD"], cwd).strip() or base_ref
+    return _drop_cosmetic_only(result, base_commit, cwd)
 
 
 def spec_tags_removed(base_ref: str, cwd: Path) -> set[str]:

--- a/hydra-gates/scripts/lib/test_check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_spec_coverage.py
@@ -254,6 +254,148 @@ export default {
         self.assertTrue(any("::buildPayload" in f for f in findings), findings)
 
 
+class NormalisationTest(unittest.TestCase):
+    """`.github#395` — layout is not a change, and a change is not layout.
+
+    Each pair below is one normalisation rule and ITS POSITIVE CONTROL: the
+    A-arm proves the reformat stops being a change, the B-arm proves a real
+    change still travels THROUGH that same rule. A rule with only an A-arm is
+    indistinguishable from a rule that switched the gate off.
+    """
+
+    def _changed(self, base: str, head: str, is_php: bool = True) -> set[int]:
+        return csc._substantively_changed_lines(base, head, is_php)
+
+    # --- braces ------------------------------------------------------------
+    def test_brace_move_alone_is_not_a_change(self):
+        base = "public function foo(): int\n{\n    return 1;\n}\n"
+        head = "public function foo(): int {\n\treturn 1;\n}\n"
+        self.assertEqual(self._changed(base, head), set(),
+                         "K&R vs Allman is where the brace SITS, not what the code does")
+
+    def test_a_body_change_through_the_brace_move_is_still_reported(self):
+        base = "public function foo(): int\n{\n    return 1;\n}\n"
+        head = "public function foo(): int {\n\treturn 2;\n}\n"
+        self.assertEqual(self._changed(base, head), {2},
+                         "the reformatted line whose VALUE changed must survive normalisation")
+
+    # --- whitespace --------------------------------------------------------
+    def test_indent_and_operator_spacing_alone_is_not_a_change(self):
+        base = "    $a = (array) $x;\n    $b = 'p'.$q;\n"
+        head = "\t$a = (array)$x;\n\t$b = 'p' . $q;\n"
+        self.assertEqual(self._changed(base, head), set(),
+                         "php-cs-fixer both adds and removes spacing; neither is a change")
+
+    def test_whitespace_inside_a_string_is_still_a_change(self):
+        # The reason literals are lifted out before whitespace is touched: this
+        # is text a user reads.
+        base = "    $msg = 'not installed. ';\n"
+        head = "\t$msg = 'not installed.';\n"
+        self.assertEqual(self._changed(base, head), {1})
+
+    # --- trailing comma ----------------------------------------------------
+    def test_trailing_comma_alone_is_not_a_change(self):
+        base = "public function f(\n    string $a,\n    int $b\n) {\n"
+        head = "public function f(\n\tstring $a,\n\tint $b,\n) {\n"
+        self.assertEqual(self._changed(base, head), set())
+
+    def test_a_new_parameter_through_the_trailing_comma_is_still_reported(self):
+        base = "public function f(\n    string $a,\n    int $b\n) {\n"
+        head = "public function f(\n\tstring $a,\n\tint $b,\n\tbool $c,\n) {\n"
+        self.assertIn(4, self._changed(base, head),
+                      "an ADDED parameter is not a trailing comma")
+
+    def test_trailing_comma_is_not_normalised_in_javascript(self):
+        # `[1, 2,]` and `[1, 2,,]` differ in JS (elision), so the rule is PHP-only.
+        base = "const a = [1, 2]\n"
+        head = "const a = [1, 2,]\n"
+        self.assertEqual(self._changed(base, head, is_php=False), {1})
+
+    # --- quote style -------------------------------------------------------
+    def test_quote_style_alone_is_not_a_change(self):
+        base = '    $m = "PDF extraction failed: ";\n'
+        head = "\t$m = 'PDF extraction failed: ';\n"
+        self.assertEqual(self._changed(base, head), set())
+
+    def test_quote_style_with_escaped_quotes_is_not_a_change(self):
+        # MEASURED on shillinq#532: `"CAST(\"object\" AS TEXT)"` became
+        # `'CAST("object" AS TEXT)'` — the same characters, differently spelled.
+        base = '    $q = "CAST(\\"object\\" AS TEXT)";\n'
+        head = "\t$q = 'CAST(\"object\" AS TEXT)';\n"
+        self.assertEqual(self._changed(base, head), set())
+
+    def test_string_content_change_through_the_quote_rule_is_still_reported(self):
+        base = '    $m = "PDF extraction failed: ";\n'
+        head = "\t$m = 'PDF extraction succeeded: ';\n"
+        self.assertEqual(self._changed(base, head), {1},
+                         "re-quoting must not carry a CONTENT edit through with it")
+
+    def test_dropping_interpolation_is_a_change(self):
+        # `"$name"` is the value of $name; `'$name'` is six literal characters.
+        # A rule that equated these would hide a real bug behind a style fix.
+        base = '    $m = "$name";\n'
+        head = "\t$m = '$name';\n"
+        self.assertEqual(self._changed(base, head), {1})
+
+    def test_dropping_an_escape_sequence_is_a_change(self):
+        # `"\n"` is a newline; `'\n'` is a backslash and an n.
+        base = '    $m = "a\\nb";\n'
+        head = "\t$m = 'a\\nb';\n"
+        self.assertEqual(self._changed(base, head), {1})
+
+    # --- statement re-wrap -------------------------------------------------
+    def test_rewrapping_one_php_statement_is_not_a_change(self):
+        base = "    $x = 'a: '.$b.' c: '.$d;\n"
+        head = "\t$x = 'a: '.$b\n\t\t.' c: '.$d;\n"
+        self.assertEqual(self._changed(base, head), set(),
+                         "the same characters, redistributed across lines")
+
+    def test_a_changed_operand_in_a_rewrapped_statement_is_still_reported(self):
+        base = "    $x = 'a: '.$b.' c: '.$d;\n"
+        head = "\t$x = 'a: '.$b\n\t\t.' c: '.$e;\n"
+        self.assertTrue(self._changed(base, head),
+                        "a re-wrap that also changes an operand is a change")
+
+    def test_rewrap_is_not_applied_across_a_line_comment(self):
+        # Inserting a break after `//` UNCOMMENTS what followed: the same
+        # characters, a different program.
+        base = "    // fixme $flag = true;\n"
+        head = "    // fixme\n    $flag = true;\n"
+        self.assertTrue(self._changed(base, head),
+                        "uncommenting a statement is not a re-wrap")
+
+    def test_rewrap_is_not_applied_to_javascript(self):
+        # ASI: `return` on its own line returns undefined.
+        base = "    return buildThing(a)\n"
+        head = "    return\n    buildThing(a)\n"
+        self.assertTrue(self._changed(base, head, is_php=False),
+                        "JavaScript has automatic semicolon insertion; PHP does not")
+
+    # --- what is NOT normalised -------------------------------------------
+    def test_a_respelled_type_is_still_a_change(self):
+        # `string|null` -> `?string` is another rule in the same php-cs-fixer
+        # run and it IS equivalent — but it is deliberately NOT normalised: the
+        # line is a method SIGNATURE, the set of rules a normaliser can carry is
+        # open-ended, and every one of them costs a little more of the gate's
+        # eyesight. MEASURED on openregister#2445, where exactly two methods
+        # change this way; both are already `@spec`-tagged, so the gate sees
+        # them, has an answer for them, and reports nothing.
+        base = "    public function f(): string|null\n    {\n"
+        head = "\tpublic function f(): ?string {\n"
+        self.assertEqual(self._changed(base, head), {1})
+
+    # --- the narrowing can only ever narrow --------------------------------
+    def test_an_added_method_is_entirely_in_scope(self):
+        base = "class A {\n}\n"
+        head = "class A {\n\tpublic function b(): int {\n\t\treturn 1;\n\t}\n}\n"
+        changed = self._changed(base, head)
+        # Declaration and body. (Which of the two identical `}` lines the
+        # matcher calls "the new one" is ambiguous and irrelevant — a closing
+        # brace is never what puts a method in scope.)
+        self.assertTrue({2, 3} <= changed, changed)
+        self.assertEqual(len(changed), 3, changed)
+
+
 class DiffScopeFullRunTest(unittest.TestCase):
     """End-to-end: a real git repo where only one method is in the diff."""
 
@@ -391,6 +533,106 @@ class BarService {
         # would surface inherited debt the author never touched, which is what
         # ADR-020 exists to keep out of a PR.
         self.assertNotIn("legacyThing", out)
+
+    # ---- .github#395, end to end through changed_lines -------------------
+    _ALLMAN = """<?php
+class ReportService {
+    /**
+     * Untagged legacy — inherited debt, and it stays that way.
+     */
+    public function buildLabel(
+        string $id,
+        string $kind
+    ): string {
+        $prefix = "row";
+
+        return $prefix . ':' . $kind . ':' . $id;
+    }
+
+    /**
+     * Also untagged.
+     */
+    public function totalWeights(array $rows): int
+    {
+        $total = 0;
+        foreach ($rows as $row) {
+            $total = $total + (int) ($row['weight'] ?? 0);
+        }
+
+        return $total;
+    }
+}
+"""
+    # Every difference below is one `nextcloud/coding-standard` rule.
+    _KNR = """<?php
+class ReportService {
+\t/**
+\t * Untagged legacy — inherited debt, and it stays that way.
+\t */
+\tpublic function buildLabel(
+\t\tstring $id,
+\t\tstring $kind,
+\t): string {
+\t\t$prefix = 'row';
+
+\t\treturn $prefix . ':' . $kind
+\t\t\t. ':' . $id;
+\t}
+
+\t/**
+\t * Also untagged.
+\t */
+\tpublic function totalWeights(array $rows): int {
+\t\t$total = 0;
+\t\tforeach ($rows as $row) {
+\t\t\t$total = $total %s (int)($row['weight'] ?? 0);
+\t\t}
+
+\t\treturn $total;
+\t}
+}
+"""
+
+    def _reformat_fixture(self, operator: str) -> str:
+        self._write("lib/Service/ReportService.php", self._ALLMAN)
+        self._run("git", "add", "-A")
+        self._run("git", "commit", "-q", "-m", "base: before the reformat")
+        base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(self.dir),
+                              capture_output=True, text=True).stdout.strip()
+        self._write("lib/Service/ReportService.php", self._KNR % operator)
+        self._run("git", "add", "-A")
+        self._run("git", "commit", "-q", "-m", "style: adopt nextcloud/coding-standard")
+        return base
+
+    def test_a_coding_standard_reformat_is_not_a_set_of_changed_methods(self):
+        # `.github#395`. The changed-method set came from a plain `git diff -U0`,
+        # so K&R braces made EVERY method in a migrated app "modified" and
+        # gate-16 demanded an @spec tag on all of them. Measured on procest#819:
+        # 1 finding on the base branch, 185 on the formatting-only PR.
+        base = self._reformat_fixture("+")
+
+        # NOT VACUOUS: git still sees a large diff here. If the two fixture
+        # strings were accidentally equal, the assertion below would pass on an
+        # empty change set and prove nothing.
+        churn = subprocess.run(
+            ["git", "diff", "--numstat", f"{base}...HEAD"],
+            cwd=str(self.dir), capture_output=True, text=True).stdout.split()
+        self.assertGreaterEqual(int(churn[0]), 10, f"the reformat must BE a diff: {churn}")
+
+        out, rc = self._gate(base)
+        self.assertEqual(out, "# count=0\n", f"expected a clean run, got: {out}")
+        self.assertEqual(rc, 0)
+
+    def test_a_body_change_inside_a_reformatted_file_is_still_reported(self):
+        # The anti-widening control, and the half that matters most: a gate that
+        # stops reporting is worse than one that over-reports. Same reformat,
+        # one operator flipped.
+        base = self._reformat_fixture("-")
+        out, rc = self._gate(base)
+        self.assertIn("totalWeights", out, "the method whose body changed must be named")
+        self.assertNotIn("buildLabel", out,
+                         "the method beside it carries the same reformat and no change")
+        self.assertEqual(rc, 1)
 
     def test_an_unrelated_docblock_edit_does_not_surface_legacy_debt(self):
         # The anti-widening control for the arm above. The fix must key on

--- a/hydra-gates/scripts/lib/test_gate16_spec_coverage_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate16_spec_coverage_scope.sh
@@ -293,6 +293,103 @@ else
     _ok "gate-16 does NOT sweep the inherited legacy surface even at full file scope — the delta contract survived the reversal"
 fi
 
+# ===========================================================================
+echo
+echo "== arm 4 — a CODING-STANDARD REFORMAT is not a set of changed methods =="
+# ===========================================================================
+#
+# `.github#395`, the third false positive of this class after gate-14 (#391)
+# and gate-48 (#388). gate-16 derived its changed-method set from a plain
+# `git diff -U0`, so when `nextcloud/coding-standard` moved every `{` onto its
+# signature line, EVERY method in the app read as modified and every one of them
+# was asked for an `@spec` tag it never had. MEASURED on ConductionNL/procest#819
+# (921 PHP files, gate package `80691a7a`): 1 finding on the base branch, 185 on
+# the reformat. `git diff -w` does not help — the brace is a token that MOVED
+# LINES, not whitespace whose width changed.
+#
+# The two arms below are the same tree twice, and they pull in opposite
+# directions:
+#
+#   4a  reformat ONLY            -> gate-16 must report NOTHING
+#   4b  reformat + ONE operator  -> gate-16 must still report THAT method, and
+#                                   must not report the untouched one beside it
+#
+# 4b is the arm that stops the fix from being a false-negative machine: a
+# normalisation loose enough to swallow `+` -> `-` would pass 4a and retire the
+# gate. The `.knr` and `.knr-changed` fixtures differ in exactly one character.
+gf_build_repo "${WORK}/reformat" "${SRC}"
+gf_commit_all "${WORK}/reformat" "base: app before the coding-standard reformat"
+gf_mark_base  "${WORK}/reformat"
+cp "${SRC}/lib/Controller/ReformattedController.php.knr" \
+   "${WORK}/reformat/lib/Controller/ReformattedController.php"
+rm -f "${WORK}/reformat/lib/Controller/ReformattedController.php.knr" \
+      "${WORK}/reformat/lib/Controller/ReformattedController.php.knr-changed"
+gf_commit_paths "${WORK}/reformat" "style: adopt nextcloud/coding-standard" \
+    lib/Controller/ReformattedController.php
+
+# PRE-CONDITION 1 — the reformat has to BE a diff. If the two fixtures were
+# accidentally identical, 4a would pass on an empty change set and prove nothing.
+_churn="$(cd "${WORK}/reformat" && git diff --numstat "$(git rev-parse refs/remotes/origin/development)"...HEAD -- lib/Controller/ReformattedController.php)"
+_churn_added="$(printf '%s' "${_churn}" | awk '{print $1}')"
+if [ "${_churn_added:-0}" -ge 10 ]; then
+    _ok "pre-condition: the reformat rewrites ${_churn_added} lines of ReformattedController.php — 4a is judging a real diff"
+else
+    _bad "pre-condition: the reformat produced ${_churn_added:-0} added line(s). The two fixture variants must differ, or arm 4a is vacuous."
+fi
+
+# PRE-CONDITION 2 — those methods must be findable subject matter. Both are
+# public, in lib/Controller, non-accessor and untagged; if they were not, a
+# silent gate-16 in 4a would be silence about nothing.
+_pc4="$(cd "${WORK}/reformat" && python3 "${CHECKER}" . --mode report 2>&1)"
+if printf '%s' "${_pc4}" | grep -qF 'ReformattedController.php::totalRowWeights'; then
+    _ok "pre-condition: the checker's own report mode names ReformattedController::totalRowWeights as untagged — it IS in scope and IS uncovered"
+else
+    _bad "pre-condition: report mode does not name ReformattedController::totalRowWeights, so arms 4a/4b are not measuring an in-scope untagged method at all"
+fi
+
+_out4="$(gf_run_wrapper "${WORK}/reformat" "${WORK}/log-reformat")"
+_v4="$(gf_verdict "${_out4}" 16)"
+case "${_v4}" in
+    *PASS*) _ok "gate-16 PASSES on a formatting-only reformat — brace style is not a changed method (#395)" ;;
+    *FAIL*) _bad ".github#395 is LIVE: gate-16 reports changed methods on a diff whose only content is brace placement, indentation, quote style and a trailing comma. Got: ${_v4:0:160}" ;;
+    "")     _bad "gate-16 emitted no verdict at all on the reformat arm" ;;
+    *)      _bad "gate-16 gave an unrecognised verdict on the reformat arm: ${_v4:0:160}" ;;
+esac
+if grep -qF 'ReformattedController.php' "${WORK}/log-reformat/hydra-gate-spec-coverage.log" 2>/dev/null; then
+    _bad "gate-16 named ReformattedController.php on a formatting-only diff — even without a FAIL that is #395 still in the log, and it is what a reviewer is asked to act on"
+else
+    _ok "gate-16 writes no finding for the reformatted file"
+fi
+
+# --- 4b — the same reformat with one operator changed ----------------------
+gf_build_repo "${WORK}/reformat-plus" "${SRC}"
+gf_commit_all "${WORK}/reformat-plus" "base: app before the coding-standard reformat"
+gf_mark_base  "${WORK}/reformat-plus"
+cp "${SRC}/lib/Controller/ReformattedController.php.knr-changed" \
+   "${WORK}/reformat-plus/lib/Controller/ReformattedController.php"
+rm -f "${WORK}/reformat-plus/lib/Controller/ReformattedController.php.knr" \
+      "${WORK}/reformat-plus/lib/Controller/ReformattedController.php.knr-changed"
+gf_commit_paths "${WORK}/reformat-plus" "style: adopt the standard, and change one operator" \
+    lib/Controller/ReformattedController.php
+
+_out4b="$(gf_run_wrapper "${WORK}/reformat-plus" "${WORK}/log-reformat-plus")"
+_v4b="$(gf_verdict "${_out4b}" 16)"
+case "${_v4b}" in
+    *FAIL*) _ok "gate-16 still FAILS when a method's BODY changed inside the reformat — ${_v4b:0:90}" ;;
+    *)      _bad "gate-16 did NOT report a method whose operator changed, because the change arrived inside a reformatted file. The normalisation has become a false-negative machine — worse than the over-reporting it replaced. Got: ${_v4b:0:160}" ;;
+esac
+_log4b="${WORK}/log-reformat-plus/hydra-gate-spec-coverage.log"
+if grep -qF 'ReformattedController.php::totalRowWeights' "${_log4b}" 2>/dev/null; then
+    _ok "gate-16 NAMES totalRowWeights — the method whose body actually changed"
+else
+    _bad "gate-16 failed without naming totalRowWeights; a verdict with no evidence cannot be acted on"
+fi
+if grep -qF '::buildRowLabel' "${_log4b}" 2>/dev/null; then
+    _bad "gate-16 also named buildRowLabel, which carries the SAME reformat and no change. The normalisation is not being applied per method — one real change re-opens the whole file, which is #395 at file granularity."
+else
+    _ok "gate-16 does NOT name buildRowLabel — the reformatted-but-unchanged method beside it stays out of scope"
+fi
+
 echo
 echo "== summary =="
 echo "   passed: ${_pass_n}"

--- a/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php
+++ b/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * THE BEFORE SIDE OF A CODING-STANDARD REFORMAT (.github#395).
+ *
+ * Written in the style the fleet is migrating AWAY from: Allman braces, four
+ * spaces, a double-quoted literal, no trailing comma in the multi-line
+ * parameter list, and one long expression on a single line.
+ *
+ * Neither method carries an `@spec` tag, deliberately. That is what makes the
+ * reformat arms falsifiable: if brace style counts as a change, both methods
+ * become findings on a diff that changed nothing a user or a caller can see —
+ * measured as 185 findings on ConductionNL/procest#819.
+ *
+ * The `.knr` sibling is this same file after php-cs-fixer; the `.knr-changed`
+ * sibling is that reformat PLUS one genuinely altered operator, which must
+ * still be reported through the normalisation.
+ */
+
+namespace OCA\SpecCoverageFixture\Controller;
+
+class ReformattedController
+{
+    /**
+     * Build a label for a row. No @spec — inherited debt, and it stays that way.
+     */
+    public function buildRowLabel(
+        string $id,
+        string $kind
+    ): string {
+        $prefix = "row";
+
+        return $prefix . ':' . $kind . ':' . $id;
+    }
+
+    /**
+     * Total the weights of the given rows. No @spec — inherited debt.
+     */
+    public function totalRowWeights(array $rows): int
+    {
+        $total = 0;
+        foreach ($rows as $row) {
+            $total = $total + (int) ($row['weight'] ?? 0);
+        }
+
+        return $total;
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php.knr
+++ b/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php.knr
@@ -1,0 +1,51 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * THE AFTER SIDE OF A CODING-STANDARD REFORMAT (.github#395), and NOTHING ELSE.
+ *
+ * Every difference from `ReformattedController.php` is one php-cs-fixer rule
+ * from `nextcloud/coding-standard`:
+ *
+ *   - K&R braces: `{` moved onto the signature line (which is why `git diff -w`
+ *     does not neutralise this — the brace is a TOKEN THAT MOVED LINES, not
+ *     whitespace whose width changed);
+ *   - tabs instead of four spaces;
+ *   - a trailing comma after the last multi-line parameter;
+ *   - `"row"` -> `'row'`;
+ *   - `(int) (...)` -> `(int)(...)`;
+ *   - the long concatenation re-wrapped across two lines.
+ *
+ * The token stream is unchanged apart from the added `,`, and every one of
+ * those rules is a no-op at runtime. gate-16 must report NOTHING here.
+ */
+
+namespace OCA\SpecCoverageFixture\Controller;
+
+class ReformattedController {
+	/**
+	 * Build a label for a row. No @spec — inherited debt, and it stays that way.
+	 */
+	public function buildRowLabel(
+		string $id,
+		string $kind,
+	): string {
+		$prefix = 'row';
+
+		return $prefix . ':' . $kind
+			. ':' . $id;
+	}
+
+	/**
+	 * Total the weights of the given rows. No @spec — inherited debt.
+	 */
+	public function totalRowWeights(array $rows): int {
+		$total = 0;
+		foreach ($rows as $row) {
+			$total = $total + (int)($row['weight'] ?? 0);
+		}
+
+		return $total;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php.knr-changed
+++ b/hydra-gates/scripts/test-fixtures/spec-coverage-scope/app/lib/Controller/ReformattedController.php.knr-changed
@@ -1,0 +1,46 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * THE ANTI-WIDENING ARM (.github#395) — the same reformat as `.knr`, plus ONE
+ * real change: `totalRowWeights()` now SUBTRACTS each weight instead of adding
+ * it.
+ *
+ * This is the half that matters most. "Ignore brace style" could have been
+ * written as "ignore reformatted files", or as any normalisation loose enough
+ * to swallow an operator — and a gate that stops reporting is worse than one
+ * that over-reports, because this gate's entire job is traceability.
+ *
+ * So gate-16 must FAIL here, must NAME `totalRowWeights`, and must NOT name
+ * `buildRowLabel` — which carries the same reformat and no change at all.
+ */
+
+namespace OCA\SpecCoverageFixture\Controller;
+
+class ReformattedController {
+	/**
+	 * Build a label for a row. No @spec — inherited debt, and it stays that way.
+	 */
+	public function buildRowLabel(
+		string $id,
+		string $kind,
+	): string {
+		$prefix = 'row';
+
+		return $prefix . ':' . $kind
+			. ':' . $id;
+	}
+
+	/**
+	 * Total the weights of the given rows. No @spec — inherited debt.
+	 */
+	public function totalRowWeights(array $rows): int {
+		$total = 0;
+		foreach ($rows as $row) {
+			$total = $total - (int)($row['weight'] ?? 0);
+		}
+
+		return $total;
+	}
+}


### PR DESCRIPTION
Closes #395.

## The defect

`check_spec_coverage.py` derived its changed-method set from a plain `git diff -U0`. `nextcloud/coding-standard` is K&R, so a reformat moves every `{` onto its signature line — every method reads as modified, and gate-16 asks all of them for an `@spec` anchor they never had.

`git diff -w` does not neutralise it: the brace is a **token that moved lines**, not whitespace whose width changed, so `foo()` and `foo() {` differ under `-w`. That is presumably why this survived the #388/#391 sweep. Third instance of the class today, and the only one in a **delta** gate — which is why a formatting-only PR can genuinely regress it.

## Measured, on the seven live coding-standard PRs

Base = each app's merge-base with `development`. Before = `check_spec_coverage.py` at `50c7e7b`; after = this branch.

| app | PR | changed files | before | after |
|---|---|---|---|---|
| procest | #819 | 930 | **185** | **0** |
| openregister | #2445 | 2616 | **183** | **0** |
| pipelinq | #809 | 761 | **374** | **0** |
| shillinq | #532 | 1304 | **274** | **0** |
| openconnector | #1229 | 725 | **30** | **0** |
| openbuild | #189 | 258 | **19** | **0** |
| scholiq | #322 | 399 | **6** | **0** |
| | | | **1071** | **0** |

## What is normalised — and what is not

Both sides of a line-by-line comparison against the file's own base version are normalised, and the result is **intersected** with git's own added-line set, so this can only ever remove lines from the scope, never add one.

Equated:

* brace placement, K&R vs Allman;
* indentation and intra-line spacing, **including** cast and operator spacing — php-cs-fixer both adds spacing (`'a'.$b` → `'a' . $b`) and removes it (`(array) $x` → `(array)$x`), which is why whitespace outside a literal is removed rather than collapsed. Collapsing to one space was measured on procest to recover 71 of 185; removal recovers 183;
* a trailing comma at the end of a **PHP** line (the last 2 of procest's 185);
* quote style, only where the two spellings are the same string;
* a **PHP** statement re-wrapped across lines — the same characters, different line breaks.

Deliberately **not** equated, each with a test:

* anything inside a string literal — `'a b'` → `'ab'` is text a user reads;
* an interpolating or escaped literal — `"$x"` is not `'$x'`, `"\n"` is not `'\n'`;
* a trailing comma in JS (elision) or a re-wrap in JS (ASI: `return` alone on a line returns `undefined`);
* a re-wrap across a `//` — inserting a break after one **uncomments** what followed: same characters, different program;
* a respelled type, `string|null` → `?string`. Equivalent, and equally a fixer rule — but it is a **signature** line and the list of such rules is open-ended. Measured: openregister has exactly two, both already `@spec`-tagged.

## The anti-widening half

A gate that stops reporting is worse than one that over-reports, so every rule ships with a positive control proving a real change still travels through it:

* **17 assertions** in `NormalisationTest` pairing each rule with a change it must still see — a changed value through the brace move, a new parameter through the trailing comma, a string's **content** through the quote rule, a changed operand inside a re-wrap;
* **2 end-to-end arms** through `run_gate` on a real git repo: a fully reformatted file reports nothing, and the same reformat with one operator flipped still names `totalWeights` and still does **not** name `buildLabel` beside it;
* **arm 4** in the shell suite, through `bin/hydra-gates`, with two pre-conditions (the reformat rewrites 35 lines; report mode confirms the methods are in scope and untagged) so a silent PASS cannot be mistaken for a correct one. `.knr` and `.knr-changed` differ in **one character**.

Mutation-checked against the pre-fix checker, both suites:

```
python  pre-fix: 2 FAILED + 17 errors     fixed: 37 passed
shell   pre-fix: 21 passed / 3 FAILED     fixed: 24 passed / 0 failed
```

## Is the suppression correct? An independent layer says yes

Not this normaliser but **PHP's own tokeniser**: for each of the 399 files the 1071 suppressed findings named, base and head token streams were compared with whitespace, comments, trailing commas and quote style set aside, `else if`/`elseif` merged and the import block excluded.

**396 of 399 are token-identical.** All three exceptions are outside the suppressed methods:

* openconnector `SynchronizationService.php` — `const` → `public const`, class-level, inside no method;
* openregister `FolderManagementHandler::getRegisterFolderName` and `FileService::debugFindFileById` — `string|null` → `?string`. These are **still in scope** after normalisation. They report nothing because one carries an `@spec` tag and the other a reason-bearing `@spec exclude`. That is the gate working, not the gate blind.

## Unchanged

`--mode report`, the empty-scope contract (#361 — no base is still `NOT APPLICABLE`, not a pass), the `COVERAGE:` line, and every existing assertion in both suites.

## Cost

One `git show` per in-scope changed file. openregister's 2616-file diff: **24s → 54s**. Batching through `git cat-file --batch` would recover most of it and was left out on purpose — a desynchronised batch parse could hand the comparison the wrong base text, and the failure mode of that is a **wrong suppression**.

## One thing observed, not fixed here

`spec_tags_removed()` detects removals against `BASE...HEAD` (the merge base) but then reads the base text with `git show BASE:<path>` — the branch **tip**. Where `development` has moved on (openregister, shillinq, today), those are different commits. It changes no result on any of the seven PRs, so it is noted rather than folded into this PR.
