### PR TITLE
fix(gates 19, 25, 26, 51, 52, 54, 55): the scope decision has exactly one source (#416)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
+++ b/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
@@ -167,7 +167,11 @@ _set_env="$(_verdict_set "${_out_env}")"
 # "the rig was misconfigured" and "the gates agree" are indistinguishable
 # downstream. So pin the inputs before grading the outputs.
 for _arm in arg env; do
-    eval "_o=\${_out_${_arm}}"
+    # Indirect expansion rather than `eval`: it assigns `_o` where ShellCheck
+    # can see it (an `eval` form trips SC2154, and this repo's wrapper fails on
+    # any finding, note severity included).
+    _ovar="_out_${_arm}"
+    _o="${!_ovar}"
     if printf '%s' "${_o}" | grep -qF 'SCOPE-MODE: full'; then
         _ok "arm ${_arm}: ran at FULL file scope"
     else
@@ -205,7 +209,11 @@ echo "== the subject must be REPORTED, in BOTH arms =="
 # APPLICABLE agree perfectly and prove nothing — that is the exact state
 # `#416` produced. Assert the finding, by name, on each side independently.
 for _arm in arg env; do
-    eval "_o=\${_out_${_arm}}"
+    # Indirect expansion rather than `eval`: it assigns `_o` where ShellCheck
+    # can see it (an `eval` form trips SC2154, and this repo's wrapper fails on
+    # any finding, note severity included).
+    _ovar="_out_${_arm}"
+    _o="${!_ovar}"
     _v="$(gf_verdict "${_o}" 19)"
     case "${_v}" in
         *FAIL*) _ok "arm ${_arm}: gate-19 FAILS — ${_v#*: }" ;;
@@ -227,7 +235,11 @@ if [ "${_set_arg}" = "${_set_env}" ]; then
     _ok "every gate returned the same verdict through both channels ($(printf '%s\n' "${_set_arg}" | grep -c . ) gate(s) compared)"
 else
     _bad "THE DELIVERY CHANNEL CHANGED THE VERDICT. One tree, one base, full scope in both arms — the gates below answered differently depending on whether the base arrived as --base or in the environment. That is a second, unprinted source of scope (.github#416)."
-    printf '   gate | --base            | $HYDRA_GATE_BASE_REF\n'
+    # The column header names the variable WITHOUT a leading `$`. With one, every
+    # spelling ShellCheck accepts is either SC2016 or an actual expansion, and
+    # this repo's wrapper fails the build on findings of any severity — so the
+    # sigil would cost a suppression directive to buy nothing a reader needs.
+    printf '   gate | --base            | env HYDRA_GATE_BASE_REF\n'
     printf '   -----+-------------------+---------------------\n'
     # Join on the gate number so the reader gets the PAIR, not two lists.
     #

--- a/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
+++ b/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_base_ref_delivery_channel.sh — one tree, one base, two channels.
+#
+# THE PROPERTY
+# ------------
+#   FOR ONE TREE AND ONE BASE, THE PER-GATE VERDICTS MUST NOT DEPEND ON WHICH
+#   CHANNEL DELIVERED THE BASE.
+#
+# `--base X` and `HYDRA_GATE_BASE_REF=X` are two spellings of ONE input. A gate
+# that can tell them apart is reading a second, unprinted source of scope — and
+# a scope nobody can name is the defect this whole package is organised around.
+#
+# WHY IT EXISTS (.github#416)
+# ---------------------------
+# `#378` made whole-tree the default file scope. It did not reach the event that
+# gates a merge. Seven state gates — 19, 25, 26, 51, 52, 54, 55 — were invoked
+# through this shape:
+#
+#     if [ "${SCOPE_TO_DIFF}" = "1" ]; then
+#         HYDRA_GATE_BASE_REF="${BASE_REF}" python3 …/check_x.py .
+#     else
+#         python3 …/check_x.py .          # <-- inherits the AMBIENT variable
+#     fi
+#
+# The `if` guards the EXPLICIT pass — it was written for `#242`, and gate-19's
+# copy of the comment explains that defect at length. It cannot guard the
+# ENVIRONMENT. The shared quality workflow exports the variable on
+# `pull_request` and leaves it empty on `push`, so those seven silently
+# diff-scoped themselves on pull requests and swept the tree on pushes, while
+# both runs printed `SCOPE-MODE: full` and the same preamble sentence:
+#
+#     "The DELTA gates (16, 29, 47, 48, 61) judge that change set.
+#      Every other gate reads the whole tree."
+#
+# Measured on a clean docudesk clone, `ConductionNL/.github@5e73e640`, one tree,
+# one base (`origin/development`), full scope in both arms:
+#
+#     channel                     gate-19          gate-25   gate-26   COVERAGE
+#     $HYDRA_GATE_BASE_REF        NOT APPLICABLE   NOT APPL. NOT APPL. 56 of 65
+#     --base                      FAIL — 396       PASS      FAIL — 6  59 of 65
+#
+# 402 findings, invisible on every pull request in that repository, surfacing
+# only on the push that happens AFTER the merge.
+#
+# WHY THIS SUITE AND NOT A PER-GATE ASSERTION
+# -------------------------------------------
+# Because the bug is not in any of the seven gates. Each one is individually
+# reasonable; the leak is a property of the process boundary they share. An
+# assertion about gate-19 would have to be written seven times and remembered an
+# eighth, which is exactly the failure that produced four more instances of the
+# defect AFTER gate-19's author documented it. So this suite compares the WHOLE
+# verdict set and names whatever differs, including gates that do not exist yet.
+#
+# WHAT KEEPS IT FROM BEING VACUOUS
+# --------------------------------
+# Two arms agreeing that nothing is applicable is not parity, it is silence —
+# and it is the precise shape the defect wore. So the suite refuses to grade
+# until a positive control proves the subject is present and findable, and it
+# separately asserts that gate-19 FAILS IN BOTH ARMS naming the fixture's own
+# scenario. Agreement alone can never satisfy this file.
+#
+# Run: bash scripts/lib/test_gate_base_ref_delivery_channel.sh
+set -uo pipefail
+
+GF_PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+export GF_PKG_ROOT
+# shellcheck source=./gate_fixture_support.sh
+. "${GF_PKG_ROOT}/scripts/lib/gate_fixture_support.sh"
+
+SRC="${GF_PKG_ROOT}/scripts/test-fixtures/base-ref-channel/app"
+RUNNER="${GF_PKG_ROOT}/scripts/run-hydra-gates.sh"
+CHECKER="${GF_PKG_ROOT}/scripts/lib/check_e2e_coverage.py"
+# The fixture's one uncovered scenario. Deliberately a token that appears
+# nowhere else in this package, so a finding about any OTHER subject cannot
+# satisfy an assertion below.
+#
+# Matched case-INSENSITIVELY on purpose: the checker reports the scenario by its
+# SLUG (`channel-parity::channelparityuntracedscenario-…`), not by the title in
+# the spec. An exact-case match here silently fails and reads as "the positive
+# control did not fire" — i.e. as a dead checker — which is the same
+# absence-from-a-bad-lookup shape the control exists to rule out.
+SUBJECT="ChannelParityUntracedScenario"
+
+_fail_n=0; _pass_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+if [ ! -d "${SRC}" ]; then
+    echo "FAIL — base-ref-channel fixture missing at ${SRC}; every assertion below would be vacuous."
+    exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/hydra-channel.XXXXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Extract every gate's verdict as `<n>|<VERDICT-WORD><count>` — enough to detect
+# a scope change (NOT APPLICABLE vs FAIL vs PASS) and a count change, without
+# dragging in log paths, which contain a per-run mktemp directory and would make
+# every comparison differ for free.
+#
+# EXTRACT ON THE VERDICT SHAPE, NEVER BY EXCLUDING WHAT LOOKS LIKE A PASS: a
+# FAIL line whose remedial prose contains the word "pass" was silently dropped
+# by a `grep -v PASS` elsewhere in this programme on 2026-08-12.
+_verdict_set() {
+    printf '%s\n' "$1" \
+        | grep -E '^\[gate-[0-9]+\] [a-z0-9-]+: (PASS|FAIL|NOT APPLICABLE|SKIPPED)' \
+        | sed -E 's/^\[gate-([0-9]+)\] [a-z0-9-]+: (PASS|FAIL — [0-9]+|FAIL|NOT APPLICABLE|SKIPPED).*/\1|\2/' \
+        | sort -t'|' -k1,1n -u
+}
+
+# ---------------------------------------------------------------------------
+# Build ONE repository. Both arms read this same tree at this same commit, so
+# nothing but the channel can differ.
+#
+# The diff deliberately touches only docs/CHANGELOG.md: no spec, no controller,
+# no page component. That is what makes a diff-scoped gate-19/25/26 decline —
+# and therefore what makes the leak visible. A diff that touched the spec would
+# put it in scope through either channel and the arms would agree while the bug
+# was live.
+# ---------------------------------------------------------------------------
+gf_build_repo "${WORK}/app" "${SRC}"
+gf_commit_all "${WORK}/app" "base: fixture app carrying one uncovered scenario"
+gf_mark_base  "${WORK}/app"
+printf '\n- unrelated doc tweak\n' >> "${WORK}/app/docs/CHANGELOG.md"
+gf_commit_paths "${WORK}/app" "docs: unrelated change" docs/CHANGELOG.md
+BASE="$(cd "${WORK}/app" && git rev-parse refs/remotes/origin/development)"
+
+# ===========================================================================
+echo "== positive control: the subject IS present and findable in this tree =="
+# ===========================================================================
+# Without this, agreement between the arms is ambiguous between "the leak is
+# fixed" and "this fixture never contained anything to find". Run FIRST, always.
+_pc="$(cd "${WORK}/app" && env -u HYDRA_GATE_BASE_REF python3 "${CHECKER}" . 2>&1)"
+if printf '%s' "${_pc}" | grep -qiF "${SUBJECT}"; then
+    _ok "positive control: check_e2e_coverage.py NAMES ${SUBJECT} on an unscoped read"
+else
+    echo "FAIL — the positive control did not fire. check_e2e_coverage.py, run with no base"
+    echo "       at all, did not name ${SUBJECT} in a tree that contains it. EITHER the"
+    echo "       fixture stopped carrying the uncovered scenario (someone added an anchor"
+    echo "       or an exclusion to openspec/specs/channel-parity/spec.md) OR the checker"
+    echo "       went blind. Both are fatal here: every arm below reads agreement as"
+    echo "       meaningful ONLY if this control proves there was something to disagree"
+    echo "       about. Refusing to grade."
+    printf '%s\n' "${_pc}" | sed 's/^/       /' | head -20
+    exit 1
+fi
+
+# ===========================================================================
+echo
+echo "== arm 1 — the base arrives as --base (the push channel) =="
+# ===========================================================================
+_out_arg="$(env -u HYDRA_GATE_BASE_REF bash "${GF_PKG_ROOT}/bin/hydra-gates" \
+    --base "${BASE}" --app-dir "${WORK}/app" 2>&1)"
+_set_arg="$(_verdict_set "${_out_arg}")"
+
+# ===========================================================================
+echo "== arm 2 — the same base arrives as \$HYDRA_GATE_BASE_REF (the PR channel) =="
+# ===========================================================================
+_out_env="$(HYDRA_GATE_BASE_REF="${BASE}" bash "${GF_PKG_ROOT}/bin/hydra-gates" \
+    --app-dir "${WORK}/app" 2>&1)"
+_set_env="$(_verdict_set "${_out_env}")"
+
+# --- both arms must actually be the run we think they are -------------------
+# A comparison between two runs that were not the same shape proves nothing, and
+# "the rig was misconfigured" and "the gates agree" are indistinguishable
+# downstream. So pin the inputs before grading the outputs.
+for _arm in arg env; do
+    eval "_o=\${_out_${_arm}}"
+    if printf '%s' "${_o}" | grep -qF 'SCOPE-MODE: full'; then
+        _ok "arm ${_arm}: ran at FULL file scope"
+    else
+        _bad "arm ${_arm}: did NOT report 'SCOPE-MODE: full', so this is not the scope the property is about; the comparison below is uninterpretable"
+    fi
+    if printf '%s' "${_o}" | grep -qE "^\[hydra-gates\] Delta base: .*$(printf '%s' "${BASE}" | cut -c1-8)"; then
+        _ok "arm ${_arm}: resolved the delta base to the commit both arms were given"
+    else
+        _bad "arm ${_arm}: did not resolve the delta base to ${BASE:0:8}; the two arms are not comparing one base"
+    fi
+done
+
+# The two arms must have been delivered DIFFERENTLY, or this file is comparing a
+# run with itself. Check the printed source LABEL rather than reasoning about
+# the value — the label is the only thing that distinguishes the channels, and
+# on 2026-08-12 checking the label instead of reasoning about the value is what
+# exposed this defect in the first place.
+if printf '%s' "${_out_arg}" | grep -qF 'Delta base:' \
+    && printf '%s' "${_out_arg}" | grep -F 'Delta base:' | grep -qF -- '(--base)'; then
+    _ok "arm arg: the run labels its base source as (--base)"
+else
+    _bad "arm arg: the run does not label its base source as (--base), so the two arms may have used the SAME channel and the parity assertion below would be vacuous"
+fi
+if printf '%s' "${_out_env}" | grep -F 'Delta base:' | grep -qF 'HYDRA_GATE_BASE_REF'; then
+    _ok "arm env: the run labels its base source as \$HYDRA_GATE_BASE_REF"
+else
+    _bad "arm env: the run does not label its base source as \$HYDRA_GATE_BASE_REF, so the two arms may have used the SAME channel and the parity assertion below would be vacuous"
+fi
+
+# ===========================================================================
+echo
+echo "== the subject must be REPORTED, in BOTH arms =="
+# ===========================================================================
+# This is what makes agreement non-vacuous. Two arms that both say NOT
+# APPLICABLE agree perfectly and prove nothing — that is the exact state
+# `#416` produced. Assert the finding, by name, on each side independently.
+for _arm in arg env; do
+    eval "_o=\${_out_${_arm}}"
+    _v="$(gf_verdict "${_o}" 19)"
+    case "${_v}" in
+        *FAIL*) _ok "arm ${_arm}: gate-19 FAILS — ${_v#*: }" ;;
+        *"NOT APPLICABLE"*)
+            _bad "arm ${_arm}: gate-19 reported NOT APPLICABLE at FULL file scope over a tree whose uncovered scenario the positive control just named. This is .github#416: the base leaked past the scope decision and diff-scoped a state gate. Verdict: ${_v:0:200}"
+            ;;
+        "") _bad "arm ${_arm}: gate-19 emitted no verdict line at all" ;;
+        *)  _bad "arm ${_arm}: gate-19 gave an unrecognised verdict: ${_v:0:200}" ;;
+    esac
+done
+
+# ===========================================================================
+echo
+echo "== THE PROPERTY: the verdict sets must be identical =="
+# ===========================================================================
+# Gate-agnostic and future-proof: a gate added tomorrow that reads the ambient
+# variable is caught here without anyone editing this file.
+if [ "${_set_arg}" = "${_set_env}" ]; then
+    _ok "every gate returned the same verdict through both channels ($(printf '%s\n' "${_set_arg}" | grep -c . ) gate(s) compared)"
+else
+    _bad "THE DELIVERY CHANNEL CHANGED THE VERDICT. One tree, one base, full scope in both arms — the gates below answered differently depending on whether the base arrived as --base or in the environment. That is a second, unprinted source of scope (.github#416)."
+    printf '   gate | --base            | $HYDRA_GATE_BASE_REF\n'
+    printf '   -----+-------------------+---------------------\n'
+    # Join on the gate number so the reader gets the pair, not two lists.
+    join -t'|' -j1 \
+        <(printf '%s\n' "${_set_arg}") \
+        <(printf '%s\n' "${_set_env}") 2>/dev/null \
+        | awk -F'|' '$2 != $3 { printf "   %4s | %-17s | %s\n", $1, $2, $3 }'
+    # A gate present in one arm and absent from the other never reaches `join`,
+    # and vanishing entirely is a WORSE symptom than answering differently.
+    comm -3 \
+        <(printf '%s\n' "${_set_arg}" | cut -d'|' -f1) \
+        <(printf '%s\n' "${_set_env}" | cut -d'|' -f1) \
+        | tr -d '\t' | sed 's/^/   only one arm emitted a verdict for gate-/'
+fi
+
+# ===========================================================================
+echo
+echo "== the environment variable is still an ACCEPTED INPUT to the runner =="
+# ===========================================================================
+# The fix must not be "stop reading it". Direct callers — the builder skill, a
+# human at a shell, scripts/lib/test_check_schema_property_meta.py — set the
+# variable and invoke the RUNNER, with no `bin/hydra-gates` in between. If that
+# path stopped honouring it, the delta gates would go NOT APPLICABLE fleet-wide
+# and this suite's parity assertion above would still pass, because both arms
+# would be equally deaf.
+_out_direct="$(HYDRA_GATE_BASE_REF="${BASE}" bash "${RUNNER}" --full "${WORK}/app" 2>&1)"
+if printf '%s' "${_out_direct}" | grep -qE '^\[hydra-gates\] Delta base: .* — [0-9]+ changed file\(s\)'; then
+    _ok "the runner, invoked directly, still resolves a delta base from \$HYDRA_GATE_BASE_REF"
+else
+    _bad "the runner invoked directly with \$HYDRA_GATE_BASE_REF set did NOT resolve a delta base. The variable was removed as an INPUT rather than as an ambient inheritance, which silently retires gates 16/29/47/48/61 for every direct caller. Preamble: $(printf '%s' "${_out_direct}" | grep -F 'Delta base:' | head -1)"
+fi
+# And the delta gates must actually have used it.
+_v16="$(gf_verdict "${_out_direct}" 16)"
+case "${_v16}" in
+    *"NOT APPLICABLE"*|"")
+        _bad "gate-16 reported '${_v16:0:120}' on a direct runner call that was given a base in the environment — the delta gates are not receiving it"
+        ;;
+    *) _ok "gate-16 has a real verdict on the direct-runner call — the env channel still feeds the delta gates" ;;
+esac
+
+echo
+echo "== summary =="
+echo "   passed: ${_pass_n}"
+echo "   failed: ${_fail_n}"
+[ "${_fail_n}" -eq 0 ] || exit 1
+[ "${_pass_n}" -gt 0 ] || { echo "FAIL — zero assertions ran; an empty suite is not a green one."; exit 1; }
+echo
+echo "ALL base-ref delivery-channel controls PASSED"
+exit 0

--- a/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
+++ b/hydra-gates/scripts/lib/test_gate_base_ref_delivery_channel.sh
@@ -229,16 +229,25 @@ else
     _bad "THE DELIVERY CHANNEL CHANGED THE VERDICT. One tree, one base, full scope in both arms — the gates below answered differently depending on whether the base arrived as --base or in the environment. That is a second, unprinted source of scope (.github#416)."
     printf '   gate | --base            | $HYDRA_GATE_BASE_REF\n'
     printf '   -----+-------------------+---------------------\n'
-    # Join on the gate number so the reader gets the pair, not two lists.
+    # Join on the gate number so the reader gets the PAIR, not two lists.
+    #
+    # ⚠️ `join` and `comm` both require their inputs in the collating order they
+    # compare with, and `_verdict_set` sorts NUMERICALLY so the table reads 1, 2,
+    # …, 10 rather than 1, 10, 2. Feeding that straight in makes `join` skip
+    # pairs SILENTLY — it would drop differing gates out of the very message that
+    # is supposed to name them, which is worse than no diagnostic at all. So both
+    # are re-sorted lexically here, and only here; the equality test above is
+    # order-insensitive as long as both sides use one order, which they do.
     join -t'|' -j1 \
-        <(printf '%s\n' "${_set_arg}") \
-        <(printf '%s\n' "${_set_env}") 2>/dev/null \
+        <(printf '%s\n' "${_set_arg}" | LC_ALL=C sort -t'|' -k1,1) \
+        <(printf '%s\n' "${_set_env}" | LC_ALL=C sort -t'|' -k1,1) 2>/dev/null \
+        | LC_ALL=C sort -t'|' -k1,1n \
         | awk -F'|' '$2 != $3 { printf "   %4s | %-17s | %s\n", $1, $2, $3 }'
     # A gate present in one arm and absent from the other never reaches `join`,
     # and vanishing entirely is a WORSE symptom than answering differently.
     comm -3 \
-        <(printf '%s\n' "${_set_arg}" | cut -d'|' -f1) \
-        <(printf '%s\n' "${_set_env}" | cut -d'|' -f1) \
+        <(printf '%s\n' "${_set_arg}" | cut -d'|' -f1 | LC_ALL=C sort) \
+        <(printf '%s\n' "${_set_env}" | cut -d'|' -f1 | LC_ALL=C sort) \
         | tr -d '\t' | sed 's/^/   only one arm emitted a verdict for gate-/'
 fi
 

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -297,6 +297,57 @@ case "${HYDRA_GATE_SCOPE:-full}" in
         ;;
 esac
 BASE_REF="${HYDRA_GATE_BASE_REF:-}"
+# ---------------------------------------------------------------------------
+# THE SCOPE DECISION HAS EXACTLY ONE SOURCE, AND IT IS THIS SHELL (.github#416)
+# ---------------------------------------------------------------------------
+# The line above CONSUMES the variable. It is an INPUT to this runner — one of
+# three, alongside `--base` and the auto-detection below — and once read, the
+# decision lives in `${BASE_REF}` and `${SCOPE_TO_DIFF}`, both of which are
+# printed. So the variable is removed from this process's environment right
+# here, and every checker below is spawned into an environment that does not
+# contain it.
+#
+# WHY, and it is not hygiene. TEN helpers in scripts/lib/ read
+# `HYDRA_GATE_BASE_REF` from `os.environ` and diff-scope themselves when they
+# find it. Three of them — gate-16's, gate-53's scoper and gate-61's — are
+# always handed their base explicitly and were never exposed. The other SEVEN
+# (gates 19, 25, 26, 51, 52, 54, 55) are invoked through the same shape:
+#
+#     if [ "${SCOPE_TO_DIFF}" = "1" ]; then
+#         HYDRA_GATE_BASE_REF="${BASE_REF}" python3 …/check_x.py .
+#     else
+#         python3 …/check_x.py .          # <-- inherits the AMBIENT variable
+#     fi
+#
+# That `if` guards the EXPLICIT pass and was added for `#242`. It cannot guard
+# the environment: on any run where the caller exported the variable, the
+# `else` branch spawned a child that read it anyway, and the gate silently
+# diff-scoped itself on a run this script had already announced as full scope.
+#
+# The shared quality workflow exports it on `pull_request` and leaves it empty
+# on `push` — so this reopened `#242` on exactly the event that gates a merge,
+# and nowhere else. Measured on docudesk (`ConductionNL/.github@5e73e640`), one
+# tree, one base, `SCOPE-MODE: full` in both arms, only the delivery channel
+# different: gates 19/25/26 reported `NOT APPLICABLE` when the base arrived
+# through the environment and `FAIL — 396` / `PASS` / `FAIL — 6` when the same
+# base arrived through `--base`. The preamble printed four lines above says
+# "every other gate reads the whole tree"; those three did not, and no reader
+# could tell.
+#
+# Unsetting it here rather than patching the seven `else` branches is
+# deliberate. A per-gate `env -u` is a fix each of the seven has to remember,
+# and gate 51/52/54/55's authors each wrote the same shape after gate-19's
+# author had already written the `#242` comment explaining it. A new gate added
+# tomorrow with the same `if/else` is correct BY CONSTRUCTION under this line,
+# and cannot be made incorrect by anything a caller exports.
+#
+# The invariant, stated so it can be tested (and it is, by
+# scripts/lib/test_gate_base_ref_delivery_channel.sh): FOR ONE TREE AND ONE
+# BASE, THE PER-GATE VERDICTS MUST NOT DEPEND ON WHICH CHANNEL DELIVERED THE
+# BASE. `--base X` and `HYDRA_GATE_BASE_REF=X` are two spellings of one input;
+# a gate that can tell them apart is reading a second, unprinted source of
+# scope.
+unset HYDRA_GATE_BASE_REF
 while [ $# -gt 0 ]; do
     case "$1" in
         --scope-to-diff|--diff) SCOPE_TO_DIFF=1; shift ;;

--- a/hydra-gates/scripts/test-fixtures/base-ref-channel/app/appinfo/info.xml
+++ b/hydra-gates/scripts/test-fixtures/base-ref-channel/app/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<id>channelfixture</id>
+	<name>Base-Ref Delivery Channel Fixture</name>
+	<summary>Fixture app for the base-ref delivery-channel parity suite. Not a real app.</summary>
+	<description>Carries one uncovered spec scenario so gate-19 has a subject, and a real git history so the same base can be delivered two ways.</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Conduction</author>
+	<namespace>ChannelFixture</namespace>
+	<category>tools</category>
+	<dependencies><nextcloud min-version="30" max-version="32"/></dependencies>
+</info>

--- a/hydra-gates/scripts/test-fixtures/base-ref-channel/app/docs/CHANGELOG.md
+++ b/hydra-gates/scripts/test-fixtures/base-ref-channel/app/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Initial fixture tree. The suite appends to this file to create a diff that
+  touches nothing gate-19, gate-25 or gate-26 cares about, which is what makes
+  the pre-fix env-channel arm report NOT APPLICABLE.

--- a/hydra-gates/scripts/test-fixtures/base-ref-channel/app/lib/AppInfo/Application.php
+++ b/hydra-gates/scripts/test-fixtures/base-ref-channel/app/lib/AppInfo/Application.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\ChannelFixture\AppInfo;
+
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap {
+
+	public const APP_ID = 'channelfixture';
+
+	public function __construct() {
+		parent::__construct(self::APP_ID);
+	}
+
+	public function register(IRegistrationContext $context): void {
+	}
+
+	public function boot(IBootContext $context): void {
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/base-ref-channel/app/openspec/specs/channel-parity/spec.md
+++ b/hydra-gates/scripts/test-fixtures/base-ref-channel/app/openspec/specs/channel-parity/spec.md
@@ -1,0 +1,27 @@
+# channel-parity
+
+Spec for the base-ref delivery-channel fixture.
+
+## Purpose
+
+This spec exists to give gate-19 a subject in this fixture. The scenario below
+carries NO traceability anchor and NO exclusion, so gate-19 must report it as
+uncovered on any run that reads the whole tree — and must report it identically
+whether the delta base arrived through `--base` or through the environment.
+
+Do not add an anchor or an exclusion to this file. Either one makes the suite
+that reads it vacuous: both arms would then agree at zero findings, and two arms
+agreeing about nothing is exactly the shape `.github#416` hid behind.
+
+## Requirements
+
+### Requirement: the fixture declares one deliberately untraceable scenario
+
+The scenario title below is unique in this package. It is what the suite greps
+for, so a finding about any other subject cannot satisfy the assertion.
+
+#### Scenario: ChannelParityUntracedScenario is reported by the whole-tree audit
+
+- **GIVEN** a repository whose specs are unchanged from the delta base
+- **WHEN** the gates run at full file scope with that base supplied
+- **THEN** this scenario is reported as missing traceability, whichever channel carried the base


### PR DESCRIPTION
Closes #416.

## What was wrong

`#378` made whole-tree the default file scope. **It did not reach `pull_request` — the event that gates a merge.**

Seven state gates take their base ref from the environment and are invoked through a shape whose `else` branch spawns the checker without clearing it:

```bash
if [ "${SCOPE_TO_DIFF}" = "1" ]; then
    HYDRA_GATE_BASE_REF="${BASE_REF}" python3 .../check_x.py .
else
    python3 .../check_x.py .          # <-- inherits the AMBIENT variable
fi
```

That `if` guards the *explicit* pass; gate-19's copy of the comment cites `#242` and explains this precise hazard. It cannot guard the *environment*. The shared quality workflow exports the variable on `pull_request` and leaves it empty on `push` — so those seven silently diff-scoped themselves on pull requests and swept the tree only on the push that happens **after** the merge, where nothing can block.

**The issue named gates 19, 25 and 26. Reading the runner, the same unguarded shape is at seven sites** — 19, 25, 26, 51, 52, 54 and 55 — and all seven helpers read the variable from `os.environ`.

## The control, before anything was changed

Fresh clone of `ConductionNL/docudesk` `development` at `272ec7a1` plus one commit touching only `README.md` — the shape of a one-file PR. Gate package at `5e73e640`. Both arms full scope, base `origin/development`, one changed file. Only the delivery channel differs.

| gate | base via the environment | base via `--base` |
|---|---|---|
| 19 e2e-coverage | not applicable | fails, 396 scenarios |
| 25 contract-coverage | not applicable | passes — it ran |
| 26 visual-coverage | not applicable | fails, 6 page components |
| coverage line | 56 of 65 | 59 of 65 |
| exit | 5 gates failed | 7 gates failed |

Diffing the two complete 65-gate verdict sets: **exactly three lines differ**, and they are 19, 25 and 26. The delta gates, which read the same resolved base, are unaffected by the channel.

The sharpest form of the defect is the runner's own preamble. Both arms print *"The DELTA gates (16, 29, 47, 48, 61) judge that change set. Every other gate reads the whole tree."* In the environment arm that sentence is **false**, and the log gives the reader no way to tell. Each of the three even states a *true* reason — the diff really did touch no spec file — but the scope it applied is not the scope the run announced.

## The fix, and why it is not the `else` branches

One line in `run-hydra-gates.sh`, immediately after the variable is consumed into `BASE_REF`:

```bash
unset HYDRA_GATE_BASE_REF
```

The runner reads the variable, then removes it from its own environment. Every checker is spawned into an environment that does not contain it, so a checker can receive a base **only** when this script explicitly supplies one — which is exactly what the `SCOPE_TO_DIFF` branches already do.

Patching the seven `else` branches (the remedy the issue suggested) also works. I did not choose it because **that repair has to be remembered by each gate, and it already failed six times**: gate-19's author wrote the `#242` comment explaining the hazard, and gates 25, 26, 51, 52, 54 and 55 were each subsequently written with the same unguarded `else`. Under the `unset`, a gate written tomorrow with the identical shape is correct *by construction*.

**The invariant this establishes:** the scope decision has exactly one source — the shell variables `BASE_REF` and `SCOPE_TO_DIFF`, resolved in one place and printed. `--base X` and the environment variable become two spellings of one input rather than two channels, one of them unprinted.

**What it deliberately does not do:** it does not stop the runner reading the variable. It stays a supported input for direct callers (the builder skill, a human at a shell); only the ambient inheritance is removed. "Stop reading it" would silently retire gates 16/29/47/48/61 for every direct caller *while leaving the parity property satisfied* — so the new suite asserts that distinction separately.

Post-fix, same rig, same two arms: the verdict sets are identical, both report 59 of 65, both exit 7.

Side note: `scripts/lib/test_gate16_spec_coverage_scope.sh:22` already asserts in prose that *"gate-19's else-branch drops `HYDRA_GATE_BASE_REF` and scans the whole tree"*. That sentence was false when it was written and is true after this change.

## The acceptance arm

`scripts/lib/test_gate_base_ref_delivery_channel.sh` — auto-discovered by `tests/run-helper-suites.sh`, driving the real `bin/hydra-gates`.

It pins the property **generically**: for one tree and one base at full scope, the per-gate verdict set must be identical whichever channel delivered the base. A gate added tomorrow that reads the ambient variable is caught without anyone editing the file.

Three things keep it from being vacuous, because *two arms agreeing that nothing is applicable* is exactly the state the defect produced:

- a **positive control** runs first and refuses to grade unless the fixture's uncovered scenario is provably findable;
- gate-19 must **fail in both arms**, naming the fixture's own scenario — agreement alone can never satisfy the file;
- the **base-source labels** are checked, not reasoned about, so the two arms cannot secretly be the same channel.

The fixture's subject is a single scenario whose title is a token appearing nowhere else in the package, so a finding about any other subject cannot satisfy the assertion, and the file carries exactly one finding.

**Revert-proven.** With the one-line change commented out, the suite goes red, names gate-19, and prints the differing pair:

```
   gate | --base            | $HYDRA_GATE_BASE_REF
   -----+-------------------+---------------------
     19 | FAIL — 1          | NOT APPLICABLE
```

## Blast radius — measured on all 18 core apps, and it is the point

**These are not new findings.** They are the numbers the `push` run has been printing all along, now arriving on the event where they can block.

Fresh clones of `development`, each checker run with the variable absent — which is what the runner now does. Validated against the full runner on docudesk, where the direct-checker numbers are byte-identical to the post-fix wrapper verdicts.

| app | SHA | gate-19 | gate-25 | gate-26 |
|---|---|---|---|---|
| decidesk | `e36dbc4` | 983 | pass | pass |
| docudesk | `0be7cbcf` | 396 | pass | 6 |
| doriath | `85d4c7d` | 149 | pass | 3 |
| hermiq | `61b3f1a` | 491 | 5 | 6 |
| larpingapp | `5373b2d` | 42 | pass | pass |
| launchpad | `30cd0bd` | 128 | pass | 1 |
| nldesign | `62a04f1` | 126 | pass | n/a |
| openbuild | `f17df03` | 158 | pass | 4 |
| opencatalogi | `634876f` | 31 | pass | 1 |
| openconnector | `00ab159` | 332 | pass | pass |
| openregister | `c9d9696` | 845 | 66 | 27 |
| pipelinq | `4c5fa97` | 33 | pass | 3 |
| portaliq | `3b0b6d4` | pass | pass | 1 |
| procest | `bf54f3c` | 1142 | 118 | 78 |
| scholiq | `e45aa95` | 93 | pass | 9 |
| shillinq | `0742123` | 290 | 52 | 2 |
| softwarecatalog | `051aa85` | 266 | pass | 5 |
| zaakafhandelapp | `86393c4` | pass | pass | n/a |

**Totals: gate-19 5,505 · gate-25 241 · gate-26 146.** portaliq and zaakafhandelapp are already clean on gate-19 and stay clean.

Four of these independently reproduce figures reported earlier in the programme — decidesk 983, docudesk 396, openconnector 332, launchpad 128 — measured here from a different rig, a different clone and a direct checker invocation.

⚠️ **gate-19 is a coverage backlog, not a defect**, and its only annotation-shaped remedy is scored by the gate as *positive* coverage (`#345`). Mass-excluding would turn every cell green while covering nothing. Nobody should. Every number above is also a **floor**, not a ceiling: exclusion inheritance (`#356`) only moves scenarios *into* `excluded`.

## Verification

- new suite: 12 assertions, green; red on revert, naming gate-19 and printing the differing pair
- `tests/test-hydra-gates-bin.sh`: **70 passed, 0 failed**
- `tests/run-helper-suites.sh`: 79 passed, 2 quarantined (pre-existing and documented), 2 failed — **both disproven as failures of this change**:
  - `test_gate_45_to_55_acceptance.sh` refuses to run when `ajv` is unresolvable. **Reproduced identically on a pristine clone of `main` at the same SHA.** Re-run with `NODE_PATH` at an `ajv` install it is ALL GREEN on both trees — and that is the arm covering gates 51/52/54/55.
  - `test_gate_route_registration.sh` aborted mid-run under my own parallel load (two full 65-gate sweeps running concurrently). Isolated re-run on this branch: 47 passed, 0 failed; the pristine control likewise 47/0.
- `test_gate_scope_matrix.sh`, `test_gate16_spec_coverage_scope.sh`, `test_gate19_coverage_credibility.sh` and `test_gate_acceptance_matrix.sh` all pass — the fixture-coverage ratchet accepted the new bundle without an entry.
- ShellCheck 0.10.0 locally: the new suite is clean; the runner's single pre-existing finding is byte-identical to `main`'s.

## What this does not establish

- **No behavioural change is demonstrated for gates 51, 52, 54 and 55.** Their exposure is established by reading the code — identical unguarded `else`, all four helpers read the variable from `os.environ` — and they are in scope of the fix. But their whole-tree finding count is zero in every app measured, so scoped and swept are typographically identical there. Unproven behaviourally, not immune.
- gate-25/26 numbers for 15 of the 18 apps come from the direct checker. They were validated against the full wrapper on docudesk, openregister and procest, where the two paths agree exactly; the other fifteen are one code path.
- Nothing here is CI-side. Everything was measured locally through the real `bin/hydra-gates`. **The first app pull request after this lands is the confirming observation** and is worth looking at deliberately.
