### PR TITLE
fix(phpstan-base): a conditional path has no spelling that is safe on both PHPStan majors

### DIFF
--- a/quality-config/phpstan-base.neon
+++ b/quality-config/phpstan-base.neon
@@ -56,32 +56,51 @@ parameters:
     bootstrapFiles:
         - %currentWorkingDirectory%/phpstan-bootstrap.php
 
-    # ── WHY TWO OF THESE CARRY THE `(?)` OPTIONAL MARKER ─────────────────────
-    # PHPStan 2.x VALIDATES excludePaths and aborts the whole run when an entry
-    # names something that does not exist:
-    #   Path "/app/vendor-bin" is neither a directory, nor a file path, nor a
-    #   fnmatch pattern. If the excluded path can sometimes exist, append (?)
-    # PHPStan 1.x accepts the missing path silently, which is why this went
-    # unnoticed. Measured 2026-08-12 during the step-2b rollout: zaakafhandelapp
-    # is the only fleet app on PHPStan 2 (2.2.8; the other seventeen are on
-    # 1.12.33), it has neither `vendor-bin` nor `lib/Resources/template`, and
-    # including this file unchanged made `composer phpstan` exit before
-    # analysing a single file — the same failure shape as the v1.7.0 relative-path
-    # bug, from a different cause.
+    # ── ONLY PATHS THAT ALWAYS EXIST BELONG HERE ─────────────────────────────
+    # `vendor` is the only one: phpstan runs from `vendor/bin/`, so it is always
+    # there. A CONDITIONAL path in a shared base has no spelling that is safe on
+    # both PHPStan majors, and this file tried two of them:
     #
-    # `vendor` stays mandatory: phpstan is invoked from `vendor/bin/`, so it
-    # always exists. The other two are genuinely per-app.
+    #   plain `%cwd%/vendor-bin`        PHPStan 2.x VALIDATES excludePaths and
+    #                                   ABORTS when the entry does not exist
+    #                                   ("neither a directory, nor a file path,
+    #                                   nor a fnmatch pattern"). 1.x accepts it
+    #                                   silently, which is why v1.7.0 and v1.7.1
+    #                                   shipped it. zaakafhandelapp — the fleet's
+    #                                   only 2.x app (2.2.8; the other 17 are on
+    #                                   1.12.33) — analysed ZERO files.
     #
-    # The marker is stripped during resolution, so this changes no app's resolved
-    # value: verified on docudesk (PHPStan 1.12.33) with a planted
-    # `no-such-dir-control (?)`, which analysed cleanly and dumped as a plain
-    # `/app/no-such-dir-control`.
+    #   `%cwd%/vendor-bin (?)`          v1.7.2's attempted fix. WORSE on 2.x, not
+    #                                   better: NEON reads `… (?)` after a `%…%`
+    #                                   expansion as an ENTITY, so PHPStan 2 dies
+    #                                   with `FileExcluder::isAbsolutePath():
+    #                                   Argument #1 ($path) must be of type
+    #                                   string, Nette\DI\Definitions\Statement
+    #                                   given`.
+    #
+    #   `'%cwd%/vendor-bin (?)'`        Quoting stops the entity parse and 2.x is
+    #                                   happy — but 1.x then does NOT strip the
+    #                                   marker: `dump-parameters` resolves it to
+    #                                   the literal `"/app/vendor-bin (?)"`, a
+    #                                   path that matches nothing. Harmless where
+    #                                   the directory is absent, and SILENTLY
+    #                                   BREAKING where it is present — openbuild
+    #                                   ships 31 files under lib/Resources/template
+    #                                   and would have started analysing them.
+    #
+    # All three measured on 2026-08-13 against real apps, not fixtures. So the
+    # conditional paths move to the apps that actually have the directory, where
+    # they need no marker and work on both majors:
+    #
+    #   vendor-bin              openregister only
+    #   lib/Resources/template  portaliq, openbuild, hermiq
+    #
+    # Fifteen to seventeen apps were carrying an exclusion for a directory they do
+    # not have. An app that later grows one adds a plain path to its own
+    # phpstan.neon — `excludePaths` APPENDS to this list unless the app writes
+    # `excludePaths!`.
     excludePaths:
         - %currentWorkingDirectory%/vendor
-        - %currentWorkingDirectory%/vendor-bin (?)
-        # Apps that ship a verbatim template snapshot under lib/Resources/template/
-        # (openbuild). A no-op everywhere else.
-        - %currentWorkingDirectory%/lib/Resources/template (?)
 
     scanDirectories:
         - %currentWorkingDirectory%/vendor/nextcloud/ocp


### PR DESCRIPTION
## What v1.7.2 got wrong

v1.7.2 fixed *"PHPStan 2 aborts on an `excludePaths` entry that does not exist"* by
appending the documented `(?)` optional marker. Measured today against the real apps,
**that made 2.x worse rather than better** — and the obvious next spelling breaks 1.x.

| spelling | PHPStan 1.12.33 | PHPStan 2.2.8 |
| --- | --- | --- |
| `%cwd%/vendor-bin` | accepted silently | **ABORTS** — validates the entry, analysed **0 files** |
| `%cwd%/vendor-bin (?)` ← v1.7.2 | fine | **ABORTS** — `FileExcluder::isAbsolutePath(): Argument #1 ($path) must be of type string, Nette\DI\Definitions\Statement given`. NEON reads `… (?)` after a `%…%` expansion as an **entity**, not a string |
| `'%cwd%/vendor-bin (?)'` | **marker NOT stripped** — resolves to the literal `"/app/vendor-bin (?)"`, matching nothing | fine |

The quoted form is the dangerous one. Where the directory is absent it is harmless;
where it is **present** the exclusion silently stops working — and **openbuild ships 31
files under `lib/Resources/template`**, so it would have started analysing a verbatim
template snapshot with nobody told.

## The fix

A conditional path does not belong in a shared base. `vendor` is the only one that
always exists (phpstan runs from `vendor/bin/`), so it is the only one that stays. The
other two move to the apps that actually have the directory, where they need no marker
and behave identically on both majors:

| path | apps that actually have it |
| --- | --- |
| `vendor-bin` | **openregister** only |
| `lib/Resources/template` | **portaliq, openbuild, hermiq** |

Fifteen to seventeen apps were carrying an exclusion for a directory they do not have.
`excludePaths` **appends** to the base unless an app writes `excludePaths!`, so an app
that later grows one adds a plain path to its own `phpstan.neon`.

## Evidence — real apps, not fixtures

```
zaakafhandelapp, PHPStan 2.2.8, new base, app override REMOVED
    57 files analysed, no errors
positive control, same tree, v1.7.2's form restored
    TypeError … Statement given — still aborts
larpingapp, PHPStan 1.12.33, quoted form
    dump-parameters resolves "/app/vendor-bin (?)" verbatim — marker intact
```

The `[OK] No errors` line was deliberately **not** taken as proof: a zero-file run prints
exactly the same thing, and that is the original failure. The 57 is a count of files the
analyser actually walked.

## Follow-up (not in this PR)

Needs a **v1.7.3** release, then one small PR each for `openregister`, `portaliq`,
`openbuild` and `hermiq` to carry their own path, plus removing zaakafhandelapp's
temporary `excludePaths!` override. Their locks pin v1.7.1/v1.7.2, so nothing changes
for them until they update — no rush window.
