### PR TITLE
fix(phpstan-base): mark vendor-bin and lib/Resources/template optional

### DIFF
--- a/quality-config/phpstan-base.neon
+++ b/quality-config/phpstan-base.neon
@@ -56,12 +56,32 @@ parameters:
     bootstrapFiles:
         - %currentWorkingDirectory%/phpstan-bootstrap.php
 
+    # ── WHY TWO OF THESE CARRY THE `(?)` OPTIONAL MARKER ─────────────────────
+    # PHPStan 2.x VALIDATES excludePaths and aborts the whole run when an entry
+    # names something that does not exist:
+    #   Path "/app/vendor-bin" is neither a directory, nor a file path, nor a
+    #   fnmatch pattern. If the excluded path can sometimes exist, append (?)
+    # PHPStan 1.x accepts the missing path silently, which is why this went
+    # unnoticed. Measured 2026-08-12 during the step-2b rollout: zaakafhandelapp
+    # is the only fleet app on PHPStan 2 (2.2.8; the other seventeen are on
+    # 1.12.33), it has neither `vendor-bin` nor `lib/Resources/template`, and
+    # including this file unchanged made `composer phpstan` exit before
+    # analysing a single file — the same failure shape as the v1.7.0 relative-path
+    # bug, from a different cause.
+    #
+    # `vendor` stays mandatory: phpstan is invoked from `vendor/bin/`, so it
+    # always exists. The other two are genuinely per-app.
+    #
+    # The marker is stripped during resolution, so this changes no app's resolved
+    # value: verified on docudesk (PHPStan 1.12.33) with a planted
+    # `no-such-dir-control (?)`, which analysed cleanly and dumped as a plain
+    # `/app/no-such-dir-control`.
     excludePaths:
         - %currentWorkingDirectory%/vendor
-        - %currentWorkingDirectory%/vendor-bin
+        - %currentWorkingDirectory%/vendor-bin (?)
         # Apps that ship a verbatim template snapshot under lib/Resources/template/
         # (openbuild). A no-op everywhere else.
-        - %currentWorkingDirectory%/lib/Resources/template
+        - %currentWorkingDirectory%/lib/Resources/template (?)
 
     scanDirectories:
         - %currentWorkingDirectory%/vendor/nextcloud/ocp


### PR DESCRIPTION
## The defect

`quality-config/phpstan-base.neon` declares `vendor-bin` and `lib/Resources/template`
under `excludePaths` without the `(?)` optional marker. **PHPStan 2.x validates
`excludePaths` and aborts the entire run when an entry names something that does not
exist:**

> Path "/app/vendor-bin" is neither a directory, nor a file path, nor a fnmatch
> pattern. If the excluded path can sometimes exist, append (?)

PHPStan 1.x accepts a missing path silently, which is why this was invisible.

## How it was found, and what it cost

Measured today while moving all eighteen core apps onto the base (step 2b of the
Nextcloud alignment programme). Seventeen apps are on PHPStan **1.12.33** and adopted
the base cleanly. **zaakafhandelapp is on PHPStan 2.2.8**, has neither `vendor-bin` nor
`lib/Resources/template`, and including this file unchanged made `composer phpstan`
exit before analysing a single file — zero files, no findings, exit 1.

That is the same failure *shape* as the v1.7.0 relative-path bug this file's own
header documents, arriving from a different cause: a centralised config asserting
something about the consumer's tree that is not true of every consumer.

The two `(?)` markers that zaakafhandelapp's own config carried were therefore not a
typo, which is how they first read.

## The fix, and why it is safe on 1.x too

`vendor` stays mandatory — phpstan is invoked from `vendor/bin/`, so it always exists.
The other two become optional.

The marker is stripped during resolution, so **no app's resolved `excludePaths` value
changes**. Verified on docudesk (PHPStan 1.12.33) with a planted
`no-such-dir-control (?)` entry: the run analysed 228 files cleanly and
`dump-parameters` reported it as a plain `/app/no-such-dir-control`.

## Follow-up

zaakafhandelapp currently ships an `excludePaths!` override carrying exactly these
three paths with the two markers, plus a comment pointing here. Once this is released,
that override and its `!` can be deleted.
