### PR TITLE
fix(gate-acceptance): a subject that another finding contains is not a subject

### DIFF
--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/auth-guards/expect.conf
@@ -9,6 +9,28 @@
 #
 # Bundle: auth-guards — gate-7 (no-admin-idor), .github#353.
 # planted/ removes the per-object guard from show() and update() while LEAVING
-# diff() guarded, so a checker that simply flagged every #[NoAdminRequired]
-# method would score 3 here and be caught by the count, not just the verdict.
-gate 7 hydra-gate-no-admin-idor.log FAIL PASS lib/Controller/AgentController.php
+# diff() guarded. A checker that simply flagged every #[NoAdminRequired] method
+# would score 3 here; that over-flagging is caught by the clean/ arm.
+#
+# ⚠️ It is NOT caught by any count. The driver's `_grade` matches a SUBSTRING of
+# the verdict line and never reads the finding count, so the older wording here
+# — "would score 3 here and be caught by the count" — described a mechanism
+# that does not exist. Corrected rather than deleted, because the sentence was
+# load-bearing for someone's confidence.
+#
+# 🔴 ONE ROW PER PLANT, AND NOT THE FILE PATH.
+# --------------------------------------------
+# This bundle used to declare a single row whose subject was the file path
+# `lib/Controller/AgentController.php`. Both plants live in that one file, so
+# ANY non-empty subset of them satisfied it. MEASURED on 2026-08-12: an
+# injected regression that dropped multi-parameter methods at the emit site
+# lost `update()` and kept `show()` — half the planted detection gone — and the
+# suite printed `ALL gate acceptance controls PASSED`. This is the `Faces.vue`
+# defect verbatim (.github#380).
+#
+# The subjects below name the METHOD and close it on the right with the
+# ` rule=…` field, so neither plant can be satisfied by the other and neither
+# can be satisfied by an unrelated finding that merely happens to be in this
+# file. diff() must never appear: it is the negative control.
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=show rule=no-auth-guard-in-body
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=update rule=no-auth-guard-in-body

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/authn-vs-authz/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/authn-vs-authz/expect.conf
@@ -11,10 +11,36 @@
 # preamble. Both arms KEEP that preamble, which is the point: the clean arm
 # proves the fix ignores it rather than punishing it.
 #
-# The subject is `method=preamble`, not the file path, and that is deliberate.
-# The file path is named by the bare unguarded method too, so a checker that
+# The subject is the METHOD, not the file path, and that is deliberate. The
+# file path is named by the bare unguarded method too, so a checker that
 # regressed to pre-#365 behaviour would still FAIL this arm (on `bare()`) and
 # still NAME the file — and would pass this bundle without ever having noticed
 # the 401 arm. Requiring the METHOD name is what makes this fixture a control
 # for `#365` specifically rather than a second copy of the auth-guards bundle.
-gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=preamble
+#
+# 🔴 ONE ROW PER ARM, AND EVERY SUBJECT ANCHORED ON BOTH SIDES.
+# ------------------------------------------------------------
+# This bundle was VACUOUS FOR ITS OWN DEFECT until 2026-08-12, in a way the
+# `Faces.vue` remedy ("one mechanism per named FILE") would not have caught,
+# because all three arms legitimately belong in one controller — the fixture's
+# whole argument is that they differ from each other ONLY by the preamble.
+#
+# It declared a single row whose subject was the bare string `method=preamble`.
+# The driver's `_names` is `grep -qF`, and the sibling plant logs
+#
+#     …:85 method=preambleForbiddenCode rule=no-auth-guard-in-body
+#
+# which CONTAINS that substring. MEASURED: reverting only the 401 half of the
+# `#365` fix — so the 403 spelling is still demoted and the 401 one is not —
+# removed `preamble()` from the log entirely, and the suite printed
+# `PASS — gate-7 NAMES 'method=preamble'` and `ALL gate acceptance controls
+# PASSED`. The exact regression the fixture exists to pin, invisible to it.
+#
+# 🔑 A `grep -F` subject discriminates only if NO OTHER finding the bundle can
+# produce contains it. A method name is a prefix of every longer method name,
+# so the name alone is never enough. Each row below therefore carries the
+# trailing ` rule=…` field, which closes the token on the right, and there is
+# one row per planted arm so no arm can be lost inside another's PASS.
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=bare rule=no-auth-guard-in-body
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=preamble rule=no-auth-guard-in-body
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=preambleForbiddenCode rule=no-auth-guard-in-body

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>commentguardfixture</id>
+	<name>Comment-Silenced Guard Fixture</name>
+	<summary>Fixture app for gate-7's guard-helper recognition. Not a real app.</summary>
+	<description>Exists so the acceptance matrix can express the three repairs .github#373 made to _collect_guard_helpers as separately-revertable arms.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>CommentGuardFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/appinfo/routes.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+return [
+	'routes' => [
+		['name' => 'webhook#rotate',     'url' => '/api/agents/{id}/webhook', 'verb' => 'POST'],
+		['name' => 'webhook#readOwned',  'url' => '/api/agents/{id}/webhook', 'verb' => 'GET'],
+		['name' => 'theme#show',         'url' => '/api/themes/{id}',         'verb' => 'GET'],
+		['name' => 'theme#showShared',   'url' => '/api/themes/{id}/shared',  'verb' => 'GET'],
+	],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Controller/ThemeController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Controller/ThemeController.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * The CLEAN arm for `.github#373`, MECHANISM B.
+ *
+ * BYTE-FOR-BYTE the planted arm, INCLUDING `getObjectService()` and its
+ * `throw`, with one change: `show()` now makes its own per-object decision.
+ *
+ * The locator is KEPT deliberately, and unchanged. `#373` did not make it
+ * illegal to resolve a dependency by throwing; it made that throw stop counting
+ * as an answer to "may this caller touch this object?". So the locator must
+ * still be here, still throwing, and the arm must still be silent — because the
+ * silence is now bought by the comparison in `show()` and by nothing else. An
+ * arm that had also deleted the locator would have passed against the broken
+ * checker too.
+ *
+ * This file must produce ZERO findings.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Controller;
+
+use OCA\CommentGuardFixture\Service\ThemeService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class ThemeController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly ThemeService $themes,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * The same locator call, plus the decision the planted arm lacks.
+	 */
+	#[NoAdminRequired]
+	public function show(string $id): JSONResponse {
+		$objects = $this->getObjectService();
+		$theme = $objects->find($id);
+		if ($theme['ownerId'] !== $this->userId) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($theme);
+	}
+
+	/**
+	 * Identical to the planted arm.
+	 */
+	#[NoAdminRequired]
+	public function showShared(string $id): JSONResponse {
+		$theme = $this->themes->find($id);
+		if ($theme === null || !$this->canUserAccessTheme($theme, $this->userId)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($theme);
+	}
+
+	/**
+	 * Identical to the planted arm.
+	 */
+	private function getObjectService(): ThemeService {
+		if (!class_exists('\OCA\OpenRegister\Service\ObjectService')) {
+			throw new \RuntimeException('OpenRegister is not installed');
+		}
+		return $this->themes;
+	}
+
+	private function canUserAccessTheme(array $theme, string $userId): bool {
+		return $theme['ownerId'] === $userId || $this->themes->isShared($theme, $userId);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Controller/WebhookController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Controller/WebhookController.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * The CLEAN arm for `.github#373`, MECHANISM A.
+ *
+ * BYTE-FOR-BYTE the planted arm, INCLUDING THE COMMENT, with one change:
+ * `loadAgent()` now makes a real decision — it compares object ownership
+ * against the caller and answers `null`. Nothing else differs, and that is the
+ * whole point of the pair.
+ *
+ * The comment is KEPT deliberately. `#373` did not make prose illegal, it made
+ * prose uncountable, and this arm is what proves the difference: a helper that
+ * says "throw … Forbidden" in a sentence AND decides in code must still clear
+ * its caller. An arm that also deleted the sentence would have passed against
+ * the broken checker too, and would have proved nothing.
+ *
+ * This file must produce ZERO findings. It reports TWO if the ownership-
+ * comparison recognition added by `#373` is removed — `rotate()` because
+ * `loadAgent()` stops clearing it, and `readOwned()` because `loadOwnedAgent()`
+ * does. That is mechanism C, and this arm is the only place it can be seen.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Controller;
+
+use OCA\CommentGuardFixture\Service\WebhookService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class WebhookController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly WebhookService $webhooks,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Identical to the planted arm. Cleared by the helper below.
+	 */
+	#[NoAdminRequired]
+	public function rotate(string $id): JSONResponse {
+		$agent = $this->loadAgent($id);
+		return new JSONResponse($this->webhooks->rotate($agent));
+	}
+
+	/**
+	 * The same helper, the same sentence — and now an actual decision.
+	 */
+	private function loadAgent(string $id): ?array {
+		// The caller invokes this helper OUTSIDE its own try block, so a
+		// throw here — Forbidden or otherwise — escapes as a framework 500.
+		$agent = $this->webhooks->find($id);
+		if ($agent['ownerId'] !== $this->userId) {
+			return null;
+		}
+		return $agent;
+	}
+
+	/**
+	 * Identical to the planted arm.
+	 */
+	#[NoAdminRequired]
+	public function readOwned(string $id): JSONResponse {
+		$agent = $this->loadOwnedAgent($id);
+		return new JSONResponse($agent);
+	}
+
+	/**
+	 * Identical to the planted arm.
+	 */
+	private function loadOwnedAgent(string $id): ?array {
+		$agent = $this->webhooks->find($id);
+		if ($agent['ownerId'] !== $this->userId) {
+			return null;
+		}
+		return $agent;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Service/ThemeService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Service/ThemeService.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Service;
+
+class ThemeService {
+
+	public function find(string $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function isShared(array $theme, string $userId): bool {
+		return in_array($userId, $theme['sharedWith'] ?? [], true);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Service/WebhookService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/clean/lib/Service/WebhookService.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Service;
+
+class WebhookService {
+
+	public function find(string $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function rotate(?array $agent): array {
+		return ['id' => $agent['id'] ?? null, 'secret' => 'rotated'];
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/expect.conf
@@ -1,0 +1,43 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: comment-silenced-guard — gate-7 (no-admin-idor), .github#373.
+#
+# WHY THIS BUNDLE EXISTS
+# ----------------------
+# gate-7 was proven blind THREE ways on 2026-08-12. Two of those repairs had a
+# repo-shaped fixture the same day; the third — `_collect_guard_helpers` reading
+# COMMENT-BEARING text — had none at all. Its only coverage was
+# `test_check_no_admin_idor.py::test_a_comment_mentioning_throw_is_not_a_guard`,
+# i.e. exactly the layer this suite's own header argues is not enough:
+#
+#     gate-7 has 86 unit tests. All 86 passed. The gate was still wrong.
+#
+# A unit test asserts a regex against strings the regex's author thought of. The
+# defect was found in a real repository that spells its helpers differently, and
+# only a repo-shaped fixture driven through the REAL wrapper can hold it.
+#
+# THREE MECHANISMS, THREE SEPARATE REVERTS, THREE PLACES THEY SHOW
+# ---------------------------------------------------------------
+#   A  the body test reads comment-free text          planted, WebhookController
+#      revert: `body = src[...]` in _collect_guard_helpers
+#      -> loadAgent() is guard-bearing by prose, rotate() is cleared
+#
+#   B  a `throw` must NAME an authorisation exception  planted, ThemeController
+#      revert: the `\bthrow\b…(?:Forbidden|…)` alternative back to bare `\bthrow\b`
+#      -> getObjectService() is guard-bearing, show() is cleared
+#
+#   C  an ownership comparison answered with `null`    clean/, both controllers
+#      is recognised instead, so the narrowing costs no true clear
+#      revert: delete the _has_ownership_comparison_guard branch
+#      -> the clean arm reports two findings and this bundle goes red
+#
+# A and B live in DIFFERENT FILES with DIFFERENT SUBJECTS, so neither revert can
+# hide inside the other's PASS (.github#380). Each subject is closed on the
+# right by the ` rule=…` field, so no method name can be satisfied by a longer
+# method name that contains it — the defect that made authn-vs-authz vacuous for
+# its own arm.
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=rotate rule=no-auth-guard-in-body
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=show rule=no-auth-guard-in-body

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>commentguardfixture</id>
+	<name>Comment-Silenced Guard Fixture</name>
+	<summary>Fixture app for gate-7's guard-helper recognition. Not a real app.</summary>
+	<description>Exists so the acceptance matrix can express the three repairs .github#373 made to _collect_guard_helpers as separately-revertable arms.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>CommentGuardFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/appinfo/routes.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+return [
+	'routes' => [
+		['name' => 'webhook#rotate',     'url' => '/api/agents/{id}/webhook', 'verb' => 'POST'],
+		['name' => 'webhook#readOwned',  'url' => '/api/agents/{id}/webhook', 'verb' => 'GET'],
+		['name' => 'theme#show',         'url' => '/api/themes/{id}',         'verb' => 'GET'],
+		['name' => 'theme#showShared',   'url' => '/api/themes/{id}/shared',  'verb' => 'GET'],
+	],
+];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Controller/ThemeController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Controller/ThemeController.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * The PLANTED arm for `.github#373`, MECHANISM B — A SERVICE LOCATOR IS NOT A GUARD.
+ *
+ * WHAT THIS FILE PINS
+ * -------------------
+ * `_HELPER_GUARD_BODY_RE` used to accept a BARE `throw` as proof that a helper
+ * performed an authorisation action. `getObjectService()` — the fleet's standard
+ * OpenRegister accessor, present in 36 controller files across 7 apps — throws
+ * when OpenRegister is absent. So a locator that answers "this dependency is
+ * missing" was read as an answer to "may this caller touch this object?", and it
+ * cleared EVERY method that calls it before its first write. That is how the fix
+ * for gate-7's `#[PublicPage]` scope hid its own motivating case: Pattern 8 was
+ * written and green on its rig while opencatalogi `ThemesController::show`
+ * stayed silent.
+ *
+ * `#373` narrowed the alternative so a `throw` must NAME an authorisation
+ * exception. Widen it back to a bare `\bthrow\b` — one token — and
+ * `getObjectService()` is a guard again, `show()` is cleared again, and this arm
+ * goes green.
+ *
+ * MECHANISM B IS INDEPENDENT OF MECHANISM A. The locator's `throw` is in CODE,
+ * not in a comment, so restoring comment-bearing text (mechanism A) does not
+ * clear `show()`, and narrowing the throw alternative (mechanism B) does not
+ * clear `rotate()`. Each arm has exactly one revert that turns it green, which
+ * is what makes the two rows in expect.conf worth having separately.
+ *
+ * `showShared()` is the NEGATIVE CONTROL: a genuine verb-object predicate, so
+ * this arm is not uniformly guilty.
+ *
+ * ⚠️ Austere per-method docblocks, for the reason given in WebhookController.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Controller;
+
+use OCA\CommentGuardFixture\Service\ThemeService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class ThemeController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly ThemeService $themes,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * PLANTED — resolves the dependency, then reads any id. See the file header.
+	 */
+	#[NoAdminRequired]
+	public function show(string $id): JSONResponse {
+		$objects = $this->getObjectService();
+		return new JSONResponse($objects->find($id));
+	}
+
+	/**
+	 * NEGATIVE CONTROL — must stay silent. See the file header.
+	 */
+	#[NoAdminRequired]
+	public function showShared(string $id): JSONResponse {
+		$theme = $this->themes->find($id);
+		if ($theme === null || !$this->canUserAccessTheme($theme, $this->userId)) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return new JSONResponse($theme);
+	}
+
+	/**
+	 * The locator. It reports a missing dependency and decides nothing else.
+	 */
+	private function getObjectService(): ThemeService {
+		if (!class_exists('\OCA\OpenRegister\Service\ObjectService')) {
+			throw new \RuntimeException('OpenRegister is not installed');
+		}
+		return $this->themes;
+	}
+
+	private function canUserAccessTheme(array $theme, string $userId): bool {
+		return $theme['ownerId'] === $userId || $this->themes->isShared($theme, $userId);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Controller/WebhookController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Controller/WebhookController.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * The PLANTED arm for `.github#373`, MECHANISM A — A SENTENCE IS NOT A GUARD.
+ *
+ * WHAT THIS FILE PINS
+ * -------------------
+ * Until `#373`, `_collect_guard_helpers` matched `_HELPER_GUARD_BODY_RE`
+ * against the auth-blanked source, which still contained every COMMENT. So the
+ * pattern read prose. MEASURED on hermiq `AgentWebhookController::loadOwnedAgent`,
+ * whose body contains no `throw` statement at all — the word appears only in a
+ * code comment explaining why the helper CATCHES one — and that one sentence
+ * made the helper guard-bearing, which cleared ALL FOUR routed methods calling
+ * it. `getObjectService()`, the same shape in code rather than in prose, is
+ * pinned next door in ThemeController.
+ *
+ * `rotate()` here is the routed method. It has no guard of its own; the only
+ * thing standing between it and a gate-7 finding is whether `loadAgent()`
+ * counts as a guard. Under the merged checker it does not, and `rotate()` is
+ * reported. Restore `body = src[...]` in `_collect_guard_helpers` — one line —
+ * and the comment silences the gate again and this arm goes green.
+ *
+ * `readOwned()` is the NEGATIVE CONTROL, and it is load-bearing in the other
+ * direction: `#373` narrowed the body test precisely because a real helper that
+ * compares object ownership and answers `null` — the deliberate anti-oracle
+ * choice — must still clear its callers. It is recognised by its CONDITION, not
+ * by a token in its text. Delete that recognition and this arm reports two
+ * findings instead of one, and the clean/ arm reports two instead of none.
+ *
+ * ⚠️ The per-method docblocks below are deliberately austere. gate-7's routed
+ * method scan still reads comment-bearing text (a known, named, open leak), so
+ * an explanatory docblock naming a status constant or an authorisation
+ * exception would clear the very method this file plants — the fixture's own
+ * prose satisfying the gate it is written to test. Everything explanatory lives
+ * up here, outside every method body span.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Controller;
+
+use OCA\CommentGuardFixture\Service\WebhookService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class WebhookController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly WebhookService $webhooks,
+		private readonly string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * PLANTED — nothing here decides anything. See the file header.
+	 */
+	#[NoAdminRequired]
+	public function rotate(string $id): JSONResponse {
+		$agent = $this->loadAgent($id);
+		return new JSONResponse($this->webhooks->rotate($agent));
+	}
+
+	/**
+	 * The helper whose body is prose. It fetches and returns; it decides nothing.
+	 */
+	private function loadAgent(string $id): ?array {
+		// The caller invokes this helper OUTSIDE its own try block, so a
+		// throw here — Forbidden or otherwise — escapes as a framework 500.
+		return $this->webhooks->find($id);
+	}
+
+	/**
+	 * NEGATIVE CONTROL — must stay silent. See the file header.
+	 */
+	#[NoAdminRequired]
+	public function readOwned(string $id): JSONResponse {
+		$agent = $this->loadOwnedAgent($id);
+		return new JSONResponse($agent);
+	}
+
+	/**
+	 * A real decision, written as a comparison answered with null.
+	 */
+	private function loadOwnedAgent(string $id): ?array {
+		$agent = $this->webhooks->find($id);
+		if ($agent['ownerId'] !== $this->userId) {
+			return null;
+		}
+		return $agent;
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Service/ThemeService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Service/ThemeService.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Service;
+
+class ThemeService {
+
+	public function find(string $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function isShared(array $theme, string $userId): bool {
+		return in_array($userId, $theme['sharedWith'] ?? [], true);
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Service/WebhookService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/comment-silenced-guard/planted/lib/Service/WebhookService.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\CommentGuardFixture\Service;
+
+class WebhookService {
+
+	public function find(string $id): ?array {
+		return ['id' => $id, 'ownerId' => 'alice'];
+	}
+
+	public function rotate(?array $agent): array {
+		return ['id' => $agent['id'] ?? null, 'secret' => 'rotated'];
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/exception-translation/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/exception-translation/expect.conf
@@ -17,4 +17,26 @@
 # and `\Exception` are supersets of every tracked exception and MUST be
 # accepted (they were rejected on hermiq#162, which pushed authors toward the
 # NARROWER handler).
-gate 49 hydra-gate-controller-exception-translation.log FAIL PASS purge()
+#
+# 🟠 TWO MECHANISMS, SO TWO ROWS.
+# -------------------------------
+# planted/ carries two distinct defects in one controller:
+#
+#   destroy()  the file-header `@throws` credited FORWARD to a method it does
+#              not describe — the `#343` header-binding family.
+#   purge()    an attribute-separated docblock, which the pre-#377 METHOD_RE
+#              swallowed into a non-overlapping `finditer` match, so the method
+#              was never inspected at all (11.7% of methods fleet-wide).
+#
+# The bundle used to name only `purge()`. That reasoning was correct in ONE
+# direction — a reintroduced unbounded docblock group keeps `destroy()`
+# reporting, so naming `destroy()` alone would not have caught it — and it left
+# the complementary direction unguarded. MEASURED on 2026-08-12: an injected
+# `methods = methods[1:]`, which loses only the FIRST method per file, deleted
+# `destroy()` and with it the entire `#343` header-binding property from the
+# log, and the suite still printed `ALL gate acceptance controls PASSED`.
+#
+# Each subject is anchored on the right by ` calls a service method` so a method
+# whose name merely contains another's cannot satisfy it.
+gate 49 hydra-gate-controller-exception-translation.log FAIL PASS destroy() calls a service method
+gate 49 hydra-gate-controller-exception-translation.log FAIL PASS purge() calls a service method


### PR DESCRIPTION
## A bundle that stays green over a reverted fix is not evidence of anything

Three of the ten acceptance bundles could not detect the regression they exist to
prevent. All ten go red on a **full** revert — which is the test anybody actually runs,
and which is why nobody noticed. Three were blind to a **partial** one, and one of those
was blind to *precisely the defect it was built for*.

This PR touches **only `hydra-gates/scripts/test-fixtures/gate-acceptance/`**. No checker,
no runner, no driver. The driver (`test_gate_acceptance_matrix.sh`) needed no change at
all — see "the anchor" below.

### The general fix: close the subject on the RIGHT

`#380`'s remedy was *one mechanism per named file*. That is a special case, and it would
**not** have caught `authn-vs-authz`, whose three plants legitimately belong in one
controller — the fixture's whole argument is that they differ from each other *only* by
the preamble.

The real invariant is that **a subject must be unsatisfiable by every OTHER finding the
bundle can produce.** `_names` is `grep -qF`, and gate-7's log line is
`path:LINE method=NAME rule=RULE`. So `method=preamble` is **contained in**
`method=preambleForbiddenCode`, and a method name is a prefix of every longer method name.
Every subject here is now closed on the right by its ` rule=…` / ` calls a service method`
field, with one row per arm.

Three controls, run before any edit:

```
grep -qF 'method=preamble rule=no-auth-guard-in-body'  <preambleForbiddenCode line>  -> rc=1  ✅
grep -qF 'method=preamble rule=no-auth-guard-in-body'  <preamble line>               -> rc=0  ✅
grep -qF 'method=preamble'                             <preambleForbiddenCode line>  -> rc=0  🔴 the bug
```

⚠️ A trailing **space** would not have worked — `read` strips trailing IFS whitespace from
the last field, so `method=preamble ` collapses back to `method=preamble` and the bundle
stays vacuous while looking fixed. The anchor has to be a token.

### What changed

| bundle | rows | mechanisms | named files |
|---|---|---|---|
| `authn-vs-authz` | 1 → **3** | 3 (bare · 401 preamble · 403 preamble) | 1 |
| `auth-guards` | 1 → **2** (was the **file path**) | 1 × 2 instances | 1 |
| `exception-translation` | 1 → **2** | 2 (`destroy` header-binding · `purge` docblock span) | 1 |
| 🆕 `comment-silenced-guard` | **2** | **3** | **2** |

### 🆕 `comment-silenced-guard` — the third gate-7 blindness had no fixture at all

Of the three ways gate-7 was proven blind, the **comment-silenced guard helper** was
covered only by unit tests. That is exactly the layer this suite's own header argues is
insufficient:

> gate-7 has 86 unit tests. All 86 passed. The gate was still wrong.

Three mechanisms, two named files, three separate reverts:

- **A** — the body test reads **comment-free** text. hermiq's `loadOwnedAgent()` contains
  **no `throw` statement at all**; the word appears only in a comment explaining why it
  *catches* one, and that sentence cleared all four routed methods.
- **B** — a `throw` must **name an authorisation exception**. opencatalogi's
  `getObjectService()` — **36 controller files across 7 apps** — throws when OpenRegister
  is absent, and so cleared every caller.
- **C** — an ownership comparison answered with `null` **is** recognised, so the narrowing
  costs no true clear. This one only shows in the `clean/` arm.

Both arms keep the comment and keep the locator **verbatim**. `#373` did not make prose
illegal, it made prose *uncountable* — an arm that had also deleted the sentence would
have passed against the broken checker too.

Structurally modelled on gate-65's probe suite: greps a **rule name, never a file name**,
so a no-op plant leaves the fixture clean and the probe goes red.

### Every repair is proven by reverting the fix it defends

**Twelve probes. Twelve predictions written before the run. Twelve matched exactly** —
count *and* the identity of every failing assertion. Baseline **52 → 70 assertions, 0
failed**.

| probe | revert | predicted | got |
|---|---|---|---|
| 1 | `#365`, **401 half only** — the "just delete 401 from it" repair | 69/1, `method=preamble` | ✅ |
| 2 | `#365`, **403 half only** (the mirror) | 69/1, `method=preambleForbiddenCode` | ✅ |
| 3 | `#365` full | 68/2, `bare` survives as liveness control | ✅ |
| 4 | drop multi-parameter methods → lose `update()` | 69/1 | ✅ |
| 5 | off-by-one, lose first finding per file | **62/5, all five named in advance** | ✅ |
| 6 | gate-49 `METHOD_RE` unbounded docblock | 66/2 | ✅ |
| 7 | `_method_bodies(src)[1:]` → lose `destroy()` | 69/1 | ✅ |
| 8 | `[:1]` → lose `purge()` | 69/1 | ✅ |
| 9 | mechanism **A** (`body = src[...]`) | 69/1, `method=rotate` | ✅ |
| 9b | **pure-prose control** — A reverted **and** the comment deleted | back to **70/0** | ✅ |
| 10 | mechanism **B** (bare `\bthrow\b`) | 69/1, `method=show` | ✅ |
| 11 | mechanism **C** | 68/2, **clean/** arm, `FAIL — 2 method(s)` | ✅ |
| 12 | A+B+C | 66/4, clean shows `1 method(s)` | ✅ |

Probes **4** and **7** are the two the vacuity audit measured at **28 passed / 0 failed —
green over the exact defect.** They are now 1 failure each, naming the lost plant.

Probe **9b** matters on its own: gate-7's routed-method scan still reads comment-bearing
text, so **an explanatory docblock in a fixture can clear the very method the fixture
plants**. With mechanism A reverted, deleting *only* the two comment lines restored the
finding — proving the silencer is the comment and nothing else in the file. Every
per-method docblock in the new fixture is austere for that reason; the explanation lives
in the file header, outside every method body span.

### ⚠️ A trap for the next person adding a bundle

The new fixture's first run reported `NOT APPLICABLE — scope was empty — 0 lib/Controller
PHP file(s)` **because the files were untracked** — gate-7 enumerates via `git ls-files`.
An untracked bundle is not a failing bundle, it is an absent one, and its `clean/` arm
goes green because nothing was inspected. **Stage a new bundle before measuring it.**

### Scope, honestly

- `publicpage-scope`, `contract-coverage`, `license-triangle`, `prose-not-proof`,
  `relation-dialect` were audited sound and are untouched.
- **`a11y-noise` and `debug-and-conflict` (`#380`) have not been revert-audited by
  anyone.** They were authored with the one-mechanism-per-file remedy, which this PR shows
  is necessary but **not sufficient**. Next job.
- The **wider comment leak is still open by design** — `scan_file` matches `_GUARD_BODY_RE`
  against comment-bearing text, so a comment in a *routed* method containing
  `Http::STATUS_FORBIDDEN` / `, 403)` still clears it. This bundle pins the **helper** path
  only, and says so in its header.
- Coverage is unchanged at **22 of 65 gates fixtured**. "The acceptance matrix is green"
  is still a statement about 22 gates, not 65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
