### PR TITLE
fix(gates 17, 52, 57): three more exclusion markers graded by the wrong rule (#412)

### DIFF
--- a/hydra-gates/scripts/lib/check_custom_widget_ratchet.py
+++ b/hydra-gates/scripts/lib/check_custom_widget_ratchet.py
@@ -25,8 +25,11 @@ Documented exception (matching the gate-16/19 ``exclude``-reason convention):
 a comment carrying ``@custom-widget-ratchet exclude <reason>`` inside the
 entry object — or on one of the three lines directly above it — removes that
 ADDED/MODIFIED entry from the head count, so a justified one-off can grow the
-total. A bare marker without a reason does not count. The ``_note`` is still
-required either way.
+total. A bare marker without a reason does not count, and neither does a
+punctuation-only one: the reason is graded by the shared
+``exclusion_reason.is_reason_bearing()`` (``.github#412``; before that this
+gate asked only for ``\\S+``, which a full stop satisfies — ``.github#400``
+under a different tag). The ``_note`` is still required either way.
 
 Usage:
     check_custom_widget_ratchet.py <src-file> [<src-file> ...]
@@ -80,6 +83,9 @@ import subprocess
 import sys
 from bisect import bisect_right
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+
 BUILTIN_WIDGET_KEYS = {
     "object-table",
     "card-grid",
@@ -110,7 +116,46 @@ _KIND_WIDGET_RE = re.compile(r"\bkind\s*:\s*(['\"])widget\1")
 
 # The <reason> must be on the same line as the marker — a bare `exclude`
 # followed by a newline (i.e. no reason) does not count.
-_EXCLUDE_RE = re.compile(r"@custom-widget-ratchet[ \t]+exclude[ \t]+\S+")
+#
+# `\S+` WAS NOT A REASON TEST (.github#412)
+# -----------------------------------------
+# It asked only "is there a non-whitespace character after the marker", which a
+# single full stop satisfies. That is `.github#400` under a different tag: the
+# four coverage gates asked the same question with `if reason:` and `.` walked
+# through all four. The reason is now CAPTURED and graded by the shared
+# `exclusion_reason.is_reason_bearing()`, so this tag and those four cannot
+# disagree about what a justification is.
+#
+# re.MULTILINE is load-bearing and preserves the same-line rule stated above:
+# `.` never matches a newline, so `(?P<reason>.*?)\s*$` cannot reach past the
+# marker's own line, and `$` needs MULTILINE to mean "end of THIS line" in a
+# multi-line registry-entry window. Without it the marker would only be
+# recognised at the very end of the window.
+_EXCLUDE_RE = re.compile(exclude_pattern("custom-widget-ratchet"), re.MULTILINE)
+
+# Comment closers that can sit on the marker's own line in a JS/TS/Vue registry
+# — the same normalisation gate-26 applies to Vue text, kept LOCAL here for the
+# reason `#411` recorded: normalisation is a property of the file type, only the
+# VERDICT is shared.
+_COMMENT_CLOSERS = ("-->", "*/")
+
+
+def _has_reason_bearing_exclude(window: str) -> bool:
+    """True when ``window`` carries a `@custom-widget-ratchet exclude` marker
+    WITH a usable reason.
+
+    First match wins, as in all seven exclusion call sites: a window whose first
+    marker is bare is not rescued by a better one further down.
+    """
+    m = _EXCLUDE_RE.search(window)
+    if not m:
+        return False
+    reason = m.group("reason").strip()
+    for close in _COMMENT_CLOSERS:
+        if reason.endswith(close):
+            reason = reason[: -len(close)].strip()
+    return is_reason_bearing(reason)
+
 
 # Registry key preceding the entry's `{`, comment-stripped tail match:
 #   registry['key'] =   |  registry["key"] =  |  'key':  |  "key":
@@ -278,7 +323,7 @@ def parse_entries(text):
         # The documented exception marker may sit inside the entry object or
         # on one of the three lines directly above it.
         ext_start = line_starts[max(0, line_of(open_pos) - 1 - 3)]
-        has_exclude = bool(_EXCLUDE_RE.search(text[ext_start:close_pos + 1]))
+        has_exclude = _has_reason_bearing_exclude(text[ext_start:close_pos + 1])
         entries.append(
             Entry(
                 key=key,

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -54,9 +54,13 @@ Prints one finding per line:
 Always exits 0 — the calling gate (bash) counts the printed lines.
 
 Suppression: a docblock ``@orphaned-write-capability exclude <reason>``
-(reason >= 10 chars) immediately preceding the method declaration
-suppresses that one method. Mirrors the fleet's
-``@spec exclude <reason>`` / ``@e2e exclude <reason>`` convention.
+immediately preceding the method declaration suppresses that one method.
+Mirrors the fleet's ``@spec exclude <reason>`` / ``@e2e exclude <reason>``
+convention. The reason must be at least :data:`REASON_MIN_CHARS` characters —
+this tag's own, deliberately higher floor — AND carry a letter or digit, the
+rule shared with every other exclusion tag via
+``exclusion_reason.is_reason_bearing()``. Before ``.github#412`` only the
+length half existed, so ``..........`` was a reason here.
 """
 
 from __future__ import annotations
@@ -65,6 +69,9 @@ import os
 import re
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
 
 # Foundation repos: the abstractions every leaf app consumes (ADR-022,
 # apps-consume-or-abstractions). A PUBLIC method here is frequently invoked
@@ -269,8 +276,34 @@ _MCP_TOOL_ATTR_RE = re.compile(
 # directly above a method's attribute block — the previous method's `}`, a
 # property or `use` `;`, the class's opening `{` — ends in one of these.
 _ATTR_BOUNDARY_RE = re.compile(r"[{};]\s*$")
+# THIS TAG'S OWN FLOOR, KEPT DELIBERATELY (.github#412)
+# ------------------------------------------------------
+# Ten characters is what this gate's author chose and it has been live since the
+# gate was written. `#412` aligned this tag on the shared LETTER-OR-DIGIT rule —
+# the half it never had, under which `..........` was a reason — and left the
+# floor alone. Collapsing it to the shared default of 3 would have been a silent
+# RELAXATION of a live bar smuggled in beside a tightening; raising the other
+# tags to 10 would have been a silent fleet policy change in the other direction.
+# Both were measured to be free today, which is exactly why the choice belongs to
+# a human and not to this patch. See the threshold question in .github#412.
+REASON_MIN_CHARS = 10
+
+# `.{10,}` GRADED LENGTH AND NOTHING ELSE (.github#412)
+# -----------------------------------------------------
+# It is the inverse of `#400`'s hole: those four gates had no floor and no
+# alphabet rule; this one had a floor and no alphabet rule, so ten full stops
+# were a justification.
+#
+# A SECOND, UNREPORTED HOLE IN THE SAME PATTERN: the old separator between the
+# marker and the reason was `\s+`, and `\s` matches a NEWLINE. So a marker with
+# no reason at all on its own line silently borrowed the docblock CONTINUATION
+# LINE beneath it — `* Wired up in a later PR` — as its justification. That is
+# the shillinq continuation-line shape from `#400`, except reachable: nothing
+# here breaks on a first match. `exclude_pattern()` separates with `[ \t]*` and
+# terminates at `$`, so the reason must be on the marker's own line, and the
+# pattern is now the same one the other six exclusion tags use.
 _EXCLUDE_RE = re.compile(
-    r"@orphaned-write-capability\s+exclude\s+(?P<reason>.{10,})"
+    exclude_pattern("orphaned-write-capability"), re.MULTILINE
 )
 
 
@@ -340,7 +373,14 @@ def _preceding_docblock_has_exclude(lines: list[str], method_line_idx: int) -> b
             break
         i -= 1
     text = "\n".join(reversed(block))
-    return bool(_EXCLUDE_RE.search(text))
+    m = _EXCLUDE_RE.search(text)
+    if not m:
+        return False
+    # Trailing `*/` is PHP-docblock syntax, not part of the reason. Local, as
+    # `#411` established: normalisation belongs to the file type, the VERDICT is
+    # shared. First match wins, as at every other exclusion call site.
+    reason = m.group("reason").strip().rstrip("*/").strip()
+    return is_reason_bearing(reason, min_chars=REASON_MIN_CHARS)
 
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/detect-redundant-controllers.py
+++ b/hydra-gates/scripts/lib/detect-redundant-controllers.py
@@ -40,15 +40,25 @@ written as the last line, prefixed with `# count=`, for easy parsing.
 
 Optional `--changed-files=<newline-separated-paths>` filters the scan to
 those paths only — used in PR-scoped runs (Phase G).
+
+Opt-out: a docblock `@spec exclude <reason>` on the method. The reason is
+REQUIRED and is graded by the shared `exclusion_reason.is_reason_bearing()`,
+the same predicate gate-16 spec-coverage applies to the same tag. Until
+`.github#412` this gate required no reason at all, so a marker gate-16 refused
+still silenced this one — see the note above SPEC_EXCLUDE_RE.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Iterable
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
 
 # Methods on OpenRegister's ObjectService that are pure CRUD pass-throughs.
 # A method body that calls ONE of these and nothing else of substance is
@@ -189,7 +199,42 @@ CRUD_NAME_RE = re.compile(
 # ANY `$this->*Service->` call (incl. legitimate domain services like
 # `applicationService`, and the deliberate ObjectServiceMapperAdapter facade),
 # so this annotation is how authors declare a flagged pass-through is by design.
-SPEC_EXCLUDE_RE = re.compile(r"@spec\s+exclude\b")
+#
+# THE REASON IS PART OF THE MARKER, AND THIS GATE USED TO IGNORE IT (.github#412)
+# ------------------------------------------------------------------------------
+# The pattern here was `@spec\s+exclude\b`: no reason was captured and none was
+# required, so a BARE `@spec exclude` silenced this gate. That is worse than the
+# `#400` defect it sits next to, because this gate reads the SAME TAG as gate-16.
+# After `#411`, gate-16 refuses both a bare marker and `@spec exclude .` — while
+# this gate went on honouring both. An author blocked by one gate could waive the
+# other with the identical keystrokes, and the two gates' disagreement about the
+# validity of one annotation was invisible from either side.
+#
+# Both the pattern and the verdict now come from exclusion_reason, the same
+# module gate-16 uses, so the two CANNOT drift apart again. re.MULTILINE because
+# this is matched against a whole docblock, not line by line as gate-16 does it:
+# the reason must end at ITS OWN line's end, not at the end of the block.
+SPEC_EXCLUDE_RE = re.compile(exclude_pattern("spec"), re.MULTILINE)
+
+
+def _has_reason_bearing_spec_exclude(docblock: str) -> bool:
+    """True when ``docblock`` carries a `@spec exclude` marker WITH a reason.
+
+    First match wins, exactly as gate-16's `_docblock_spec_status` decides it —
+    a docblock whose first marker is bare is not rescued by a second, better one
+    further down. Two gates reading one tag must agree about which marker
+    speaks for the method.
+
+    The trailing-`*/` strip is gate-16's local normalisation for PHP docblocks
+    and is repeated here rather than shared, for the reason `#411` recorded:
+    normalisation differs legitimately per file type, and only the VERDICT is
+    common. Both callers read PHP, so both strip the same thing.
+    """
+    m = SPEC_EXCLUDE_RE.search(docblock)
+    if not m:
+        return False
+    reason = m.group("reason").strip().rstrip("*/").strip()
+    return is_reason_bearing(reason)
 
 
 def _split_methods(php_source: str):
@@ -407,9 +452,11 @@ def scan_files(
             # body shape, and must not be flagged.
             if not CRUD_NAME_RE.match(method_name):
                 continue
-            # Honour an explicit `@spec exclude` docblock — intentional
-            # facade/adapter plumbing the author has declared out of scope.
-            if SPEC_EXCLUDE_RE.search(_method_docblock(src_lines, line_no)):
+            # Honour an explicit `@spec exclude <reason>` docblock — intentional
+            # facade/adapter plumbing the author has declared out of scope. A
+            # marker with no usable reason is NOT honoured (.github#412): it
+            # would let this gate be waived by an annotation gate-16 refuses.
+            if _has_reason_bearing_spec_exclude(_method_docblock(src_lines, line_no)):
                 continue
             if _is_redundant_body(body):
                 findings.append(

--- a/hydra-gates/scripts/lib/exclusion_reason.py
+++ b/hydra-gates/scripts/lib/exclusion_reason.py
@@ -4,13 +4,25 @@
 
 WHY THIS FILE EXISTS (.github#400)
 ==================================
-Four gates let a change opt out of coverage by writing a reason next to the
+Seven gates let a change opt out of coverage by writing a reason next to the
 marker::
 
     @spec     exclude <reason>     gate-16  spec-coverage
     @e2e      exclude <reason>     gate-19  e2e-coverage      (scenario, requirement AND whole-spec)
     @contract exclude <reason>     gate-25  contract-coverage
     @visual   exclude <reason>     gate-26  visual-coverage
+
+    @spec     exclude <reason>     gate-17  redundant-controller       (.github#412)
+    @custom-widget-ratchet exclude <reason>
+                                   gate-52  custom-widget-ratchet      (.github#412)
+    @orphaned-write-capability exclude <reason>
+                                   gate-57  orphaned-write-capability  (.github#412)
+
+The first four were repaired by `#411`; the second three by `#412`, and the
+worst of those was gate-17: it reads the SAME `@spec exclude` tag as gate-16 but
+honoured a BARE marker with no reason at all, so an annotation gate-16 refused
+still silenced gate-17. Two gates disagreeing about whether one annotation is
+valid is worse than either being wrong on its own.
 
 All four captured the reason with the same regex and then asked the same
 question about it — ``if reason:`` — which is Python truthiness, i.e. "is this
@@ -90,15 +102,18 @@ _ALNUM_RE = re.compile(r"[^\W_]", re.UNICODE)
 # knowing before anyone "harmonises" it:
 #
 #   run-hydra-gates.sh gate-level opt-outs  `.{20,}`   20 chars
-#   check_orphaned_write_capability.py      `.{10,}`   10 chars
-#   these four gates, before .github#400    (any non-empty string)
+#   check_orphaned_write_capability.py      `.{10,}`   10 chars  (gate-57)
+#   the four #400 gates, before that fix    (any non-empty string)
+#   gate-17, before .github#412             (NO reason required at all)
+#   gate-52, before .github#412             (any non-whitespace character)
 #
 # A gate-level opt-out written in a PR body waives an ENTIRE gate, so a high bar
-# there is proportionate. These four markers are per-method and per-scenario and
+# there is proportionate. The per-marker tags are per-method and per-scenario and
 # are used ~11,600 times across the fleet; they are a different act. Raising
 # their bar from "any character" to 10 would be a POLICY change about how the
 # fleet writes exclusions, not a bug fix, and it does not belong in the repair
-# of #400. It is filed as a question for a human rather than decided here.
+# of #400 or #412. It is filed as a question for a human rather than decided
+# here — see the "threshold question" section of .github#412.
 #
 # So: 3, which is far enough below the data to have margin (the lowest reason
 # length a checker actually credits is 10), and low enough that it is plainly a
@@ -110,7 +125,7 @@ _ALNUM_RE = re.compile(r"[^\W_]", re.UNICODE)
 REASON_MIN_CHARS = 3
 
 
-def is_reason_bearing(reason: str | None) -> bool:
+def is_reason_bearing(reason: str | None, *, min_chars: int | None = None) -> bool:
     """Does ``reason`` count as a justification for an exclusion marker?
 
     ``reason`` is the text already normalised by the caller (each checker strips
@@ -119,29 +134,50 @@ def is_reason_bearing(reason: str | None) -> bool:
     normalisation stays with the caller and only the VERDICT is shared).
 
     Returns ``True`` only when the reason has at least one letter or digit and
-    is at least :data:`REASON_MIN_CHARS` characters long.
+    is at least ``min_chars`` characters long, defaulting to
+    :data:`REASON_MIN_CHARS`.
 
-    This replaces a bare ``if reason:`` truthiness test in four checkers, under
-    which every non-empty string — including ``.`` — was a reason (`#400`).
+    WHY ``min_chars`` IS A PARAMETER AND NOT A CONSTANT
+    ---------------------------------------------------
+    Because the package genuinely disagrees with itself about the floor (see the
+    table above) and that disagreement is NOT this module's to settle. gate-57
+    has demanded 10 characters since it was written; `#412` aligned it on the
+    ALPHABET rule — the half it was missing — while deliberately leaving its
+    floor where its author put it. Collapsing it to 3 would have been a silent
+    relaxation of a live bar, smuggled in beside a tightening; hard-coding 10 for
+    everyone would have been a silent fleet policy change in the other direction.
+
+    So the LETTER-OR-DIGIT rule is universal and shared, and the floor is stated
+    per tag at the call site where a reader can see which number applies. Passing
+    the floor explicitly also keeps every caller's choice greppable: the answer
+    to "what does gate-57 demand" is at gate-57, not inferred from a default.
+
+    This replaces a bare ``if reason:`` truthiness test in the four `#400`
+    checkers — under which every non-empty string, including ``.``, was a reason
+    — and, in `#412`, a no-reason-at-all test in gate-17, a bare ``\\S+`` in
+    gate-52 and an alphabet-free ``.{10,}`` in gate-57.
     """
+    floor = REASON_MIN_CHARS if min_chars is None else min_chars
     if not reason:
         return False
-    if len(reason) < REASON_MIN_CHARS:
+    if len(reason) < floor:
         return False
     return _ALNUM_RE.search(reason) is not None
 
 
-def why_rejected(reason: str | None) -> str:
+def why_rejected(reason: str | None, *, min_chars: int | None = None) -> str:
     """A short, human-facing explanation for use in a gate finding.
 
     Kept beside the predicate so the message cannot drift out of step with the
-    rule it describes.
+    rule it describes — including the per-tag floor, which the message must
+    quote correctly or it sends the author to pad to the wrong number.
     """
+    floor = REASON_MIN_CHARS if min_chars is None else min_chars
     if not reason:
         return "no reason given"
-    if len(reason) < REASON_MIN_CHARS:
+    if len(reason) < floor:
         return (
-            f"reason {reason!r} is shorter than {REASON_MIN_CHARS} characters — "
+            f"reason {reason!r} is shorter than {floor} characters — "
             f"too short to name anything"
         )
     if _ALNUM_RE.search(reason) is None:

--- a/hydra-gates/scripts/lib/test_exclusion_reason_adjacent.py
+++ b/hydra-gates/scripts/lib/test_exclusion_reason_adjacent.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""test_exclusion_reason_adjacent — .github#412, gates 17, 52 and 57.
+
+WHAT IS UNDER TEST
+==================
+`#411` put one shared predicate behind the four `#400` coverage gates. Three
+more checkers grade an exclusion marker, and none of them was on that list:
+
+    gate-17  detect-redundant-controllers.py     `@spec exclude`
+    gate-52  check_custom_widget_ratchet.py      `@custom-widget-ratchet exclude`
+    gate-57  check_orphaned_write_capability.py  `@orphaned-write-capability exclude`
+
+Each was wrong in its own way, and gate-17 is the one that matters most: it
+reads the SAME `@spec` tag as gate-16, and it required NO REASON AT ALL. So
+after `#411` a bare `@spec exclude` was refused by gate-16 and still honoured by
+gate-17 — one annotation, two gates, opposite verdicts, and nothing in either
+gate's output that would let a reader notice. gate-52 asked only for `\\S+`,
+which a full stop satisfies (`#400` under another tag). gate-57 asked for ten
+characters and never for a letter, so `..........` was a justification.
+
+WHY THE FLOORS STILL DIFFER, AND WHY THAT IS ASSERTED HERE
+-----------------------------------------------------------
+gate-57 keeps its own floor of ten. That is not an oversight and it is not a
+detail — it is the package's open threshold disagreement, left open on purpose
+(`#412`). `assertion 'gate-57 keeps its OWN floor of 10'` below exists so that a
+future "harmonisation" of these numbers cannot happen SILENTLY: collapsing
+gate-57 to the shared 3 turns that assertion red and forces the decision to be
+made out loud, by whoever makes it.
+
+WHY EACH DEFECT LIVES IN ITS OWN NAMED FILE
+-------------------------------------------
+`#404` and `#409`: a subject that a SIBLING finding can also satisfy makes an
+assertion vacuous, and one named file emitting two findings from two different
+code paths survives a partial revert. So every probe here is a file with exactly
+ONE method, hence at most one finding, and the file names are pairwise
+non-containing — no name is a substring of another, including across the
+extension.
+
+ANTI-WIDENING NEEDS A WITNESS
+-----------------------------
+"`X` is not reported" is equally true of a run that inspected nothing. Every
+"must NOT be reported" arm therefore runs in a fixture that also contains a
+witness which MUST be reported, so the negative claim is only reachable through
+a run that provably opened the directory.
+
+Run: python3 hydra-gates/scripts/lib/test_exclusion_reason_adjacent.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+sys.path.insert(0, str(LIB))
+
+from exclusion_reason import (  # noqa: E402
+    REASON_MIN_CHARS,
+    exclude_pattern,
+    is_reason_bearing,
+    why_rejected,
+)
+import check_orphaned_write_capability as owc  # noqa: E402
+
+# An empty run is not a green run — the same trap run-helper-suites.sh guards.
+MIN_ASSERTIONS = 31
+
+_passed: list[str] = []
+_failed: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    if ok:
+        _passed.append(name)
+        print(f"  ok   — {name}")
+    else:
+        _failed.append(name)
+        print(f"  FAIL — {name}")
+        if detail:
+            for line in str(detail).splitlines():
+                print(f"           {line}")
+
+
+def run(script: str, argv: list[str], cwd: str | None = None,
+        base: str | None = None) -> str:
+    env = dict(os.environ)
+    if base:
+        env["HYDRA_GATE_BASE_REF"] = base
+    else:
+        env.pop("HYDRA_GATE_BASE_REF", None)
+    r = subprocess.run(["python3", str(LIB / script), *argv],
+                       capture_output=True, text=True, env=env, cwd=cwd,
+                       check=False)
+    return r.stdout + r.stderr
+
+
+def _git(repo: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@example.invalid", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", "-C", repo, *args],
+        capture_output=True, text=True, check=False)
+
+
+def make_repo(root: str, base_files: dict[str, str], head_files: dict[str, str]) -> str:
+    """Two commits; returns the BASE sha. HARD-FAILS on every git step.
+
+    `#411` learned this the expensive way: `git init -b main` does not exist on
+    git 2.25, every fixture silently failed to be a repo, the files were on disk
+    either way, and the gates ran at a DIFFERENT SCOPE while still printing a
+    plausible verdict. A fixture that failed to build must not look like one.
+    """
+    def must(*args: str) -> subprocess.CompletedProcess:
+        r = _git(root, *args)
+        if r.returncode != 0:
+            raise RuntimeError(f"fixture build failed: git {' '.join(args)} -> "
+                               f"{r.returncode}\n{r.stdout}{r.stderr}")
+        return r
+
+    def write(files: dict[str, str]) -> None:
+        for rel, body in files.items():
+            p = Path(root) / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+
+    must("init", "-q")
+    write(base_files)
+    must("add", "-A")
+    must("commit", "-q", "-m", "base")
+    base = must("rev-parse", "HEAD").stdout.strip()
+    if len(base) != 40:
+        raise RuntimeError(f"fixture build failed: no base sha (got {base!r})")
+    write(head_files)
+    must("add", "-A")
+    must("commit", "-q", "-m", "head")
+    if _git(root, "diff", "--quiet", f"{base}...HEAD").returncode == 0:
+        raise RuntimeError("fixture build failed: base...HEAD is an EMPTY diff")
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. The predicate's per-tag floor
+# ---------------------------------------------------------------------------
+
+
+def suite_predicate() -> None:
+    print("\n== the shared predicate, with a per-tag floor ==")
+    check("the default floor is unchanged by #412",
+          REASON_MIN_CHARS == 3, f"REASON_MIN_CHARS={REASON_MIN_CHARS}")
+    check("min_chars raises the bar: 'abcde' passes at the default and is "
+          "refused at 10",
+          is_reason_bearing("abcde") is True
+          and is_reason_bearing("abcde", min_chars=10) is False)
+    check("min_chars does NOT replace the alphabet rule: ten full stops are "
+          "refused at a floor of 10 — the exact gate-57 hole",
+          is_reason_bearing("." * 10, min_chars=10) is False)
+    check("ANTI-WIDENING: a real reason still passes at a floor of 10",
+          is_reason_bearing("Wired in the next PR (issue 999)", min_chars=10) is True)
+    check("why_rejected quotes the CALLER's floor, not the default — a message "
+          "naming 3 would send a gate-57 author to pad to the wrong number",
+          "10 characters" in why_rejected("abcde", min_chars=10)
+          and "3 characters" in why_rejected("ab"))
+    check("why_rejected blames the ALPHABET, not the length, when the reason is "
+          "long enough and still degenerate",
+          "no letter or digit" in why_rejected("." * 10, min_chars=10))
+    check("gate-57 keeps its OWN floor of 10 — #412 aligned its ALPHABET rule "
+          "and deliberately left the threshold question open (harmonising this "
+          "silently is what this assertion exists to prevent)",
+          owc.REASON_MIN_CHARS == 10, f"got {owc.REASON_MIN_CHARS}")
+    check("all three tags now generate their marker pattern from the ONE "
+          "template, so the regexes cannot drift apart again",
+          exclude_pattern("spec")
+          == r"@spec\s+exclude\b[ \t]*(?P<reason>.*?)\s*$"
+          and exclude_pattern("custom-widget-ratchet").startswith(
+              r"@custom-widget-ratchet\s+exclude\b")
+          and exclude_pattern("orphaned-write-capability").startswith(
+              r"@orphaned-write-capability\s+exclude\b"))
+
+
+# ---------------------------------------------------------------------------
+# 2. gate-17 redundant-controller — the bare-marker hole
+# ---------------------------------------------------------------------------
+
+_CTRL = """<?php
+namespace OCA\\Fixture\\Controller;
+{classdoc}class {cls} {{
+    /**{marker}
+     */
+    public function index() {{
+        return new JSONResponse($this->objectService->findAll([]));
+    }}
+}}
+"""
+
+_G17_FILES = {
+    # one method per file => at most one finding per named subject (#409)
+    "SpecExcludeBareProbeController":
+        ("\n     * @spec exclude", "", True),
+    "SpecExcludeDotProbeController":
+        ("\n     * @spec exclude .", "", True),
+    "SpecExcludeUnderscoreProbeController":
+        ("\n     * @spec exclude ___", "", True),
+    "SpecExcludeHonouredProbeController":
+        ("\n     * @spec exclude deliberate ObjectService facade, ADR-022", "", False),
+    "SpecExcludeClassLevelProbeController":
+        ("", "/**\n * @spec exclude a class-level marker is not a method marker\n */\n", True),
+    "RedundantWitnessProbeController":
+        ("", "", True),
+}
+
+
+def suite_gate17() -> None:
+    print("\n== gate-17 redundant-controller (@spec exclude) ==")
+    with tempfile.TemporaryDirectory() as d:
+        ctrl = Path(d) / "lib" / "Controller"
+        ctrl.mkdir(parents=True)
+        for cls, (marker, classdoc, _exp) in _G17_FILES.items():
+            (ctrl / f"{cls}.php").write_text(
+                _CTRL.format(cls=cls, marker=marker, classdoc=classdoc),
+                encoding="utf-8")
+        out = run("detect-redundant-controllers.py", [d])
+
+    if "# count=" not in out:
+        check("gate-17 finished (it printed its terminal `# count=` marker)",
+              False, out[-1500:])
+        return
+    check("gate-17 finished (it printed its terminal `# count=` marker)", True)
+
+    def reported(cls: str) -> bool:
+        return any(f"{cls}.php" in ln and "rule=pass-through-to-ObjectService" in ln
+                   for ln in out.splitlines())
+
+    check("WITNESS: an unannotated pass-through IS reported, so every "
+          "'is not reported' claim below came from a run that opened this "
+          "directory (RedundantWitnessProbeController)",
+          reported("RedundantWitnessProbeController"), out)
+    check("gate-17 refuses a BARE `@spec exclude` and names "
+          "SpecExcludeBareProbeController — the marker gate-16 already refuses",
+          reported("SpecExcludeBareProbeController"), out)
+    check("gate-17 refuses `@spec exclude .` and names "
+          "SpecExcludeDotProbeController",
+          reported("SpecExcludeDotProbeController"), out)
+    check("gate-17 refuses `@spec exclude ___` and names "
+          "SpecExcludeUnderscoreProbeController — \\w would have accepted it",
+          reported("SpecExcludeUnderscoreProbeController"), out)
+    check("SCOPE CONTROL: a `@spec exclude` in the CLASS docblock does not "
+          "silence the method below it (SpecExcludeClassLevelProbeController)",
+          reported("SpecExcludeClassLevelProbeController"), out)
+    check("ANTI-WIDENING: a real reason is still honoured and "
+          "SpecExcludeHonouredProbeController is NOT reported",
+          not reported("SpecExcludeHonouredProbeController"), out)
+    expected = sum(1 for _c, (_m, _cd, exp) in _G17_FILES.items() if exp)
+    got = int(out.rsplit("# count=", 1)[1].split()[0])
+    check(f"gate-17's own terminal count is exactly {expected} — a COUNT arm, so "
+          "one probe silently ceasing to fire cannot hide behind the others "
+          "keeping the log non-empty (#409)",
+          got == expected, f"# count={got}, expected {expected}\n{out}")
+
+
+# ---------------------------------------------------------------------------
+# 3. gate-52 custom-widget-ratchet
+# ---------------------------------------------------------------------------
+
+_REG_BASE = """export const registry = {
+\t'keptCanvas': {
+\t\tkind: 'widget',
+\t\t_note: "bespoke analytics canvas",
+\t},
+};
+"""
+
+_REG_HEAD = """export const registry = {{
+{marker}\t'grownCanvas': {{
+\t\tkind: 'widget',
+\t\t_note: "bespoke analytics canvas",
+\t}},
+\t'keptCanvas': {{
+\t\tkind: 'widget',
+\t\t_note: "bespoke analytics canvas",
+\t}},
+}};
+"""
+
+
+def _g52(marker: str) -> str:
+    with tempfile.TemporaryDirectory() as d:
+        base = make_repo(
+            d,
+            {"src/registry.js": _REG_BASE},
+            {"src/registry.js": _REG_HEAD.format(marker=marker)})
+        # RELATIVE path, with cwd at the repo root: the helper resolves the base
+        # side with `git show <base>:<path>`, which only works for a
+        # repo-relative path. Handed an absolute one it silently reads base=0 —
+        # a ratchet whose base is empty reports growth for everything, which
+        # looks exactly like the marker being refused.
+        return run("check_custom_widget_ratchet.py",
+                   [os.path.join("src", "registry.js")], cwd=d, base=base)
+
+
+def suite_gate52() -> None:
+    print("\n== gate-52 custom-widget-ratchet (@custom-widget-ratchet exclude) ==")
+    arms = {
+        "dot": "\t// @custom-widget-ratchet exclude .\n",
+        "real": "\t// @custom-widget-ratchet exclude no built-in widget renders "
+                "a computed scorecard\n",
+        "nextline": "\t// @custom-widget-ratchet exclude\n"
+                    "\t// no built-in widget renders a computed scorecard\n",
+        "bare": "\t// @custom-widget-ratchet exclude\n",
+    }
+    out = {k: _g52(v) for k, v in arms.items()}
+
+    for k, o in out.items():
+        if "[custom-widget-ratchet] findings=" in o:
+            continue
+        check(f"gate-52 finished on the {k!r} arm (it printed `findings=`)",
+              False, o[-1500:])
+        return
+    check("gate-52 finished on all four arms (each printed its `findings=` "
+          "count, so none of the verdicts below came from a crash)", True)
+
+    check("gate-52 refuses `@custom-widget-ratchet exclude .` — the entry is "
+          "NOT ratchet-excluded and the growth is reported",
+          "ratchet-excluded" not in out["dot"]
+          and "the ratchet forbids growth" in out["dot"], out["dot"])
+    check("UNCHANGED BEHAVIOUR: a bare marker with no reason still does not "
+          "count (this was already true under `\\S+` and must stay true)",
+          "ratchet-excluded" not in out["bare"]
+          and "the ratchet forbids growth" in out["bare"], out["bare"])
+    check("SAME-LINE RULE PRESERVED: a reason on the line BELOW the marker does "
+          "not count, exactly as the old `\\S+` form required",
+          "ratchet-excluded" not in out["nextline"]
+          and "the ratchet forbids growth" in out["nextline"], out["nextline"])
+    check("ANTI-WIDENING: a real reason still lifts the entry out of the head "
+          "count, and the growth is NOT reported",
+          "(1 ratchet-excluded)" in out["real"]
+          and "the ratchet forbids growth" not in out["real"], out["real"])
+    check("WITNESS on the anti-widening arm: the ratchet still RAN and still "
+          "counted both entries (base=1 head=2), so 'not reported' is not a "
+          "claim about a run that computed nothing",
+          "base=1 head=2 delta=+1" in out["real"], out["real"])
+
+
+# ---------------------------------------------------------------------------
+# 4. gate-57 orphaned-write-capability
+# ---------------------------------------------------------------------------
+
+_SVC = """<?php
+namespace OCA\\Fixture\\Service;
+class {cls} {{
+    /**{marker}
+     */
+    public function publishReport(): void {{}}
+}}
+"""
+
+_G57_FILES = {
+    "OrphanDotsProbeService":
+        ("\n     * @orphaned-write-capability exclude ..........", True),
+    "OrphanContinuationProbeService":
+        ("\n     * @orphaned-write-capability exclude"
+         "\n     * wired up in a later PR, see issue 999", True),
+    "OrphanFloorProbeService":
+        ("\n     * @orphaned-write-capability exclude abcde", True),
+    "OrphanHonouredProbeService":
+        ("\n     * @orphaned-write-capability exclude Wired in the next PR (issue 999)", False),
+    "OrphanWitnessProbeService":
+        ("", True),
+}
+
+
+def suite_gate57() -> None:
+    print("\n== gate-57 orphaned-write-capability ==")
+    with tempfile.TemporaryDirectory() as d:
+        svc = Path(d) / "lib" / "Service"
+        svc.mkdir(parents=True)
+        paths = []
+        for cls, (marker, _exp) in _G57_FILES.items():
+            p = svc / f"{cls}.php"
+            p.write_text(_SVC.format(cls=cls, marker=marker), encoding="utf-8")
+            paths.append(str(p))
+        out = run("check_orphaned_write_capability.py", sorted(paths), cwd=d)
+
+    if "SKIP:" in out:
+        check("gate-57 judged the fixture rather than declining it", False, out)
+        return
+
+    def reported(cls: str) -> bool:
+        return any(f"{cls}.php" in ln and "rule=orphaned-write-capability" in ln
+                   for ln in out.splitlines())
+
+    check("WITNESS: an unannotated orphaned write IS reported, so every "
+          "'is not reported' claim below came from a run that opened this "
+          "directory (OrphanWitnessProbeService)",
+          reported("OrphanWitnessProbeService"), out)
+    check("gate-57 refuses ten full stops and names OrphanDotsProbeService — "
+          "the exact input `.{10,}` accepted",
+          reported("OrphanDotsProbeService"), out)
+    check("gate-57 refuses a bare marker that borrows the docblock "
+          "CONTINUATION LINE below it (OrphanContinuationProbeService) — the "
+          "`\\s+` separator used to let a newline in",
+          reported("OrphanContinuationProbeService"), out)
+    check("gate-57's floor of 10 SURVIVES: a 5-character alphanumeric reason is "
+          "still refused (OrphanFloorProbeService). If #412 had collapsed this "
+          "tag to the shared floor of 3, this arm would go green and a live bar "
+          "would have been relaxed inside a tightening.",
+          reported("OrphanFloorProbeService"), out)
+    check("ANTI-WIDENING: a real >=10-character reason is still honoured and "
+          "OrphanHonouredProbeService is NOT reported",
+          not reported("OrphanHonouredProbeService"), out)
+    expected = sum(1 for _c, (_m, exp) in _G57_FILES.items() if exp)
+    got = sum(1 for ln in out.splitlines()
+              if "rule=orphaned-write-capability" in ln)
+    check(f"gate-57 reports exactly {expected} of the {len(_G57_FILES)} probes — "
+          "a COUNT arm beside the by-name arms, so a probe that stops firing "
+          "cannot hide behind its siblings (#409)",
+          got == expected, f"got {got}, expected {expected}\n{out}")
+
+
+# ---------------------------------------------------------------------------
+# 5. The three gates agree with gate-16 about one tag
+# ---------------------------------------------------------------------------
+
+
+def suite_cross_gate() -> None:
+    print("\n== gate-16 and gate-17 now agree about `@spec exclude` ==")
+    # NOT str.format — the PHP body is full of braces, and `.format` on it
+    # raises `unexpected '{' in field name`. A template that cannot render is a
+    # suite that cannot run.
+    spec = """<?php
+namespace OCA\\Fixture\\Controller;
+class SpecAgreementProbeController {
+    /**
+     * @spec exclude __REASON__
+     */
+    public function index() {
+        return new JSONResponse($this->objectService->findAll([]));
+    }
+}
+"""
+    import importlib.util
+    s = importlib.util.spec_from_file_location(
+        "csc", str(LIB / "check_spec_coverage.py"))
+    csc = importlib.util.module_from_spec(s)
+    sys.modules["csc"] = csc
+    s.loader.exec_module(csc)
+    s2 = importlib.util.spec_from_file_location(
+        "drc", str(LIB / "detect-redundant-controllers.py"))
+    drc = importlib.util.module_from_spec(s2)
+    sys.modules["drc"] = drc
+    s2.loader.exec_module(drc)
+
+    for label, reason, expect_honoured in (
+        ("a full stop", ".", False),
+        ("nothing at all", "", False),
+        ("a real reason", "deliberate ObjectService facade, ADR-022", True),
+    ):
+        lines = spec.replace("__REASON__", reason).splitlines()
+        idx = next(i for i, ln in enumerate(lines) if "public function index" in ln)
+        opening = next(i for i in range(idx - 1, -1, -1) if "/**" in lines[i])
+        docblock = "\n".join(lines[opening:idx])
+        # The two gates are handed the same docblock in the same shape their own
+        # callers hand it to them, and must agree.
+        if "@spec exclude" not in docblock:
+            check("cross-gate fixture actually carries the marker", False, docblock)
+            return
+        g16 = csc._docblock_spec_status(lines, idx)[0] == "excluded"
+        g17 = drc._has_reason_bearing_spec_exclude(docblock)
+        check(f"gate-16 and gate-17 give the SAME verdict for `@spec exclude` "
+              f"with {label} (both {'honour' if expect_honoured else 'refuse'} it)",
+              g16 is expect_honoured and g17 is expect_honoured,
+              f"gate-16 honoured={g16} gate-17 honoured={g17}")
+
+
+def main() -> int:
+    suite_predicate()
+    suite_gate17()
+    suite_gate52()
+    suite_gate57()
+    suite_cross_gate()
+    total = len(_passed) + len(_failed)
+    print(f"\n== {len(_passed)} passed / {len(_failed)} failed / {total} run ==")
+    if total < MIN_ASSERTIONS:
+        print(f"SUITE TOO SHORT: {total} assertions ran, expected at least "
+              f"{MIN_ASSERTIONS}. A run that stopped early prints a green "
+              f"summary exactly like a complete one.")
+        return 1
+    if _failed:
+        print("FAILURES:")
+        for n in _failed:
+            print(f"  - {n}")
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #412.

`#411` put one shared predicate behind the four exclusion gates named in #400, and
its author swept the rest of the package rather than trusting that there were
four. The sweep found three more checkers that grade an exclusion marker by a
rule that is not the shared one, and reported them without fixing them because
each needed its own per-tag fleet measurement first. This is that measurement and
that fix.

## The three

**gate-17 redundant-controller required no reason at all.** Its marker regex
captured nothing and graded nothing, so a bare `@spec exclude` silenced it. That
is the worst of the three, because it reads the same tag as gate-16: after `#411`
one annotation had two opposite verdicts, an author blocked by the strict gate
could waive the permissive one with identical keystrokes, and nothing in either
gate's output would let a reader notice. Three assertions now hand the same
docblock to both gates and require the same answer.

**gate-52 custom-widget-ratchet asked only for a non-whitespace character**,
which a full stop satisfies — #400 under a different tag, on a marker whose whole
job is to lift an entry out of the ratchet head count.

**gate-57 orphaned-write-capability had a length floor and no alphabet rule**, so
ten full stops were a justification. It is the inverse of the #400 shape.

A fourth hole, specific to gate-57 and not in the handover, turned up while
reading its pattern rather than its symptom: the separator between marker and
reason matched a newline, so a marker with no reason on its own line silently
borrowed the docblock continuation line beneath it. That is the shillinq
continuation-line shape from #400, except reachable — nothing here breaks on a
first match. Measured both ways: the pre-fix copy suppresses that method, the
patched copy reports it.

## Fleet cost, measured twice per tag

An unanchored upper-bound scan over all eighteen core apps at a pinned
`origin/development`, with every byte taken from each app's own committed tree so
an untracked nested checkout cannot be walked, and prose about the tag
deliberately kept and then triaged by hand. Across the three tags: two thousand
eight hundred and ninety-nine markers, four hundred and seventy-eight of them in
a path a checker actually reads, and none of those newly rejected. Alignment is
free at every tag, and equally free at a floor of ten.

Then the live arm: the real checkers, before against after, over trees
materialised from each app's own pinned commit so both arms read byte-identical
input, with a positive control run first confirming the pre-fix copy reproduces
all three defects. No app's count moves on any of the three gates.

A third arm establishes that the null means something: with the exclusion
mechanism switched off entirely, gate-17 rises by four and gate-57 by one, and
gate-52 already reports eight ratchet exclusions in hermiq. So the branch this
patch edits is live in three apps, and the unchanged totals are a measurement
over markers that were inspected and kept rather than over markers nobody looked
at.

My first version of that live arm was worthless and said so only through the
reachability figure. It materialised each app's `lib/` and `src/` but not
`appinfo/`, and gate-57 requires a neighbour to carry both an `appinfo/info.xml`
and a `lib/` before it counts as a consuming app — so all eighteen trees looked
like stray directories, both foundation repos took the hydra#106 skip path, and
all three live markers are in exactly those two repos. The rig could not have
moved and printed the same zero as a real result. Correcting it moves gate-57's
fleet total by nine with no code change at all.

## The threshold question is restated, not resolved — and now guarded

The package disagrees with itself about how long a reason must be: twenty
characters for the runner's gate-level opt-outs, ten for gate-57, three for the
gates `#411` touched. `#411` chose three for its four and was explicit that this
was a judgement rather than a measurement. The same holds here, so each tag keeps
the floor it already has: gate-17 and gate-52 adopt the shared three, gate-57
keeps its ten.

What this PR adds that a comment could not is that the disagreement is now
load-bearing on a named assertion. The shared predicate takes an explicit
per-tag floor, gate-57 passes its own at the call site, and two assertions go red
the moment anyone collapses it. That was one of the four reverts below, and it is
the one a future reader is most likely to make by accident: tidying three numbers
into one looks like cleanup and is a fleet policy change about roughly eleven and
a half thousand markers. A disagreement that is merely documented gets
harmonised; one that fails a named assertion gets escalated instead.

## Revert-proofs

Four reverts, each applied with the editor rather than a stream editor, each
verified by re-reading which line had changed before any suite result was
believed, and each with its prediction written down first. All four matched
exactly, in the number of failing assertions and in their identity. Reverting
gate-17's call site reddens six assertions; gate-52's reddens one; gate-57's
reddens three; collapsing gate-57's floor reddens three others.

Two of those are worth reading together. The gate-52 revert reddens only one
assertion, and that is correct rather than thin: its bare-marker and same-line
arms pin behaviour the old regex also had, so they are anti-regression arms, not
defect arms. The gate-57 revert leaves its floor arm green for the same reason,
which is the proof that the floor arm and the alphabet arm are independent and
neither covers the other.

## Coverage and scope

New suite `test_exclusion_reason_adjacent.py`: thirty-one assertions, zero
failures, an assertion floor so a short run fails rather than printing a green
summary, one probe per named file so no subject is satisfiable by a sibling
finding, pairwise non-containing subject names, count arms beside the by-name
arms, and a witness that must be reported in every fixture carrying an
anti-widening claim. Fixtures are built by a helper that hard-fails on every git
step and asserts a non-empty base-to-head diff.

No existing suite was edited, and none of them encoded any of the three holes —
checked deliberately, since two suites were caught asserting a defect during this
programme. gate-17 previously had no dedicated helper suite of its own, so its
exclusion branch had never been exercised by anything.

The acceptance registries are deliberately untouched. gate-52's row there
describes a different missing arm — that an entry carrying a `_note` is silent —
which this suite does not supply, and claiming credit for coverage it does not
provide is the overclaim that `#405` was filed to clean up.

Both test surfaces were run, with ajv installed first exactly as the workflow
does: the entry-point suite reports seventy passing and none failing, and the
helper sweep discovers eighty-three suites and reports every one of them passing
with two quarantined.
