### PR TITLE
docs(runner): quote the misleading preamble line instead of misdirecting to it

### DIFF
--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -330,9 +330,11 @@ BASE_REF="${HYDRA_GATE_BASE_REF:-}"
 # tree, one base, `SCOPE-MODE: full` in both arms, only the delivery channel
 # different: gates 19/25/26 reported `NOT APPLICABLE` when the base arrived
 # through the environment and `FAIL — 396` / `PASS` / `FAIL — 6` when the same
-# base arrived through `--base`. The preamble printed four lines above says
-# "every other gate reads the whole tree"; those three did not, and no reader
-# could tell.
+# base arrived through `--base`. And the run's own preamble — the line this
+# file prints once the base resolves, "The DELTA gates (16, 29, 47, 48, 61)
+# judge that change set. Every other gate reads the whole tree." — was FALSE in
+# the first arm, identically worded in both, with nothing in the log letting a
+# reader tell which one they were holding.
 #
 # Unsetting it here rather than patching the seven `else` branches is
 # deliberate. A per-gate `env -u` is a fix each of the seven has to remember,


### PR DESCRIPTION
Comment-only follow-up to #418.

That PR auto-merged the moment its checks went green, at `b8c53a2` — before this correction reached the branch. Nothing about the fix changes; stripping comments and blank lines from `run-hydra-gates.sh` gives the same md5 (`fa41262d8d67a4386bf04c5ba3732876`) on `main` and on this branch.

**What is wrong on `main`.** The new comment block says the misleading sentence appears *"four lines above"*. It does not — it is emitted further down, once the base resolves. A comment that sends the reader to the wrong line is the same defect class the block is about: a claim nobody can check against the thing it names. It now quotes the sentence instead of pointing at a location.
