### PR TITLE
fix(gate-50): a comment must neither consume the window nor satisfy it (#415)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -539,6 +539,83 @@ _outC13="${_tmp}/c13.txt"
 _run "${_appC}" "${_outC13}"
 _expect "${_outC13}" 50 "FAIL" "does not mistake an arrow closure's => for an array key"
 
+# C14 / C15 — A COMMENT MUST NEITHER CONSUME THE WINDOW NOR SATISFY IT (#415).
+#
+# One cause, two failures pointing opposite ways, so both arms are needed: a
+# fix for either one alone can be had by moving the window boundary, and that
+# makes the other worse.
+#
+# C14 (was a FALSE POSITIVE): a textbook guard, reported unsafe because twelve
+# lines of ordinary explanation sat between it and the call. 8 of gate-50's 16
+# opencatalogi findings were this shape. The gate penalised the DOCUMENTED fix
+# and passed the undocumented one — an author who deletes the comment goes
+# green having changed nothing about the code's safety.
+_write_service '    public function listing(): array
+    {
+        $reg = $this->config->getValueString(Application::APP_ID, '"'"'listing_register'"'"', '"'"''"'"');
+        // We deliberately do not fail hard on a missing register: it is
+        // optional in single-tenant installs, the directory sync job re-runs
+        // nightly, and a missing value therefore self-heals within a day.
+        // See ADR-012 for the full rationale, and the migration plan that
+        // removes this branch entirely once the 3.x provisioning path has
+        // landed in every deployment we currently support. Until then the
+        // empty case must return an empty listing rather than raise, because
+        // the public directory endpoint is unauthenticated and a raise there
+        // is an information leak of its own. Twelve lines is not an unusual
+        // amount of explanation for a decision with that many moving parts,
+        // and none of it changes what the code below does.
+        //
+        // The actual guard follows.
+        if ($reg === '"'"''"'"') {
+            return [];
+        }
+
+        return $this->load($reg);
+    }'
+_commit "${_appC}" "a guarded read with a long comment between read and guard"
+_outC14="${_tmp}/c14.txt"
+_run "${_appC}" "${_outC14}"
+_expect "${_outC14}" 50 "PASS" "a comment between the read and its guard does not consume the window"
+
+# C15 (was a FALSE NEGATIVE, and the more serious half): an unguarded read of
+# an api_token reported CLEAN because the TODO above it happened to contain
+# the words the guard regex looks for. A comment STATING THE DEBT satisfied
+# the gate that exists to collect it — the same defect gate 19 was fixed for,
+# never looked for here. Note the fixture's comment contains BOTH a `throw
+# new` and a `=== ''`, so it exercises two of the six guard arms at once.
+_write_service '    public function push(): void
+    {
+        $tok = $this->config->getValueString(Application::APP_ID, '"'"'api_token'"'"', '"'"''"'"');
+        // TODO: we should throw new RuntimeException here when this is empty,
+        // and compare $tok === '"'"''"'"' before use. Not done yet.
+        $this->client->post($tok);
+    }'
+_commit "${_appC}" "an unguarded read whose TODO names the missing guard"
+_outC15="${_tmp}/c15.txt"
+_run "${_appC}" "${_outC15}"
+_expect "${_outC15}" 50 "FAIL" "a comment naming the missing guard does not satisfy the gate"
+
+# C16 — the string-safety control for C14/C15. Comment stripping must not be a
+# naive split: `'https://x'` is a URL inside a string literal, not a comment,
+# and `#[PublicPage]` is a PHP 8 attribute. If either is mis-stripped the
+# guard on the following line is destroyed and this arm fails, which is how a
+# stripper bug shows up as a finding rather than as silence.
+_write_service '    #[PublicPage]
+    public function docs(): string
+    {
+        $url = '"'"'https://example.org//docs#anchor'"'"';
+        $reg = $this->config->getValueString(Application::APP_ID, '"'"'listing_register'"'"', '"'"''"'"');
+        if ($reg === '"'"''"'"') {
+            return $url;
+        }
+
+        return $this->load($reg);
+    }'
+_commit "${_appC}" "a guarded read alongside a URL literal and an attribute"
+_outC16="${_tmp}/c16.txt"
+_run "${_appC}" "${_outC16}"
+_expect "${_outC16}" 50 "PASS" "a // inside a string literal and a #[Attribute] are not comments"
+
 # ===========================================================================
 # FAMILY D — gate-53 must block the PR that CREATES larpingapp#286.
 #

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7774,6 +7774,79 @@ _ARRAY_VALUE = re.compile(
     r"(?:['\"][^'\"]*['\"]|\w+)\s*=>\s*"
     r"(?:[\w\$]+(?:\s*(?:->|::)\s*[\w\$]+)*\s*(?:->|::)\s*)?$"
 )
+# A COMMENT MUST NEITHER CONSUME THE WINDOW NOR SATISFY IT (#415).
+#
+# The window was raw file text, so comment lines did BOTH — and the two
+# failures point in opposite directions from one cause. Measured on this
+# checker directly, four fixtures, one variable:
+#
+#   FALSE POSITIVE   A textbook guard — `if ($reg === '') { return []; }` —
+#                    reported as an unsafe read because twelve lines of
+#                    ordinary explanation sat between it and the call. 8 of
+#                    gate-50's 16 opencatalogi findings were this. The gate
+#                    penalised the DOCUMENTED fix and passed the undocumented
+#                    one: an author who deletes the comment goes green having
+#                    changed nothing about the code's safety.
+#
+#   FALSE NEGATIVE   An unguarded read of an `api_token` reported CLEAN
+#                    because the TODO above it said "we should throw new
+#                    RuntimeException here when empty, and compare $tok === ''
+#                    before use. Not done yet." A comment stating the debt
+#                    satisfied the gate that exists to collect it. This is the
+#                    same defect as the one gate 19 was fixed for; it was
+#                    never looked for here.
+#
+# Both are closed by stripping comment TEXT before the window is built, so
+# comments occupy no budget and offer no evidence. Line numbering is
+# preserved (text is blanked, lines are not removed) because findings report
+# a line number.
+#
+# STRING-SAFE, not a naive split: `'https://x'` must not truncate the line,
+# and `#[PublicPage]` is a PHP 8 attribute, not a comment. Quote state is
+# reset per line, so an unterminated literal (a heredoc body) can corrupt at
+# most its own line rather than the rest of the file.
+def _strip_php_comments(raw_lines):
+    out, in_block = [], False
+    for line in raw_lines:
+        buf, i, n, quote = [], 0, len(line), None
+        while i < n:
+            c = line[i]
+            if in_block:
+                if c == '*' and i + 1 < n and line[i + 1] == '/':
+                    in_block = False
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if quote is not None:
+                buf.append(c)
+                if c == '\\' and i + 1 < n:
+                    buf.append(line[i + 1])
+                    i += 2
+                    continue
+                if c == quote:
+                    quote = None
+                i += 1
+                continue
+            if c in ('"', "'"):
+                quote = c
+                buf.append(c)
+                i += 1
+                continue
+            if c == '/' and i + 1 < n and line[i + 1] == '/':
+                break
+            if c == '/' and i + 1 < n and line[i + 1] == '*':
+                in_block = True
+                i += 2
+                continue
+            if c == '#' and not (i + 1 < n and line[i + 1] == '['):
+                break
+            buf.append(c)
+            i += 1
+        out.append(''.join(buf).rstrip('\n'))
+    return out
+
+
 notes_path = log_path + '.notes'
 open(notes_path, 'w', encoding='utf-8').close()
 for fp in files:
@@ -7782,6 +7855,7 @@ for fp in files:
             lines = f.readlines()
     except OSError:
         continue
+    code_lines = _strip_php_comments(lines)
     src = ''.join(lines)
     for m in SEC_KEY.finditer(src):
         # Find the line number of the match
@@ -7829,7 +7903,18 @@ for fp in files:
         _end_line = src[:_p].count('\n') + 1 if _p < len(src) else lineno
         # `_end_line - 1` is the 0-based index of the call's closing line, so
         # the window INCLUDES the rest of that line (the same-line case).
-        window = ''.join(lines[_end_line-1:_end_line+10])
+        #
+        # THE BUDGET IS ELEVEN LINES OF CODE, NOT ELEVEN LINES OF FILE (#415).
+        # Blank and comment-only lines no longer spend it, and the text
+        # searched below is comment-stripped, so a comment can neither push a
+        # guard out of range nor stand in for one.
+        _budget, _win, _i = 11, [], _end_line - 1
+        while _i < len(code_lines) and _budget > 0:
+            _win.append(code_lines[_i])
+            if code_lines[_i].strip():
+                _budget -= 1
+            _i += 1
+        window = '\n'.join(_win)
         # Look for fail-mode signals
         #
         # THE EMPTY-COMPARE ARM MUST SURVIVE A COMPOUND CONDITION.


### PR DESCRIPTION
Closes #415.

gate-50's guard window was raw file text, so comment lines **both consumed the budget and supplied the evidence**. One cause, two failures pointing opposite ways.

| arm | before | after |
|---|---|---|
| textbook guard, 12 comment lines above it | **FAIL** (false positive) | PASS |
| unguarded `api_token`, TODO naming the missing guard | **PASS** (false negative) | FAIL |
| clean guard, no comments | PASS | PASS |
| genuinely unguarded read | FAIL | FAIL |

**The false negative is the serious half.** An unguarded read reported clean because the TODO above it read *"we should throw new RuntimeException here when empty, and compare `$tok === ''` before use. Not done yet."* — a comment **stating the debt** satisfied the gate that exists to collect it. That is the defect gate 19 was fixed for; nobody looked for it here.

**The false positive is the one that erodes the gate.** 8 of gate-50's 16 opencatalogi findings were real guards pushed out of range by the comment explaining them. The gate penalised the documented fix and passed the undocumented one — an author who deletes the comment goes green having changed nothing about the code's safety.

## Fix

Strip comment **text** before building the window: comments occupy no budget and offer no evidence. Budget becomes eleven lines of **code**, not eleven lines of file. Line numbers are preserved (text blanked, lines kept) because findings report one.

String-safe rather than a naive split — `'https://x'` must not truncate a line, `#[PublicPage]` is a PHP 8 attribute. Quote state resets per line, so an unterminated literal corrupts at most its own line.

## Proof

New arms C14/C15/C16. **With the runner change reverted, C14 and C15 both flip and C16 does not** — so the two new arms detect this regression, and the third is the control against a stripper that eats code rather than comments. Suite 42 → 45 assertions, all green.

Half of every gate-50 count fleet-wide was suspect until this landed.
