### PR TITLE
fix(gates 16, 19, 25, 26): a full stop is not an exclusion reason (#400)

### DIFF
--- a/hydra-gates/scripts/lib/check_contract_coverage.py
+++ b/hydra-gates/scripts/lib/check_contract_coverage.py
@@ -56,6 +56,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+
 GATE_NUM = 25
 
 # ---------------------------------------------------------------------------
@@ -97,7 +100,10 @@ _PUBLIC_AUTH_RE = re.compile(
 )
 
 _CONTRACT_REF_RE = re.compile(r"@contract\s+(?!exclude\b)(?P<ref>\S+)")
-_CONTRACT_EXCLUDE_RE = re.compile(r"@contract\s+exclude\b[ \t]*(?P<reason>.*?)\s*$")
+# What counts as a <reason> is decided by exclusion_reason.is_reason_bearing(),
+# shared with gates 16, 19 and 26 — all four graded it with plain truthiness, so
+# `@contract exclude .` was a reason (.github#400).
+_CONTRACT_EXCLUDE_RE = re.compile(exclude_pattern("contract"))
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +306,10 @@ def _contract_status(lines: list[str], decl_idx: int) -> tuple[str, str | None]:
         m = _CONTRACT_EXCLUDE_RE.search(b)
         if m:
             reason = m.group("reason").strip().rstrip("*/").strip()
-            return ("excluded", reason) if reason else ("exclude_noreason", None)
+            # `if reason:` here was .github#400.
+            if is_reason_bearing(reason):
+                return ("excluded", reason)
+            return ("exclude_noreason", None)
     return ("none", None)
 
 

--- a/hydra-gates/scripts/lib/check_e2e_coverage.py
+++ b/hydra-gates/scripts/lib/check_e2e_coverage.py
@@ -121,6 +121,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Slug helpers
 # ---------------------------------------------------------------------------
@@ -160,16 +163,21 @@ _ALT_SCENARIO_ITEM_RE = re.compile(
 )
 
 # Exclusion marker: `@e2e exclude <reason>` (inline or on its own line)
-_EXCLUDE_RE = re.compile(r"@e2e\s+exclude\b[ \t]*(?P<reason>.*?)\s*$")
+#
+# What counts as a <reason> is decided by exclusion_reason.is_reason_bearing(),
+# shared with gates 16, 25 and 26. Both forms below used plain truthiness, under
+# which `@e2e exclude .` was reason-bearing (.github#400). That mattered most
+# HERE: an exclusion scores as POSITIVE coverage (#345) and the whole-spec form
+# below blankets every scenario in the file (#356), so one full stop could
+# credit dozens of scenarios at once.
+_EXCLUDE_RE = re.compile(exclude_pattern("e2e"))
 
 # Whole-spec exclusion must be a STANDALONE directive line: the `@e2e exclude`
 # token is the dominant content of the line, optionally prefixed by markdown
 # bullet / blockquote / heading markers. Prose that merely *mentions*
 # `@e2e exclude` mid-sentence (e.g. a Purpose paragraph "...scenarios annotated
 # @e2e exclude below") must NOT exclude the entire spec.
-_WHOLE_SPEC_EXCLUDE_RE = re.compile(
-    r"^[ \t>*#\-]*@e2e\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"
-)
+_WHOLE_SPEC_EXCLUDE_RE = re.compile(exclude_pattern("e2e", standalone=True))
 
 
 def _parse_exclusion(text: str) -> tuple[bool, str | None]:
@@ -184,7 +192,8 @@ def _parse_exclusion(text: str) -> tuple[bool, str | None]:
     if not m:
         return False, None
     reason = m.group("reason").strip()
-    return True, reason if reason else None
+    # `reason if reason else None` was .github#400.
+    return True, reason if is_reason_bearing(reason) else None
 
 
 def _parse_whole_spec_exclusion(text: str) -> tuple[bool, str | None]:
@@ -199,7 +208,9 @@ def _parse_whole_spec_exclusion(text: str) -> tuple[bool, str | None]:
     if not m:
         return False, None
     reason = m.group("reason").strip()
-    return True, reason if reason else None
+    # `reason if reason else None` was .github#400 — and this is the form that
+    # blankets an entire spec file, so it is the most expensive of the four.
+    return True, reason if is_reason_bearing(reason) else None
 
 
 def _make_scenario_entry(

--- a/hydra-gates/scripts/lib/check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/check_spec_coverage.py
@@ -76,11 +76,20 @@ import sys
 from difflib import SequenceMatcher
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+
 SPEC_RE = re.compile(r"@spec\s+openspec/")
 # `@spec exclude <reason>` — intentional, reason-required non-coverage marker.
 # A bare `@spec exclude` (no reason) is NOT compliant — it would let a method
 # silently hide a gap, so it is flagged like a missing @spec.
-SPEC_EXCLUDE_RE = re.compile(r"@spec\s+exclude\b[ \t]*(?P<reason>.*?)\s*$")
+#
+# NEITHER IS `@spec exclude .` (.github#400). The marker used to be graded by
+# `if reason:` — plain truthiness — so any non-empty string counted, and a
+# single full stop was the whole difference between a blocked PR and a green
+# one. The rule now lives in exclusion_reason.is_reason_bearing(), shared with
+# gates 19, 25 and 26, which had the identical defect.
+SPEC_EXCLUDE_RE = re.compile(exclude_pattern("spec"))
 
 # ---- backend ---------------------------------------------------------------
 
@@ -440,8 +449,8 @@ def spec_tags_removed(base_ref: str, cwd: Path) -> set[str]:
 def _docblock_spec_status(lines: list[str], decl_idx: int) -> tuple[str, str | None]:
     """Classify the docblock immediately above ``decl_idx`` into one of:
       - ``("covered", None)``        — has ``@spec openspec/...``
-      - ``("excluded", reason)``     — has ``@spec exclude <reason>`` (reason non-empty)
-      - ``("exclude_noreason", None)`` — has a bare ``@spec exclude`` with no reason
+      - ``("excluded", reason)``     — has ``@spec exclude <reason>`` (reason-bearing)
+      - ``("exclude_noreason", None)`` — has ``@spec exclude`` with no usable reason
       - ``("none", None)``           — neither (an uncovered gap)
     """
     block = _docblock_block(lines, decl_idx)
@@ -451,7 +460,12 @@ def _docblock_spec_status(lines: list[str], decl_idx: int) -> tuple[str, str | N
         m = SPEC_EXCLUDE_RE.search(b)
         if m:
             reason = m.group("reason").strip().rstrip("*/").strip()
-            return ("excluded", reason) if reason else ("exclude_noreason", None)
+            # `if reason:` here was .github#400 — "." is a non-empty string, so
+            # it was truthy, so it was a reason. The normalisation above stays
+            # local (PHP docblocks close with `*/`); only the VERDICT is shared.
+            if is_reason_bearing(reason):
+                return ("excluded", reason)
+            return ("exclude_noreason", None)
     return ("none", None)
 
 

--- a/hydra-gates/scripts/lib/check_visual_coverage.py
+++ b/hydra-gates/scripts/lib/check_visual_coverage.py
@@ -82,6 +82,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
 from source_scope import js_comment_mask  # noqa: E402
 
 GATE_NUM = 26
@@ -94,9 +95,11 @@ EXIT_EMPTY_SCOPE = 3
 
 _PAGE_DIRS = ("src/views/", "src/pages/")
 
-_VISUAL_EXCLUDE_RE = re.compile(
-    r"@visual\s+exclude\b[ \t]*(?P<reason>.*?)\s*$", re.MULTILINE
-)
+# What counts as a <reason> is decided by exclusion_reason.is_reason_bearing(),
+# shared with gates 16, 19 and 25 — all four graded it with plain truthiness, so
+# `@visual exclude .` was a reason (.github#400). MULTILINE stays here: this is
+# the only one of the four that searches whole-file text rather than one line.
+_VISUAL_EXCLUDE_RE = re.compile(exclude_pattern("visual"), re.MULTILINE)
 
 
 # ---------------------------------------------------------------------------
@@ -407,7 +410,9 @@ def _visual_exclude_status(vue_text: str) -> tuple[bool, str | None]:
     for close in ("-->", "*/"):
         if reason.endswith(close):
             reason = reason[: -len(close)].strip()
-    return (True, reason if reason else None)
+    # `reason if reason else None` was .github#400. The normalisation above is
+    # Vue-specific and stays local; only the VERDICT is shared.
+    return (True, reason if is_reason_bearing(reason) else None)
 
 
 def _e2e_corpus(app_dir: Path, visual_only: bool) -> str:

--- a/hydra-gates/scripts/lib/exclusion_reason.py
+++ b/hydra-gates/scripts/lib/exclusion_reason.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""exclusion_reason — the ONE definition of "this exclusion carries a reason".
+
+WHY THIS FILE EXISTS (.github#400)
+==================================
+Four gates let a change opt out of coverage by writing a reason next to the
+marker::
+
+    @spec     exclude <reason>     gate-16  spec-coverage
+    @e2e      exclude <reason>     gate-19  e2e-coverage      (scenario, requirement AND whole-spec)
+    @contract exclude <reason>     gate-25  contract-coverage
+    @visual   exclude <reason>     gate-26  visual-coverage
+
+All four captured the reason with the same regex and then asked the same
+question about it — ``if reason:`` — which is Python truthiness, i.e. "is this
+string non-empty". So::
+
+    @spec exclude       ->  reason == ""    ->  falsy  ->  correctly REFUSED
+    @spec exclude .     ->  reason == "."   ->  TRUTHY ->  credited as a reason
+
+One full stop is the entire difference between a blocked PR and a green one.
+Reproduced through the real wrapper on two repositories that were byte-identical
+apart from that character.
+
+THE COST OF THE BUG IS NOT ONE GATE
+-----------------------------------
+`#345` scores an exclusion as POSITIVE coverage, and `#356` lets a
+requirement-level (or, in gate-19, whole-spec) marker blanket every sibling
+scenario beneath it. Stack the three and a single punctuation mark can credit
+dozens of scenarios as covered and add one to the distinct-reason count the
+programme reads as evidence that exclusions were considered.
+
+WHY A SHARED MODULE AND NOT FOUR PATCHES
+----------------------------------------
+The regex-plus-truthiness pair existed in four files. That is why it survived:
+fixing gate-16 alone leaves three copies, and the next reader of
+``check_visual_coverage.py`` has no way to know the rule lives somewhere else.
+The predicate is defined ONCE here and imported. A fifth exclusion gate gets the
+rule by construction rather than by copy-paste.
+
+WHAT THIS MODULE DELIBERATELY DOES *NOT* DECIDE
+-----------------------------------------------
+The standing rule is that **an exemption's reason is a testable claim**: reasons
+naming a *test artifact* hold, reasons naming a *state of the world* rot. That
+is a SEMANTIC property, and no character count can measure it. ``@e2e exclude
+not applicable here`` is twenty characters and says nothing; ``@e2e exclude
+covered by`` is ten and is a truncated sentence. A length threshold that pretends
+to grade reason QUALITY just teaches people to pad.
+
+So this module draws a deliberately narrow line: it rejects reasons that are
+STRUCTURALLY DEGENERATE — a marker that cannot be naming anything at all. It
+does not, and must not, be read as certifying that what survives is a good
+reason. Judging that needs a purpose-built check (see the residuals in the
+`#400` findings note), not a `len()`.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# The rule
+# ---------------------------------------------------------------------------
+
+# 1. AT LEAST ONE LETTER OR DIGIT.
+#
+# This is the rule that closes `#400`. Note it is deliberately stricter than
+# "at least one word character": Python's ``\w`` also matches the underscore, so
+# a reason of ``___`` would satisfy a ``\w`` rule while being exactly as
+# meaningless as ``.``. Measured over all 18 core apps, the two rules reject the
+# IDENTICAL set, so the stricter one is free.
+_ALNUM_RE = re.compile(r"[^\W_]", re.UNICODE)
+
+# 2. AT LEAST THIS MANY CHARACTERS, after the caller's normalisation.
+#
+# WHY 3, AND WHY NOT MORE — this number is a judgement call, so here is the
+# reasoning rather than just the constant.
+#
+# The alphanumeric rule above cannot reject ``x``, ``ok`` or ``na``, which are
+# no more testable than ``.``; the floor exists only for those. It is NOT an
+# attempt to grade reasons (see the module docstring).
+#
+# Measured over all 18 core apps: a floor of 3, 8 or even 10 newly rejects
+# NOTHING that a checker actually credits today. So the number was not chosen by
+# what is affordable — all of them are free — but by what a character count can
+# honestly claim.
+#
+# THIS PACKAGE ALREADY DISAGREES WITH ITSELF ABOUT THE ANSWER, and that is worth
+# knowing before anyone "harmonises" it:
+#
+#   run-hydra-gates.sh gate-level opt-outs  `.{20,}`   20 chars
+#   check_orphaned_write_capability.py      `.{10,}`   10 chars
+#   these four gates, before .github#400    (any non-empty string)
+#
+# A gate-level opt-out written in a PR body waives an ENTIRE gate, so a high bar
+# there is proportionate. These four markers are per-method and per-scenario and
+# are used ~11,600 times across the fleet; they are a different act. Raising
+# their bar from "any character" to 10 would be a POLICY change about how the
+# fleet writes exclusions, not a bug fix, and it does not belong in the repair
+# of #400. It is filed as a question for a human rather than decided here.
+#
+# So: 3, which is far enough below the data to have margin (the lowest reason
+# length a checker actually credits is 10), and low enough that it is plainly a
+# degenerate-token filter rather than a quality bar it cannot enforce.
+#
+# Raising this later is a ratchet and must be re-measured against the fleet
+# first — at 11 it newly rejects 3 live reasons, all of them the truncated
+# ``covered by``.
+REASON_MIN_CHARS = 3
+
+
+def is_reason_bearing(reason: str | None) -> bool:
+    """Does ``reason`` count as a justification for an exclusion marker?
+
+    ``reason`` is the text already normalised by the caller (each checker strips
+    the trailing comment syntax of the file type it reads — ``*/`` for PHP
+    docblocks, ``-->`` for Vue templates — and those differ legitimately, so
+    normalisation stays with the caller and only the VERDICT is shared).
+
+    Returns ``True`` only when the reason has at least one letter or digit and
+    is at least :data:`REASON_MIN_CHARS` characters long.
+
+    This replaces a bare ``if reason:`` truthiness test in four checkers, under
+    which every non-empty string — including ``.`` — was a reason (`#400`).
+    """
+    if not reason:
+        return False
+    if len(reason) < REASON_MIN_CHARS:
+        return False
+    return _ALNUM_RE.search(reason) is not None
+
+
+def why_rejected(reason: str | None) -> str:
+    """A short, human-facing explanation for use in a gate finding.
+
+    Kept beside the predicate so the message cannot drift out of step with the
+    rule it describes.
+    """
+    if not reason:
+        return "no reason given"
+    if len(reason) < REASON_MIN_CHARS:
+        return (
+            f"reason {reason!r} is shorter than {REASON_MIN_CHARS} characters — "
+            f"too short to name anything"
+        )
+    if _ALNUM_RE.search(reason) is None:
+        return (
+            f"reason {reason!r} contains no letter or digit — punctuation is "
+            f"not a justification"
+        )
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# The marker pattern
+# ---------------------------------------------------------------------------
+
+
+def exclude_pattern(tag: str, *, standalone: bool = False) -> str:
+    """Return the regex SOURCE for a ``@<tag> exclude <reason>`` marker.
+
+    ``standalone=True`` additionally anchors the marker to the start of the line
+    (after optional markdown bullet / blockquote / heading markers). gate-19's
+    WHOLE-SPEC form needs that: without the anchor, a Purpose paragraph reading
+    "...scenarios annotated @e2e exclude below" silently excludes an entire spec
+    file (`#358`). The scenario- and requirement-level forms are intentionally
+    unanchored, because an inline marker appended to a heading or bullet is the
+    documented way to write them.
+
+    Returned as a source string, not a compiled pattern, so each caller keeps
+    control of its own flags (``check_visual_coverage`` searches whole-file text
+    and needs ``re.MULTILINE``; the others match line by line and must not).
+    """
+    lead = r"^[ \t>*#\-]*" if standalone else ""
+    return lead + rf"@{tag}\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"

--- a/hydra-gates/scripts/lib/test_exclusion_reason.py
+++ b/hydra-gates/scripts/lib/test_exclusion_reason.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""test_exclusion_reason — .github#400, across all FOUR exclusion gates.
+
+WHAT IS UNDER TEST
+==================
+Four gates let a change opt out of coverage by writing a justification beside a
+marker. All four captured that justification with the same regex and then graded
+it with plain Python truthiness, so a single full stop was accepted as a reason:
+
+    gate-16 spec-coverage      check_spec_coverage.py
+    gate-19 e2e-coverage       check_e2e_coverage.py   (scenario AND whole-spec)
+    gate-25 contract-coverage  check_contract_coverage.py
+    gate-26 visual-coverage    check_visual_coverage.py
+
+Reproduced through the real wrapper on two repositories byte-identical apart
+from one character: `@spec exclude` FAILED, `@spec exclude.` PASSED.
+
+The repair is a single shared predicate, exclusion_reason.is_reason_bearing().
+This suite exists because the defect's real cause was STRUCTURAL — the rule was
+copied four times — so the assertions below deliberately exercise all four call
+sites separately. Reverting any ONE of them to `if reason:` must turn a NAMED
+assertion red; that is the revert-proof, and it is why there are four fixtures
+and not one.
+
+WHY EACH FIXTURE HAS ITS OWN SUBJECT TOKEN
+------------------------------------------
+Every assertion greps for a token unique to its own fixture
+(`specReasonPunctuationProbe`, `contractReasonPunctuationProbe`,
+`VisualReasonPunctuationProbe`, `e2e-scenario-punctuation-probe`,
+`wholespecpunctuationprobe`). None is a prefix of another. A subject that a
+SIBLING finding could also satisfy makes a bundle vacuous for its own defect —
+an assertion that passes because some other gate produced some other finding has
+measured nothing.
+
+WHY THERE IS A PURE-PROSE CONTROL
+---------------------------------
+A test fixture that EXPLAINS an exclusion marker contains the marker, and a
+scanner cannot tell the explanation from the thing. So one fixture mentions the
+markers only in prose and must produce NO exclusion at all. If that control ever
+goes red, this suite has started measuring its own commentary.
+
+ANTI-WIDENING
+-------------
+Every gate also gets an arm in which a REAL reason is written, and it must still
+be credited. A predicate that rejected everything would satisfy every defect
+assertion here while retiring the exclusion mechanism fleet-wide — strictly
+worse than the bug it replaces.
+
+Run: python3 hydra-gates/scripts/lib/test_exclusion_reason.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+sys.path.insert(0, str(LIB))
+
+from exclusion_reason import (  # noqa: E402
+    REASON_MIN_CHARS,
+    exclude_pattern,
+    is_reason_bearing,
+    why_rejected,
+)
+
+# An empty run is not a green run — see run-helper-suites.sh on the same trap.
+MIN_ASSERTIONS = 38
+
+_passed: list[str] = []
+_failed: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    if ok:
+        _passed.append(name)
+        print(f"  ok   — {name}")
+    else:
+        _failed.append(name)
+        print(f"  FAIL — {name}")
+        if detail:
+            for line in str(detail).splitlines():
+                print(f"           {line}")
+
+
+# ---------------------------------------------------------------------------
+# git fixture support
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@example.invalid", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", "-C", str(repo), *args],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def make_repo(root: Path, base_files: dict[str, str], head_files: dict[str, str]) -> str:
+    """Two commits. Returns the BASE sha, for HYDRA_GATE_BASE_REF.
+
+    A FIXTURE THAT FAILED TO BUILD MUST NOT LOOK LIKE A FIXTURE.
+    ------------------------------------------------------------
+    The first version of this helper called ``git init -b main``, which git
+    2.25 does not support. Every repo silently failed to exist, so the gates ran
+    with no base ref at all — i.e. at FULL SCOPE — and two arms went green while
+    testing something other than what they claimed. The files are on disk either
+    way, which is exactly what makes the failure invisible. So every git step is
+    now checked, and a broken fixture raises instead of degrading into a
+    differently-scoped run that still prints a plausible verdict.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+
+    def must(*args: str) -> subprocess.CompletedProcess:
+        r = _git(root, *args)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"fixture build failed: git {' '.join(args)} -> rc={r.returncode}\n"
+                f"{r.stdout}{r.stderr}"
+            )
+        return r
+
+    def write(files: dict[str, str]) -> None:
+        for rel, body in files.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+
+    must("init", "-q")
+    write(base_files)
+    must("add", "-A")
+    must("commit", "-q", "-m", "base")
+    base = must("rev-parse", "HEAD").stdout.strip()
+    if len(base) < 7:
+        raise RuntimeError(f"fixture build failed: no base sha (got {base!r})")
+    write(head_files)
+    must("add", "-A")
+    must("commit", "-q", "-m", "head")
+    # The base must actually be an ancestor, or `BASE...HEAD` is not the diff
+    # the gate thinks it is.
+    if not _git(root, "diff", "--quiet", f"{base}...HEAD").returncode:
+        raise RuntimeError("fixture build failed: base...HEAD is an EMPTY diff")
+    return base
+
+
+def run_checker(script: str, app: Path, base: str | None = None,
+                mode: str | None = None) -> tuple[int, str]:
+    env = dict(os.environ)
+    if base:
+        env["HYDRA_GATE_BASE_REF"] = base
+    else:
+        env.pop("HYDRA_GATE_BASE_REF", None)
+    argv = ["python3", str(LIB / script), str(app)]
+    if mode:
+        argv += ["--mode", mode]
+    r = subprocess.run(argv, capture_output=True, text=True, env=env, check=False)
+    return r.returncode, r.stdout + r.stderr
+
+
+# ---------------------------------------------------------------------------
+# 1. The predicate itself
+# ---------------------------------------------------------------------------
+
+
+def suite_predicate() -> None:
+    print("\n== the shared predicate ==")
+    check("a full stop is NOT a reason — the exact input from .github#400",
+          is_reason_bearing(".") is False)
+    check("an empty reason is NOT a reason (unchanged behaviour)",
+          is_reason_bearing("") is False)
+    check("None is NOT a reason (unchanged behaviour)",
+          is_reason_bearing(None) is False)
+    # Every one of these is a real shape the fleet-wide scan turned up as a
+    # candidate "reason" (mostly prose whose trailing backtick or bracket became
+    # the capture). Graded as ONE assertion, but the detail names the offender —
+    # and deliberately without an early return, so a failure here does not
+    # silently shorten the rest of this suite.
+    junk_accepted = [j for j in ("..", "...", "-", "--", "?", "!", "*", "/",
+                                 ")", "`)", "`.")
+                     if is_reason_bearing(j) is not False]
+    check("every punctuation-only shape observed in the fleet scan is refused "
+          "('..', '...', '-', '--', '?', '!', '*', '/', ')', '`)', '`.')",
+          not junk_accepted,
+          f"accepted as reasons: {junk_accepted}")
+    check("an underscore run is refused — \\w would have accepted it, "
+          "so the rule is letter-or-digit, not word-character",
+          is_reason_bearing("___") is False)
+    check(f"a reason shorter than REASON_MIN_CHARS={REASON_MIN_CHARS} is refused "
+          "('x', 'ok')",
+          is_reason_bearing("x") is False and is_reason_bearing("ok") is False)
+    check("ANTI-WIDENING: a real prose reason is still a reason",
+          is_reason_bearing("pure plumbing, verified by PHPUnit") is True)
+    check("ANTI-WIDENING: a terse but alphanumeric reason is still a reason "
+          "— the floor is degenerate-token detection, NOT quality grading",
+          is_reason_bearing("below") is True
+          and is_reason_bearing("covered by") is True)
+    # 10 is the shortest reason any of the four checkers actually credits today,
+    # measured over all 18 core apps. The floor must stay clear of it, or the
+    # first legitimately terse reason someone writes goes red — and raising it
+    # to 10 would be a fleet POLICY change, not a repair of #400.
+    check("the floor keeps margin below the shortest reason a checker credits "
+          f"today (10 chars): REASON_MIN_CHARS={REASON_MIN_CHARS} <= 3",
+          REASON_MIN_CHARS <= 3)
+    check("a non-ASCII reason is accepted — the rule is Unicode letter-or-digit, "
+          "not [a-z], so a Dutch-language reason is not silently refused",
+          is_reason_bearing("één reden, gedekt door PHPUnit") is True)
+    check("why_rejected() names PUNCTUATION for '...', which is long enough to "
+          "reach that branch — the message is kept beside the rule so the two "
+          "cannot drift apart",
+          "punctuation" in why_rejected("...").lower()
+          and "letter or digit" in why_rejected("..."),
+          why_rejected("..."))
+    check("why_rejected() reports LENGTH for '.', not punctuation — a "
+          "one-character reason fails the floor first, and the message must "
+          "say which rule actually rejected it",
+          "shorter than" in why_rejected("."), why_rejected("."))
+    check("why_rejected() still says 'no reason given' for the bare marker",
+          why_rejected("") == "no reason given", why_rejected(""))
+    check("why_rejected() is EMPTY for an accepted reason — a gate must not be "
+          "handed a rejection message for something it accepted",
+          why_rejected("covered by SpecProbeServiceTest") == "")
+
+
+# ---------------------------------------------------------------------------
+# 2. The marker patterns did not move
+# ---------------------------------------------------------------------------
+
+
+def suite_patterns() -> None:
+    print("\n== the marker patterns are byte-identical to the four originals ==")
+    historical = {
+        "gate-16 @spec": (
+            ("spec", False),
+            r"@spec\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"),
+        "gate-19 @e2e scenario/requirement": (
+            ("e2e", False),
+            r"@e2e\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"),
+        "gate-19 @e2e WHOLE-SPEC (anchored, .github#358)": (
+            ("e2e", True),
+            r"^[ \t>*#\-]*@e2e\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"),
+        "gate-25 @contract": (
+            ("contract", False),
+            r"@contract\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"),
+        "gate-26 @visual": (
+            ("visual", False),
+            r"@visual\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"),
+    }
+    for label, ((tag, standalone), want) in historical.items():
+        got = exclude_pattern(tag, standalone=standalone)
+        check(f"{label} pattern is unchanged by the refactor", got == want,
+              f"want: {want}\ngot : {got}")
+    check("the whole-spec form is the ONLY anchored one — an anchor on the "
+          "scenario form would silently retire inline markers",
+          exclude_pattern("e2e").startswith("@")
+          and exclude_pattern("e2e", standalone=True).startswith("^"))
+
+
+# ---------------------------------------------------------------------------
+# 3. gate-16 — check_spec_coverage.py
+# ---------------------------------------------------------------------------
+
+_PHP_HEAD = """<?php
+namespace OCA\\Fx\\Service;
+
+class SpecProbeService {
+"""
+
+
+def _php_method(name: str, tag_line: str) -> str:
+    return f"""
+    /**
+     * Probe.
+     *
+     * {tag_line}
+     */
+    public function {name}(string $a): string {{
+        return $a;
+    }}
+"""
+
+
+def suite_gate16(tmp: Path) -> None:
+    print("\n== gate-16 spec-coverage (check_spec_coverage.py) ==")
+    base_php = _PHP_HEAD + "}\n"
+
+    # ARM A — the defect: a full stop as the whole reason.
+    app = tmp / "g16-punct"
+    base = make_repo(
+        app,
+        {"lib/Service/SpecProbeService.php": base_php},
+        {"lib/Service/SpecProbeService.php":
+            _PHP_HEAD + _php_method("specReasonPunctuationProbe", "@spec exclude .") + "}\n"},
+    )
+    rc, out = run_checker("check_spec_coverage.py", app, base)
+    check("gate-16 refuses '@spec exclude .' and names specReasonPunctuationProbe",
+          "specReasonPunctuationProbe" in out and "# count=1" in out,
+          f"rc={rc}\n{out}")
+
+    # ARM B — anti-widening: a real reason must still be credited.
+    #
+    # THE WITNESS IS WHAT MAKES THIS NON-VACUOUS. "specReasonProseProbe is not
+    # reported" is also true of a run that inspected nothing at all, which is
+    # precisely how the first draft of this suite went green while its fixtures
+    # were failing to build. So the same file carries an UNTAGGED method that
+    # MUST be reported: count=1 naming the witness is proof the walker opened
+    # the file and graded both methods.
+    app = tmp / "g16-real"
+    base = make_repo(
+        app,
+        {"lib/Service/SpecProbeService.php": base_php},
+        {"lib/Service/SpecProbeService.php":
+            _PHP_HEAD
+            + _php_method("specReasonProseProbe",
+                          "@spec exclude thin passthrough, covered by SpecProbeServiceTest")
+            + _php_method("specReasonWitnessProbe", "(no tag at all)")
+            + "}\n"},
+    )
+    rc, out = run_checker("check_spec_coverage.py", app, base)
+    check("ANTI-WIDENING gate-16 still credits a real reason "
+          "(specReasonProseProbe is not reported)",
+          "specReasonProseProbe" not in out, f"rc={rc}\n{out}")
+    check("WITNESS gate-16 did inspect that file — the untagged "
+          "specReasonWitnessProbe IS reported, so the arm above is not vacuous",
+          "specReasonWitnessProbe" in out and "# count=1" in out,
+          f"rc={rc}\n{out}")
+
+    # ARM B2 — the LOCAL normalisation still runs before the shared predicate.
+    # A docblock close is not a reason; spec/contract strip `*/` themselves and
+    # only the verdict is shared, so this must stay refused.
+    app = tmp / "g16-closeonly"
+    base = make_repo(
+        app,
+        {"lib/Service/SpecProbeService.php": base_php},
+        {"lib/Service/SpecProbeService.php":
+            _PHP_HEAD + _php_method("specReasonCloseOnlyProbe", "@spec exclude */") + "}\n"},
+    )
+    rc, out = run_checker("check_spec_coverage.py", app, base)
+    check("gate-16 refuses a reason that is only the docblock close "
+          "(specReasonCloseOnlyProbe) — local normalisation still precedes the "
+          "shared predicate",
+          "specReasonCloseOnlyProbe" in out, f"rc={rc}\n{out}")
+
+    # ARM C — the bare marker still fails, i.e. the old path is intact.
+    app = tmp / "g16-bare"
+    base = make_repo(
+        app,
+        {"lib/Service/SpecProbeService.php": base_php},
+        {"lib/Service/SpecProbeService.php":
+            _PHP_HEAD + _php_method("specReasonBareProbe", "@spec exclude") + "}\n"},
+    )
+    rc, out = run_checker("check_spec_coverage.py", app, base)
+    check("gate-16 still refuses a BARE '@spec exclude' (specReasonBareProbe) "
+          "— the pre-existing branch was not disturbed",
+          "specReasonBareProbe" in out and "# count=1" in out,
+          f"rc={rc}\n{out}")
+
+    # ARM D — the control the whole reproduction rests on: the two refused
+    # fixtures really do differ by exactly the one character in the report.
+    punct = _php_method("p", "@spec exclude .")
+    bare = _php_method("p", "@spec exclude")
+    check("CONTROL: the punctuation fixture is the bare fixture plus exactly "
+          "one character — the reproduction in .github#400",
+          punct.replace(" .", "", 1) == bare and len(punct) == len(bare) + 2,
+          f"punct={punct!r}\nbare={bare!r}")
+
+
+# ---------------------------------------------------------------------------
+# 4. gate-19 — check_e2e_coverage.py, BOTH forms
+# ---------------------------------------------------------------------------
+
+
+def _spec_md(title: str, scenario: str, marker: str) -> str:
+    return f"""---
+status: done
+---
+
+# {title}
+
+## Purpose
+
+Fixture.
+
+## Requirements
+
+### REQ-PROBE-001: probe
+
+#### Scenario: {scenario}
+
+{marker}
+
+- GIVEN a fixture
+- THEN nothing
+"""
+
+
+def _whole_spec_md(title: str, marker: str) -> str:
+    return f"""---
+status: done
+---
+
+# {title}
+
+{marker}
+
+## Requirements
+
+### REQ-PROBE-001: probe
+
+#### Scenario: first probe scenario
+
+- GIVEN a fixture
+- THEN nothing
+
+#### Scenario: second probe scenario
+
+- GIVEN a fixture
+- THEN nothing
+"""
+
+
+def suite_gate19(tmp: Path) -> None:
+    print("\n== gate-19 e2e-coverage (check_e2e_coverage.py) ==")
+
+    # ---- SCENARIO-LEVEL form ----
+    app = tmp / "g19-scenario-punct"
+    app.mkdir(parents=True)
+    (app / "openspec/specs/probe").mkdir(parents=True)
+    (app / "openspec/specs/probe/spec.md").write_text(
+        _spec_md("Probe", "e2e scenario punctuation probe", "@e2e exclude ."),
+        encoding="utf-8")
+    rc, out = run_checker("check_e2e_coverage.py", app, mode="report")
+    check("gate-19 refuses a scenario-level '@e2e exclude .' — "
+          "e2e-scenario-punctuation-probe is NOT counted as excluded",
+          '"excluded": 0' in out, out)
+
+    app = tmp / "g19-scenario-real"
+    app.mkdir(parents=True)
+    (app / "openspec/specs/probe").mkdir(parents=True)
+    (app / "openspec/specs/probe/spec.md").write_text(
+        _spec_md("Probe", "e2e scenario punctuation probe",
+                 "@e2e exclude background-only, not UI-observable"),
+        encoding="utf-8")
+    rc, out = run_checker("check_e2e_coverage.py", app, mode="report")
+    check("ANTI-WIDENING gate-19 still credits a real scenario-level reason "
+          "(e2e-scenario-punctuation-probe IS excluded)",
+          '"excluded": 1' in out, out)
+
+    # ---- WHOLE-SPEC form — the expensive one (#345 + #356) ----
+    app = tmp / "g19-wholespec-punct"
+    app.mkdir(parents=True)
+    (app / "openspec/specs/wholespecpunctuationprobe").mkdir(parents=True)
+    (app / "openspec/specs/wholespecpunctuationprobe/spec.md").write_text(
+        _whole_spec_md("Whole Spec Punctuation Probe", "@e2e exclude ."),
+        encoding="utf-8")
+    rc, out = run_checker("check_e2e_coverage.py", app, mode="report")
+    check("gate-19 refuses a WHOLE-SPEC '@e2e exclude .' — neither scenario in "
+          "wholespecpunctuationprobe is credited (this is the form that can "
+          "blanket a whole file, so one full stop credited them all)",
+          '"scenarios": 2' in out and '"excluded": 0' in out, out)
+
+    app = tmp / "g19-wholespec-real"
+    app.mkdir(parents=True)
+    (app / "openspec/specs/wholespecpunctuationprobe").mkdir(parents=True)
+    (app / "openspec/specs/wholespecpunctuationprobe/spec.md").write_text(
+        _whole_spec_md("Whole Spec Punctuation Probe",
+                       "@e2e exclude pure backend contract, covered by Newman"),
+        encoding="utf-8")
+    rc, out = run_checker("check_e2e_coverage.py", app, mode="report")
+    check("ANTI-WIDENING gate-19 still honours a real WHOLE-SPEC reason "
+          "(both wholespecpunctuationprobe scenarios excluded)",
+          '"scenarios": 2' in out and '"excluded": 2' in out, out)
+
+    # ---- the finding TEXT, in gate mode ----
+    app = tmp / "g19-gate"
+    base = make_repo(
+        app,
+        {"openspec/specs/probe/spec.md": "# Probe\n\n## Requirements\n"},
+        {"openspec/specs/probe/spec.md":
+            _spec_md("Probe", "e2e scenario punctuation probe", "@e2e exclude .")},
+    )
+    rc, out = run_checker("check_e2e_coverage.py", app, base)
+    check("gate-19 gate mode reports the punctuation marker as reasonless, "
+          "naming e2e-scenario-punctuation-probe",
+          rc == 1 and "e2e-scenario-punctuation-probe" in out
+          and "without reason" in out, f"rc={rc}\n{out}")
+
+
+# ---------------------------------------------------------------------------
+# 5. gate-25 — check_contract_coverage.py
+# ---------------------------------------------------------------------------
+
+_ROUTES = """<?php
+return ['routes' => [
+    ['name' => 'probe#contractReasonPunctuationProbe', 'url' => '/api/probe-punct', 'verb' => 'GET'],
+    ['name' => 'probe#contractReasonProseProbe', 'url' => '/api/probe-prose', 'verb' => 'GET'],
+    ['name' => 'probe#contractWitnessProbe', 'url' => '/api/probe-witness', 'verb' => 'GET'],
+]];
+"""
+
+_CTRL_HEAD = """<?php
+namespace OCA\\Fx\\Controller;
+
+use OCP\\AppFramework\\Controller;
+
+class ProbeController extends Controller {
+"""
+
+
+def _ctrl_method(name: str, tag_line: str) -> str:
+    return f"""
+    /**
+     * Probe endpoint.
+     *
+     * #[NoAdminRequired]
+     * {tag_line}
+     */
+    #[\\OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired]
+    public function {name}(): \\OCP\\AppFramework\\Http\\JSONResponse {{
+        return new \\OCP\\AppFramework\\Http\\JSONResponse([]);
+    }}
+"""
+
+
+def suite_gate25(tmp: Path) -> None:
+    print("\n== gate-25 contract-coverage (check_contract_coverage.py) ==")
+    base_files = {
+        "appinfo/routes.php": _ROUTES,
+        "lib/Controller/ProbeController.php": _CTRL_HEAD + "}\n",
+    }
+
+    app = tmp / "g25-punct"
+    base = make_repo(app, base_files, {
+        "appinfo/routes.php": _ROUTES,
+        "lib/Controller/ProbeController.php":
+            _CTRL_HEAD + _ctrl_method("contractReasonPunctuationProbe",
+                                      "@contract exclude .") + "}\n",
+    })
+    rc, out = run_checker("check_contract_coverage.py", app, base)
+    # rc is checked as well as the name: EXIT_ERROR is 2, and a crashed checker
+    # that echoed the fixture back would otherwise satisfy a name-only grep.
+    check("gate-25 refuses '@contract exclude .' and names "
+          "contractReasonPunctuationProbe",
+          rc == 1 and "contractReasonPunctuationProbe" in out, f"rc={rc}\n{out}")
+
+    # The witness makes the anti-widening arm non-vacuous — see gate-16 ARM B.
+    app = tmp / "g25-real"
+    base = make_repo(app, base_files, {
+        "appinfo/routes.php": _ROUTES,
+        "lib/Controller/ProbeController.php":
+            _CTRL_HEAD + _ctrl_method(
+                "contractReasonProseProbe",
+                "@contract exclude internal health probe, deliberately absent "
+                "from the published OAS")
+            + _ctrl_method("contractWitnessProbe", "(no contract tag at all)")
+            + "}\n",
+    })
+    rc, out = run_checker("check_contract_coverage.py", app, base)
+    check("ANTI-WIDENING gate-25 still credits a real reason "
+          "(contractReasonProseProbe is not reported)",
+          "contractReasonProseProbe" not in out, f"rc={rc}\n{out}")
+    check("WITNESS gate-25 did inspect that controller — the untagged "
+          "contractWitnessProbe IS reported, so the arm above is not vacuous",
+          "contractWitnessProbe" in out, f"rc={rc}\n{out}")
+
+
+# ---------------------------------------------------------------------------
+# 6. gate-26 — check_visual_coverage.py
+# ---------------------------------------------------------------------------
+
+
+def _vue(marker: str) -> str:
+    return f"""<template>
+  <!-- {marker} -->
+  <div class="probe">probe</div>
+</template>
+
+<script>
+export default {{ name: 'VisualReasonPunctuationProbe' }}
+</script>
+"""
+
+
+def suite_gate26(tmp: Path) -> None:
+    print("\n== gate-26 visual-coverage (check_visual_coverage.py) ==")
+    base_files = {"src/views/ExistingView.vue": _vue("nothing here")}
+
+    app = tmp / "g26-punct"
+    base = make_repo(app, base_files, {
+        "src/views/ExistingView.vue": _vue("nothing here"),
+        "src/views/VisualReasonPunctuationProbe.vue": _vue("@visual exclude ."),
+    })
+    rc, out = run_checker("check_visual_coverage.py", app, base)
+    # rc as well as the name — see the note in suite_gate25().
+    check("gate-26 refuses '@visual exclude .' and names "
+          "VisualReasonPunctuationProbe.vue",
+          rc == 1 and "VisualReasonPunctuationProbe.vue" in out, f"rc={rc}\n{out}")
+
+    # The witness makes the anti-widening arm non-vacuous — see gate-16 ARM B.
+    app = tmp / "g26-real"
+    base = make_repo(app, base_files, {
+        "src/views/ExistingView.vue": _vue("nothing here"),
+        "src/views/VisualReasonPunctuationProbe.vue":
+            _vue("@visual exclude chart canvas renders nondeterministically"),
+        "src/views/VisualWitnessProbe.vue": _vue("no marker at all"),
+    })
+    rc, out = run_checker("check_visual_coverage.py", app, base)
+    check("ANTI-WIDENING gate-26 still credits a real reason "
+          "(VisualReasonPunctuationProbe.vue is not reported)",
+          "VisualReasonPunctuationProbe.vue" not in out, f"rc={rc}\n{out}")
+    check("WITNESS gate-26 did inspect that page set — the unmarked "
+          "VisualWitnessProbe.vue IS reported, so the arm above is not vacuous",
+          "VisualWitnessProbe.vue" in out, f"rc={rc}\n{out}")
+
+
+# ---------------------------------------------------------------------------
+# 7. The prose control
+# ---------------------------------------------------------------------------
+
+
+def suite_prose_control(tmp: Path) -> None:
+    print("\n== control: prose ABOUT a marker is not a marker ==")
+    # Every hit in the fleet-wide scan that looked like a punctuation-only
+    # reason was PROSE — a sentence discussing the mechanism, whose trailing
+    # backtick or bracket became "the reason". If this suite ever starts
+    # measuring its own commentary, this control is what says so.
+    app = tmp / "prose-control"
+    app.mkdir(parents=True)
+    (app / "openspec/specs/probe").mkdir(parents=True)
+    (app / "openspec/specs/probe/spec.md").write_text(
+        """---
+status: done
+---
+
+# Probe
+
+## Purpose
+
+Backend scenarios below are annotated with the e2e exclusion marker (see the
+gate docs) and the frontend ones are not.
+
+## Requirements
+
+### REQ-PROBE-001: probe
+
+#### Scenario: prose control scenario
+
+- GIVEN a fixture
+- THEN nothing
+""", encoding="utf-8")
+    rc, out = run_checker("check_e2e_coverage.py", app, mode="report")
+    check("CONTROL: a spec whose Purpose merely DESCRIBES exclusion excludes "
+          "nothing (0 of 1 scenarios excluded)",
+          '"scenarios": 1' in out and '"excluded": 0' in out, out)
+
+
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("== .github#400 — an exclusion reason must not be punctuation ==")
+    with tempfile.TemporaryDirectory(prefix="hydra-excl-reason.") as td:
+        tmp = Path(td)
+        suite_predicate()
+        suite_patterns()
+        suite_gate16(tmp)
+        suite_gate19(tmp)
+        suite_gate25(tmp)
+        suite_gate26(tmp)
+        suite_prose_control(tmp)
+
+    total = len(_passed) + len(_failed)
+    print()
+    print(f"== {len(_passed)} passed / {len(_failed)} failed / {total} run ==")
+    if total < MIN_ASSERTIONS:
+        print(f"FAIL — only {total} assertions ran, expected at least "
+              f"{MIN_ASSERTIONS}. A short run is not a green run.")
+        return 1
+    if _failed:
+        print("FAILED assertions:")
+        for f in _failed:
+            print(f"  - {f}")
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #400.

## The defect

One character apart, everything else byte-identical, through the real wrapper:

| tag | gate-16 |
|---|---|
| `@spec exclude` | **FAIL** — correctly refused as reasonless |
| `@spec exclude.` | **PASS** — credited as reason-bearing |

All four exclusion gates captured the reason with the same regex and then graded it with plain
Python truthiness. `"."` is a non-empty string, so it is truthy, so it was a reason.

## It was four checkers, and that is why it survived

| gate | file | call site |
|---|---|---|
| 16 spec-coverage | `check_spec_coverage.py` | `_docblock_spec_status` |
| 19 e2e-coverage | `check_e2e_coverage.py` | `_parse_exclusion` **and** `_parse_whole_spec_exclusion` |
| 25 contract-coverage | `check_contract_coverage.py` | `_contract_status` |
| 26 visual-coverage | `check_visual_coverage.py` | `_visual_exclude_status` |

Fixing gate-16 alone would leave three copies and no way for the next reader of
`check_visual_coverage.py` to know the rule lives elsewhere. So this adds **one** module,
`scripts/lib/exclusion_reason.py`, and all five call sites import it.

The gate-19 **whole-spec** form is the expensive one: stacked with #345 (an exclusion scores as
*positive* coverage) and #356 (one marker blankets its siblings), a single full stop there credits
every scenario in the file.

## The rule

`is_reason_bearing(reason)` — at least one **letter or digit**, and at least **3** characters.

- **Letter-or-digit, not `\w`.** `\w` also matches the underscore, so `___` would have passed a
  word-character rule while being exactly as meaningless as `.`. Measured over all 18 core apps
  the two rules reject the identical set, so the stricter one is free.
- **The floor is 3, and that is a judgement call, so it is argued in the module.** It exists only
  to catch `x` / `ok` / `na`, which the alphabet rule cannot reach. Measured, floors of **3, 8 and
  10 are all free** — none rejects anything a checker credits today — so the number was chosen by
  what a character count can honestly claim, not by cost.

  ⚠️ **This package already disagrees with itself three ways**, which I found while sweeping:
  the runner's gate-level opt-outs require `.{20,}`, `check_orphaned_write_capability.py` requires
  `.{10,}`, and these four required one truthy character. A gate-level opt-out in a PR body waives
  an *entire gate*, so 20 there is proportionate; these four markers are per-method and are written
  **~11,600 times across the fleet**. Raising their bar to 10 would be a **policy change about how
  the fleet writes exclusions, not a repair of #400**, so it is filed as a question rather than
  decided here.

  Supporting: the lowest length a checker credits today is 10 (three `@e2e exclude covered by`
  markers — themselves truncated, so the boundary is defined by a defect), leaving a 10-floor with
  no margin. And length is a poor proxy for the property that matters — an exemption's reason is a
  *testable claim*, and `not applicable here` is 20 characters of nothing. The module says in terms
  that it rejects **structurally degenerate** markers and must not be read as certifying that what
  survives is a good reason.

The pattern is shared too (`exclude_pattern()`), because the copies were *regex plus truthiness* —
sharing only the verdict would leave four regexes to drift. Five assertions pin each generated
pattern **byte-for-byte** against the literal it replaced.

**Normalisation deliberately stays local.** The four strip different trailing comment syntax
(`*/`, `-->`, none). Unifying it would change the reported `exclude_reason` string that #356's
distinct-reason counting reads, with no bearing on #400. Only the verdict is shared.

A rejected reason routes into the branch that **already existed** for the bare marker
(`exclude_noreason` / `bare_exclude`), so no new finding shape is invented.

## Fleet cost: zero, re-derived rather than inherited

Re-measured over all **18** core apps at `origin/development` (three cloned fresh — they are not
git checkouts locally). Files come from `git grep <rev>` against the committed tree, so nested
`custom_apps/` checkouts cannot be walked; positive control confirms 0 tracked paths under
`custom_apps/`.

The scan is deliberately **unanchored** — an upper bound. Over-reporting is work; under-reporting
is a confident wrong answer.

```
raw marker hits                     : 11669
reason-bearing today                : 11663   (7231 in a path a checker actually reads)
UPPER BOUND rejected by the new rule:    69   ->  IN-SCOPE: 1
```

68 of 69 are **prose about the tag** in `openspec/changes/archive/**`, which no checker reads. The
one in-scope hit (shillinq `bookkeeping-purchase-order-3way/spec.md:430`) is a *continuation* line
below a real reason-bearing marker; `_parse_exclusion` breaks on the first match, so it is
unreachable.

**Live A/B, both arms on the same working trees** (the "before" arm materialised from `git show
HEAD:`), positive-controlled first — the before-copy returns `('excluded', '.')`:

| | scenarios | excluded BEFORE | excluded AFTER | delta |
|---|---|---|---|---|
| all 18 core apps | 24,918 | 17,930 | 17,930 | **+0** |

No app goes red.

## Revert-proven, five times

Each call site reverted **separately** to `if reason:`; each turns a **named** assertion red.

| revert | red | assertion |
|---|---|---|
| gate-16 | 1 | *refuses '@spec exclude .' and names `specReasonPunctuationProbe`* |
| gate-19 scenario | 2 | *refuses a scenario-level '@e2e exclude .'* + *gate mode reports it as reasonless* |
| gate-19 whole-spec | 1 | *refuses a WHOLE-SPEC '@e2e exclude .' — neither scenario credited* |
| gate-25 | 1 | *refuses '@contract exclude .' and names `contractReasonPunctuationProbe`* |
| gate-26 | 1 | *refuses '@visual exclude .' and names `VisualReasonPunctuationProbe.vue`* |
| `exclude_pattern` anchoring | 6 | all five pattern-identity assertions + a real gate-26 regression |

The two gate-19 reverts are separate on purpose: neither half can be dropped later while the suite
stays green.

## The suite — `scripts/lib/test_exclusion_reason.py`

**38 assertions, 0 failures.** Discovered automatically by `tests/run-helper-suites.sh`, so it runs
in CI with no workflow edit.

- **Anchored subjects.** Every assertion greps a token unique to its own fixture, and **none is a
  prefix of another** — a subject a sibling finding could satisfy makes a bundle vacuous for its
  own defect.
- **Prose control.** Fixtures are generated into temp directories, and a spec whose `## Purpose`
  merely *describes* exclusion must exclude nothing. If the suite ever starts measuring its own
  commentary, that control says so.
- **Anti-widening** on all four gates — a predicate that rejected everything would satisfy every
  defect assertion while retiring the exclusion mechanism fleet-wide.
- **Assertion floor** (`< 38 ⇒ FAIL`), so a short run cannot be a green run.

### Two vacuous greens caught in my own suite

**The fixture repos were not being built at all.** `make_repo` used `git init -b main`; this box
runs git 2.25, which has no `-b`. The files land on disk regardless, so the gates ran at **full
scope** and two arms went green while testing something other than what they claimed. `make_repo`
now checks every git step and asserts `base...HEAD` is a non-empty diff — a fixture that failed to
build raises rather than degrading into a differently-scoped run with a plausible verdict.

**Three anti-widening arms were vacuity-capable** — "X is not reported" is equally true of a run
that inspected nothing. Each now carries a **witness** in the same fixture that *must* be reported.

## No existing suite asserted the defect

Checked explicitly. Every existing exclusion assertion uses real reason text; the shortest is 11
characters. **No existing suite was edited.**

## Adjacent holes found while sweeping — reported, not fixed

- `detect-redundant-controllers.py:192` honours a **bare** `@spec exclude` (no reason captured at
  all), so a marker gate-16 refuses still silences gate-17.
- `check_custom_widget_ratchet.py:113` accepts punctuation (`exclude[ \t]+\S+`); 9 live uses.
- `check_orphaned_write_capability.py:272` requires 10 chars but no letter or digit; 8 live uses.

Each is a one-line change against the shared predicate, but each needs its own per-tag fleet
measurement, which is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
