### PR TITLE
feat(gate-65): guard phpmd, phpstan, prettier and the stylelint:fix glob

### DIFF
--- a/hydra-gates/scripts/lib/check_coding_standard_adoption.py
+++ b/hydra-gates/scripts/lib/check_coding_standard_adoption.py
@@ -98,6 +98,8 @@ import re
 import sys
 
 CENTRAL_RULESET = "quality-config/phpcs.xml"
+CENTRAL_PHPMD = "quality-config/phpmd.xml"
+CENTRAL_PHPSTAN = "quality-config/phpstan-base.neon"
 
 # Sniff families php-cs-fixer owns. A phpcs.xml that names one locally is
 # re-opening the jurisdiction conflict rule 5 describes. Matched against the
@@ -305,9 +307,16 @@ def check(root: str) -> tuple[list[str], int]:
             )
 
     # ── 8. stylelint glob ────────────────────────────────────────────────
+    # BOTH scripts, not just `stylelint`. Measured on launchpad: `stylelint` was
+    # correctly quoted while `stylelint:fix` was not, so the autofix covered a
+    # NARROWER set than the check — `npm run stylelint:fix` reports done and
+    # leaves violations the gate then flags. An earlier revision of this rule
+    # inspected only the check script and reported that app as clean.
     if package is not None:
-        sl = (package.get("scripts") or {}).get("stylelint")
-        if sl:
+        for script_name in ("stylelint", "stylelint:fix"):
+            sl = (package.get("scripts") or {}).get(script_name)
+            if not sl:
+                continue
             checked += 1
             # Everything after the binary name. An unquoted glob containing `**`
             # is expanded by the SHELL, and without globstar `src/**/` matches
@@ -319,12 +328,102 @@ def check(root: str) -> tuple[list[str], int]:
                 ):
                     fail(
                         "stylelint-glob-unquoted",
-                        f"the stylelint script passes an unquoted glob {token!r}. "
-                        "The shell expands it, and without globstar `src/**/` "
-                        "matches exactly one directory level — nested components "
-                        "are silently not linted. Quote it so stylelint expands it.",
+                        f"the '{script_name}' script passes an unquoted glob "
+                        f"{token!r}. The shell expands it, and without globstar "
+                        "`src/**/` matches exactly one directory level — nested "
+                        "components are silently not linted. Quote it so stylelint "
+                        "expands it.",
                     )
                     break
+
+    # ── 12 + 13. PHPMD comes from the package ────────────────────────────
+    # The same argument as rules 5/6, for the other analyser. 18 mutually
+    # different copies of one ruleset is what the fleet had; six of them differed
+    # in ways nobody had decided, and one carried a rule that was DEAD (launchpad
+    # set DevelopmentCodeFragment ignore-namespaces=false while every class in the
+    # repo is namespaced).
+    phpmd_raw = read(os.path.join(root, "phpmd.xml"))
+    if phpmd_raw is not None:
+        checked += 1
+        if CENTRAL_PHPMD not in strip_xml_comments(phpmd_raw):
+            fail(
+                "phpmd-not-centralised",
+                f"phpmd.xml does not reference {CENTRAL_PHPMD}. A deliberate "
+                "divergence is allowed and expected — declare it as "
+                '<rule ref="…central…"><exclude name="X"/></rule> plus a '
+                "re-declared X with this app's properties, so the deviation is "
+                "visible as a deviation instead of hiding inside a full copy.",
+            )
+
+    checked += 1
+    if os.path.isfile(os.path.join(root, "phpmd-unusedparams.xml")):
+        fail(
+            "local-phpmd-unusedparams",
+            "phpmd-unusedparams.xml exists locally. It comes from "
+            "vendor/conduction/hydra-gates/quality-config/. The `phpmd` script "
+            "runs two rulesets and keeps the worst exit code; point its second "
+            "leg at the vendored file and delete this copy.",
+        )
+
+    # ── 14. PHPStan includes the shared base ─────────────────────────────
+    phpstan_raw = read(os.path.join(root, "phpstan.neon")) or read(
+        os.path.join(root, "phpstan.neon.dist")
+    )
+    if phpstan_raw is not None:
+        checked += 1
+        body = re.sub(r"^\s*#.*$", "", phpstan_raw, flags=re.M)
+        if CENTRAL_PHPSTAN not in body:
+            fail(
+                "phpstan-not-centralised",
+                f"phpstan.neon does not include {CENTRAL_PHPSTAN}. Keep only this "
+                "app's own baseline include and ignores naming symbols no other "
+                "app has. NOTE: this requires conduction/hydra-gates >= v1.7.1 — "
+                "v1.7.0's base declared bare relative paths, and PHPStan resolves "
+                "those against the file that DECLARES them, so `paths: lib` became "
+                "vendor/…/quality-config/lib and the run aborted.",
+            )
+
+    # ── 15. no unreferenced prettier config ──────────────────────────────
+    # Nextcloud publishes @nextcloud/prettier-config and nextcloud/forms consumes
+    # it properly — prettier + eslint-config-prettier + a real `format` script. So
+    # prettier is not forbidden; an UNWIRED prettier config is.
+    #
+    # What the fleet had was neither: a hand-rolled .prettierrc setting 2-space
+    # indent and double quotes — the OPPOSITE of @nextcloud/prettier-config's
+    # useTabs/singleQuote — with no dependency, no script and no CI leg. Inert
+    # where it would help, active in editors, where every save produced code
+    # @nextcloud/eslint-config then rejected.
+    if package is not None:
+        deps = {}
+        deps.update(package.get("dependencies") or {})
+        deps.update(package.get("devDependencies") or {})
+        has_prettier = any(d == "prettier" or d.endswith("/prettier-config") for d in deps)
+        configs = [
+            f
+            for f in (
+                ".prettierrc",
+                ".prettierrc.json",
+                ".prettierrc.js",
+                ".prettierrc.cjs",
+                "prettier.config.js",
+                "prettier.config.cjs",
+            )
+            if os.path.isfile(os.path.join(root, f))
+        ]
+        if configs:
+            checked += 1
+            if not has_prettier:
+                fail(
+                    "prettier-config-without-prettier",
+                    f"{', '.join(configs)} exists but neither prettier nor a "
+                    "*/prettier-config package is a dependency, so nothing in CI "
+                    "ever runs it. It still applies in editors, which is the worst "
+                    "of both: contributors get their files reformatted into a state "
+                    "the linter rejects. Either delete it, or adopt it properly the "
+                    "way nextcloud/forms does — @nextcloud/prettier-config + "
+                    "prettier + eslint-config-prettier + a format script and a CI "
+                    "leg.",
+                )
 
     # ── 9. ocp major vs info.xml min-version ─────────────────────────────
     info = read(os.path.join(root, "appinfo", "info.xml"))

--- a/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
+++ b/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
@@ -75,10 +75,24 @@ EC
 {
     "name": "fixture",
     "scripts": {
-        "stylelint": "stylelint \"src/**/*.{vue,scss,css}\""
+        "stylelint": "stylelint \"src/**/*.{vue,scss,css}\"",
+        "stylelint:fix": "stylelint \"src/**/*.{vue,scss,css}\" --fix"
     }
 }
 JSON
+
+    cat > "$d/phpmd.xml" <<'XML'
+<?xml version="1.0"?>
+<ruleset name="fixture">
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpmd.xml"/>
+</ruleset>
+XML
+
+    cat > "$d/phpstan.neon" <<'NEON'
+includes:
+    - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+    - phpstan-baseline.neon
+NEON
 
     mkdir -p "$d/.github/workflows"
     cat > "$d/.github/workflows/code-quality.yml" <<'YML'
@@ -163,6 +177,80 @@ probe gates-ref-pinned         gates-ref-pinned                    "printf '    
 probe workflow-pinned          shared-workflow-pinned              "sed -i 's|quality.yml@main|quality.yml@v2.0.0|' .github/workflows/code-quality.yml"
 probe package-pinned-exact     shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"1.0.0\"|' composer.json"
 probe package-pinned-branch    shared-package-pinned               "sed -i 's|\"conduction/coding-standard\": \"^1.0\"|\"conduction/coding-standard\": \"dev-some-branch\"|' composer.json"
+
+probe phpmd-not-central        phpmd-not-centralised \
+                               "sed -i 's|vendor/conduction/hydra-gates/quality-config/phpmd.xml|rulesets/codesize.xml|' phpmd.xml"
+probe local-unusedparams       local-phpmd-unusedparams            'printf "<ruleset/>\n" > phpmd-unusedparams.xml'
+probe phpstan-not-central      phpstan-not-centralised \
+                               "sed -i '/phpstan-base.neon/d' phpstan.neon"
+probe prettierrc-unwired       prettier-config-without-prettier    'printf "{}\n" > .prettierrc'
+probe stylelintfix-unquoted    stylelint-glob-unquoted \
+                               "sed -i 's|\"stylelint:fix\": \"stylelint \\\\\"src/\\*\\*/\\*.{vue,scss,css}\\\\\" --fix\"|\"stylelint:fix\": \"stylelint src/**/*.vue --fix\"|' package.json"
+
+# ── PRETTIER IS NOT FORBIDDEN, ONLY UNWIRED PRETTIER ──────────────────────
+# Nextcloud publishes @nextcloud/prettier-config and nextcloud/forms consumes it
+# properly. A rule that failed every prettier config would push apps away from
+# the aligned form, which is the opposite of this gate's purpose.
+D="$WORK/prettierwired"
+rm -rf "$D"; scaffold "$D"
+printf '{}\n' > "$D/.prettierrc"
+cat > "$D/package.json" <<'JSON'
+{
+    "name": "fixture",
+    "devDependencies": {
+        "@nextcloud/prettier-config": "^1.2.0",
+        "prettier": "^3.9.6"
+    },
+    "scripts": {
+        "format": "prettier --check .",
+        "stylelint": "stylelint \"src/**/*.{vue,scss,css}\""
+    }
+}
+JSON
+out="$(run "$D")"
+if printf '%s' "$out" | grep -q 'FAIL prettier-config-without-prettier:'; then
+    no "a PROPERLY WIRED prettier config was reported — the rule cannot tell wired from inert" "$out"
+else
+    ok "accepts a prettier config that has prettier as a dependency"
+fi
+
+# ── A COMMENTED-OUT PHPSTAN INCLUDE IS NOT AN INCLUDE ─────────────────────
+D="$WORK/phpstancommented"
+rm -rf "$D"; scaffold "$D"
+cat > "$D/phpstan.neon" <<'NEON'
+includes:
+    # - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+    - phpstan-baseline.neon
+NEON
+out="$(run "$D")"
+if printf '%s' "$out" | grep -q 'FAIL phpstan-not-centralised:'; then
+    ok "a commented-out phpstan include does not count as centralised"
+else
+    no "a COMMENTED-OUT phpstan include was accepted as centralised" "$out"
+fi
+
+# ── A DELIBERATE PHPMD DIVERGENCE IS STILL CENTRALISED ────────────────────
+# exclude + re-declare is the sanctioned pattern for the six apps that diverge;
+# failing it would make the rule unadoptable for exactly those apps.
+D="$WORK/phpmddiverge"
+rm -rf "$D"; scaffold "$D"
+cat > "$D/phpmd.xml" <<'XML'
+<?xml version="1.0"?>
+<ruleset name="fixture">
+    <rule ref="vendor/conduction/hydra-gates/quality-config/phpmd.xml">
+        <exclude name="ShortVariable"/>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties><property name="exceptions" value="x,y,h"/></properties>
+    </rule>
+</ruleset>
+XML
+out="$(run "$D")"
+if printf '%s' "$out" | grep -q 'FAIL phpmd-not-centralised:'; then
+    no "the sanctioned exclude+re-declare divergence was reported as not centralised" "$out"
+else
+    ok "accepts a deliberate divergence declared as exclude + re-declare"
+fi
 
 probe matrix-absent            test-matrix-not-declared \
                                "sed -i '/nextcloud-test-refs/d' .github/workflows/code-quality.yml"


### PR DESCRIPTION
## Why

gate-65 guarded `phpcs.xml` and the test matrix. Everything else the fleet just
centralised — phpmd, phpstan, the inert prettier config — could drift straight back
with nothing to notice. **Centralising a file has never stopped drift in this fleet.
The gate is what stops it.**

## The four rules

| rule | the live defect it corresponds to |
| --- | --- |
| `phpmd-not-centralised` | 18 mutually different copies of one ruleset; six diverged in ways nobody had decided, and one carried a **dead** rule (launchpad set `DevelopmentCodeFragment ignore-namespaces=false` while every class in the repo is namespaced) |
| `local-phpmd-unusedparams` | the second leg of the `phpmd` script, copied per app |
| `phpstan-not-centralised` | landed in **no app at all** when measured |
| `prettier-config-without-prettier` | a config no CI job runs, active only in editors |

Plus rule 8 now inspects **both** stylelint scripts. Measured on launchpad: `stylelint`
was correctly quoted while **`stylelint:fix` was not**, so the autofix covered a narrower
set than the check — `npm run stylelint:fix` reports done and leaves violations the gate
then flags. The old rule read that app as clean.

## Two rules that had to be careful not to widen

**Prettier is not forbidden.** Nextcloud publishes `@nextcloud/prettier-config` and
`nextcloud/forms` consumes it properly — `prettier` + `eslint-config-prettier` + a real
`format` script. What this fleet had was neither: a hand-rolled `.prettierrc` setting
2-space indent and double quotes — the **opposite** of `@nextcloud/prettier-config`'s
`useTabs`/`singleQuote` — with no dependency, no script and no CI leg. The rule fires on
an **unwired** config and accepts a wired one, with a fixture for each. A rule that
failed every prettier config would push apps away from the aligned form, which is the
opposite of this gate's purpose.

**A deliberate phpmd divergence passes.** `<rule ref="…central…"><exclude name="X"/></rule>`
plus a re-declared `X` is the sanctioned shape, and six apps need exactly it. There is a
fixture asserting it is accepted — a rule those apps cannot satisfy gets switched off,
and then it guards nothing.

## Evidence — real fleet data, in both directions on the same app

This is the part that shows the rules *discriminate* rather than merely report:

```
opencatalogi@development                  phpmd-not-centralised, local-phpmd-unusedparams,
                                          phpstan-not-centralised
opencatalogi@chore/central-phpmd-ruleset  phpstan only   ← phpmd rules CLEARED
opencatalogi@chore/central-phpstan        phpmd only     ← phpstan rule CLEARED
larpingapp@development                    phpstan only   ← its phpmd PR is already merged
launchpad@development                     all three + stylelint-glob-unquoted
```

The two middle rows are the in-flight per-app PRs, so this also independently
corroborates that those PRs do what they claim.

## Self-test

**37 passed, 0 failed.** Every new rule has a positive control; the compliant fixture
gained `phpmd.xml`, `phpstan.neon` and a `stylelint:fix` script so the negative control
still holds; and a commented-out phpstan include does **not** count as an include — that
is the gate-64 defect, guarded.

## ⚠️ Sequencing

**Merge this after the per-app phpmd and phpstan PRs land**, or every app fails a rule it
cannot yet satisfy. The per-app work is in flight now.
