### PR TITLE
test(gates): close the regression gap — 58 of 65 gates now fixtured, and the two registries reconciled against the code

### DIFF
--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/COVERED-ELSEWHERE.md
@@ -18,6 +18,33 @@ coverage; only the location differs. The driver counts these as covered, so:
 The driver reads this file by grepping `^\| *gate-[0-9]+` and extracting the number,
 identically to `UNCOVERED.md`.
 
+## 2026-08-12 — the reconciliation, and why it was needed
+
+Twenty-seven rows were added on 2026-08-12. Every one of those gates was ALREADY
+driven through the real wrapper by a suite in this package, and every one was
+simultaneously listed in `UNCOVERED.md` as `no-fixture-yet · Nothing blocks
+authoring this`. Two registries of proven-ness disagreed with the code, in the
+same direction — both understating coverage — and neither had been cross-checked
+against it. That mis-registration sent two agents to redo finished work.
+
+🔑 **The failure was a search over the wrong store.** Coverage was computed from
+`gate-acceptance/` bundles and from this file; the actual planted arms lived in
+`scripts/lib/test_gate_*.sh`. A sweep of the corpus returns absence for free when
+the evidence is somewhere else — which is the same shape as gate-15 being
+declared unfixturable because no corpus root had a `type:"dashboard"` page.
+
+**So the CLAIM in every row below is: a named suite plants a defect, drives the
+REAL wrapper, and asserts that gate FAILs — and asserts a clean/anti-widening arm
+PASSes.** Each row quotes the assertion that says so, because a suite name alone
+is a label and a quoted assertion is a testable claim. Every quoted line was
+observed in a run of that suite on 2026-08-12; none is inferred from reading the
+suite's source.
+
+⚠️ **Three gates were deliberately NOT moved here** — 12, 41 and 52 have a
+planted arm but no anti-widening arm anywhere, so "planted/clean" would be an
+overclaim. They stay in `UNCOVERED.md` under the `partial-elsewhere` category
+with the missing half named.
+
 | gate | name | suite | fixtures |
 |---|---|---|---|
 | gate-16 | spec-coverage | `test_gate16_spec_coverage_scope.sh` | `test-fixtures/spec-coverage-scope/app` — diff/full scope matrix over a real two-commit history, `.github#361` |
@@ -33,3 +60,30 @@ identically to `UNCOVERED.md`.
 | gate-33 | axe-core | `test_gates_23_33_never_green_over_nothing.sh` | `test-fixtures/gates-23-33/{planted,clean}` |
 | gate-61 | listener-work-placement | `test_gate_scope_matrix.sh` | `test-fixtures/scope-matrix/app` — push / full / diff matrix, `.github#347` |
 | gate-65 | coding-standard-adoption | `test_check_coding_standard_adoption.sh` | scaffolded in-suite — 15 planted single-defect probes (one rule each) plus a negative control that fails if a broadened rule starts matching the compliant scaffold, and a wiring assertion that the checker printed its terminal `checked N rule(s)` summary |
+| gate-1 | spdx-headers | `test_gate_1_11_honest_verdicts.sh` | scaffolded in-suite. Planted: *"gate-1 FAILs its planted true positive (PHP file with no SPDX header)"*. Clean: *"gate-1 PASSes the clean fixture (anti-widening control)"*, plus a residue arm — *"gate-1 returned to PASS after its plant was removed"* |
+| gate-3 | stub-scan | `test_gate_1_11_honest_verdicts.sh` | Planted: *"gate-3 FAILs its planted true positive (caller-identity parameter ignored)"* and *"ARM 5 control: gate-3 FAILS the empty run() body when python3 works"*. Clean + residue arms as gate-1. Second planted arm in `test_gate_a11y_helper_wiring.sh` (*"positive control: gate-3 FAILS on the fixture app"*); near-miss arms in `test_gate_3_bodiless_declaration.sh` (an interface declaration is not a stub) |
+| gate-5 | route-auth | `test_gate_route_auth.sh` | `test-fixtures/route-auth/{unguarded,guarded,apphost,apphost-unguarded,orphan-route,di-registered-generic,prose-exempt,auth-declared}` — planted: *"a routed, attribute-less write still FAILS gate-5 — FAIL — 2 routed methods"* and *"prose-exempt: a docblock naming an attribute is not an attribute → FAIL"*. Clean: *"guarded fixture: same routes with attributes PASS"*, *"apphost fixture: AppHost generics produce NO auth finding"* |
+| gate-8 | unsafe-auth-resolver | `test_gate_1_11_honest_verdicts.sh` | Planted: *"gate-8 FAILs its planted true positive (tab-indented catch(Throwable){return null})"*. Clean + residue arms as gate-1 |
+| gate-10 | initial-state | `test_gate_1_11_honest_verdicts.sh` | Planted: *"gate-10 FAILs its planted true positive (two-step getElementById -> .dataset read)"* plus the `js/`-only arm (*"gate-10 FAILs the js/-only frontend"*, *"gate-10 NAMES js/admin.js"*). Anti-widening: *"gate-10 leaves \*.min.js alone"* |
+| gate-11 | admin-router | `test_gate_1_11_honest_verdicts.sh` | Planted: *"gate-11 FAILs its planted true positive (doriath /settings -> AdminRoot in src/main.js)"* — the DEAD-GATE case, since fourteen of fifteen fleet apps build their router there. Clean + residue arms as gate-1 |
+| gate-13 | modal-isolation | `test_gate_13_multiline_dialog.sh` | scaffolded in-suite — planted: *"a multi-line-opened `<NcDialog>` in a parent component → FAIL"*, *"a multi-line-opened `<NcModal>` → FAIL"*, *"the single-line form is still caught → FAIL"*. Clean: *"`<NcDialogHeader>` / `<NcModalFooter>` are NOT dialogs → PASS"*, *"a commented-out dialog, plus a https:// URL → PASS"*, *"a dialog under src/dialogs/, used by import → PASS"* |
+| gate-14 | route-reachability | `test_gate_fq_route_names.sh` + `test_gate_route_auth.sh` | `test-fixtures/fq-route-names/{fq-bound,fq-unbound}` and `route-auth/{orphan-route,apphost-unguarded,di-registered-generic}` — planted: *"an UNBOUND fully-qualified route is still raised — FAIL — 2 unrouted methods"*, *"orphan-route: gate-14 DOES raise the unreachable route"* (both invariants: `controller-class-not-found` AND the missing-method shape). Clean: *"fq-bound: DI-bound fully-qualified routes are not reachability findings → PASS"* |
+| gate-17 | redundant-controller | `test_gate_or_objectservice_surface.sh` | scaffolded in-suite — planted: *"gate-17 FAILS on a CRUD-named pass-through written against the REAL ObjectService API"* + *"gate-17 NAMES fetchAll"*. Anti-widening: *"gate-17 does NOT flag the identically-bodied domain-named sibling"*. Wiring: the checker's terminal `# count=` marker is asserted |
+| gate-20 | or-objectservice-api | `test_gate_20_comment_masking.sh` + `test_gate_or_objectservice_surface.sh` | scaffolded in-suite — planted: *"a real `$objectService->findObject()` call → FAIL"*, *"a call under a #[NoAdminRequired] attribute is still found → FAIL"*, *"gate-20 FAILS on a fabricated ObjectService method (was PASS for the gate's entire life)"*. Clean: *"//, # and /\* \*/ commented-out calls → PASS"*, *"`$this->schemaMapper->createFromArray()` is a different class → PASS"* |
+| gate-34 | window-confirm | `test_gate_a11y_markup_scope.sh` | `_tmp/{bad,good,vue}` scaffolded in-suite — planted: *"all 12 accessibility gates caught their planted true positive in a PHP template"* (gate-34's subject: a `window.confirm` in an inline script), repeated with NO `src/` directory at all. Clean: *"a CLEAN PHP template raises no accessibility finding"* |
+| gate-37 | aria-hidden-focusable | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; gate-37's subject is `aria-hidden=true` on a focusable element. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-38 | skip-link | `test_gate_monitoring_and_skiplink.sh` | `test-fixtures/monitoring-skiplink/{stated,accidental}` — planted: *"accidental: a bespoke shell with no skip link is still reported — FAIL — 2 page roots"* + *"gate-38 names the root component"*. Clean: *"stated: a CnAppRoot shell counts as having NC's skip link → PASS"* + *"gate-38 log is empty"*. Also a MISSING and a CRASHING classifier arm, each asserting `SKIPPED (wiring)` rather than PASS |
+| gate-39 | button-name | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; subject: an icon-only button with no accessible name. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-40 | form-label-association | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; subject: an input with no associated label. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-42 | link-text-quality | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; subject: non-descriptive link text. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-43 | table-headers | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; subject: a table with no `th scope`. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-44 | autocomplete-attr | `test_gate_a11y_markup_scope.sh` | same 12-gate planted/clean pair; subject: a semantic input with no `autocomplete`. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-45 | prefers-reduced-motion | `test_gate_45_stylesheet_scope.sh` + `test_gate_45_to_55_acceptance.sh` + `test_gate_a11y_markup_scope.sh` | planted: *"a css/ stylesheet with motion and no guard → FAIL"*, *"a `<style>` block with unguarded motion is still a FAIL"*, *"gate-45 sees a `<style>` transition in a PHP template with no src/ → FAIL"*. Clean: *"gate-45 accepts a template that ships the fallback → PASS"*, and a universal-`*`-reset control (*"without the reset, that file is a finding"*) |
+| gate-46 | spec-anchor-existence | `test_gate_46_tests_scope.sh` | scaffolded in-suite — planted: *"a dangling #T14 anchor in tests/ → FAIL"* + *"the finding NAMES the test file"*, *"a target file that never existed, tagged in tests/ → FAIL"* classified as `target file not found`, *"a dangling anchor in lib/ is still a FAIL"*. Clean: *"a REAL #T02 anchor, resolved through the date-prefixed archive → PASS"* |
+| gate-50 | security-config-fail-mode | `test_gate_45_to_55_acceptance.sh` | thirteen scaffolded arms — planted: an unguarded read whose app id is a class constant, one whose id is a literal, a multi-line read with no guard, the opencatalogi#86 `$this->appName` shape, and an arrow closure's `=>`. Clean: a compound `if ($a === '' \|\| $b === '')` guard, a boolean-return guard, a PHPCS-formatted multi-line read, an on-line emptiness check, a variable app id, and the array-literal value position (demotion asserted by `wc -c` on the `.notes` sidecar, so "demoted" is distinguishable from "never looked") |
+| gate-53 | effective-manifest-crossref | `test_gate_45_to_55_acceptance.sh` | `test-fixtures/effective-manifest` driven through the wrapper — planted: *"gate-53 blocks the PR that removes the last reference to a registered component → FAIL"* + *"gate-53 NAMES the orphaned component"*. Clean: *"accepts removing the component and its registry entry together → PASS"*, *"leaves a PRE-EXISTING orphan advisory (WARN), not blocking → PASS"*. ⚠️ the suite PREFLIGHTS ajv and aborts rather than reporting a wiring fault as a gate defect |
+| gate-56 | register-handler-resolution | `test_gate_5661_empty_scope_is_not_a_pass.sh` | scaffolded in-suite over a real two-commit history — clean: *"gate-56 opened its in-scope subject and PASSed"*. Planted (a `guard` class that does not exist): *"gate-56 FAILs its planted true positive when the diff touches it"* |
+| gate-57 | orphaned-write-capability | `test_gate_5661_empty_scope_is_not_a_pass.sh` | same rig — clean arm, then a NEW write capability with no caller anywhere: *"gate-57 FAILs its planted true positive when the diff touches it"* |
+| gate-58 | e2e-networkidle | `test_gate_5661_empty_scope_is_not_a_pass.sh` | same rig — clean arm, then a `page.waitForLoadState('networkidle')`: *"gate-58 FAILs its planted true positive when the diff touches it"*. Second planted arm in `test_gate_a11y_helper_wiring.sh` |
+| gate-59 | unclosable-gate | `test_gate_5661_empty_scope_is_not_a_pass.sh` | same rig — clean arm, the diff-scoped planted arm, AND the arm that discriminates: *"gate-59 CATCHES the violation on an unscoped full-tree audit"*, the one mode this gate could not reach before `.github#276` |
+| gate-60 | icon-vocabulary | `test_gate_5661_empty_scope_is_not_a_pass.sh` | same rig — clean arm, then an MDI name that exists nowhere: *"gate-60 FAILs its planted true positive when the diff touches it"* |

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/UNCOVERED.md
@@ -18,22 +18,56 @@ number, so the first column cell of every row must literally start with
   runner and left untested in silence.
 
 Gates already covered by a bundle in THIS directory are deliberately absent
-too: **7** (`auth-guards/`), **2** and **21** (`debug-and-conflict/`), **35**
-and **36** (`a11y-noise/`).
+too: **7** (`auth-guards/`, `authn-vs-authz/`, `publicpage-scope/`), **2** and
+**21** (`debug-and-conflict/`), **35** and **36** (`a11y-noise/`), **25**
+(`contract-coverage/`), **28** (`license-triangle/`), **49**
+(`exception-translation/`), **54** (`relation-dialect/`), **19** and **26**
+(`prose-not-proof/`), and — added 2026-08-12 — **6** and **9**
+(`semantic-authz/`), **15** and **55** (`dashboard-and-detail/`), **18** and
+**51** (`register-dialect/`), **62** and **63** (`manifest-planes/`), **64**
+(`apphost-prelude/`).
 
-Gates already covered by a repo-shaped bundle are deliberately absent from this
-table: **23, 24, 26, 27, 29, 30, 31, 32, 33** (`scripts/test-fixtures/gates-23-33/`
-via `scripts/lib/test_gates_23_33_never_green_over_nothing.sh`), **61**
-(`scripts/test-fixtures/scope-matrix/` via `scripts/lib/test_gate_scope_matrix.sh`)
-and **19** (`scripts/test-fixtures/e2e-credibility/` via
-`scripts/lib/test_gate19_coverage_credibility.sh`).
+Gates covered by a suite OUTSIDE this directory are listed in
+`COVERED-ELSEWHERE.md`, which the driver counts identically. That file carries
+forty rows, each quoting the assertion that proves the claim.
+
+## ⚠️ 2026-08-12 — THIS FILE WAS WRONG ABOUT THIRTY-SIX GATES
+
+Thirty-six rows were deleted on 2026-08-12. **Nine** of them gained a bundle in
+this directory on the same day. The other **twenty-seven already had a planted
+defect driven through the real wrapper**, in a suite under `scripts/lib/`, and
+this file said `no-fixture-yet · Nothing blocks authoring this` about every one
+of them.
+
+Two of those rows — gates 46 and 50 — were provably false when written:
+`test_gate_46_tests_scope.sh` and five gate-50 FAIL arms inside
+`test_gate_45_to_55_acceptance.sh` had been in the package for some time. Two
+independent registries of "what has been proven" disagreed with the code, in
+the same direction — both understating coverage — and neither had been
+cross-checked against it. **That mis-registration sent two agents to redo
+finished work.**
+
+🔑 **A registry of proven-ness is only as good as the store it was computed
+from.** Coverage here was computed from `gate-acceptance/` bundles; the missing
+arms lived in `scripts/lib/test_gate_*.sh`. A sweep of the wrong store returns
+absence for free. **Before writing `no-fixture-yet` about a gate, grep
+`scripts/lib/test_*` for its number and read what the hits assert** — the same
+discipline as running a positive control before believing a zero.
 
 ## What the categories claim
 
-A reason is a testable claim, so each row states which of four kinds it is.
+A reason is a testable claim, so each row states which of five kinds it is.
 
 * `no-fixture-yet` — nothing blocks it; a bundle simply has not been authored.
   The reason names roughly what the planted subject would be.
+  **No gate currently qualifies.** The category is kept because it is the right
+  answer for a gate added to the runner tomorrow — but it is also the label
+  that was wrong thirty-six times, so writing it now requires the grep above.
+* `partial-elsewhere` — a suite outside this directory ALREADY plants a defect
+  and asserts the gate FAILs, but there is no anti-widening arm anywhere. The
+  row names the suite, the assertion that exists, and the half that is missing.
+  These gates are NOT in `COVERED-ELSEWHERE.md`, because that file's claim is
+  "planted **and** clean" and half of it would be an overclaim.
 * `needs-diff` — the gate is intrinsically diff-relative and needs a purpose-built
   git history, not just a directory of files.
 * `needs-external` — the gate depends on something a fixture directory cannot
@@ -67,51 +101,24 @@ Two notes on authoring, both measured rather than assumed:
    this repository's own work tree — so a planted file must be **committed** to
    be enumerated at all. An untracked plant reproduces the very silence these
    bundles exist to expose.
+3. **Added 2026-08-12.** A bundle's arms are run through the WHOLE runner, so a
+   fixture arms every gate whose ingredients it happens to ship. Check what
+   yours arms before landing it: the four manifests added on 2026-08-12 were
+   all invalid against the v2 schema on first write, and would have put
+   gate-22 into a permanent FAIL on eight new arms. Harmless while every
+   bundle grades PER-GATE expectations — and the moment any suite adds a
+   run-level-green or exhaustive-FAIL-set assertion, it detonates. Standing
+   exposure across the corpus, measured: gate-25 fires in 27 of 58 roots,
+   gate-1 in 27, gate-7 in 13, gate-65 in 4.
 
 ## The list
 
 | gate | name | category | reason |
 |---|---|---|---|
-| gate-1 | spdx-headers | no-fixture-yet | A planted `lib/Service/Unlicensed.php` with no `@license`/`@copyright` docblock tags would trip it; the clean arm is the same file carrying both. Nothing blocks authoring this. |
-| gate-3 | stub-scan | no-fixture-yet | A planted `lib/BackgroundJob/EmptyJob.php` whose `run()` body does no non-logger call, plus a `lib/Service/` method taking `$userId` and never referencing it, would trip both arms of the checker. Nothing blocks it. |
 | gate-4 | composer-audit | needs-external | Requires the `composer` binary on PATH **and** a network round-trip to the Packagist security-advisories API, since `composer audit --locked` resolves advisories remotely. A planted arm would additionally need a lock pinning a package with a live published CVE, which rots as advisories are superseded. |
-| gate-5 | route-auth | no-fixture-yet | `scripts/test-fixtures/route-auth/` and `fq-route-names/` already exercise this gate, but through `scripts/lib/test_gate_route_auth.sh`, which drives the checker's helper level rather than a planted/clean pair through the real wrapper. A planted `appinfo/routes.php` entry whose controller method carries no auth attribute would give it wrapper-level coverage. |
-| gate-6 | orphan-auth | no-fixture-yet | A planted `lib/Service/AccessService.php::isTransitionAllowed()` carrying an authorisation-domain signal and called from nowhere in `lib/` or `src/` would trip it; the clean arm adds one production caller. Nothing blocks it. |
-| gate-8 | unsafe-auth-resolver | no-fixture-yet | A planted `lib/Service/DecisionService.php::getAuthorizationService()` ending `catch (\Throwable) { return null; }` would trip it; the clean arm rethrows. Nothing blocks it. |
-| gate-9 | semantic-auth | no-fixture-yet | A planted controller method annotated `#[NoAdminRequired]` whose body calls `requireAdmin()` would trip it; the clean arm swaps the attribute for `#[AuthorizedAdminSetting(...)]`. Nothing blocks it. |
-| gate-10 | initial-state | no-fixture-yet | A planted `src/AdminRoot.vue` reading `document.getElementById('x').dataset.version` (and the two-step form, which the old single-line regex could not see) would trip it; the clean arm uses `loadState()`. Nothing blocks it. |
-| gate-11 | admin-router | no-fixture-yet | A planted `src/main.js` calling `createRouter()` with a `{ path: '/settings', component: AdminRoot }` entry would trip it; the clean arm registers the component via `AdminSettings.php` only. Nothing blocks it. |
-| gate-12 | nc-input-labels | no-fixture-yet | A planted `.vue` component with an `<NcSelect>` carrying neither `inputLabel` nor `ariaLabelCombobox` — written multi-line and after a `:reduce="(o) => o.id"` prop, which is what defeated the old `[^>]*` extractor — would trip it. Nothing blocks it. |
-| gate-13 | modal-isolation | no-fixture-yet | A planted `src/components/Thing.vue` opening a multi-line `<NcDialog` tag inline (the shape that made 0 of pipelinq's 9 real violations visible) would trip it; the clean arm moves it to `src/dialogs/`. Nothing blocks it. |
-| gate-14 | route-reachability | no-fixture-yet | `scripts/test-fixtures/route-registration/` and `fq-route-names/` already exercise this gate, but through `scripts/lib/test_gate_route_registration.sh` at helper level, not as a planted/clean pair through the wrapper. A planted `Response`-returning controller method with no route entry, plus a route naming a method that does not exist, would cover both invariants at wrapper level. |
-| gate-15 | dashboard-antipattern | no-fixture-yet | A planted `src/manifest.json` with a `type:"dashboard"` page whose widget body slot template renders `<CnDashboardPage>` would trip it; the clean arm renders an ordinary widget component. Nothing blocks it. |
-| gate-17 | redundant-controller | no-fixture-yet | A planted `lib/Controller/MeetingController.php::index()` whose body is a literal pass-through to OpenRegister's `ObjectService` would trip it; the clean arm deletes the wrapper. Runs full-tree when unscoped, so no diff is required. |
-| gate-18 | notification-dialect | no-fixture-yet | A planted `lib/Settings/register.json` whose `x-openregister-notifications` block uses the obsolete singular `channel`/`recipient` + `lifecycleEnter` dialect would trip the blocking half (a); the clean arm uses plural `channels`/`recipients` + `trigger.type`. Half (b) is advisory and never decides the verdict. |
-| gate-20 | or-objectservice-api | no-fixture-yet | A planted `lib/Service/Thing.php` calling `$this->objectService->findObjects(...)` would trip it; the clean arm calls `findAll()`. A second clean file with the same call **commented out** would pin the `source_scope.py --mask php` behaviour. Nothing blocks it. |
-| gate-22 | manifest-validation | needs-external | `scripts/test-fixtures/manifest-validation/` exists but feeds `check_manifest.js` directly via `test_check_manifest.sh` rather than driving the wrapper. Wrapper-level coverage additionally needs `node` on PATH **and** `ajv/dist/2020` resolvable: no `node_modules` ships anywhere in this package, so today the validator exits 3 and the clean arm cannot go green. |
-| gate-34 | window-confirm | no-fixture-yet | A planted `src/components/Thing.vue` calling `window.confirm(...)` — and the bracket form `window['confirm'](...)`, which the old regex missed — would trip it; the clean arm uses `NcDialog`. Nothing blocks it. |
-| gate-37 | aria-hidden-focusable | no-fixture-yet | A planted element with `aria-hidden="true"` and `tabindex="0"` would trip it; the clean arm must include the canonical `aria-hidden` + `tabindex="-1"` hidden file input, which is correct code this gate previously reported. Nothing blocks it. |
-| gate-38 | skip-link | no-fixture-yet | `scripts/test-fixtures/monitoring-skiplink/` exists but is driven by `scripts/lib/test_gate_monitoring_and_skiplink.sh` at helper level, not as a planted/clean pair through the wrapper. A planted `src/App.vue` that is neither an `<NcContent>` nor a `<CnAppRoot>` and carries no skip-link anchor would give it wrapper-level coverage. |
-| gate-39 | button-name | no-fixture-yet | A planted `<button><CloseIcon /></button>` with no accessible name would trip it; the clean arm must include a `:title="t('app', 'Remove tab')"` bound name, which is the shape that produced all 22 of openbuild's false positives. Nothing blocks it. |
-| gate-40 | form-label-association | no-fixture-yet | A planted bare `<input type="text">` with no label association would trip it; the clean arm must include an `<NcCheckboxRadioSwitch>` labelled by default-slot content only, which is the relaxation this gate depends on. Nothing blocks it. |
-| gate-41 | html-lang | no-fixture-yet | A planted `templates/standalone.php` that emits `<html>` without a `lang=` attribute would trip it; the clean arm adds `lang`. A second clean template whose PHP comment merely mentions `<html>` would pin the `php_template_scope.emitted_markup` behaviour. |
-| gate-42 | link-text-quality | no-fixture-yet | A planted `<a href="/docs">Click here</a>` would trip it; the clean arm gives the anchor descriptive text. Nothing blocks it. |
-| gate-43 | table-headers | no-fixture-yet | A planted `<table>` in which one `<th>` carries `scope="col"` and another carries none would trip it — the exact case a single `scope=` used to green — and the clean arm scopes every header. Nothing blocks it. |
-| gate-44 | autocomplete-attr | no-fixture-yet | A planted `<input id="e" type="text" name="email">` with no `autocomplete=` would trip it, and it doubles as the regression case for "first name-like attribute wins". The clean arm adds `autocomplete="email"`. Nothing blocks it. |
-| gate-45 | prefers-reduced-motion | no-fixture-yet | A planted `css/main.css` declaring `transition: all .3s` with no `@media (prefers-reduced-motion: reduce)` block would trip it; the clean arm adds the guard. The clean arm must NOT ship a universal `*` reset, which globally suppresses every finding. |
-| gate-46 | spec-anchor-existence | no-fixture-yet | A planted `@spec openspec/specs/nope/spec.md#no-such-anchor` in a `lib/` file (and one under `tests/`, the directory the enumerator only recently gained) would trip it; the clean arm points at a spec file and heading that exist. Nothing blocks it. |
-| gate-47 | security-change-has-tests | needs-diff | The gate reports `na` outright unless `--scope-to-diff` is active with a resolvable base, because its whole subject is "which hunks did this change touch, and did it also touch a test". It needs a purpose-built commit pair, which a static fixture directory cannot express. |
+| gate-12 | nc-input-labels | partial-elsewhere | `test_gate_a11y_helper_wiring.sh` plants a defect and asserts *"positive control: gate-12 FAILS on the fixture app"*, driven through the real wrapper — so this gate is NOT blind. What is missing is the anti-widening half: no suite asserts that a CORRECT `<NcSelect>` is silent. `test_gate_a11y_markup_scope.sh` has exactly that arm for twelve a11y gates and gate-12 is not among them, because its subject is a Vue component prop rather than PHP-template markup. A bundle would plant a multi-line `<NcSelect>` written after a `:reduce="(o) => o.id"` prop — the shape that defeated the old `[^>]*` extractor — and give the clean arm one carrying `inputLabel`. |
+| gate-22 | manifest-validation | needs-external | ⚠️ **Reason corrected 2026-08-12; the previous one had rotted.** It read *"no `node_modules` ships anywhere in this package, so the clean arm cannot go green"*. That is no longer true of CI: `.github/workflows/hydra-gates-package.yml` runs `npm install --no-save ajv ajv-formats` BEFORE the helper-suite step, precisely so gates 22 and 53 validate with the real Ajv. Verified on 2026-08-12 that a schema-valid manifest returns clean and an invalid one returns thirteen errors. What actually blocks a bundle is different and is about the DRIVER: `test_gate_acceptance_matrix.sh` has no ajv preflight, so on a developer machine without ajv gate-22 reports `SKIPPED (wiring)` on both arms and the planted-arm assertion would report a WIRING fault as a gate defect. `test_gate_45_to_55_acceptance.sh` solves this for gate-53 with a preflight that aborts with exit 2 and says so; the acceptance driver needs the same before gate-22 can be bundled here. |
+| gate-41 | html-lang | partial-elsewhere | `test_gate_a11y_helper_wiring.sh` plants a defect and asserts *"positive control: gate-41 FAILS on the fixture app"* through the real wrapper. The missing half is anti-widening: `test_gate_a11y_markup_scope.sh`'s clean PHP template emits no `<html>` element at all, so nothing anywhere asserts that a template WITH `lang=` is silent. A bundle would plant a `templates/standalone.php` emitting `<html>` with no `lang`, give the clean arm the same template with `lang`, and add a second clean template whose PHP COMMENT merely mentions `<html>` — pinning `php_template_scope.emitted_markup`. |
+| gate-47 | security-change-has-tests | needs-diff | The gate reports `na` outright unless `--scope-to-diff` is active with a resolvable base, because its whole subject is "which hunks did this change touch, and did it also touch a test". It needs a purpose-built commit pair, which a static fixture directory cannot express. `test_gate_45_to_55_acceptance.sh` does exercise both directions over a real history (*"classified a real (non-security) diff → PASS"*, *"on a whole-repository run → NOT APPLICABLE"*), but never plants a security change WITHOUT a test, so it is not `partial-elsewhere` either. |
 | gate-48 | csrf-cochange | needs-diff | Same shape as gate-47: "was `@NoCSRFRequired` REMOVED" is a property of a change set, not of a checkout, and the gate reports `na` on any non-diff-scoped run. It needs a two-commit history where the attribute is present in the base and absent in the head. |
-| gate-50 | security-config-fail-mode | no-fixture-yet | A planted `$this->appConfig->getValueString(Application::APP_ID, 'listing_register', '')` with no empty-value guard within the window would trip it — using the class-constant app id, which was the measured blind spot. The clean arm adds `if ($reg === '' \|\| $sch === '')`. |
-| gate-51 | schema-property-titles | no-fixture-yet | A planted `lib/Settings/register.json` with a schema property carrying neither `title` nor `description` would trip it; the clean arm supplies both. Unscoped runs ratchet every property, so no diff is required. |
-| gate-52 | custom-widget-ratchet | no-fixture-yet | A planted `kind:"widget"` component-registry entry with no `_note` field would trip the justification half, which is what runs unscoped; the clean arm adds the `_note`. The count-ratchet half additionally needs a base ref and is therefore not exercised by a fixture pair. |
-| gate-53 | effective-manifest-crossref | needs-external | `scripts/test-fixtures/effective-manifest/` exists but is driven at helper level by `test_check_manifest_crossref.js` / `test_build_effective_manifest.js`, not through the wrapper. Wrapper-level coverage needs `node` plus `ajv/dist/2020` resolvable from `scripts/lib`; no `node_modules` ships in this package, so the gate currently fails closed with "ajv not resolvable" on both arms. |
-| gate-55 | detail-page-discipline | no-fixture-yet | A planted `type:"detail"` page declaring both page-level `widgets[]` and `config.widgets` (render-path shadowing) would trip it; the clean arm keeps one render path. Unscoped runs check every detail page in the manifest, so no diff is required. |
-| gate-56 | register-handler-resolution | no-fixture-yet | A planted `lib/Settings/register.d/10-thing.json` naming a `guard` class that does not exist in the tree, plus a real class with a `::method` that was never written, would trip both rules; the clean arm ships both. Nothing blocks it. |
-| gate-57 | orphaned-write-capability | no-fixture-yet | A planted `lib/Service/JournalEmitter.php::emit()` with no non-test production caller and no register.d/listener/background-job seam would trip it; the clean arm wires one of the recognised seams. Nothing blocks it. |
-| gate-58 | e2e-networkidle | no-fixture-yet | A planted `tests/e2e/nav.spec.ts` calling `page.waitForLoadState('networkidle')` would trip it; the clean arm uses `waitUntil: 'domcontentloaded'`, and should also carry a comment merely *mentioning* networkidle, which used to be counted as a live call. Unscoped runs put every e2e file in scope. |
-| gate-59 | unclosable-gate | no-fixture-yet | A planted `lib/Service/SettingsInitializer.php` reading a `configuration_version` config key that nothing anywhere writes would trip it; the clean arm writes it after the guarded setup. Unscoped runs walk all of `lib/`, so no diff is required. |
-| gate-60 | icon-vocabulary | needs-external | The planted arm can go red without help (an invented MDI name returns 1), but the clean arm **cannot go green**: with `node_modules/vue-material-design-icons` absent the helper returns `EXIT_TOOLING_MISSING` (5) and the runner reports SKIPPED (wiring), never PASS. A bundle needs that package's `*.vue` files present under the fixture. |
-| gate-62 | store-plane | no-fixture-yet | A planted `src/manifest.json` whose store/templates/catalogue naming or discovery breaks ADR-080 would trip it; the clean arm conforms. The runner omits `--base` on unscoped runs, so a fixture directory is enough. |
-| gate-63 | settings-surface | no-fixture-yet | A planted `src/manifest.json` placing a settings surface against ADR-079 would trip it; the clean arm conforms. Same helper and same unscoped behaviour as gate-62, so a fixture directory is enough. |
-| gate-64 | apphost-autoload-prelude | no-fixture-yet | A planted `lib/AppInfo/Application.php` whose `register()` resolves an `OCA\OpenRegister\AppHost\` class without first registering OpenRegister's PSR-4 prefix would trip it; the clean arm adds the autoload prelude. The clean arm should also carry a lazy service closure merely *mentioning* an AppHost class, which must not be flagged. |
+| gate-52 | custom-widget-ratchet | partial-elsewhere | `test_gate_45_to_55_acceptance.sh` plants a `kind:"widget"` component-registry entry with no `_note` and asserts *"gate-52 still catches a kind:\"widget\" entry with no `_note` → FAIL"*, plus a crashed-helper arm asserting `SKIPPED (wiring)` and *"gate-52 invents no finding count when the helper did not finish"*. The missing half is anti-widening: no arm asserts that a registry entry WITH a `_note` is silent, so a gate-52 widened to flag every widget would pass everything that exists today. A bundle would supply exactly that clean arm. The count-ratchet half of the gate additionally needs a base ref and stays out of scope for a fixture pair. |

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>apphostfx</id>
+	<name>AppHost Prelude Fixture</name>
+	<summary>Fixture app for gate-64 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an ADR-040 AppHost adoption without the autoload prelude through the real wrapper. The id sorts BEFORE openregister on purpose: that is the half of the fleet where the defect is live rather than latent.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>AppHostFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/clean/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/clean/lib/AppInfo/Application.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Application bootstrap.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\AppHostFx\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+/**
+ * The clean arm. The AppHost adoption is IDENTICAL to the planted arm's —
+ * same import, same call, same position inside register(). Only the ADR-040
+ * prelude is added above it, so this pair tests whether gate-64 reads the
+ * prelude and not merely whether it can spot an AppHost name.
+ */
+class Application extends App implements IBootstrap
+{
+
+    public const APP_ID = 'apphostfx';
+
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(self::APP_ID);
+
+    }//end __construct()
+
+
+    /**
+     * Registers the app.
+     *
+     * @param IRegistrationContext $context The registration context.
+     *
+     * @return void
+     */
+    public function register(IRegistrationContext $context): void
+    {
+        try {
+            $orPath = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppPath('openregister');
+            \OC_App::registerAutoloading('openregister', $orPath);
+        } catch (\Throwable) {
+            // OpenRegister absent or disabled — fall through to the degraded path.
+        }
+
+        Bootstrap::registerGenerics($context, self::APP_ID);
+
+        // THE ANTI-WIDENING NEAR-MISS. A lazy service closure that MENTIONS an
+        // AppHost class. Its body runs at resolution time, long after every app
+        // has registered, so the prefix is on the autoloader by then and this
+        // is correct code. A gate-64 that matched on the NAME rather than on
+        // what register() actually resolves would report it.
+        $context->registerService(
+            'apphostfx.reader',
+            function () {
+                return new \OCA\OpenRegister\AppHost\Reader();
+            }
+        );
+
+    }//end register()
+
+
+    /**
+     * Boots the app.
+     *
+     * @param IBootContext $context The boot context.
+     *
+     * @return void
+     */
+    public function boot(IBootContext $context): void
+    {
+
+    }//end boot()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/expect.conf
@@ -1,0 +1,31 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: apphost-prelude — gate-64 (apphost-autoload-prelude), ADR-040.
+#
+# The two arms' AppHost adoption is IDENTICAL: same `use OCA\OpenRegister\
+# AppHost\Bootstrap`, same `Bootstrap::registerGenerics()` call, same position
+# inside register(). The ONLY difference is the four-line autoload prelude
+# above it. A pair that differed by the adoption itself would be passed by a
+# gate that just greps for the AppHost namespace; this one is not.
+#
+# The app id sorts BEFORE `openregister` deliberately. That is the half of the
+# fleet where this defect is LIVE rather than latent, because getEnabledApps()
+# sort()s and Coordinator::registerApps() calls registerAutoloading() then
+# register() one app at a time — so an earlier-sorting app reaches register()
+# with the OCA\OpenRegister\ prefix not yet on the autoloader.
+#
+# clean/ carries the anti-widening near-miss in the same file: a lazy service
+# closure that MENTIONS an AppHost class. Its body runs at resolution time,
+# long after every app has registered, so it is correct code. A gate-64 that
+# matched on the NAME rather than on what register() resolves turns the CLEAN
+# arm red instead of leaving the planted one green.
+#
+# ⚠️ FOR WHOEVER TOUCHES THIS BUNDLE: the failure is silent by construction —
+# the unguarded form throws inside register(), Coordinator catches it, logs an
+# emergency and continues, and the app stays enabled while every listener
+# below the throw is simply never registered. Nothing in the UI says so. That
+# is why a planted arm is the only thing that can hold this gate honest.
+gate 64 hydra-gate-apphost-autoload-prelude.log FAIL PASS lib/AppInfo/Application.php

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>apphostfx</id>
+	<name>AppHost Prelude Fixture</name>
+	<summary>Fixture app for gate-64 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an ADR-040 AppHost adoption without the autoload prelude through the real wrapper. The id sorts BEFORE openregister on purpose: that is the half of the fleet where the defect is live rather than latent.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>AppHostFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/planted/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/apphost-prelude/planted/lib/AppInfo/Application.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Application bootstrap.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\AppHostFx\AppInfo;
+
+use OCA\OpenRegister\AppHost\Bootstrap;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+/**
+ * The gate-64 mechanism, and nothing else: an AppHost adoption resolved
+ * DURING register(), with no ADR-040 autoload prelude above it.
+ */
+class Application extends App implements IBootstrap
+{
+
+    public const APP_ID = 'apphostfx';
+
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(self::APP_ID);
+
+    }//end __construct()
+
+
+    /**
+     * Registers the app.
+     *
+     * @param IRegistrationContext $context The registration context.
+     *
+     * @return void
+     */
+    public function register(IRegistrationContext $context): void
+    {
+        Bootstrap::registerGenerics($context, self::APP_ID);
+
+    }//end register()
+
+
+    /**
+     * Boots the app.
+     *
+     * @param IBootContext $context The boot context.
+     *
+     * @return void
+     */
+    public function boot(IBootContext $context): void
+    {
+
+    }//end boot()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>dashfx</id>
+	<name>Dashboard And Detail Fixture</name>
+	<summary>Fixture app for gate-15 and gate-55 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive a nested dashboard and a shadowed detail-page render path through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>DashFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/components/MetricsPanel.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/components/MetricsPanel.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnIndexPage page-id="metrics" />
+</template>
+
+<script>
+export default {
+	name: 'MetricsPanel',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/manifest.json
@@ -1,0 +1,67 @@
+{
+    "name": "dashfx",
+    "menu": [
+        {
+            "id": "homeNav",
+            "label": "Home",
+            "icon": "HomeOutline",
+            "route": "home"
+        },
+        {
+            "id": "thingsNav",
+            "label": "Things",
+            "icon": "FormatListBulletedSquare",
+            "route": "thingDetail"
+        }
+    ],
+    "pages": [
+        {
+            "id": "home",
+            "type": "dashboard",
+            "component": "Home",
+            "config": {
+                "widgets": [
+                    { "id": "kpis", "type": "custom" },
+                    { "id": "recent", "type": "custom" },
+                    { "id": "metrics", "type": "custom", "component": "MetricsPanel" }
+                ]
+            }
+        },
+        {
+            "id": "metrics",
+            "type": "custom",
+            "component": "MetricsPanel"
+        },
+        {
+            "id": "overview",
+            "type": "dashboard",
+            "component": "Overview"
+        },
+        {
+            "id": "thingDetail",
+            "type": "detail",
+            "component": "ThingDetail",
+            "config": {
+                "widgets": [
+                    { "id": "meta", "type": "custom" }
+                ],
+                "layout": [
+                    { "widgetId": "meta", "x": 0, "y": 0, "w": 12, "h": 4 }
+                ]
+            }
+        },
+        {
+            "id": "caseDetail",
+            "type": "detail",
+            "component": "CaseDetail",
+            "config": {
+                "widgets": [
+                    { "id": "openCount", "type": "stats-block" }
+                ],
+                "layout": [
+                    { "widgetId": "openCount", "x": 0, "y": 0, "w": 12, "h": 3 }
+                ]
+            }
+        }
+    ]
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "dashfx",
+    "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+    "version": "1.0.0",
     "menu": [
         {
             "id": "homeNav",
@@ -17,6 +18,8 @@
     "pages": [
         {
             "id": "home",
+            "route": "/",
+            "title": "Home",
             "type": "dashboard",
             "component": "Home",
             "config": {
@@ -29,16 +32,23 @@
         },
         {
             "id": "metrics",
+            "route": "/metrics",
+            "title": "Metrics",
             "type": "custom",
-            "component": "MetricsPanel"
+            "component": "MetricsPanel",
+            "_note": "Custom because the metrics panel is embedded as a dashboard widget as well as being routable."
         },
         {
             "id": "overview",
+            "route": "/overview",
+            "title": "Overview",
             "type": "dashboard",
             "component": "Overview"
         },
         {
             "id": "thingDetail",
+            "route": "/things/:id",
+            "title": "Thing",
             "type": "detail",
             "component": "ThingDetail",
             "config": {
@@ -52,6 +62,8 @@
         },
         {
             "id": "caseDetail",
+            "route": "/cases/:id",
+            "title": "Case",
             "type": "detail",
             "component": "CaseDetail",
             "config": {

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/CaseDetail.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/CaseDetail.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDetailPage page-id="caseDetail" />
+</template>
+
+<script>
+export default {
+	name: 'CaseDetail',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/Home.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/Home.vue
@@ -1,0 +1,19 @@
+<template>
+	<CnDashboardPage page-id="home">
+		<template #widget-kpis>
+			<CnStatsBlock :items="kpis" />
+		</template>
+		<template #widget-recent>
+			<CnStatsBlock :items="recent" />
+		</template>
+	</CnDashboardPage>
+</template>
+
+<script>
+export default {
+	name: 'Home',
+	data() {
+		return { kpis: [], recent: [] }
+	},
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/Overview.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/Overview.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDashboardPage page-id="overview" />
+</template>
+
+<script>
+export default {
+	name: 'Overview',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/ThingDetail.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/clean/src/views/ThingDetail.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDetailPage page-id="thingDetail" />
+</template>
+
+<script>
+export default {
+	name: 'ThingDetail',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/expect.conf
@@ -1,0 +1,63 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: dashboard-and-detail — gate-15 (dashboard-antipattern) and gate-55
+# (detail-page-discipline). One manifest carries both, because both gates read
+# `src/manifest.json` and differ only in which page TYPE they judge.
+#
+# 🔑 WHY gate-15 HAD NO FIXTURE FOR A YEAR, AND WHY A CORPUS SWEEP CANNOT FIND
+# ONE
+# ---------------------------------------------------------------------------
+# gate-15 is inert unless the manifest declares a page with `type: "dashboard"`
+# AND that page declares `type: "custom"` widgets. openregister has 36 pages
+# and ZERO dashboards, so the gate can never fire there no matter how many
+# `.vue` files it ships — 207 of them, one of which genuinely renders
+# `<CnDashboardPage>`. Every VISIBLE ingredient is present and the gate is
+# still dead. That is the arming ingredient this bundle supplies and nothing
+# else in the corpus did.
+#
+# ⚠️ WHY THERE ARE TWO ROWS PER GATE — the driver grades a VERDICT plus ONE
+# named subject, so a one-row bundle stays green over any regression that
+# leaves one finding standing. Each row names a DIFFERENT mechanism.
+#
+# gate-15, two mechanisms, two different files:
+#   src/views/Home.vue          the SLOT shape — a `<template #widget-kpis>`
+#                               whose body renders `<CnDashboardPage>`. This
+#                               is pipelinq's three-nested-headings bug.
+#   src/components/MetricsPanel.vue
+#                               the PAGE shape — a `type:"custom"` page whose
+#                               component renders `<CnDashboardPage>` AND is
+#                               referenced as a custom widget on the dashboard
+#                               page. Different code path entirely
+#                               (check_custom_pages_as_widgets), and a repair
+#                               that dropped it would leave the slot rule
+#                               still failing the arm.
+#
+# gate-15's ANTI-WIDENING near-misses live in BOTH arms:
+#   * `#widget-recent` renders `CnStatsBlock` — a custom widget slot that is
+#     correct, so the gate cannot be passed by flagging every declared widget.
+#   * `src/views/Overview.vue` is a `type:"dashboard"` page that renders
+#     `<CnDashboardPage>` and is NOT referenced as a widget anywhere. That is
+#     what a dashboard is SUPPOSED to look like. A gate-15 widened to "any
+#     .vue containing CnDashboardPage" turns the CLEAN arm red.
+#
+# gate-55, two mechanisms, two different pages:
+#   thingDetail   page-level `widgets[]` AND `config.widgets` both present —
+#                 render-path shadowing (ADR-062 rule 1/5).
+#   caseDetail    `config.summaryAggregates` — the deprecated KPI-chip shape
+#                 that collided with the header on procest's CaseDetail
+#                 (rule 2).
+#   The clean arm keeps ONE render path on thingDetail and replaces
+#   caseDetail's chips with an in-grid stats-block, widget↔layout matched,
+#   which is the remedy the gate actually prescribes.
+#
+# ⚠️ FOR WHOEVER TOUCHES THIS BUNDLE: gate-55 is diff-scoped to the detail
+# pages a change TOUCHES when HYDRA_GATE_BASE_REF is set. The acceptance
+# driver runs unscoped, so every detail page is judged here. Giving the driver
+# a base ref would empty this arm without changing a single expectation.
+gate 15 hydra-gate-dashboard-antipattern.log FAIL PASS widget=kpis rule=dashboard-in-dashboard-slot
+gate 15 hydra-gate-dashboard-antipattern.log FAIL PASS page=metrics component=MetricsPanel rule=dashboard-component-used-as-widget
+gate 55 hydra-gate-detail-page-discipline.log FAIL PASS page 'thingDetail' — page-level widgets[] AND config.widgets both
+gate 55 hydra-gate-detail-page-discipline.log FAIL PASS page 'caseDetail' — config.summaryAggregates is deprecated

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>dashfx</id>
+	<name>Dashboard And Detail Fixture</name>
+	<summary>Fixture app for gate-15 and gate-55 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive a nested dashboard and a shadowed detail-page render path through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>DashFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/components/MetricsPanel.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/components/MetricsPanel.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDashboardPage page-id="metrics" />
+</template>
+
+<script>
+export default {
+	name: 'MetricsPanel',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/manifest.json
@@ -1,0 +1,67 @@
+{
+    "name": "dashfx",
+    "menu": [
+        {
+            "id": "homeNav",
+            "label": "Home",
+            "icon": "HomeOutline",
+            "route": "home"
+        },
+        {
+            "id": "thingsNav",
+            "label": "Things",
+            "icon": "FormatListBulletedSquare",
+            "route": "thingDetail"
+        }
+    ],
+    "pages": [
+        {
+            "id": "home",
+            "type": "dashboard",
+            "component": "Home",
+            "config": {
+                "widgets": [
+                    { "id": "kpis", "type": "custom" },
+                    { "id": "recent", "type": "custom" },
+                    { "id": "metrics", "type": "custom", "component": "MetricsPanel" }
+                ]
+            }
+        },
+        {
+            "id": "metrics",
+            "type": "custom",
+            "component": "MetricsPanel"
+        },
+        {
+            "id": "overview",
+            "type": "dashboard",
+            "component": "Overview"
+        },
+        {
+            "id": "thingDetail",
+            "type": "detail",
+            "component": "ThingDetail",
+            "widgets": [
+                { "id": "meta", "type": "custom" }
+            ],
+            "config": {
+                "widgets": [
+                    { "id": "meta", "type": "custom" }
+                ],
+                "layout": [
+                    { "widgetId": "meta", "x": 0, "y": 0, "w": 12, "h": 4 }
+                ]
+            }
+        },
+        {
+            "id": "caseDetail",
+            "type": "detail",
+            "component": "CaseDetail",
+            "config": {
+                "summaryAggregates": [
+                    { "label": "Open", "value": "count" }
+                ]
+            }
+        }
+    ]
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "dashfx",
+    "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+    "version": "1.0.0",
     "menu": [
         {
             "id": "homeNav",
@@ -17,6 +18,8 @@
     "pages": [
         {
             "id": "home",
+            "route": "/",
+            "title": "Home",
             "type": "dashboard",
             "component": "Home",
             "config": {
@@ -29,20 +32,35 @@
         },
         {
             "id": "metrics",
+            "route": "/metrics",
+            "title": "Metrics",
             "type": "custom",
-            "component": "MetricsPanel"
+            "component": "MetricsPanel",
+            "_note": "Custom because the metrics panel is embedded as a dashboard widget as well as being routable."
         },
         {
             "id": "overview",
+            "route": "/overview",
+            "title": "Overview",
             "type": "dashboard",
             "component": "Overview"
         },
         {
             "id": "thingDetail",
+            "route": "/things/:id",
+            "title": "Thing",
             "type": "detail",
             "component": "ThingDetail",
             "widgets": [
-                { "id": "meta", "type": "custom" }
+                {
+                    "id": "meta",
+                    "widgetKey": "object-meta",
+                    "slot": "body",
+                    "gridX": 0,
+                    "gridY": 0,
+                    "gridWidth": 12,
+                    "gridHeight": 4
+                }
             ],
             "config": {
                 "widgets": [
@@ -55,6 +73,8 @@
         },
         {
             "id": "caseDetail",
+            "route": "/cases/:id",
+            "title": "Case",
             "type": "detail",
             "component": "CaseDetail",
             "config": {

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/CaseDetail.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/CaseDetail.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDetailPage page-id="caseDetail" />
+</template>
+
+<script>
+export default {
+	name: 'CaseDetail',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/Home.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/Home.vue
@@ -1,0 +1,19 @@
+<template>
+	<CnDashboardPage page-id="home">
+		<template #widget-kpis>
+			<CnDashboardPage page-id="kpis-inner" />
+		</template>
+		<template #widget-recent>
+			<CnStatsBlock :items="recent" />
+		</template>
+	</CnDashboardPage>
+</template>
+
+<script>
+export default {
+	name: 'Home',
+	data() {
+		return { recent: [] }
+	},
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/Overview.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/Overview.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDashboardPage page-id="overview" />
+</template>
+
+<script>
+export default {
+	name: 'Overview',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/ThingDetail.vue
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/dashboard-and-detail/planted/src/views/ThingDetail.vue
@@ -1,0 +1,9 @@
+<template>
+	<CnDetailPage page-id="thingDetail" />
+</template>
+
+<script>
+export default {
+	name: 'ThingDetail',
+}
+</script>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>planefx</id>
+	<name>Manifest Planes Fixture</name>
+	<summary>Fixture app for gate-62 and gate-63 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an ADR-080 store-plane naming violation and an ADR-079 settings-surface violation through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>PlaneFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/src/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "planefx",
+    "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+    "version": "1.0.0",
     "menu": [
         {
             "id": "storeNav",
@@ -30,33 +31,36 @@
     "pages": [
         {
             "id": "storePage",
+            "route": "/store",
+            "title": "Store",
             "type": "index",
-            "component": "StorePage",
             "config": {
                 "storeRegistry": true
             }
         },
         {
             "id": "catalogPage",
+            "route": "/catalog",
+            "title": "Catalog",
             "type": "index",
-            "component": "CatalogPage",
             "config": {
                 "schema": "publication"
             }
         },
         {
             "id": "templatePage",
+            "route": "/templates",
+            "title": "Templates",
             "type": "index",
-            "component": "TemplatePage",
             "config": {
                 "schema": "template"
             }
         },
         {
             "id": "appearance",
-            "type": "settings",
+            "route": "/appearance",
             "title": "Appearance",
-            "component": "SettingsPage"
+            "type": "settings"
         }
     ]
 }

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/clean/src/manifest.json
@@ -1,0 +1,62 @@
+{
+    "name": "planefx",
+    "menu": [
+        {
+            "id": "storeNav",
+            "label": "Store",
+            "icon": "StoreOutline",
+            "route": "storePage"
+        },
+        {
+            "id": "catalogNav",
+            "label": "Catalog",
+            "icon": "Bookshelf",
+            "route": "catalogPage"
+        },
+        {
+            "id": "templatesNav",
+            "label": "Templates",
+            "icon": "FileReplaceOutline",
+            "route": "templatePage"
+        },
+        {
+            "id": "settingsNav",
+            "label": "Appearance",
+            "section": "settings",
+            "icon": "CogOutline",
+            "route": "appearance"
+        }
+    ],
+    "pages": [
+        {
+            "id": "storePage",
+            "type": "index",
+            "component": "StorePage",
+            "config": {
+                "storeRegistry": true
+            }
+        },
+        {
+            "id": "catalogPage",
+            "type": "index",
+            "component": "CatalogPage",
+            "config": {
+                "schema": "publication"
+            }
+        },
+        {
+            "id": "templatePage",
+            "type": "index",
+            "component": "TemplatePage",
+            "config": {
+                "schema": "template"
+            }
+        },
+        {
+            "id": "appearance",
+            "type": "settings",
+            "title": "Appearance",
+            "component": "SettingsPage"
+        }
+    ]
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/expect.conf
@@ -1,0 +1,51 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: manifest-planes — gate-62 (store-plane, ADR-080) and gate-63
+# (settings-surface, ADR-079). One manifest carries both: they are two --gate
+# modes of the SAME helper, so a fixture that armed only one of them would
+# leave half of check_store_and_settings_surface.py unexercised.
+#
+# ⚠️ WHY MULTIPLE ROWS PER GATE — the driver grades a VERDICT plus ONE named
+# subject, and both of these gates report through a single `_count '^FAIL'`.
+# A one-row bundle is therefore satisfied by a helper that lost every rule but
+# one. Each row below names a rule that lives in its own branch.
+#
+# gate-62, three branches:
+#   'Store' + wrong glyph        the STORE_LABELS branch's Tier A icon rule.
+#   'Store' + ViewGridOutline    the one-glyph-two-meanings rule (ADR-077
+#                                rule 5) — a SEPARATE test on the same entry,
+#                                so dropping it leaves the first still firing.
+#   'Catalog' + catalog_item     the CATALOGUE_LABELS branch: a catalogue over
+#                                an installable schema is a mislabelled store.
+#
+# gate-63, three branches:
+#   adminSettings[]              the manifest-level D2 rule.
+#   page 'settings'              the reserved-name rule on a type:settings
+#                                page (D1).
+#   settings-foldout 'Settings'  the D4 rule on a menu entry in the gear
+#                                foldout — reached through _walk_menu, which
+#                                for gate 63 deliberately does NOT skip
+#                                captions. A repair that aligned gate 63's
+#                                walk to gate 62's would drop this one alone.
+#
+# THE CLEAN ARM IS THE INTERESTING ONE. It keeps ALL THREE concept labels —
+# Store, Catalog and Templates — spelled correctly, plus a settings-foldout
+# entry and a type:settings page under non-reserved names. So a gate widened
+# until it flags any mention of a store, a catalogue or a settings page turns
+# this arm red rather than leaving the planted one green. That matters here
+# more than usual: gate-62 and gate-60 disagreed about the caption node for
+# months, and the way that was noticed was a fixture carrying a legitimate
+# entry, not a violating one.
+#
+# Both arms deliberately ship NO lib/Settings/*.php, so gate-63's "no
+# platform-authorized home" WARN is present in both. WARN lines never reach
+# the verdict (`_count '^FAIL'`), and having one on both sides pins that.
+gate 62 hydra-gate-store-plane.log FAIL PASS menu entry 'Store' names the STORE concept but renders 'ViewGridOutline'
+gate 62 hydra-gate-store-plane.log FAIL PASS one glyph, two meanings
+gate 62 hydra-gate-store-plane.log FAIL PASS menu entry 'Catalog' backs schema 'catalog_item'
+gate 63 hydra-gate-settings-surface.log FAIL PASS manifest declares adminSettings[]
+gate 63 hydra-gate-settings-surface.log FAIL PASS page 'settings' is a type:settings page claiming the platform meaning
+gate 63 hydra-gate-settings-surface.log FAIL PASS settings-foldout entry is labelled 'Settings'

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>planefx</id>
+	<name>Manifest Planes Fixture</name>
+	<summary>Fixture app for gate-62 and gate-63 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an ADR-080 store-plane naming violation and an ADR-079 settings-surface violation through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>PlaneFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/src/manifest.json
@@ -1,0 +1,68 @@
+{
+    "name": "planefx",
+    "adminSettings": [
+        {
+            "id": "connection",
+            "label": "Connection"
+        }
+    ],
+    "menu": [
+        {
+            "id": "storeNav",
+            "label": "Store",
+            "icon": "ViewGridOutline",
+            "route": "storePage"
+        },
+        {
+            "id": "catalogNav",
+            "label": "Catalog",
+            "icon": "Bookshelf",
+            "route": "catalogPage"
+        },
+        {
+            "id": "templatesNav",
+            "label": "Templates",
+            "icon": "FileReplaceOutline",
+            "route": "templatePage"
+        },
+        {
+            "id": "settingsNav",
+            "label": "Settings",
+            "section": "settings",
+            "icon": "CogOutline",
+            "route": "settings"
+        }
+    ],
+    "pages": [
+        {
+            "id": "storePage",
+            "type": "index",
+            "component": "StorePage",
+            "config": {
+                "storeRegistry": true
+            }
+        },
+        {
+            "id": "catalogPage",
+            "type": "index",
+            "component": "CatalogPage",
+            "config": {
+                "schema": "catalog_item"
+            }
+        },
+        {
+            "id": "templatePage",
+            "type": "index",
+            "component": "TemplatePage",
+            "config": {
+                "schema": "template"
+            }
+        },
+        {
+            "id": "settings",
+            "type": "settings",
+            "title": "Settings",
+            "component": "SettingsPage"
+        }
+    ]
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/manifest-planes/planted/src/manifest.json
@@ -1,9 +1,11 @@
 {
-    "name": "planefx",
+    "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+    "version": "1.0.0",
     "adminSettings": [
         {
             "id": "connection",
-            "label": "Connection"
+            "label": "Connection",
+            "type": "organisation-credentials"
         }
     ],
     "menu": [
@@ -36,33 +38,36 @@
     "pages": [
         {
             "id": "storePage",
+            "route": "/store",
+            "title": "Store",
             "type": "index",
-            "component": "StorePage",
             "config": {
                 "storeRegistry": true
             }
         },
         {
             "id": "catalogPage",
+            "route": "/catalog",
+            "title": "Catalog",
             "type": "index",
-            "component": "CatalogPage",
             "config": {
                 "schema": "catalog_item"
             }
         },
         {
             "id": "templatePage",
+            "route": "/templates",
+            "title": "Templates",
             "type": "index",
-            "component": "TemplatePage",
             "config": {
                 "schema": "template"
             }
         },
         {
             "id": "settings",
-            "type": "settings",
+            "route": "/settings",
             "title": "Settings",
-            "component": "SettingsPage"
+            "type": "settings"
         }
     ]
 }

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>registerfx</id>
+	<name>Register Dialect Fixture</name>
+	<summary>Fixture app for gate-18 and gate-51 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an obsolete notification dialect and an undocumented schema property through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>RegisterFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/clean/lib/Settings/register.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/clean/lib/Settings/register.json
@@ -1,0 +1,71 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Register Dialect Fixture",
+        "version": "1.0.0"
+    },
+    "components": {
+        "schemas": {
+            "Thing": {
+                "title": "Thing",
+                "type": "object",
+                "x-openregister-notifications": {
+                    "onIntakeClosed": {
+                        "trigger": {
+                            "type": "lifecycle",
+                            "state": "closed"
+                        },
+                        "channels": ["mail"],
+                        "recipients": ["owner"],
+                        "subject": {
+                            "en": "Intake closed"
+                        }
+                    },
+                    "onScoreChanged": {
+                        "trigger": {
+                            "type": "propertyChange",
+                            "property": "score"
+                        },
+                        "channels": ["mail"],
+                        "recipients": ["owner"],
+                        "subject": {
+                            "en": "Score changed"
+                        }
+                    }
+                },
+                "x-openregister-aggregations": {
+                    "openIntakes": {
+                        "filter": {
+                            "@self.register": "things",
+                            "status": "open"
+                        },
+                        "operation": "count"
+                    }
+                },
+                "properties": {
+                    "governanceBody": {
+                        "type": "string",
+                        "title": "Governance body",
+                        "description": "The body that governs this thing."
+                    },
+                    "closedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Closed at",
+                        "description": "The moment this thing was closed."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "title": "Channel",
+                        "description": "The delivery channel this thing was received on."
+                    },
+                    "label": {
+                        "type": "string",
+                        "title": "Label",
+                        "description": "The human-readable name of this thing."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/expect.conf
@@ -1,0 +1,52 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: register-dialect — gate-18 (notification-dialect, check (a), the
+# BLOCKING half) and gate-51 (schema-property-titles). One register file
+# carries both, because both gates read exactly `lib/Settings/*register*.json`
+# and a second fixture app would only duplicate the scaffolding.
+#
+# ⚠️ WHY THERE ARE TWO ROWS PER GATE — the driver grades a VERDICT plus ONE
+# NAMED SUBJECT, so a bundle with a single row is blind to any regression that
+# leaves one finding standing. Each row below names a DIFFERENT mechanism,
+# living in a different rule or a different property, so losing that mechanism
+# drops its line out of the log and the subject assertion fires.
+#
+# gate-18, two mechanisms in two separate rules:
+#   onIntakeClosed   ONLY the legacy `lifecycleEnter` trigger key — a
+#                    SUBSTRING token, matched against the serialised rule.
+#   onScoreChanged   ONLY the rule-level singular `channel` — a KEY-SHAPE
+#                    token, matched structurally and suppressed when the
+#                    canonical plural `channels` is present alongside it.
+#   Those are two different code paths in check_notification_dialect.py
+#   (_SUBSTRING_TOKENS vs the explicit singular-key test). Dropping either one
+#   leaves the other still failing the arm, which is exactly the false green a
+#   one-row bundle would hand out.
+#
+# gate-18's ANTI-WIDENING near-misses are in BOTH arms, and they are the whole
+# reason this gate parses JSON instead of grepping the file:
+#   * `@self.register` inside x-openregister-aggregations — legitimate, and a
+#     whole-file grep reported it on decidesk and scholiq.
+#   * a schema PROPERTY literally named `channel` — legitimate, and the same
+#     grep reported it too.
+#   A gate-18 that regressed to a whole-file grep turns the CLEAN arm red.
+#
+# gate-51, two mechanisms in two separate properties:
+#   governanceBody   missing BOTH title and description.
+#   closedAt         carries a title and is missing ONLY the description —
+#                    the half that a checker "fixed" by accepting any one of
+#                    the two would stop reporting. It is also the property
+#                    shape the gate exists for: the nc-vue form renderer uses
+#                    `prop.title || key`, so a title alone renders, and only
+#                    the description is invisible until someone needs it.
+#
+# ⚠️ FOR WHOEVER TOUCHES THIS BUNDLE: gate-51 is diff-scoped at the PROPERTY
+# level when HYDRA_GATE_BASE_REF is set. The acceptance driver runs unscoped,
+# so every property is ratcheted here. Adding a base ref to the driver would
+# silently empty this arm.
+gate 18 hydra-gate-notification-dialect.log FAIL PASS rule=onIntakeClosed token=lifecycleEnter
+gate 18 hydra-gate-notification-dialect.log FAIL PASS rule=onScoreChanged token=channel
+gate 51 hydra-gate-schema-property-titles.log FAIL PASS Thing.governanceBody — missing title + description
+gate 51 hydra-gate-schema-property-titles.log FAIL PASS Thing.closedAt — missing description

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>registerfx</id>
+	<name>Register Dialect Fixture</name>
+	<summary>Fixture app for gate-18 and gate-51 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive an obsolete notification dialect and an undocumented schema property through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>RegisterFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/planted/lib/Settings/register.json
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/register-dialect/planted/lib/Settings/register.json
@@ -1,0 +1,67 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Register Dialect Fixture",
+        "version": "1.0.0"
+    },
+    "components": {
+        "schemas": {
+            "Thing": {
+                "title": "Thing",
+                "type": "object",
+                "x-openregister-notifications": {
+                    "onIntakeClosed": {
+                        "trigger": {
+                            "lifecycleEnter": "closed"
+                        },
+                        "channels": ["mail"],
+                        "recipients": ["owner"],
+                        "subject": {
+                            "en": "Intake closed"
+                        }
+                    },
+                    "onScoreChanged": {
+                        "trigger": {
+                            "type": "propertyChange",
+                            "property": "score"
+                        },
+                        "channel": "mail",
+                        "recipients": ["owner"],
+                        "subject": {
+                            "en": "Score changed"
+                        }
+                    }
+                },
+                "x-openregister-aggregations": {
+                    "openIntakes": {
+                        "filter": {
+                            "@self.register": "things",
+                            "status": "open"
+                        },
+                        "operation": "count"
+                    }
+                },
+                "properties": {
+                    "governanceBody": {
+                        "type": "string"
+                    },
+                    "closedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Closed at"
+                    },
+                    "channel": {
+                        "type": "string",
+                        "title": "Channel",
+                        "description": "The delivery channel this thing was received on."
+                    },
+                    "label": {
+                        "type": "string",
+                        "title": "Label",
+                        "description": "The human-readable name of this thing."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>semauthzfx</id>
+	<name>Semantic Authz Fixture</name>
+	<summary>Fixture app for gate-6 and gate-9 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive a planted authorisation defect through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>SemAuthzFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Controller/PanelController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Controller/PanelController.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Panel controller.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Controller;
+
+use OCA\SemAuthzFx\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+
+/**
+ * The clean arm of the gate-9 pair, plus the near-miss.
+ */
+class PanelController extends Controller
+{
+
+    /**
+     * Reads the admin panel state.
+     *
+     * The body is byte-identical to the planted arm's. Only the attribute
+     * moved, which is what makes this pair a test of the SEMANTIC match
+     * rather than of whether the gate can find requireAdmin().
+     *
+     * @return JSONResponse
+     *
+     * @throws \Throwable
+     */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function adminPanelState(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse(['state' => 'ok']);
+
+    }//end adminPanelState()
+
+
+    /**
+     * A genuinely public endpoint that authenticates its caller from the
+     * REQUEST rather than from the session, and denies when it cannot.
+     *
+     * This is the anti-widening near-miss. It is #[PublicPage] and it
+     * returns 401, which is the shape gate-9's unsourced-denial rule reports
+     * — but the credential is resolved here, in code, so the rule must stay
+     * silent. A gate-9 that stopped reading the credential surface, or that
+     * went back to earning the exemption from a docblock, turns THIS arm red.
+     *
+     * @return JSONResponse
+     *
+     * @throws \Throwable
+     */
+    #[PublicPage]
+    public function ingest(): JSONResponse
+    {
+        $presentedToken = $this->request->getHeader('Authorization');
+        if ($presentedToken === '') {
+            return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+        }
+
+        return new JSONResponse(['accepted' => true]);
+
+    }//end ingest()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Service/TransitionCoordinator.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Service/TransitionCoordinator.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Transition coordinator.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Service;
+
+/**
+ * The caller seam. In the planted arm moveTo() does the state change WITHOUT
+ * consulting the guard; here the same method consults it. Nothing else about
+ * the two arms differs, so this pair tests whether gate-6 reads CALLERS and
+ * not merely whether it can see a guard-shaped method.
+ */
+class TransitionCoordinator
+{
+
+    /**
+     * @var TransitionService
+     */
+    private TransitionService $transitions;
+
+
+    /**
+     * Constructor.
+     *
+     * @param TransitionService $transitions The guard holder.
+     */
+    public function __construct(TransitionService $transitions)
+    {
+        $this->transitions = $transitions;
+
+    }//end __construct()
+
+
+    /**
+     * Moves a record into a state.
+     *
+     * @param string $userId The acting user.
+     * @param string $state  The target state.
+     *
+     * @return boolean
+     */
+    public function moveTo(string $userId, string $state): bool
+    {
+        if ($this->transitions->isTransitionAllowed($userId, $state) === false) {
+            return false;
+        }
+
+        return ($state !== '');
+
+    }//end moveTo()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Service/TransitionService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/clean/lib/Service/TransitionService.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Transition service.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Service;
+
+/**
+ * Holds one access-control predicate and one reference-data predicate.
+ *
+ * The two differ ONLY in whether they carry an authorisation-domain signal:
+ * isTransitionAllowed takes a subject parameter and its name carries the
+ * `Allowed` token; isValidCode takes a bare string and carries neither.
+ * Both are uncalled, in both arms.
+ */
+class TransitionService
+{
+
+
+    /**
+     * Decides whether a user may move a record into a state.
+     *
+     * @param string $userId The acting user.
+     * @param string $state  The target state.
+     *
+     * @return boolean
+     */
+    public function isTransitionAllowed(string $userId, string $state): bool
+    {
+        return ($userId !== '' && $state !== '');
+
+    }//end isTransitionAllowed()
+
+
+    /**
+     * Reference-data lookup. Not an access control.
+     *
+     * @param string $code The code to look up.
+     *
+     * @return boolean
+     */
+    public function isValidCode(string $code): bool
+    {
+        return (strlen($code) === 4);
+
+    }//end isValidCode()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/expect.conf
@@ -1,0 +1,55 @@
+# expect.conf — read by scripts/lib/test_gate_acceptance_matrix.sh
+#
+# Columns:
+#   gate <n> <log-basename|-> <planted-verdict> <clean-verdict> <subject-substring>
+#
+# Bundle: semantic-authz — gate-9 (semantic-auth) and gate-6 (orphan-auth).
+# Both are SECURITY gates and neither had a planted/clean pair anywhere in
+# this package before 2026-08-12: gate-9 appeared only in the crashed-checker
+# and empty-scope suites, which assert SKIPPED and NOT APPLICABLE and can both
+# be satisfied by a gate that never fires at all.
+#
+# WHAT EACH ARM PINS
+# ------------------
+# gate-9  The two arms' adminPanelState() bodies are BYTE-IDENTICAL — both
+#         call $this->requireAdmin(). The only difference is the attribute
+#         above them. So this pair cannot be passed by a gate that merely
+#         greps for requireAdmin(); it has to bind the attribute to the
+#         method it sits on. That binding is the gate.
+#
+#         clean/ additionally carries ingest(): #[PublicPage], returns 401,
+#         and resolves its credential from the REQUEST. That is the shape
+#         gate-9's unsourced-denial rule reports, and it must stay silent
+#         because the credential is resolved in CODE. A gate-9 that went back
+#         to earning that exemption from a docblock, or that stopped reading
+#         the credential surface at all, turns the CLEAN arm red rather than
+#         leaving the planted one green.
+#
+# gate-6  TransitionService holds two uncalled predicates in BOTH arms:
+#         isTransitionAllowed (subject parameter + `Allowed` name token =
+#         authorisation domain) and isValidCode (neither = reference data).
+#         Only the caller in TransitionCoordinator::moveTo() moves between
+#         arms. So:
+#           * a gate-6 that stopped reading callers leaves clean/ red;
+#           * a gate-6 widened back to the bare verb-prefix filter reports
+#             TWO in planted/ and the count assertion below fires;
+#           * a gate-6 narrowed until it sees nothing leaves planted/ green.
+#
+# ⚠️ WHY gate-6's ROW GRADES A COUNT AND NOT A FILE NAME
+# -----------------------------------------------------
+# gate-6 is the ONE gate in the runner whose findings log is a mktemp path
+# (`hydra-gate-orphan-auth.XXXXXX.log`, chosen deliberately for hydra#110 so
+# parallel app runs cannot clobber each other's counts). The acceptance
+# driver resolves <log-basename> as a LITERAL filename under the run's log
+# directory, so there is no name it can be given. The `-` form grades the
+# runner's stdout instead, and the only subject stdout carries for this gate
+# is the count.
+#
+# That is weaker than a named subject and it is recorded here rather than
+# hidden: with a single planted true positive and a near-miss sitting beside
+# it in the same file, "exactly 1" is two-directional (widening reads 2,
+# narrowing reads 0) — but it would NOT notice a gate that swapped which of
+# the two methods it reported. Fixing that needs either a stable log name for
+# gate-6 or a glob in the driver, and both are outside this bundle.
+gate 9 hydra-gate-semantic-auth.log FAIL PASS method=adminPanelState
+gate 6 - FAIL PASS FAIL — 1 orphan method(s)

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>semauthzfx</id>
+	<name>Semantic Authz Fixture</name>
+	<summary>Fixture app for gate-6 and gate-9 acceptance. Not a real app.</summary>
+	<description>Exists so the gate suite can drive a planted authorisation defect through the real wrapper.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>SemAuthzFx</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Controller/PanelController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Controller/PanelController.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Panel controller.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * The gate-9 mechanism, and nothing else.
+ */
+class PanelController extends Controller
+{
+
+    /**
+     * Reads the admin panel state.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse
+     *
+     * @throws \Throwable
+     */
+    public function adminPanelState(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse(['state' => 'ok']);
+
+    }//end adminPanelState()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Service/TransitionCoordinator.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Service/TransitionCoordinator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Transition coordinator.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Service;
+
+/**
+ * The caller seam. In the planted arm it does the state change WITHOUT
+ * consulting the guard; in the clean arm the same method consults it.
+ * Nothing else about the two arms differs.
+ */
+class TransitionCoordinator
+{
+
+    /**
+     * @var TransitionService
+     */
+    private TransitionService $transitions;
+
+
+    /**
+     * Constructor.
+     *
+     * @param TransitionService $transitions The guard holder.
+     */
+    public function __construct(TransitionService $transitions)
+    {
+        $this->transitions = $transitions;
+
+    }//end __construct()
+
+
+    /**
+     * Moves a record into a state.
+     *
+     * @param string $userId The acting user.
+     * @param string $state  The target state.
+     *
+     * @return boolean
+     */
+    public function moveTo(string $userId, string $state): bool
+    {
+        return ($state !== '');
+
+    }//end moveTo()
+
+
+}//end class

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Service/TransitionService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/semantic-authz/planted/lib/Service/TransitionService.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Transition service.
+ *
+ * @license  EUPL-1.2
+ * @copyright 2026 Conduction B.V.
+ */
+
+namespace OCA\SemAuthzFx\Service;
+
+/**
+ * Holds one access-control predicate and one reference-data predicate.
+ *
+ * The two differ ONLY in whether they carry an authorisation-domain signal:
+ * isTransitionAllowed takes a subject parameter and its name carries the
+ * `Allowed` token; isValidCode takes a bare string and carries neither.
+ * Both are uncalled, in both arms.
+ */
+class TransitionService
+{
+
+
+    /**
+     * Decides whether a user may move a record into a state.
+     *
+     * @param string $userId The acting user.
+     * @param string $state  The target state.
+     *
+     * @return boolean
+     */
+    public function isTransitionAllowed(string $userId, string $state): bool
+    {
+        return ($userId !== '' && $state !== '');
+
+    }//end isTransitionAllowed()
+
+
+    /**
+     * Reference-data lookup. Not an access control.
+     *
+     * @param string $code The code to look up.
+     *
+     * @return boolean
+     */
+    public function isValidCode(string $code): bool
+    {
+        return (strlen($code) === 4);
+
+    }//end isValidCode()
+
+
+}//end class


### PR DESCRIPTION
## What this closes

The acceptance corpus protected 22 of 65 gates by the ratchet's own arithmetic.
The other 43 sat in `UNCOVERED.md`, and **thirty-six of those rows were wrong** —
nine because nothing blocked authoring a bundle, twenty-seven because a planted
defect was **already** being driven through the real wrapper by a suite under
`scripts/lib/`, which neither registry knew about.

After this PR the ratchet reports **58 of 65**, and the seven that remain each
name a specific thing a fixture directory cannot supply.

## 1. Five new bundles — nine gates, security and data first

| bundle | gates | what the planted arm is |
|---|---|---|
| `semantic-authz/` | **9** semantic-auth, **6** orphan-auth | `#[NoAdminRequired]` over a `requireAdmin()` body; an uncalled `isTransitionAllowed(string $userId, …)` |
| `apphost-prelude/` | **64** apphost-autoload-prelude | an `OCA\OpenRegister\AppHost\Bootstrap` reference in `register()` with no ADR-040 prelude |
| `register-dialect/` | **18** notification-dialect, **51** schema-property-titles | a `lifecycleEnter` trigger and a rule-level singular `channel`; a property with no `title`, and one with a title and no `description` |
| `dashboard-and-detail/` | **15** dashboard-antipattern, **55** detail-page-discipline | `<CnDashboardPage>` inside a `#widget-kpis` slot, and a `type:"custom"` page used as a widget; page-level `widgets[]` shadowing `config.widgets`, and a deprecated `summaryAggregates` |
| `manifest-planes/` | **62** store-plane, **63** settings-surface | a `Store` entry rendering `ViewGridOutline` and a `Catalog` over `catalog_item`; `adminSettings[]`, a reserved-name settings page, and a `Settings > Settings` foldout |

Thirteen `expect.conf` rows across nine gates. **Every gate that could carry two
mechanisms carries two rows, each naming a subject in a different file, rule or
page** — because the driver grades a verdict plus ONE named subject, so a
one-row bundle stays green over any regression that leaves one finding standing.
That is the `method=preamble` / `method=preambleForbiddenCode` lesson applied
before it could bite.

Both arms of every bundle were run through `scripts/run-hydra-gates.sh` by
`test_gate_acceptance_matrix.sh`: **102 assertions, 0 failures on the fixture
arms.**

## 2. Every bundle is revert-proven, one mechanism at a time

Each row was proven by BREAKING THE GATE and watching the named subject leave
the log. A prediction was written before each run; all nine matched.

| gate | mutation | predicted | measured |
|---|---|---|---|
| 15 | disable the slot rule | `widget=kpis` gone, `page=metrics` survives | exactly that, `# count=1` |
| 55 | disable rule (a) | `thingDetail` gone, `caseDetail` survives | exactly that |
| 18 | disable the singular-`channel` test | `token=channel` gone, `token=lifecycleEnter` survives | exactly that |
| 51 | accept a property that carries a title | `closedAt` gone, `governanceBody` survives | exactly that |
| 62 | disable the Tier A icon rule | row 1 gone, `one glyph, two meanings` + `Catalog` survive | exactly that, 3 → 2 |
| 63 | disable the `adminSettings[]` rule | row 1 gone, other two survive | exactly that, 3 → 2 |
| 64 | disable `BOOTSTRAP_REF` | no finding at all | `apphost-autoload-prelude: OK` |
| 9 | disable the admin-body test | `method=adminPanelState` gone | no output |
| 6 | **widen**: drop the auth-signal requirement | 1 → 2 findings, so `FAIL — 1 orphan method(s)` no longer matches | `isValidCode` joined it |

The gate-6 arm is the anti-widening direction on purpose: its near-miss lives in
the same file as its true positive, so the row is two-directional even though it
grades a count (see below).

## 3. The reconciliation — the deliverable, not a side effect

`UNCOVERED.md` loses thirty-six rows. Nine to the new bundles; twenty-seven to
`COVERED-ELSEWHERE.md`, each row naming the suite **and quoting the assertion
that proves the claim**, every quote observed in a run of that suite today —
`test_gate_1_11_honest_verdicts.sh` (1, 3, 5, 8, 10, 11),
`test_gate_a11y_markup_scope.sh` (34, 37, 39, 40, 42, 43, 44, 45),
`test_gate_5661_empty_scope_is_not_a_pass.sh` (56–60),
`test_gate_13_multiline_dialog.sh` (13), `test_gate_route_auth.sh` +
`test_gate_fq_route_names.sh` (5, 14), `test_gate_or_objectservice_surface.sh` +
`test_gate_20_comment_masking.sh` (17, 20), `test_gate_46_tests_scope.sh` (46),
`test_gate_monitoring_and_skiplink.sh` (38), `test_gate_45_to_55_acceptance.sh`
(50, 53).

**Three gates were deliberately NOT moved.** 12, 41 and 52 have a planted arm
but no anti-widening arm anywhere, so `COVERED-ELSEWHERE`'s "planted **and**
clean" claim would be an overclaim. They get a new `partial-elsewhere` category
that names the suite, the assertion that exists, and the missing half.

**gate-22's reason had rotted and is corrected.** It said "no `node_modules`
ships anywhere in this package, so the clean arm cannot go green".
`.github/workflows/hydra-gates-package.yml` installs ajv before the helper-suite
step, and a schema-valid manifest was measured clean today. What actually blocks
a bundle is that the acceptance driver has no ajv preflight, so a wiring fault
would be reported as a gate defect — the exact false pass
`test_gate_45_to_55_acceptance.sh` grew its own preflight to prevent. A reason
naming a state of the world rots; a reason naming a test artefact does not.

## 4. Two things found while doing this

**gate-6 is the only gate in the runner whose findings log is a mktemp path.**
`hydra-gate-orphan-auth.XXXXXX.log`, chosen for hydra#110 so parallel app runs
cannot clobber counts. The acceptance driver resolves `<log-basename>` as a
literal filename, so **gate-6 cannot be graded by subject at all** — its row
uses the `-` (stdout) form and grades the count. That is weaker and it is
written into the bundle rather than hidden: it would not notice a gate that
swapped which of the two methods it reported. Fixing it needs a stable log name
or a glob in the driver, both outside this PR.

**All four new manifests were invalid against the v2 schema on first write**, and
would have put gate-22 into a permanent FAIL on eight new arms. Fixed in
`d3b662f` — every new manifest now validates clean. Harmless while every bundle
grades per-gate expectations; the moment a suite adds a run-level-green
assertion it detonates. The hazard is now note 3 in `UNCOVERED.md`.

## Verification

* `bash hydra-gates/tests/run-helper-suites.sh` — **80 discovered, 78 passed, 2
  quarantined, 0 failed**, with `NODE_PATH` pointing at an ajv install (the same
  thing CI's `npm install --no-save ajv ajv-formats` step provides).
* `test_gate_acceptance_matrix.sh` — coverage ratchet intact, **58 of 65 gates
  fixtured**, no gate in both registries, no declared gate in neither.
* Thirteen sibling suites re-run individually to source every `COVERED-ELSEWHERE`
  quote.

No checker, no runner, no existing bundle, and no `expect.conf` outside the five
new directories was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
