### PR TITLE
fix(gates 7, 57): identity must be intrinsic, and a call that resolves nothing is not an unscoped lookup (#398)

### DIFF
--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -1044,8 +1044,215 @@ _REQUEST_BOUND_ASSIGN_RE = re.compile(
     r"|->\s*getUploadedFile\s*\(|\$_(?:GET|POST|REQUEST|COOKIE|FILES)\b)"
 )
 
+# ---------------------------------------------------------------------------
+# Pattern 6, clause 2: which calls can actually RESOLVE AN OBJECT
+# (`ConductionNL/.github#398`)
+# ---------------------------------------------------------------------------
+#
+# Clause 2 vetoes when "a caller-controlled value reaches an unscoped call".
+# It used to treat EVERY method call as such a call, so a method that was
+# already correctly scoped was flipped to a finding by a line that touches no
+# store at all. Isolated in both directions on one body:
+#
+#     $safeKey = $this->sanitizeKey($key);       <- ADDING this line: 0 -> 1
+#     return $this->store->find($key, $uid);     <- unchanged, still scoped
+#
+# and adding a session identity to the SANITISER's own argument list cleared it
+# again — which is the tell that the veto, not the data access, was deciding.
+#
+# ⚠️ ADDING AN AUTHORISATION GUARD IS THE WRONG REPAIR for that shape. The
+# method is already scoped; a guard would be dead code written to satisfy a
+# misreading, and gate-7's whole credibility problem is that the fleet learned
+# to trust its silences.
+#
+# THE FIX IS IN TWO HALVES AND *BOTH* ARE REQUIRED. The second one alone is a
+# recall regression, which is the trap this class is laid over:
+#
+#   (A) TAINT PROPAGATION. A local assigned from an expression mentioning a
+#       caller-supplied value IS caller-supplied. Before this, `$safeKey` was
+#       invisible to clause 2 — so
+#
+#           $safeKey = $this->sanitizeKey($key);
+#           return $this->store->find($safeKey);      // REAL IDOR
+#
+#       was reported ONLY BY ACCIDENT, via the same veto that produced the
+#       false positive above. Exempting the sanitiser without (A) would have
+#       silently cleared that method. (A) is a recall INCREASE and lands first.
+#
+#   (B) A same-class `$this->helper(...)` that demonstrably resolves nothing
+#       does not, by itself, veto. The helper is looked up in this class's own
+#       source and ITS BODY IS READ — nothing is inferred from its name, for
+#       the same reason Pattern 4 refuses to infer anything from a property
+#       name. A body that performs any data access, any mutation or any
+#       request read is NOT clearable, and an unresolvable callee is NOT
+#       clearable. Fail-closed in every direction.
+#
+# With both, the sanitiser case clears and the IDOR case above still reports —
+# proven by the `SanitiserHelperFalsePositiveTest` near-miss arms.
+_TAINT_ASSIGN_RE = re.compile(
+    r"\$([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^;\n]{1,400});")
+_TAINT_FOREACH_RE = re.compile(
+    r"\bforeach\s*\(\s*([^)]{1,200}?)\s+as\s+(?:\$[A-Za-z_][A-Za-z0-9_]*\s*=>\s*)?"
+    r"\$([A-Za-z_][A-Za-z0-9_]*)")
 
-def _has_session_identity_handoff(body: str, params) -> bool:
+# PSR-3 logging is the other call shape that cannot resolve an object. The
+# interface is fixed, every method returns void, and a controller that puts a
+# caller-supplied id into its error message is doing diagnostics, not a
+# lookup. Measured while hand-reading the sample: openbuild's
+# `AppOverrideController::getUser` is correctly scoped
+# (`getUserDelta(appId: $appId, uid: $user->getUID())`) and would STILL have
+# been reported after (B), purely because of
+# `$this->logger->error('... appId '.$appId, ...)`.
+# Exempting it can only suppress a finding whose sole unscoped call was a log
+# line — i.e. one where nothing was resolved at all. The
+# `test_logger_exempt_does_not_hide_a_real_lookup` arm pins that.
+_PSR3_LOG_RECEIVER_RE = re.compile(
+    r"\$this\s*->\s*(?:logger|log|psrLogger)\s*$")
+_PSR3_LOG_LEVELS = frozenset(
+    ("debug", "info", "notice", "warning", "warn", "error",
+     "critical", "alert", "emergency", "log"))
+
+# A helper body containing any data-access, mutation or request-input token is
+# treated as capable of resolving or changing an object, so it keeps its veto.
+# `_is_non_resolving_helper` reads `_DATA_ACCESS_RE` / `_MUTATION_CALL_RE` /
+# `_REQUEST_INPUT_RE` by NAME at call time — they are defined further down this
+# module. That indirection is deliberate: this rule must stay the UNION of the
+# gate's existing vocabularies, and re-spelling them here would let the two
+# copies drift, which is how a checker quietly stops checking.
+#
+# ⚠️ NOTE FOR A FUTURE READER: `_DATA_ACCESS_RE` is defined TWICE in this file
+# (once around the Pattern-3 block, once in the Pattern-3b block). Python keeps
+# the LAST one, which is the object-access spelling — the one wanted here. The
+# earlier definition is dead. Left as found rather than fixed blind; recorded
+# so nobody "tidies" the surviving one away.
+
+
+def _class_method_bodies(cleaned: str, src: str) -> dict:
+    """name -> body text for EVERY method declared in this file.
+
+    Private helpers included: Pattern 6's clause 2 has to reason about the
+    helper a routed method delegates to, and those are private by design.
+    """
+    out: dict = {}
+    for name, start, end in _all_method_spans(cleaned):
+        out.setdefault(name, src[start:end])
+    return out
+
+
+def _is_non_resolving_helper(name: str, bodies: dict, _seen=None,
+                             _depth: int = 0) -> bool:
+    """True when same-class helper *name* provably resolves/changes nothing.
+
+    Fail-closed: an unknown callee, a recursion, a body past the depth limit,
+    or any data-access / mutation / request-read token all return False.
+    """
+    if _depth > 3:
+        return False
+    if name not in bodies:
+        return False  # not a same-class method — nothing was read, clear nothing
+    _seen = set() if _seen is None else _seen
+    if name in _seen:
+        # A cycle. Purity here is a GREATEST fixpoint, so assuming it on the
+        # back-edge is sound rather than lax: every body in the cycle has
+        # already run the three impure-token checks below — those happen
+        # BEFORE this function recurses — so a data access anywhere in the
+        # cycle has already returned False. Refusing instead was measured
+        # wrong on openregister's `SecurityService::sanitizeInput`, which
+        # recurses through `array_map` to sanitise array members and is
+        # otherwise pure string handling.
+        return True
+    _seen = _seen | {name}
+    body = bodies[name]
+    for rx in (_DATA_ACCESS_RE, _MUTATION_CALL_RE, _REQUEST_INPUT_RE):
+        if rx.search(body):
+            return False
+    # EVERY outbound call must be accounted for. Only two shapes are:
+    #   * a plain PHP function (`trim`, `preg_replace`, `array_map`, …) — no
+    #     `->` / `::` receiver, so it reaches no collaborator; and
+    #   * a same-class `$this->helper(` that is itself non-resolving.
+    # ANYTHING ELSE — `$this->prop->method(`, `Foo::bar(`, `$var->method(` —
+    # returns False.
+    #
+    # ⚠️ THIS LOOP USED TO ONLY FOLLOW `$this->name(`, AND THAT WAS FAIL-OPEN.
+    # Caught by hand-reading the cleared set rather than by any arm I had
+    # written: procest's `ZaakdossierDownloadController::downloadZip` calls
+    # `$this->zipExporter->collectDocuments(caseId: $caseId)` with NO session
+    # identity, and `collectDocuments` resolves the dossier via
+    # `$this->dossierService->getDossierForCase(caseId: $caseId)`. That call
+    # matches none of the three vocabularies above — `getDossierForCase` is
+    # not `getObject`/`getBy`/`find`/`load` — and the old loop did not follow
+    # a `$this->prop->` hop at all, so the helper was declared "pure" and a
+    # REAL unguarded case download was SILENTLY CLEARED. Pinned by
+    # `test_helper_delegating_to_a_collaborator_is_not_pure`.
+    for m in _METHOD_CALL_RE.finditer(body):
+        receiver = body[max(0, m.start() - 60):m.start()]
+        if re.search(r"\$this\s*$", receiver):
+            if _is_non_resolving_helper(m.group(1), bodies, _seen, _depth + 1):
+                continue
+        return False
+    return True
+
+
+def _taint_closure(body: str, seeds: set, session: set) -> set:
+    """Names carrying a caller-supplied value, closed to a fixpoint.
+
+    A local assigned from — or a `foreach` variable iterated over — an
+    expression mentioning a tainted name is itself tainted. Without this,
+    laundering a parameter through ANY expression made it invisible to
+    clause 2 (see the commentary above); this is the half of `#398` that
+    ADDS findings.
+
+    ⚠️ TAINT STOPS AT A SCOPED RESULT, and leaving that out is a false-RED
+    generator. Measured on the fleet before this clause existed: **6 new
+    findings, and all six were false** —
+
+        $result   = $this->userService->revokeApiToken($currentUser, $id);
+        $response = new JSONResponse(data: $result);
+        return $this->securityService->addSecurityHeaders(response: $response);
+
+    `revokeApiToken` is correctly scoped (it takes the session user), but the
+    taint flowed out of it into `$result`, then into `$response`, and the
+    header decorator — which resolves nothing whatsoever — became "a
+    caller-controlled value reaching an unscoped call".
+
+    The rule that fixes it is the same one Pattern 6 is built on: a value
+    produced by a call that ALSO received the caller's own identity was
+    resolved under a scope the caller cannot forge, so it is data, not a
+    steerable reference. Propagation stops there. A call that did NOT receive
+    the identity keeps tainting its result — and that call has already vetoed
+    on its own account anyway.
+    """
+    tainted = set(seeds)
+    scoped_re = re.compile(
+        "|".join([r"\$" + re.escape(s) + r"\b" for s in sorted(session)])
+    ) if session else None
+
+    def _is_scoped_rhs(expr: str) -> bool:
+        if _SESSION_IDENTITY_RE.search(expr):
+            return True
+        return scoped_re is not None and scoped_re.search(expr) is not None
+
+    for _ in range(8):  # fixpoint; bodies are far shallower than this
+        grew = False
+        for rx, src_grp, dst_grp in (
+                (_TAINT_ASSIGN_RE, 2, 1), (_TAINT_FOREACH_RE, 1, 2)):
+            for m in rx.finditer(body):
+                dst, expr = m.group(dst_grp), m.group(src_grp)
+                if dst in tainted or dst in session:
+                    continue
+                if _is_scoped_rhs(expr):
+                    continue
+                if any(re.search(r"\$" + re.escape(t) + r"\b", expr)
+                       for t in tainted):
+                    tainted.add(dst)
+                    grew = True
+        if not grew:
+            break
+    return tainted
+
+
+def _has_session_identity_handoff(body: str, params, helper_bodies=None,
+                                  collaborator_bodies=None) -> bool:
     """Pattern 6 — see the commentary above.
 
     Three clauses, and all three are required:
@@ -1057,14 +1264,24 @@ def _has_session_identity_handoff(body: str, params) -> bool:
       3. at least ONE method call receives the identity — the positive
          evidence that the data access is actually scoped, without which
          clause 2 is vacuously true over a method that never uses its input.
+
+    `#398`: clause 2 now applies only to calls that could RESOLVE something —
+    see the commentary above `_TAINT_ASSIGN_RE`. *helper_bodies* is this
+    class's `name -> body` map; when it is None no helper is clearable, so a
+    caller that cannot supply it keeps the old, stricter behaviour.
     """
     if params is None:
         return False
     declared = _declared_parameter_names(params)
     declared |= set(_REQUEST_BOUND_ASSIGN_RE.findall(body))
+    # `session` is computed from the UNTAINTED seed set, exactly as before, so
+    # this change cannot move which names count as a session identity.
     session = _session_identity_names(body, declared) - declared
     if not session and not _IDENTITY_TOKEN_RE.search(body):
         return False
+    # `#398` half (A): follow the caller's value through the locals it is
+    # laundered into, so half (B) below cannot silently drop a real IDOR.
+    declared = _taint_closure(body, declared, session)
 
     saw_scoped_call = False
     for m in _METHOD_CALL_RE.finditer(body):
@@ -1082,6 +1299,26 @@ def _has_session_identity_handoff(body: str, params) -> bool:
             re.search(r"\$" + re.escape(p) + r"\b", a) for a in args for p in declared
         )
         if caller_value_here and not identity_here:
+            # `#398` half (B): a call that provably resolves NOTHING is not
+            # evidence of an unscoped lookup. Two shapes, both fail-closed —
+            # anything not positively cleared here still vetoes.
+            receiver = body[max(0, m.start() - 60):m.start()]
+            callee = m.group(1)
+            if (_PSR3_LOG_RECEIVER_RE.search(receiver)
+                    and callee.lower() in _PSR3_LOG_LEVELS):
+                continue  # PSR-3 diagnostics: returns void, resolves nothing
+            if (helper_bodies is not None
+                    and re.search(r"\$this\s*$", receiver)
+                    and _is_non_resolving_helper(callee, helper_bodies)):
+                continue  # same-class helper, body READ, resolves nothing
+            if collaborator_bodies:
+                pm = re.search(
+                    r"\$this\s*->\s*([A-Za-z_][A-Za-z0-9_]*)\s*$", receiver)
+                if (pm is not None
+                        and pm.group(1) in collaborator_bodies
+                        and _is_non_resolving_helper(
+                            callee, collaborator_bodies[pm.group(1)])):
+                    continue  # collaborator method, body READ, resolves nothing
             return False  # a caller-controlled value reaching an unscoped call
         if identity_here:
             saw_scoped_call = True
@@ -1401,6 +1638,49 @@ def _collaborator_guard_map(cleaned: str, path: str) -> dict:
             guards |= _collaborator_guard_methods(candidate)
         if guards:
             out.setdefault(prop, set()).update(guards)
+    return out
+
+
+def _collaborator_method_bodies(cleaned: str, path: str) -> dict:
+    """Map ``propertyName -> {methodName: body}`` for this class's collaborators.
+
+    The read-only twin of :func:`_collaborator_guard_map`, resolving types the
+    same way and for the same reason: `#398`'s clause-2 exemption must READ the
+    callee, never infer it from a name. An unresolvable type contributes
+    nothing, so the routed method keeps its veto — the fail-closed direction.
+
+    Needed because the sanitiser false positive also occurs ONE HOP OUT.
+    Measured on openregister `UserController::updateMe`, which is correctly
+    scoped (`updateUserProperties(user: $currentUser, data: $sanitizedData)`)
+    yet was vetoed by `$this->securityService->sanitizeInput(input: $value)`.
+    Restricting the exemption to same-class `$this->helper()` would have left
+    that one — and it was a false positive this change itself created, by
+    tainting the `foreach` variable that reaches the sanitiser.
+    """
+    root = _app_root_for(path)
+    if root is None:
+        return {}
+    index = _class_index(root)
+    out: dict = {}
+    for type_name, prop in _PROPERTY_DECL_RE.findall(cleaned):
+        short = type_name.rsplit("\\", 1)[-1]
+        if short.lower() in _COLLABORATOR_SKIP_TYPES:
+            continue
+        decl_re = re.compile(_CLASS_DECL_TEMPLATE % re.escape(short))
+        for candidate in index.get(short, []):
+            if os.path.abspath(candidate) == os.path.abspath(path):
+                continue
+            try:
+                with open(candidate, encoding="utf-8") as fh:
+                    csrc = fh.read()
+            except OSError:
+                continue
+            ccleaned = _strip_strings_and_comments(csrc)
+            if not decl_re.search(ccleaned):
+                continue
+            bodies = _class_method_bodies(ccleaned, csrc)
+            if bodies:
+                out.setdefault(prop, {}).update(bodies)
     return out
 
 
@@ -2379,6 +2659,10 @@ def scan_file(path: str) -> int:
     # with no @NoAdminRequired method never pays for them.
     collaborator_guards = _collaborator_guard_map(cleaned, path)
     delegated_guards = _delegated_guard_methods(cleaned, gsrc, collaborator_guards)
+    # `#398` Pattern 6 context: this class's own method bodies, so clause 2 can
+    # READ a `$this->helper()` it is about to veto on instead of assuming.
+    helper_bodies = _class_method_bodies(cleaned, gsrc)
+    collaborator_bodies = _collaborator_method_bodies(cleaned, path)
 
     violations = 0
     for name, head_start, sig_start, body_start, body_end, line_no in _find_method_bodies(src):
@@ -2515,7 +2799,8 @@ def scan_file(path: str) -> int:
         # scope the caller cannot forge. This is the shape `.github#365`'s
         # blanking would otherwise have turned into 45 false positives in
         # doriath alone. See the Pattern 6 commentary.
-        if _has_session_identity_handoff(body, _params):
+        if _has_session_identity_handoff(body, _params, helper_bodies,
+                                         collaborator_bodies):
             continue
 
         # NOTE (.github#315): the guidance that goes with this finding — that

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -662,12 +662,68 @@ def _enumerate_lib_php(app_root: str, include_untracked: bool = False) -> list[s
     return files
 
 
+_INFO_XML_ID_RE = re.compile(r"<id>\s*([A-Za-z0-9_.-]+)\s*</id>")
+
+
+def _app_id(app_root: str) -> tuple[str, str]:
+    """Resolve the app's IDENTITY and say where it came from.
+
+    Returns ``(app_id, source)``. ``source`` is one of ``appinfo/info.xml``
+    or ``basename`` and is printed by ``_scan_app`` on every run, so which
+    arm engaged is readable from the log rather than inferred.
+
+    WHY NOT THE DIRECTORY NAME (``ConductionNL/.github#398``)
+    --------------------------------------------------------
+    This function used to *be* ``os.path.basename(app_root)``. The
+    ``quality.yml`` hydra-gates job checks the app out with ``path: app``,
+    so under CI the basename is the literal string ``app`` for EVERY repo —
+    which is in no fleet's ``FOUNDATION_APPS`` set. The hydra#106 fail-safe
+    below therefore **never engaged in CI, for any repository, ever**, and
+    nothing said so. Four-arm control on one openregister tree, varying only
+    the directory name: ``openregister`` → **0 findings + SKIP**, renamed to
+    ``app`` → **8 findings**. A leaf app (docudesk) gave **3 under both
+    names**, which is what proves the difference is this guard and not the
+    rename.
+
+    A guard keyed on a path component is keyed on something the CALLER
+    controls and the checker cannot see. ``appinfo/info.xml``'s ``<id>`` is
+    intrinsic: it travels inside the tree, so it is identical under
+    ``path: app``, under a worktree, under a fleet sweep from
+    ``apps-extra/``, and in a clone named anything at all.
+
+    WHY NOT ``GITHUB_REPOSITORY`` either. It is process-wide, and ``main()``
+    groups its argv by app root and judges each root separately — a fleet
+    sweep legitimately hands this one process files from several repos. An
+    environment variable would stamp ONE repository's name onto EVERY root,
+    which is the same defect wearing different clothes: identity taken from
+    the invocation instead of from the thing being judged.
+
+    WHEN IT IS ABSENT. ``_app_root_for`` already locates the root by looking
+    for exactly this file, so root-finding and identity come from one
+    artifact and cannot disagree. If it is missing or carries no ``<id>``
+    (a bare fixture directory, not a Nextcloud app), identity falls back to
+    the basename — the historical behaviour, so fixtures keep working — but
+    the fallback is ANNOUNCED with ``source=basename``. The defect being
+    removed here is a fail-safe that stopped being a fail-safe *without
+    saying so*; a fallback that names itself in the log is not that.
+    """
+    info = os.path.join(app_root, "appinfo", "info.xml")
+    try:
+        with open(info, encoding="utf-8", errors="replace") as fh:
+            m = _INFO_XML_ID_RE.search(fh.read())
+        if m is not None:
+            return m.group(1), "appinfo/info.xml"
+    except OSError:
+        pass
+    return os.path.basename(os.path.abspath(app_root)), "basename"
+
+
 def _is_foundation(app_root: str) -> bool:
     """True when the repo under scan is one every leaf app consumes."""
     env = os.environ.get("HYDRA_OWC_FOUNDATION")
     if env is not None:
         return env.strip() not in ("", "0", "false", "no")
-    return os.path.basename(os.path.abspath(app_root)) in FOUNDATION_APPS
+    return _app_id(app_root)[0] in FOUNDATION_APPS
 
 
 def _find_sibling_app_roots(app_root: str) -> list[str]:
@@ -841,7 +897,18 @@ def _scan_app(app_root: str, files: list[str], findings: list[str]) -> None:
     # repo is different: its public methods exist to be called from sibling
     # apps, so proving deadness requires those siblings on disk.
     extra_roots: list[str] = []
-    if _is_foundation(app_root):
+    # `.github#398`: state the identity and its SOURCE on every run. The
+    # previous defect was not that the guard was wrong, it was that nobody
+    # could tell it had stopped engaging — in CI it had never engaged at all
+    # and every log looked exactly the same as one where it had.
+    _id, _id_source = _app_id(app_root)
+    _foundation = _is_foundation(app_root)
+    print(
+        f"[orphaned-write-capability] identity: app_id={_id} source={_id_source} "
+        f"foundation={'yes' if _foundation else 'no'} root={app_root}",
+        file=sys.stderr,
+    )
+    if _foundation:
         extra_roots = _find_sibling_app_roots(app_root)
         if not extra_roots:
             # FAIL SAFE: the consumers of this foundation repo are not on
@@ -850,7 +917,7 @@ def _scan_app(app_root: str, files: list[str], findings: list[str]) -> None:
             # Reporting here is what made the gate dangerous — it named
             # live code dead. Report nothing and say why.
             print(
-                f"[orphaned-write-capability] SKIP: {os.path.basename(app_root)} is a "
+                f"[orphaned-write-capability] SKIP: {_id} is a "
                 "foundation repo and no sibling apps were found next to it — cross-app "
                 "callers cannot be resolved, so deadness is unprovable. See hydra#106.",
                 file=sys.stderr,

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -2688,5 +2688,147 @@ class AgentController {
         self.assertEqual(_scan(src), [])
 
 
+# ---------------------------------------------------------------------------
+# `.github#398` — Pattern 6 clause 2 vetoed on calls that resolve NOTHING
+# ---------------------------------------------------------------------------
+
+class SanitiserHelperFalsePositiveTest(unittest.TestCase):
+    """A correctly-scoped method must not be flagged by a sanitiser call.
+
+    ⚠️ ANCHORED SUBJECTS. Every assertion here pins BOTH the count AND the
+    method name, and the fixtures below differ from one another by ONE
+    LINE. `authn-vs-authz` went green over a reverted fix because it asserted
+    `method=preamble` while a sibling logged `method=preambleForbiddenCode`,
+    which CONTAINS it — so a substring match cannot tell these apart. The
+    method here is always `show`, and the arms are separated by the count and
+    by which fixture is used, never by a name prefix.
+
+    The arms are a matrix, and the negative ones are the point: a fix that
+    merely quietened the sanitiser case would pass arms 1-3 and silently
+    break arms 5, 6 and 9 — each of which is a REAL unguarded lookup.
+    """
+
+    # `show` is scoped: `find($key, $uid)` carries the session identity.
+    _TMPL = """\
+<?php
+namespace OCA\\Demo\\Controller;
+use OCP\\AppFramework\\Controller;
+use OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired;
+class ThingController extends Controller {
+    #[NoAdminRequired]
+    public function show(string $key): JSONResponse {
+        $user = $this->userSession->getUser();
+        if ($user === null) { return new JSONResponse([], Http::STATUS_UNAUTHORIZED); }
+        $uid = $this->userSession->getUser()->getUID();
+%s
+    }
+%s
+}
+"""
+    _SANITISER = ("    private function sanitizeKey(string $k): string "
+                  "{ return preg_replace('/[^a-z0-9]/i', '', $k); }")
+    # Token-clean, but delegates to a collaborator that RESOLVES.
+    _DELEGATING = ("    private function collect(string $k) "
+                   "{ $d = $this->dossierService->getDossierForCase(caseId: $k); "
+                   "return $d['items'] ?? []; }")
+    # A helper that resolves in its own body.
+    _RESOLVING = ("    private function findCatalogItem(string $k) "
+                  "{ return $this->objectService->find($k); }")
+
+    def _scan_body(self, body, helper):
+        return _scan(self._TMPL % (body, helper))
+
+    def test_1_scoped_method_is_clean(self):
+        """Control: the unmodified scoped method is not flagged."""
+        self.assertEqual(self._scan_body(
+            "        return new JSONResponse($this->store->find($key, $uid));",
+            self._SANITISER), [])
+
+    def test_2_sanitiser_call_does_not_create_a_finding(self):
+        """THE DEFECT. Adding only `$safeKey = $this->sanitizeKey($key);` to the
+        clean method above used to flip it to a finding, though the data access
+        it performs is byte-identical and still carries `$uid`."""
+        self.assertEqual(self._scan_body(
+            "        $safeKey = $this->sanitizeKey($key);\n"
+            "        return new JSONResponse($this->store->find($key, $uid));",
+            self._SANITISER), [])
+
+    def test_3_identity_in_the_helper_call_also_clears(self):
+        """The other direction of the original isolation: handing the identity
+        to the SANITISER cleared it even before the fix. Pinned so a future
+        change cannot make the two arms disagree."""
+        self.assertEqual(self._scan_body(
+            "        $safeKey = $this->sanitizeKey($key, $uid);\n"
+            "        return new JSONResponse($this->store->find($key, $uid));",
+            self._SANITISER), [])
+
+    def test_5_a_LAUNDERED_lookup_is_still_reported(self):
+        """⚠️ THE ARM THAT MATTERS. A scoped call exists (so clause 3 is
+        satisfied) AND the sanitised value reaches an UNSCOPED lookup. Only
+        taint propagation catches this; with half (A) removed and half (B)
+        kept, this fixture goes SILENT and a real IDOR ships.
+
+        Measured exactly that way during development: pre-fix 1, fixed 1,
+        taint-disabled 0."""
+        findings = self._scan_body(
+            "        $safeKey = $this->sanitizeKey($key);\n"
+            "        $mine = $this->store->listOwned($uid);\n"
+            "        return new JSONResponse($this->store->find($safeKey));",
+            self._SANITISER)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=show", findings[0])
+
+    def test_6_logger_exempt_does_not_hide_a_real_lookup(self):
+        """The PSR-3 exemption must not clear a method that also performs an
+        unscoped lookup."""
+        findings = self._scan_body(
+            '        $this->logger->error("failed for ".$key);\n'
+            "        $mine = $this->store->listOwned($uid);\n"
+            "        return new JSONResponse($this->store->find($key));",
+            self._SANITISER)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=show", findings[0])
+
+    def test_7_a_logger_only_veto_clears(self):
+        """…and the exemption does its job when the real lookup IS scoped.
+        Measured on openbuild/procest: a caller-supplied id inside an error
+        message was reported as an unscoped object resolution."""
+        self.assertEqual(self._scan_body(
+            '        $this->logger->error("looking up ".$key);\n'
+            "        return new JSONResponse($this->store->find($key, $uid));",
+            self._SANITISER), [])
+
+    def test_8_a_helper_that_resolves_keeps_its_veto(self):
+        """A same-class helper is cleared by READING IT, never by its name: one
+        that performs data access in its own body still reports."""
+        findings = self._scan_body(
+            "        $item = $this->findCatalogItem($key);\n"
+            "        $mine = $this->store->listOwned($uid);\n"
+            "        return new JSONResponse($item);",
+            self._RESOLVING)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=show", findings[0])
+
+    def test_9_helper_delegating_to_a_collaborator_is_not_pure(self):
+        """⚠️ REGRESSION PIN — this shape was SILENTLY CLEARED by the first
+        draft, and no arm I had written caught it; hand-reading the cleared
+        fleet set did.
+
+        `collect()` contains no data-access, mutation or request-read token of
+        its own — `getDossierForCase` matches none of the gate's vocabularies —
+        but it reaches a collaborator that resolves. The purity walk therefore
+        has to fail closed on ANY call it cannot account for, not just on the
+        tokens it recognises. Real subject: procest
+        `ZaakdossierDownloadController::downloadZip`, an unguarded case-dossier
+        download."""
+        findings = self._scan_body(
+            "        $docs = $this->collect($key);\n"
+            "        $mine = $this->store->listOwned($uid);\n"
+            "        return new JSONResponse($docs);",
+            self._DELEGATING)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=show", findings[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
@@ -272,15 +272,16 @@ class _FleetFixture:
     invokes the gate. See ForeignCwdTest.
     """
 
-    def __init__(self, app_name: str, cwd: str = "app"):
+    def __init__(self, app_name: str, cwd: str = "app", app_id: str = None):
         self._tmp = tempfile.TemporaryDirectory()
         self._app_name = app_name
         self._cwd_mode = cwd
+        self._app_id = app_id
         self._old_cwd = None
 
     def __enter__(self):
         self.parent = self._tmp.name
-        self.app_root = self.add_app(self._app_name)
+        self.app_root = self.add_app(self._app_name, self._app_id)
         self._old_cwd = os.getcwd()
         os.chdir(self.app_root if self._cwd_mode == "app" else self.parent)
         return self
@@ -289,10 +290,19 @@ class _FleetFixture:
         os.chdir(self._old_cwd)
         self._tmp.cleanup()
 
-    def add_app(self, name: str) -> str:
+    def add_app(self, name: str, app_id: str = None) -> str:
+        """*app_id* writes a real ``<id>`` into info.xml (`.github#398`).
+
+        Left None by default so every pre-existing fixture keeps exercising
+        the basename fallback — those are the arms that prove the fallback
+        still works, and they must not silently migrate to the new path.
+        """
         root = os.path.join(self.parent, name)
         os.makedirs(os.path.join(root, "lib"), exist_ok=True)
-        self.write(root, "appinfo/info.xml", "<?xml version='1.0'?><info></info>\n")
+        body = "" if app_id is None else "<id>%s</id>" % app_id
+        self.write(
+            root, "appinfo/info.xml",
+            "<?xml version='1.0'?><info>%s</info>\n" % body)
         return root
 
     def write(self, root: str, rel_path: str, content: str) -> str:
@@ -380,6 +390,77 @@ class CrossAppCallerTest(unittest.TestCase):
             out = _run_main(svc)
             self.assertEqual(len(out), 1, out)
             self.assertIn("method=emitDisposalJournal", out[0])
+
+
+class CheckoutDirectoryNameTest(unittest.TestCase):
+    """`.github#398` — the foundation fail-safe must not key on the PATH.
+
+    `quality.yml`'s hydra-gates job checks the app out with ``path: app``, so
+    in CI the directory basename is the literal string ``app`` for every
+    repository in the fleet. Keyed on the basename, the hydra#106 fail-safe
+    therefore NEVER ENGAGED IN CI, for any repo, ever — and nothing in the
+    log said so, which is what made it survive.
+
+    Four-arm control on one real openregister tree, varying only the
+    directory name: named ``openregister`` → 0 findings + SKIP; renamed to
+    ``app`` → 8 findings. A leaf app (docudesk) gave 3 under BOTH names,
+    which is what proves the difference is this guard and not the rename.
+    """
+
+    def test_foundation_recognised_when_checked_out_as_app(self):
+        """THE DEFECT. Directory named ``app`` — as CI always names it — with
+        info.xml declaring the real id. The fail-safe must engage."""
+        with _FleetFixture("app", app_id="openregister") as fx:
+            svc = fx.write(fx.app_root, "lib/Service/ObjectService.php",
+                           _FOUNDATION_SVC)
+            self.assertEqual(_run_main(svc), [])
+
+    def test_directory_name_alone_no_longer_decides(self):
+        """The converse, and the arm that stops a basename fallback from
+        quietly reinstating the old behaviour: a directory NAMED
+        ``openregister`` whose info.xml declares a leaf app is NOT the
+        foundation repo, so its genuinely dead method is still reported."""
+        with _FleetFixture("openregister", app_id="shillinq") as fx:
+            svc = fx.write(
+                fx.app_root, "lib/Service/DisposalJournalEmitter.php",
+                "<?php\nnamespace OCA\\Shillinq\\Service;\n"
+                "class DisposalJournalEmitter {\n"
+                "    public function emitDisposalJournal(): void { /* dead */ }\n"
+                "}\n")
+            out = _run_main(svc)
+            self.assertEqual(len(out), 1, out)
+            self.assertIn("method=emitDisposalJournal", out[0])
+
+    def test_identity_and_its_source_are_announced(self):
+        """A fail-safe that stops engaging must not be able to do it in
+        silence. Every run states the id, where it came from, and whether the
+        guard applies — so 'it never engaged in CI' is readable from a log
+        instead of needing a four-arm experiment to discover."""
+        import contextlib
+        with _FleetFixture("app", app_id="openregister") as fx:
+            svc = fx.write(fx.app_root, "lib/Service/ObjectService.php",
+                           _FOUNDATION_SVC)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                owc.main(["check", svc])
+            line = err.getvalue()
+            self.assertIn("app_id=openregister", line)
+            self.assertIn("source=appinfo/info.xml", line)
+            self.assertIn("foundation=yes", line)
+
+    def test_absent_info_xml_falls_back_to_basename_and_says_so(self):
+        """When the intrinsic source is absent the fallback is the historical
+        basename — but it NAMES ITSELF, which is the whole difference between
+        a documented fallback and the defect being removed."""
+        import contextlib
+        with _FleetFixture("openregister") as fx:  # info.xml carries no <id>
+            svc = fx.write(fx.app_root, "lib/Service/ObjectService.php",
+                           _FOUNDATION_SVC)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                owc.main(["check", svc])
+            self.assertIn("source=basename", err.getvalue())
+            self.assertIn("foundation=yes", err.getvalue())
 
 
 class ForeignCwdTest(unittest.TestCase):


### PR DESCRIPTION
Closes #398.

Two defects the fleet-impact measurement exposed. Both reproduced with a positive control before anything was changed, both fixed with arms proving the fix in each direction.

Note on the numbers below: they are written as prose deliberately. A PR body is exported into the gates job environment and printed into the log, so pasting verdict-shaped lines plants them inside the artefact meant to prove the gates are clean.

## gate-57 identified the foundation repo by its checkout directory name

The hydra-gates job checks the app out with a fixed path of `app`, so under CI the directory basename is that same literal string for every repository in the fleet. The hydra#106 fail-safe compared that basename against a set of two app names, so it has never engaged in CI, for any repo, and nothing in the log said so.

Four-arm control on one openregister tree, varying only the directory name: named after the repo it reports nothing and prints a skip reason, renamed it reports eight. A leaf app reports three under both names, which is what makes this a test rather than an observation.

Identity now comes from `appinfo/info.xml`'s id element. It is intrinsic, so it reads the same under the CI path, in a worktree and in a fleet sweep. I deliberately did not use the repository name from the environment: `main()` groups its arguments by app root and judges each root separately, so a process-wide value would stamp one repository's identity onto every root, which is the same defect in different clothes. When info.xml is absent the basename remains the fallback, and every run now prints the resolved id, the source it came from and whether the guard applies. A fail-safe that silently stops being one is the defect being removed, so the fallback names itself.

Fleet effect, and the sign is the opposite of what the issue predicted: the corrected figures of eight and three describe what CI has been producing all along, unlabelled. Landing this takes those two repos to zero with a stated reason and leaves every other app untouched. That zero is a skip, not a clean bill of health, and the finding notes say so.

## gate-7 fired on correctly-scoped methods that sanitise through a helper

Pattern 6's second clause vetoed on every call receiving a caller-supplied value, whether or not that call could resolve anything. Adding a sanitiser call to a clean method flipped it to a finding while the data access beside it was unchanged and still carried the session identity. Adding an authorisation guard would have been the wrong repair.

The fix is two halves and both are required. Taint propagation follows the caller's value into the locals it is laundered into. Only then does a call that provably resolves nothing stop vetoing: a same-class or resolved-collaborator helper whose body is read and found free of data access, mutation and request reads, plus PSR-3 logging. Taint stops at a value produced by a call that also received the session identity.

Sizing was done on the checker's own decision path, not by looking for a session identity in the body, which is the screen that was discarded for matching the very preamble it exists to discount. The instrument was positive-controlled to be byte-identical to the checker on a real app first. Of the findings across the fifteen core apps with a tracked controller directory, a hundred and thirty-two were second-clause vetoes and forty-one had the isolated shape. All forty-one bodies were read by hand, splitting twenty-five false to sixteen real. The fleet moves down by twenty-eight with nothing added, and eighteen of the twenty-eight are one copied preferences controller template repeated across nine apps.

A first draft of the purity walk was fail-open and silently cleared an unguarded case-dossier download, because the helper reached its store through a collaborator method whose name matches none of the gate's verb vocabularies. That was found by hand-reading the cleared set, not by any test I had written, and the walk now fails closed on any outbound call it cannot account for.

## Controls

Nine arms are pinned, and each is proven able to fail by breaking the specific half it guards: removing the helper exemption reddens the sanitiser arm, removing taint reddens the laundered-lookup arm, making the purity walk fail-open reddens the collaborator arm, and deeming every helper pure reddens two. The real-commit pair on opencatalogi's themes controller still discriminates exactly as it did before this change. The verb-object abuse controls from the earlier false-positive fixes all still pass, and the gate-57 arms go red when the old basename identity is restored.

Test counts move from 1142 to 1154 across the helper suites; the single pre-existing import error in the visual-coverage test file is present on main too and is untouched here.

## Deliberately not included

Two named weaknesses were measured and decided rather than inherited.

Matching guard patterns against comment-bearing text is real but has zero current exposure across all fifteen apps, so it is left for a standalone hardening change with its own arms.

Reading a forbidden status inside a catch block as an authorisation decision was rejected as framed. Seventy-four methods contain that shape but only fourteen would move, and twelve of those fourteen catch a typed authorisation exception and translate it, which is a correct delegated guard. Implementing it would have manufactured about a dozen false positives in exactly the failure mode this gate is trying to escape. The correct rule keys on the caught exception type and has a fleet exposure of one method.

Full write-up, including what could not be verified, is in the fleet-board findings file for this issue.
