### PR TITLE
fix(gates 7, 25, 48, 49): a comment must not be enough to get past a gate — 47 of 65 were (#415 class)

### DIFF
--- a/hydra-gates/scripts/lib/check_contract_coverage.py
+++ b/hydra-gates/scripts/lib/check_contract_coverage.py
@@ -58,6 +58,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+from source_scope import php_mask  # noqa: E402
 
 GATE_NUM = 25
 
@@ -364,29 +365,132 @@ def scan_new_endpoints(
 # ---------------------------------------------------------------------------
 
 
+# The fields of a Postman collection that DECLARE A REQUEST, as opposed to the
+# fields that describe one in prose. `description` is deliberately absent, and
+# it is the whole point of this list — see `_newman_paths`.
+_NEWMAN_EVIDENCE_KEYS = ("raw", "path", "host", "name", "url", "method")
+
+
+def _newman_evidence(node, out: list[str]) -> None:
+    """Collect request-declaring strings from a parsed Postman collection.
+
+    Walks the whole tree (folders nest arbitrarily) and keeps only values that
+    hang off a declaring key. A `url` may be a bare string or an object with
+    `raw` / `host` / `path`; both shapes are handled by recursing rather than
+    by knowing the schema version.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in _NEWMAN_EVIDENCE_KEYS:
+                if isinstance(value, str):
+                    out.append(value)
+                else:
+                    _newman_evidence(value, out)
+            elif isinstance(value, (dict, list)):
+                _newman_evidence(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            if isinstance(item, str):
+                out.append(item)
+            else:
+                _newman_evidence(item, out)
+
+
 def _newman_paths(app_dir: Path) -> str:
-    """Concatenated text of every Newman/Postman collection under tests/integration."""
+    """The request-declaring strings of every Postman collection under tests/integration.
+
+    A COLLECTION'S PROSE IS NOT A REQUEST — THE JSON DIALECT OF #415.
+    ------------------------------------------------------------------
+    This used to be the raw text of the collection FILE, and `is_covered` then
+    asked whether the endpoint's path appears anywhere in it. A Postman
+    `description` is prose stored in a JSON string, which is a comment wearing
+    a different syntax — so it answered too. Measured on this checker, one
+    fixture, one variable:
+
+        no collection at all              FAIL — 1 new public endpoint
+        + a collection with ZERO items    PASS — 1 endpoint, all covered
+          whose description reads
+          "NOTE: we do NOT yet cover
+           /api/things — the DELETE
+           endpoint is untested."
+
+    A collection that contains no requests at all, and SAYS SO, reported the
+    endpoint covered. Same shape as the PHPUnit TODO above and as gate 19's
+    original defect: the sentence admitting the debt is the sentence that
+    discharges it.
+
+    So the haystack is now built from the fields that DECLARE a request
+    (`raw` / `path` / `host` / `url` / `name` / `method`) rather than from the
+    file's bytes. Unlike the PHP side this cannot use a comment mask — JSON
+    has no comments and the evidence genuinely IS a string. The discriminator
+    here is WHICH string, not whether it is one.
+
+    ⚠️ A collection that does not parse falls back to the raw bytes rather
+    than to "not covered". Silently converting a malformed fixture into
+    findings would be this change inventing failures in repos it was never
+    measured against; the honest failure mode for an unreadable input is the
+    behaviour that was there before it.
+    """
     buf: list[str] = []
     root = app_dir / "tests" / "integration"
     if not root.is_dir():
         return ""
     for p in root.rglob("*.postman_collection.json"):
         try:
-            buf.append(p.read_text(encoding="utf-8"))
+            raw = p.read_text(encoding="utf-8")
         except OSError:
             continue
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, RecursionError):
+            buf.append(raw)
+            continue
+        found: list[str] = []
+        _newman_evidence(parsed, found)
+        buf.extend(found)
     return "\n".join(buf)
 
 
 def _phpunit_text(app_dir: Path) -> str:
-    """Concatenated text of every *Test.php under tests/."""
+    """Concatenated CODE of every *Test.php under tests/ — comments blanked.
+
+    A COMMENT SAYING YOU STILL OWE THE TEST MUST NOT BE THE TEST (#415).
+    -------------------------------------------------------------------
+    This used to be the raw text of every test file, and ``is_covered`` then
+    asked whether ``->destroy(`` appears anywhere in it. Prose is made of the
+    same bytes as code, so it did not have to be a call. Measured on this
+    checker directly, one fixture, one variable:
+
+        no tests at all                       FAIL — 1 new public endpoint
+        + a test file whose ONLY mention of   PASS — 1 endpoint, all covered
+          the method is
+          "// TODO: we still owe a contract
+           test that calls
+           $this->controller->destroy($id)
+           ... Not written yet."
+
+    **That is gate 19's defect, verbatim, in the gate written as gate 19's
+    API-layer companion.** A comment stating the debt satisfied the gate that
+    exists to collect it, and the sentence that switched the gate off is the
+    sentence a diligent author writes. The more honest the TODO, the more
+    coverage it fabricates.
+
+    STRING CONTENTS GO TOO. ``->destroy(`` is a call; it is never legitimately
+    spelled inside a string literal, so an error message or a fixture payload
+    that quotes one is not evidence either. The delimiters survive, so nothing
+    that depends on "is this a string" is disturbed.
+
+    The Newman side is deliberately NOT masked here — it is JSON, where the
+    evidence genuinely IS a string (a request ``name``/``raw`` url). Its own
+    prose problem is real and separate; see the note on ``_newman_paths``.
+    """
     buf: list[str] = []
     root = app_dir / "tests"
     if not root.is_dir():
         return ""
     for p in root.rglob("*Test.php"):
         try:
-            buf.append(p.read_text(encoding="utf-8"))
+            buf.append(php_mask(p.read_text(encoding="utf-8"), blank_strings=True))
         except OSError:
             continue
     return "\n".join(buf)

--- a/hydra-gates/scripts/lib/check_csrf_callers.py
+++ b/hydra-gates/scripts/lib/check_csrf_callers.py
@@ -58,6 +58,9 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import script_mask  # noqa: E402
+
 SRC_SUFFIXES = ('.vue', '.js', '.ts', '.mjs', '.cjs')
 SKIP_DIRS = {'node_modules', 'dist', 'build', 'vendor', '.git', 'coverage'}
 
@@ -120,6 +123,40 @@ def unprotected_call_sites(app_dir: str) -> list[str]:
             except OSError:
                 continue
             rel = os.path.relpath(path, app_dir)
+
+            # A COMMENT IS NOT A CSRF TOKEN (#415).
+            # ------------------------------------
+            # Every question below used to be asked of the RAW file, and this
+            # helper's whole job is to make an AFFIRMATIVE claim — "every
+            # mutating call site under src/ already carries a signal" — which
+            # the runner then prints as a NOTE and passes on. So prose here
+            # does not merely hide a finding; it manufactures a green with a
+            # sentence attached saying the code is safe.
+            #
+            # Measured on this helper, one fixture, one variable:
+            #
+            #   fetch(url, { method: 'DELETE', headers: {} })
+            #     -> reported UNPROTECTED, gate-48 FAIL          (correct)
+            #   the same call with
+            #     `// TODO: add the requesttoken header here. Not done yet.`
+            #     INSIDE the init object
+            #     -> reported protected, gate-48 PASS + the NOTE <- the defect
+            #
+            # `NEXTCLOUD_AXIOS_IMPORT` was read the same way, so a
+            # COMMENTED-OUT import silenced every axios.post in the file at
+            # once — one dead line, whole-file amnesty.
+            #
+            # STRING CONTENTS ARE KEPT, deliberately. `script_mask` blanks
+            # comments and leaves literals intact, and that is required
+            # rather than incidental: `'OCS-APIRequest': 'true'` is a header
+            # name that IS a string, and `method: 'DELETE'` is how a mutating
+            # call is recognised at all. Blanking literals here would delete
+            # the evidence in both directions at once — the classic
+            # over-applied fix that turns a repaired gate into a dead one.
+            #
+            # Offsets are preserved by the mask, so the reported line numbers
+            # still address the original file.
+            text = script_mask(text, path)
             uses_nc_axios = bool(NEXTCLOUD_AXIOS_IMPORT.search(text))
 
             # 1. axios.<verb>(...) — protected iff the file imports @nextcloud/axios.

--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -164,17 +164,33 @@ _ANY_FUNC_RE = re.compile(
 )
 
 
-def _strip_strings_and_comments(src: str) -> str:
+def _strip_strings_and_comments(src: str, *, keep_strings: bool = False) -> str:
     """Replace string literals and comments with same-length whitespace.
 
     Preserves byte offsets so brace positions in the cleaned string match
     those in the original source.
+
+    With *keep_strings*, string literals and heredocs survive and ONLY the
+    comments go. That is the text guard detection runs against — see
+    ``_guard_source``. The two callers want opposite things and both are
+    right: brace/paren structure must not be confused by a `{` inside a
+    string, while guard EVIDENCE is sometimes an argument that is a string.
     """
     out: list[str] = []
     i = 0
     n = len(src)
     while i < n:
         c = src[i]
+        # `#` comment — but `#[` opens a PHP 8 ATTRIBUTE, and `#[NoAdminRequired]`
+        # is the single token this entire gate is triggered by. Blanking it
+        # would not widen the gate, it would switch it off.
+        if c == "#" and not (i + 1 < n and src[i + 1] == "["):
+            j = src.find("\n", i)
+            if j == -1:
+                j = n
+            out.append(" " * (j - i))
+            i = j
+            continue
         # Single-line comment // …
         if c == "/" and i + 1 < n and src[i + 1] == "/":
             j = src.find("\n", i)
@@ -202,7 +218,7 @@ def _strip_strings_and_comments(src: str) -> str:
                 tail = src[i + m.end():]
                 em = end_pat.search(tail)
                 stop = i + m.end() + (em.end() if em else len(tail))
-                out.append(" " * (stop - i))
+                out.append(src[i:stop] if keep_strings else " " * (stop - i))
                 i = stop
                 continue
         # Single / double quoted string
@@ -217,7 +233,7 @@ def _strip_strings_and_comments(src: str) -> str:
                     j += 1
                     break
                 j += 1
-            out.append(" " * (j - i))
+            out.append(src[i:j] if keep_strings else " " * (j - i))
             i = j
             continue
         out.append(c)
@@ -907,11 +923,43 @@ def _authentication_only_guard_spans(cleaned: str, src: str) -> list:
 
 
 def _blank_authentication_only_guards(cleaned: str, src: str) -> str:
-    """*src* with every authentication-only guard clause blanked out.
+    """*src* with every COMMENT and every authentication-only guard blanked out.
 
     Length-preserving and newline-preserving, so every offset, span and line
     number computed elsewhere in this module stays valid.
+
+    A TODO NAMING THE GUARD IS NOT THE GUARD (#415).
+    ------------------------------------------------
+    The returned text is `gsrc`, and every guard lookup in `scan_file` runs
+    against it. It used to be the RAW source with only the authentication
+    spans removed, so prose in a method body answered "is this endpoint
+    guarded?". Measured through the runner, one fixture, ONE ADDED LINE:
+
+        #[NoAdminRequired] index(int $id) { return $this->service->find($id); }
+          -> FAIL — 1 method(s) with NoAdminRequired + no guard   (correct)
+
+        the same method with
+          `// TODO: throw new OCSForbiddenException when the caller does not
+           own $id.`
+        inserted above the return
+          -> PASS                                                <- the defect
+
+    **This is gate-50's defect in the gate that found 167 real IDORs**, and
+    the sentence that switches it off is the one an author writes while
+    acknowledging the hole. gate-7's known failure mode has always been false
+    POSITIVES, which is exactly why its silences get believed — so a false
+    negative here is the most expensive kind in this package.
+
+    STRING LITERALS ARE KEPT, deliberately, and this is the narrow reading on
+    purpose. A guard's evidence is frequently an argument that IS a string —
+    a scope name, a permission key, a route slug — and blanking literals in a
+    2,800-line checker whose known failure mode is over-reporting would trade
+    a measured false negative for an unmeasured wave of false positives on a
+    gate the fleet already learned to distrust. A guard named only inside a
+    string literal is a separate finding with its own direction; it is not
+    smuggled in behind this one.
     """
+    src = _strip_strings_and_comments(src, keep_strings=True)
     spans = _authentication_only_guard_spans(cleaned, src)
     if not spans:
         return src

--- a/hydra-gates/scripts/lib/test_check_contract_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_contract_coverage.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for check_contract_coverage (gate-25). Run with:
+
+    python3 scripts/lib/test_check_contract_coverage.py
+
+WHY THIS FILE DID NOT EXIST UNTIL NOW, AND WHAT THAT COST
+---------------------------------------------------------
+gate-25 shipped with no suite of its own. Nothing asserted that it could
+fail, so nothing noticed that **its coverage evidence was file text**.
+
+gate-25 is written as gate-19's API-layer companion, and it inherited gate
+19's original defect along with its shape: a comment saying you still owe the
+test satisfied the gate that exists to collect the test. Measured on this
+checker, one fixture, one variable each time:
+
+    no tests at all                     FAIL — 1 new public endpoint
+    + a *Test.php whose ONLY mention    PASS — 1 endpoint, all covered
+      of the method is
+      "// TODO: we still owe a contract
+       test that calls
+       $this->controller->destroy($id)
+       ... Not written yet."
+
+    no collection at all                FAIL — 1 new public endpoint
+    + a .postman_collection.json with   PASS — 1 endpoint, all covered
+      ZERO items whose description
+      reads "NOTE: we do NOT yet cover
+      /api/things — the DELETE
+      endpoint is untested."
+
+**Both greens were bought by a sentence admitting the debt.** The more honest
+the note, the more coverage it fabricated — and an author who writes neither
+note gets the red. That is the gate rewarding silence.
+
+THE STRUCTURE OF THIS SUITE
+---------------------------
+Every closure arm is paired, in the same test, with the REAL artefact it must
+not swallow — a genuine `->destroy(` call, a genuine collection request. A
+mask that eats code rather than prose passes the closure arm and fails the
+pair, which is the only way that mistake announces itself.
+
+`test_positive_control_*` is first and is not decoration: it is the arm that
+proves the rest are measuring a live gate. Every other assertion in this file
+is worthless if that one ever goes green.
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_contract_coverage as ccc  # noqa: E402
+
+ROUTES = """<?php
+return ['routes' => [
+    ['name' => 'thing#destroy', 'url' => '/api/things/{id}', 'verb' => 'DELETE'],
+]];
+"""
+
+# `#[NoAdminRequired]` is required or the method is not a PUBLIC endpoint and
+# the gate correctly ignores it. Leaving it out was the first rig error made
+# while measuring this defect: the "positive control" printed PASS — "no new
+# public endpoint" — and the false-negative arm printed PASS after it, so the
+# two agreed and neither meant anything. A control that passes for the wrong
+# reason is indistinguishable from a gate that works.
+CONTROLLER = """<?php
+namespace OCA\\Fx\\Controller;
+class ThingController
+{
+    #[NoAdminRequired]
+    public function destroy(int $id)
+    {
+        return 1;
+    }
+}
+"""
+
+
+class _App:
+    """A repo-shaped fixture: routes + one public endpoint, nothing else."""
+
+    def __init__(self) -> None:
+        self.root = Path(tempfile.mkdtemp())
+        self.write("appinfo/routes.php", ROUTES)
+        self.write("lib/Controller/ThingController.php", CONTROLLER)
+        self._git("init", "-q")
+        self._git("config", "user.email", "t@example.invalid")
+        self._git("config", "user.name", "test")
+        self.commit()
+
+    def _git(self, *args: str) -> None:
+        subprocess.run(["git", "-C", str(self.root), *args],
+                       check=False, capture_output=True)
+
+    def write(self, rel: str, body: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    def commit(self) -> None:
+        self._git("add", "-A")
+        self._git("commit", "-qm", "fixture")
+
+    def verdict(self) -> tuple[int, str]:
+        """(exit status, stdout) of a full-tree gate run over this fixture."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = ccc.run_gate(self.root)
+        return rc, buf.getvalue()
+
+    def destroy(self) -> None:
+        subprocess.run(["rm", "-rf", str(self.root)], check=False)
+
+
+class ContractCoverageEvidence(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = _App()
+        self.addCleanup(self.app.destroy)
+
+    # -- the control the rest of the file rests on --------------------------
+
+    def test_positive_control_an_untested_public_endpoint_is_a_finding(self):
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_FAIL, out)
+        self.assertIn("thing#destroy", out)
+
+    # -- PHPUnit side: prose is not a test ---------------------------------
+
+    def test_a_todo_naming_the_missing_test_is_not_the_test(self):
+        self.app.write("tests/ThingTest.php", """<?php
+class ThingTest extends \\PHPUnit\\Framework\\TestCase
+{
+    public function testSomethingElse(): void
+    {
+        // TODO: we still owe a contract test that calls
+        // $this->controller->destroy($id) and asserts the 404 shape.
+        // Not written yet.
+        $this->assertTrue(true);
+    }
+}
+""")
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_FAIL, out)
+
+    def test_a_real_call_is_still_coverage(self):
+        """The pair. A mask that ate code rather than comments passes the arm
+        above and fails this one."""
+        self.app.write("tests/ThingTest.php", """<?php
+class ThingTest extends \\PHPUnit\\Framework\\TestCase
+{
+    public function testDestroy(): void
+    {
+        $controller = new \\OCA\\Fx\\Controller\\ThingController();
+        $this->assertSame(1, $controller->destroy(7));
+    }
+}
+""")
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_PASS, out)
+
+    def test_the_method_name_inside_a_string_literal_is_not_a_call(self):
+        """`->destroy(` is a call. It is never legitimately spelled inside a
+        string, so a fixture payload quoting one is not evidence."""
+        self.app.write("tests/ThingTest.php", """<?php
+class ThingTest extends \\PHPUnit\\Framework\\TestCase
+{
+    public function testSomethingElse(): void
+    {
+        $note = 'the missing case is $controller->destroy($id)';
+        $this->assertNotEmpty($note);
+    }
+}
+""")
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_FAIL, out)
+
+    # -- Newman side: a description is a comment in JSON syntax -------------
+
+    def test_a_collection_description_is_not_a_request(self):
+        self.app.write(
+            "tests/integration/things.postman_collection.json",
+            '{"info": {"name": "Fx", "description": '
+            '"NOTE: we do NOT yet cover /api/things - the DELETE endpoint is untested."},'
+            ' "item": []}\n',
+        )
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_FAIL, out)
+
+    def test_a_real_collection_request_is_still_coverage(self):
+        """The pair for the Newman side — including the same misleading
+        description, so the ONLY difference between this arm and the one above
+        is that a request exists."""
+        self.app.write(
+            "tests/integration/things.postman_collection.json",
+            '{"info": {"name": "Fx", "description": '
+            '"NOTE: we do NOT yet cover /api/things."},'
+            ' "item": [{"name": "delete a thing", "request": {"method": "DELETE",'
+            ' "url": {"raw": "{{base}}/api/things/7", "host": ["{{base}}"],'
+            ' "path": ["api", "things", "7"]}}}]}\n',
+        )
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_PASS, out)
+
+    def test_a_url_given_as_a_bare_string_is_still_a_request(self):
+        """Postman v2.0 writes `url` as a string, v2.1 as an object. The
+        extractor must not be a schema-version check wearing a coverage check's
+        name."""
+        self.app.write(
+            "tests/integration/things.postman_collection.json",
+            '{"info": {"name": "Fx"}, "item": [{"name": "del",'
+            ' "request": {"method": "DELETE", "url": "https://x/api/things/7"}}]}\n',
+        )
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_PASS, out)
+
+    def test_an_unparseable_collection_falls_back_to_raw_text(self):
+        """A malformed fixture must not be silently converted into findings.
+
+        Inventing failures in repos this change was never measured against is
+        the failure mode of a fix applied at fleet scale, so the honest
+        behaviour for an unreadable input is the one that was there before."""
+        self.app.write(
+            "tests/integration/things.postman_collection.json",
+            '{"item": [ this is not json "/api/things"\n',
+        )
+        self.app.commit()
+        rc, out = self.app.verdict()
+        self.assertEqual(rc, ccc.EXIT_PASS, out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_csrf_callers.py
+++ b/hydra-gates/scripts/lib/test_check_csrf_callers.py
@@ -150,5 +150,111 @@ class TestCli(unittest.TestCase):
         self.assertEqual(gate.main(["check_csrf_callers.py", "a", "b"]), 2)
 
 
+class TestACommentIsNotACsrfToken(unittest.TestCase):
+    """A comment is not a token (#415).
+
+    THIS HELPER MAKES AN AFFIRMATIVE CLAIM, which is why prose here is worse
+    than elsewhere in the class. When it returns nothing the runner prints
+
+        [gate-48] NOTE: no CSRF signal was ADDED by this diff, and none was
+        needed: every mutating call site under src/ already carries one …
+
+    and passes. So a comment did not merely hide a finding — it manufactured
+    a green WITH A SENTENCE ATTACHED SAYING THE CODE IS SAFE.
+
+    Every arm below is paired with the real mechanism it must not swallow,
+    because `script_mask` keeps string literals ON PURPOSE: `'OCS-APIRequest'`
+    is a header name that IS a string, and `method: 'DELETE'` is how a
+    mutating call is recognised at all. A mask that blanked literals would
+    pass every closure arm here and turn the gate off completely.
+    """
+
+    _UNPROTECTED = """<script>
+export default { methods: { async del(id) {
+%s  await fetch(`/api/things/${id}`, { method: 'DELETE',%s headers: {} })
+} } }
+</script>
+"""
+
+    def test_positive_control_an_unprotected_fetch_is_reported(self):
+        root = app_with({'src/components/Del.vue': self._UNPROTECTED % ('', '')})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('fetch()', found[0])
+
+    def test_a_todo_above_the_call_is_not_the_header(self):
+        """CONTROL, not evidence — it passes with the mask and without it.
+
+        The comment sits ABOVE the call, outside the paren-balanced span
+        `CSRF_SIGNAL` is searched against, so it never reached the question.
+        Kept because it pins the boundary: the arm below is the same sentence
+        moved three characters into the span, and that one flips."""
+        root = app_with({'src/components/Del.vue': self._UNPROTECTED % (
+            '  // TODO: add the requesttoken header here. Not done yet.\n', '')})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+
+    def test_a_todo_inside_the_init_object_is_not_the_header(self):
+        """EVIDENCE — flips when the mask is removed.
+
+        The comment sits INSIDE the paren-balanced call text, which is the
+        span `CSRF_SIGNAL` is actually searched against. Without the mask this
+        call is reported protected and the runner prints the NOTE."""
+        root = app_with({'src/components/Del.vue': self._UNPROTECTED % (
+            '', '\n    // TODO: requesttoken goes here once #999 lands.')})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+
+    def test_a_real_header_is_still_protection(self):
+        """The pair. `requesttoken` as an object key and `'OCS-APIRequest'` as
+        a string value must both survive the mask."""
+        root = app_with({'src/components/Del.vue': """<script>
+export default { methods: { async del(id) {
+  await fetch(`/api/things/${id}`, { method: 'DELETE',
+    headers: { requesttoken: OC.requestToken, 'OCS-APIRequest': 'true' } })
+} } }
+</script>
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_a_commented_out_nextcloud_axios_import_grants_no_amnesty(self):
+        """EVIDENCE — flips when the mask is removed.
+
+        `NEXTCLOUD_AXIOS_IMPORT` was read raw too, and it is a WHOLE-FILE
+        switch: one dead import line silenced every axios.post in the file at
+        once."""
+        root = app_with({'src/components/Ax.vue': """<script>
+// import axios from '@nextcloud/axios'
+import axios from 'axios'
+export default { methods: { async save(d) { await axios.post('/api/things', d) } } }
+</script>
+"""})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('axios.post()', found[0])
+
+    def test_a_real_nextcloud_axios_import_still_protects_the_file(self):
+        """The pair for the arm above."""
+        root = app_with({'src/components/Ax.vue': """<script>
+import axios from '@nextcloud/axios'
+export default { methods: { async save(d) { await axios.post('/api/things', d) } } }
+</script>
+"""})
+        self.assertEqual(gate.unprotected_call_sites(root), [])
+
+    def test_the_reported_line_number_still_addresses_the_original_file(self):
+        """The mask is length-preserving, so masking must not shift the line a
+        finding names. A finding that points at the wrong line is how a real
+        one gets dismissed as noise."""
+        root = app_with({'src/components/Del.vue': (
+            "<script>\n// filler\n// filler\n// filler\n"
+            "export default { methods: { async del(id) {\n"
+            "  await fetch(`/api/x`, { method: 'DELETE', headers: {} })\n"
+            "} } }\n</script>\n")})
+        found = gate.unprotected_call_sites(root)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn(':6', found[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -2830,5 +2830,110 @@ class ThingController extends Controller {
         self.assertIn("method=show", findings[0])
 
 
+class CommentIsNotAGuardTest(unittest.TestCase):
+    """A TODO naming the guard is not the guard (#415).
+
+    `gsrc` — the text every guard lookup in `scan_file` runs against — was the
+    RAW source with only authentication-only spans removed. So a sentence in a
+    method body answered "is this endpoint guarded?". Measured through the
+    runner, one fixture, ONE ADDED LINE: a real unguarded `#[NoAdminRequired]`
+    endpoint went FAIL -> PASS on the strength of
+    `// TODO: throw new OCSForbiddenException when the caller does not own $id.`
+
+    **This gate's known failure mode has always been false POSITIVES**, which
+    is precisely why its silences get believed, and why a false negative here
+    costs more than in any other gate in the package. The arm below is the
+    cheap, permanent version of that measurement.
+    """
+
+    _UNGUARDED = """<?php
+namespace OCA\\Fx\\Controller;
+class ItemController {
+    #[NoAdminRequired]
+    public function index(int $id) {
+%s        return $this->service->find($id);
+    }
+}
+"""
+
+    def test_positive_control_an_unguarded_endpoint_is_a_finding(self):
+        """First, and not decoration: every arm below is worthless if this
+        one ever goes green."""
+        findings = _scan(self._UNGUARDED % "")
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=index", findings[0])
+
+    def test_a_todo_naming_the_missing_guard_is_not_a_guard(self):
+        findings = _scan(self._UNGUARDED % (
+            "        // TODO: throw new OCSForbiddenException when the caller "
+            "does not own $id.\n"))
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_a_docblock_describing_the_absent_guard_is_not_a_guard(self):
+        """The block-comment spelling of the same sentence. `//` and `/* */`
+        are two code paths in the stripper and a fix to one is not a fix to
+        the other."""
+        findings = _scan(self._UNGUARDED % (
+            "        /* Once #999 lands we throw new OCSForbiddenException here\n"
+            "           unless the caller owns $id. Not done yet. */\n"))
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_a_hash_comment_is_a_comment_too(self):
+        """`#` opens a PHP comment. It was not handled at all, so the whole
+        repair was one alternative spelling away from being bypassed."""
+        findings = _scan(self._UNGUARDED % (
+            "        # TODO: throw new OCSForbiddenException unless $id is owned "
+            "by the caller.\n"))
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_the_attribute_survives_the_comment_stripper(self):
+        """`#[NoAdminRequired]` is an ATTRIBUTE, not a `#` comment, and it is
+        the single token that makes this gate look at a method at all.
+        Blanking it would not widen the gate — it would switch it off, and the
+        symptom would be a silent PASS on every controller in the fleet."""
+        cleaned = cni._strip_strings_and_comments(
+            "#[NoAdminRequired]\npublic function index() {}\n", keep_strings=True)
+        self.assertIn("#[NoAdminRequired]", cleaned)
+
+    def test_a_real_ownership_guard_still_passes(self):
+        """The anti-widening pair. A stripper that ate code rather than
+        comments passes every arm above and fails this one."""
+        findings = _scan("""<?php
+namespace OCA\\Fx\\Controller;
+class ItemController {
+    #[NoAdminRequired]
+    public function index(int $id) {
+        $thing = $this->service->find($id);
+        if ($thing->getOwner() !== $this->userSession->getUser()->getUID()) {
+            throw new OCSForbiddenException();
+        }
+        return $thing;
+    }
+}
+""")
+        self.assertEqual(findings, [])
+
+    def test_a_guard_whose_argument_is_a_string_still_passes(self):
+        """String literals are deliberately KEPT by `keep_strings=True`. A
+        guard's evidence is often an argument that IS a string — a scope name,
+        a permission key — and blanking literals in a 2,800-line checker whose
+        known failure mode is over-reporting would trade a measured false
+        negative for an unmeasured wave of false positives."""
+        findings = _scan("""<?php
+namespace OCA\\Fx\\Controller;
+class ItemController {
+    #[NoAdminRequired]
+    public function index(int $id) {
+        $thing = $this->service->find($id);
+        if ($thing->getOwner() !== $this->userSession->getUser()->getUID()) {
+            throw new OCSForbiddenException('thing.read denied for this owner');
+        }
+        return $thing;
+    }
+}
+""")
+        self.assertEqual(findings, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -798,6 +798,120 @@ else
     _bad "gate-46 on a dead interpreter → $(grep -E '^\[gate-46\]' "${_outF2}" | head -1)"
 fi
 
+# ===========================================================================
+# FAMILY G — gate-49, the SAME defect family C caught in gate-50 (#415).
+#
+# gate-50's window was raw file text. gate-49's method BODY was raw file text.
+# Different mechanism, one cause: prose is made of the same bytes as code, so
+# a comment answered both of gate-49's questions — "is there a catch of a
+# tracked exception?" and "does this method call a risky service method?".
+#
+# Four arms, because a fix for either direction alone is available by
+# loosening or tightening the regex, and each of those makes the other worse.
+# G1 is the POSITIVE CONTROL and it is not decoration: it is the arm that
+# proves the other three are measuring a live gate rather than a silent one.
+# ===========================================================================
+_appG="${_tmp}/appG"
+mkdir -p "${_appG}/lib/Controller"
+
+_write_controller() {  # _write_controller <body>
+    cat > "${_appG}/lib/Controller/ThingController.php" <<PHP
+<?php
+namespace OCA\\Fx\\Controller;
+class ThingController
+{
+$1
+}
+PHP
+}
+
+# G1 — POSITIVE CONTROL. An unhandled call to a known-throwy service method.
+# If this arm ever prints PASS, every arm below it is measuring nothing and
+# their greens are green over a dead gate.
+_write_controller '    public function destroy(int $id)
+    {
+        return $this->objectService->deleteObject($id);
+    }'
+git -C "${_appG}" init -q . 2>/dev/null
+_commit "${_appG}" "an unhandled call to a throwy service method"
+_outG1="${_tmp}/g1.txt"
+_run "${_appG}" "${_outG1}"
+_expect "${_outG1}" 49 "FAIL" "POSITIVE CONTROL — an unhandled throwy service call is a finding"
+
+# G2 — THE FALSE NEGATIVE, and the serious half. The identical unhandled call,
+# with a TODO above it naming the catch that is missing. The gate matched
+# `catch\s*\(\s*…DoesNotExistException` against the raw body and accepted the
+# comment as the handler. A comment STATING THE DEBT satisfied the gate that
+# exists to collect it — the shape gate 19 was fixed for, and gate 50 in #415.
+_write_controller '    public function destroy(int $id)
+    {
+        // TODO: we should catch (DoesNotExistException $e) here and translate
+        // it to a 404 JSONResponse. Not done yet — tracked separately.
+        return $this->objectService->deleteObject($id);
+    }'
+_commit "${_appG}" "the same unhandled call, with a TODO naming the missing catch"
+_outG2="${_tmp}/g2.txt"
+_run "${_appG}" "${_outG2}"
+_expect "${_outG2}" 49 "FAIL" "a comment naming the missing catch does not satisfy the gate"
+
+# G3 — THE FALSE POSITIVE, and the one that erodes the gate. A method that
+# calls nothing riskier than a renderer, carrying a note about the call it no
+# longer makes. `$this->objectService->deleteObject(` was collected from the
+# comment, so the REMOVAL NOTE scored as the removed call: the better the
+# documentation, the redder the repo (#230's shape, one gate over).
+_write_controller '    public function index()
+    {
+        // This endpoint used to call $this->objectService->deleteObject($id)
+        // directly. It no longer does; deletion moved to destroy().
+        return $this->renderer->toArray();
+    }'
+_commit "${_appG}" "a method whose comment describes a call it does not make"
+_outG3="${_tmp}/g3.txt"
+_run "${_appG}" "${_outG3}"
+_expect "${_outG3}" 49 "PASS" "a comment describing a removed call is not that call"
+
+# G4 — THE ANTI-WIDENING PAIR, and the reason the mask keeps the docblock.
+# `@throws` lives in a comment BY DESIGN: it is the author's declaration, not
+# incidental prose. A fix that masked the docblock along with everything else
+# would close G2 and turn every intentionally-propagating method in the fleet
+# into a finding — trading a false negative for a fleet of false positives.
+# Both suppressions must survive.
+_write_controller '    /**
+     * @throws \\OCP\\AppFramework\\Db\\DoesNotExistException
+     */
+    public function destroy(int $id)
+    {
+        return $this->objectService->deleteObject($id);
+    }
+
+    public function purge(int $id)
+    {
+        try {
+            return $this->objectService->deleteObject($id);
+        } catch (\\OCP\\AppFramework\\Db\\DoesNotExistException $e) {
+            return 404;
+        }
+    }'
+_commit "${_appG}" "a real @throws and a real try/catch"
+_outG4="${_tmp}/g4.txt"
+_run "${_appG}" "${_outG4}"
+_expect "${_outG4}" 49 "PASS" "a real @throws docblock and a real catch still suppress"
+
+# G5 — the brace-walk control. The body span is now measured on the mask, so a
+# `{` inside a string literal cannot mis-balance the walk and hand the method
+# a span of code it does not contain. The call here is genuinely unhandled, so
+# the arm asserts the finding SURVIVES the mask rather than being eaten by it
+# — a stripper that swallows code shows up here as a PASS.
+_write_controller '    public function destroy(int $id)
+    {
+        $fmt = '"'"'{ unbalanced'"'"';
+        return $this->objectService->deleteObject($id);
+    }'
+_commit "${_appG}" "an unhandled call below a brace inside a string literal"
+_outG5="${_tmp}/g5.txt"
+_run "${_appG}" "${_outG5}"
+_expect "${_outG5}" 49 "FAIL" "a { inside a string literal does not derail the body walk"
+
 echo ""
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_45_to_55_acceptance.sh: ALL GREEN"

--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -912,6 +912,92 @@ _outG5="${_tmp}/g5.txt"
 _run "${_appG}" "${_outG5}"
 _expect "${_outG5}" 49 "FAIL" "a { inside a string literal does not derail the body walk"
 
+# ===========================================================================
+# FAMILY H — gate-48: a comment is not a CSRF token (#415).
+#
+# This file already predicted the defect and filed it as a hypothetical. The
+# runner's own note above `_csrf_callers_helper` reads:
+#
+#     "the cheapest way to green would have been a cosmetic edit under src/
+#      containing the word `requesttoken`: exactly the prose-satisfaction
+#      #191 warns against."
+#
+# It was not a hypothetical. And it is worse than one missed finding: the
+# signal count SHORT-CIRCUITS the caller-state check built as the mitigation
+# for this exact shape, so one comment skips the guard AND its backup.
+#
+# ⚠️ THE FIXTURE FILE MUST NOT SIT DIRECTLY IN src/. The gate's pathspec is
+# `src/**/*.vue`, and a plain git pathspec's `*` matches `/` too — so the
+# glob requires a SECOND slash and `src/Del.vue` is invisible to it. The
+# first cut of this family put the file there, and both arms printed FAIL:
+# the "before" and "after" agreed, for the reason that neither had measured
+# anything. A component directory is also what real apps ship.
+# ===========================================================================
+_appH="${_tmp}/appH"
+mkdir -p "${_appH}/lib/Controller" "${_appH}/src/components"
+
+cat > "${_appH}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController
+{
+    /**
+     * @NoCSRFRequired
+     */
+    public function create() { return 1; }
+}
+PHP
+# An UNPROTECTED mutating caller, so the caller-state branch has something to
+# find. Without this the fixture passes for a legitimate reason and the arm
+# below cannot tell a repaired gate from a satisfied one.
+cat > "${_appH}/src/components/Del.vue" <<'VUE'
+<script>
+export default { methods: { async del(id) {
+  await fetch(`/api/things/${id}`, { method: 'DELETE', headers: {} })
+} } }
+</script>
+VUE
+git -C "${_appH}" init -q . 2>/dev/null
+_commit "${_appH}" "a controller with @NoCSRFRequired and an unprotected caller"
+_baseH="$(git -C "${_appH}" rev-parse HEAD)"
+
+# H1 — THE FALSE NEGATIVE. Drop the annotation; the ONLY frontend change is a
+# comment saying the token has NOT been added.
+cat > "${_appH}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController
+{
+    public function create() { return 1; }
+}
+PHP
+cat > "${_appH}/src/components/Del.vue" <<'VUE'
+<script>
+export default { methods: { async del(id) {
+  // TODO: this call still needs a requesttoken header. Not done yet.
+  await fetch(`/api/things/${id}`, { method: 'DELETE', headers: {} })
+} } }
+</script>
+VUE
+_commit "${_appH}" "drop @NoCSRFRequired; add only a TODO naming the missing header"
+_outH1="${_tmp}/h1.txt"
+_run "${_appH}" "${_outH1}" --scope-to-diff --base "${_baseH}"
+_expect "${_outH1}" 48 "FAIL" "a comment naming the missing token is not a CSRF co-change"
+
+# H2 — THE ANTI-WIDENING PAIR. The same removal, with a REAL header added.
+# A fix that counted no added line at all would close H1 and fail here.
+cat > "${_appH}/src/components/Del.vue" <<'VUE'
+<script>
+export default { methods: { async del(id) {
+  await fetch(`/api/things/${id}`, { method: 'DELETE', headers: { requesttoken: OC.requestToken } })
+} } }
+</script>
+VUE
+_commit "${_appH}" "the same removal, with a real requesttoken header added"
+_outH2="${_tmp}/h2.txt"
+_run "${_appH}" "${_outH2}" --scope-to-diff --base "${_baseH}"
+_expect "${_outH2}" 48 "PASS" "a real added requesttoken header is still a co-change signal"
+
 echo ""
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_45_to_55_acceptance.sh: ALL GREEN"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7456,10 +7456,75 @@ if [ "${#_cxt_files[@]}" -gt 0 ]; then
     # of this inline python was never read, so a broken interpreter left an
     # empty log and the gate called every controller clean.
     set +e
+    # PYTHONPATH so the heredoc can import the SHARED mask (lib/source_scope.py)
+    # rather than growing a private copy of it — see the note below the argv
+    # block. `_gate_helper_dir` is the same absolute lib/ that gate-5 already
+    # resolves `source_scope.py` from, so this adds no new packaging assumption.
+    PYTHONPATH="${_gate_helper_dir}${PYTHONPATH:+:${PYTHONPATH}}" \
     python3 - "${_cxt_log}" "${_cxt_files[@]}" 2>>"${_cxt_log}.err" << 'PY'
 import re, sys, os
 log_path = sys.argv[1]
 files = sys.argv[2:]
+
+# A COMMENT MUST NEITHER SATISFY THIS GATE NOR MANUFACTURE A FINDING (#415).
+#
+# This gate asked two questions of the RAW method body — "is there a catch of
+# a tracked exception?" and "does this method call a risky service method?" —
+# and prose is made of the same bytes as code, so a comment answered both.
+# Measured on this gate directly, three fixtures, one variable:
+#
+#   POSITIVE CONTROL  destroy() calling $this->objectService->deleteObject()
+#                     with no try/catch and no @throws
+#                       -> FAIL — 1 controller method(s)          (correct)
+#
+#   FALSE NEGATIVE    the SAME method, with a TODO above the call reading
+#                     "we should catch (DoesNotExistException $e) here and
+#                     translate it to a 404 JSONResponse. Not done yet."
+#                       -> PASS                                   <- the defect
+#                     A comment STATING THE DEBT satisfied the gate that
+#                     exists to collect it. Identical to the shape gate 19 was
+#                     fixed for and gate 50 was fixed for in #415; it was
+#                     never looked for here.
+#
+#   FALSE POSITIVE    index() which calls nothing riskier than
+#                     $this->renderer->toArray(), carrying a comment saying
+#                     "this endpoint used to call
+#                     $this->objectService->deleteObject($id) directly. It no
+#                     longer does."
+#                       -> FAIL — 1 ... names index()             <- the defect
+#                     The removal note scored as the removed call. The better
+#                     the documentation, the redder the repo (#230's shape).
+#
+# Both close by anchoring the body questions on `source_scope.php_mask`, which
+# blanks comments AND string contents while PRESERVING OFFSETS, so a line
+# number computed on the mask still names the right line of the original.
+# `blank_strings=True` is deliberate: neither `catch (` nor `$this->x->y(` is
+# ever legitimately spelled inside a string literal, so an error message that
+# quotes one cannot answer either question.
+#
+# THE DOCBLOCK IS STILL READ FROM THE ORIGINAL TEXT. `@throws` lives in a
+# comment BY DESIGN — it is the author's declaration, not incidental prose —
+# and masking it would delete the only intentional suppression this gate has,
+# turning a false-negative fix into a fleet of false positives. Two questions,
+# two sources, one coordinate system: the mask answers "is this position
+# code?", the original answers "what does the author declare?".
+#
+# NOT A PRIVATE COPY, deliberately. `php_mask` already exists in
+# lib/source_scope.py and already knows that `#[` opens a PHP 8 ATTRIBUTE
+# rather than a comment and that `//` inside `'https://x'` opens nothing.
+# A fourth hand-rolled stripper is how N copies drift.
+try:
+    from source_scope import php_mask
+except ImportError as exc:                       # pragma: no cover - wiring
+    # FAIL CLOSED AND LOUD. Falling back to the raw text would silently
+    # restore the exact defect this import removes, and the gate would print
+    # PASS while doing it. A non-zero exit makes the wrapper say SKIPPED
+    # (wiring) instead, which is a verdict about the run rather than the code.
+    sys.stderr.write(
+        "controller-exception-translation: cannot import source_scope "
+        f"({exc}); refusing to grade raw text.\n"
+    )
+    sys.exit(3)
 # Documented-throw shapes we track — these are known-not-auto-translated by NC's dispatcher.
 TRACKED = [
     'DoesNotExistException',
@@ -7508,14 +7573,32 @@ METHOD_RE = re.compile(
     r'(?P<name>\w+)\s*\([^)]*\)[^{]*\{',
     re.MULTILINE,
 )
-def _method_bodies(src):
+def _method_bodies(src, masked):
+    """Declarations and docblocks from *src*; BODIES from *masked*.
+
+    `masked` is `php_mask(src)` and is the same length, so every offset means
+    the same thing in both. The declaration is matched on the original because
+    `m.group(1)` must be the real docblock text — see the `@throws` note above.
+
+    THE BRACE WALK RUNS ON THE MASK. A `{` or `}` inside a comment or a string
+    (`// close the block with }` / `$fmt = '{';`) mis-balances a walk over raw
+    text, and a mis-balanced walk does not report an error — it silently
+    attributes the wrong span of code to the method, which is a finding about
+    lines the method does not contain.
+    """
     out = []
     for m in METHOD_RE.finditer(src):
         start = m.end() - 1  # position of the `{`
+        # A DECLARATION FOUND INSIDE A COMMENT IS NOT A METHOD. If the brace
+        # the regex landed on is blank in the mask, the whole match was prose
+        # — a docblock saying `public function destroy(...) {` describes a
+        # method, it does not declare one.
+        if start >= len(masked) or masked[start] != '{':
+            continue
         depth = 0
         p = start
-        while p < len(src):
-            c = src[p]
+        while p < len(masked):
+            c = masked[p]
             if c == '{':
                 depth += 1
             elif c == '}':
@@ -7524,7 +7607,7 @@ def _method_bodies(src):
                     out.append({
                         'name': m.group('name'),
                         'docblock': m.group(1) or '',
-                        'body': src[start+1:p],
+                        'body': masked[start+1:p],
                         'start_line': src[:m.start()].count('\n') + 1,
                     })
                     break
@@ -7536,7 +7619,9 @@ for fp in files:
             src = f.read()
     except OSError:
         continue
-    methods = _method_bodies(src)
+    # Comments and string CONTENTS blanked, offsets and line count preserved.
+    masked_src = php_mask(src, blank_strings=True)
+    methods = _method_bodies(src, masked_src)
     for m in methods:
         body = m['body']
         # Find calls of shape $this->prop->method(...) which is a proxy for "calls a service"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7355,7 +7355,7 @@ elif [ "${HAVE_DELTA_BASE}" = "1" ]; then
         # back to 0 deliberately rather than to "signal found".
         _csrf_fe_signals=$(PYTHONPATH="${_gate_helper_dir}${PYTHONPATH:+:${PYTHONPATH}}" \
             python3 - "${BASE_REF}" 2>/dev/null <<'PYCSRF' || true
-import os, re, subprocess, sys
+import re, subprocess, sys
 try:
     from source_scope import script_mask
 except ImportError:

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7322,8 +7322,79 @@ elif [ "${HAVE_DELTA_BASE}" = "1" ]; then
         # i.e. "no frontend co-change at all" was read as "co-change found" and
         # the gate PASSED. A CSRF-protection removal with no frontend counterpart
         # is precisely what this gate exists to stop, so the bug was fail-OPEN.
-        _csrf_fe_signals=$(git diff "${BASE_REF}...HEAD" -- 'src/**/*.vue' 'src/**/*.js' 'src/**/*.ts' 2>/dev/null \
-            | grep -cE '^\+.*(OCS-APIRequest|requesttoken|@nextcloud/axios|getRequestToken)' 2>/dev/null || true)
+        # THE SIGNAL MUST BE ON A LINE THAT EXECUTES (#415).
+        # ---------------------------------------------------
+        # This was `grep -cE '^\+.*(…)'` over the raw diff, and this file's own
+        # note twenty lines down already named the hole: "the cheapest way to
+        # green would have been a cosmetic edit under src/ containing the word
+        # `requesttoken`: exactly the prose-satisfaction #191 warns against."
+        # It was written as a hypothetical. It was not one — measured, one
+        # fixture, one variable:
+        #
+        #   a diff dropping #[NoCSRFRequired], no frontend change
+        #     -> FAIL — @NoCSRFRequired dropped without frontend co-change
+        #   the same diff, plus ONE added line under src/ reading
+        #     `// TODO: this call still needs a requesttoken header. Not done yet.`
+        #     -> PASS                                            <- the defect
+        #
+        # A CSRF protection was removed and the gate was satisfied by a comment
+        # saying the replacement protection had NOT been added. Worse than a
+        # missed finding: the short-circuit below means the caller-state check
+        # — the mitigation built for exactly this — never runs at all once the
+        # count is non-zero. One comment skips the guard and the guard's backup.
+        #
+        # So the count is taken over the SCRIPT SCOPE of each changed file at
+        # HEAD (comments blanked, string literals kept — `requesttoken` and
+        # `'OCS-APIRequest'` are header names that ARE strings), restricted to
+        # the line numbers this diff actually added. Same question, asked of
+        # code.
+        #
+        # ⚠️ A CRASH HERE MUST NOT BE READ AS ZERO. Zero routes to the
+        # caller-state branch, which is the CONSERVATIVE direction — it can
+        # only add findings, never remove them — so a failure to compute falls
+        # back to 0 deliberately rather than to "signal found".
+        _csrf_fe_signals=$(PYTHONPATH="${_gate_helper_dir}${PYTHONPATH:+:${PYTHONPATH}}" \
+            python3 - "${BASE_REF}" 2>/dev/null <<'PYCSRF' || true
+import os, re, subprocess, sys
+try:
+    from source_scope import script_mask
+except ImportError:
+    print(0)
+    raise SystemExit(0)
+base = sys.argv[1]
+SIGNAL = re.compile(r'OCS-APIRequest|requesttoken|@nextcloud/axios|getRequestToken',
+                    re.IGNORECASE)
+out = subprocess.run(
+    ['git', 'diff', '-U0', f'{base}...HEAD', '--',
+     'src/**/*.vue', 'src/**/*.js', 'src/**/*.ts'],
+    capture_output=True, text=True, check=False).stdout
+added, path = {}, None
+hunk = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+for line in out.splitlines():
+    if line.startswith('+++ b/'):
+        path = line[6:]
+        added.setdefault(path, set())
+    elif line.startswith('+++ /dev/null'):
+        path = None
+    elif line.startswith('@@') and path is not None:
+        m = hunk.match(line)
+        if m:
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) is not None else 1
+            added[path].update(range(start, start + count))
+count = 0
+for rel, lines in added.items():
+    try:
+        with open(rel, encoding='utf-8', errors='replace') as fh:
+            masked = script_mask(fh.read(), rel).splitlines()
+    except OSError:
+        continue
+    for n in sorted(lines):
+        if 1 <= n <= len(masked) and SIGNAL.search(masked[n - 1]):
+            count += 1
+print(count)
+PYCSRF
+)
         _csrf_fe_signals="${_csrf_fe_signals%%$'\n'*}"
         case "${_csrf_fe_signals}" in ''|*[!0-9]*) _csrf_fe_signals=0 ;; esac
         if [ "${_csrf_fe_signals}" -eq 0 ]; then


### PR DESCRIPTION
Follows #420, which fixed gate-50. This surveys **all 65 gate checkers** for the same defect class and fixes the four most serious instances.

## What the survey found

**47 of 65 gates are affected. 18 are clean.**

Two instances were known — gate 19, then gate 50 in #420. This found **45 more**. It was never two bugs; it is the default behaviour of every checker written before somebody thought about it, and about a third of the ones written after.

🔑 **The comment that switches a gate off is the comment that admits the debt.** gate-50's was a TODO naming the guard it had not written. gate-49's names the catch. gate-7's names the exception. gate-25's says *"we still owe a contract test"*. gate-65's says *"we still need to require the autoloader"*. Every one is the sentence a **diligent** author writes. A gate that reads prose can be switched off by apologising to it.

Full table, all 65 gates with per-gate evidence: `fleet-board/findings/gates-comment-class.md`.

The 43 affected gates this PR does **not** fix are filed with fixtures and verdicts, grouped by root cause: #421 (gate-45, repo-wide blast radius), #422 (false-negative half), #423 (false-positive half), #424 (string literals — 8 of which are one hole in `source_scope.markup_mask`).

## What this PR fixes

Four gates, chosen by severity and by whether the fix could be **measured and controlled** rather than pattern-matched at scale.

### gate-7 — no-admin-idor 🔴

`gsrc` — the text every guard lookup in `scan_file` runs against — was the raw source with only authentication-only spans blanked. Prose in a method body therefore answered *"is this endpoint guarded?"*. One fixture, **one added line**:

| | verdict |
|---|---|
| `#[NoAdminRequired] index(int $id) { return $this->service->find($id); }` | **FAIL** — 1 method(s) with NoAdminRequired + no guard |
| the same method with `// TODO: throw new OCSForbiddenException when the caller does not own $id.` | **PASS** ← the defect |

**This gate's known failure mode has always been false POSITIVES, which is exactly why its silences get believed.** It has already reported 0 findings across 18 apps with 167 real IDORs behind it. A false negative here is the most expensive kind in this package.

`_strip_strings_and_comments` gains `keep_strings=True` and now also handles `#` comments — it never did, so the repair was one alternative spelling away from being bypassed. `#[` is excluded, because `#[NoAdminRequired]` is the single token that makes this gate look at a method at all: blanking it would not widen the gate, it would switch it off.

**String literals are kept, narrowly and deliberately.** A guard's evidence is often an argument that IS a string, and blanking literals in a 2,800-line checker whose known failure mode is over-reporting would trade a measured false negative for an unmeasured wave of false positives on a gate the fleet already learned to distrust. That variant is reported, not smuggled in.

### gate-25 — contract-coverage 🔴

**gate-19's original defect, verbatim, in the gate written as gate-19's API-layer companion.** It had no suite of its own, so nothing had ever asked it to fail.

| | verdict |
|---|---|
| an untested `#[NoAdminRequired]` endpoint | **FAIL** — 1 new public endpoint |
| + a `*Test.php` whose only mention is `// TODO: we still owe a contract test that calls $this->controller->destroy($id) ... Not written yet.` | **PASS** — all covered ← |
| + a `.postman_collection.json` with **zero items** whose description reads *"NOTE: we do NOT yet cover /api/things — the DELETE endpoint is untested."* | **PASS** — all covered ← |

Both greens bought by a sentence admitting the debt — and an author who writes neither note gets the red. That is the gate rewarding silence.

PHPUnit evidence is now `php_mask`'d. Newman evidence is built from the fields that DECLARE a request (`raw`/`path`/`host`/`url`/`name`/`method`) instead of the file's bytes: JSON has no comments, and a `description` is a comment in JSON syntax. An unparseable collection falls back to raw bytes rather than to "not covered" — converting a malformed fixture into findings would be this change inventing failures in repos it was never measured against.

### gate-48 — csrf-cochange 🔴

**Path A.** This file's own note already named the hole: *"the cheapest way to green would have been a cosmetic edit under `src/` containing the word `requesttoken`: exactly the prose-satisfaction #191 warns against."* It was written as a hypothetical. It was not one.

Worse than one missed finding: a non-zero signal count **short-circuits the caller-state check built as the mitigation for this exact shape**. One comment skips the guard and its backup.

**Path B.** `check_csrf_callers.py` read raw — and it makes an *affirmative* claim the runner prints as a NOTE. So prose did not merely hide a finding, it manufactured a green **with a sentence attached saying the code is safe**. A commented-out `@nextcloud/axios` import granted whole-file amnesty to every `axios.post` in it.

Both now anchor on `source_scope.script_mask` — comments blanked, **string literals kept**, because `'OCS-APIRequest': 'true'` is a header name that IS a string and `method: 'DELETE'` is how a mutating call is recognised at all.

### gate-49 — controller-exception-translation

Both of its questions were asked of the raw method body, so it failed in both directions from one cause:

| | verdict |
|---|---|
| an unhandled `$this->objectService->deleteObject()` | **FAIL** — 1 method(s) |
| + `// TODO: we should catch (DoesNotExistException $e) here ... Not done yet.` | **PASS** ← |
| a method calling only `$this->renderer->toArray()`, + *"used to call `$this->objectService->deleteObject($id)` directly. It no longer does."* | **FAIL**, names `index()` ← |

The removal note scored as the removed call: the better the documentation, the redder the repo.

The docblock is still read from the **original** text. `@throws` lives in a comment BY DESIGN, and masking it would trade one false negative for a fleet of false positives.

## Proof

Every fix has acceptance arms, and **every arm was re-run with the change reverted**:

| gate | arms | reverted, what flips | what does not (labelled controls) |
|---|---|---|---|
| 7 | 7 | 3 (`//`, `/* */`, `#`) + 1 signature error | positive control, 2 anti-widening pairs |
| 25 | 8 (new suite) | 3 | positive control, 4 "the real artefact still counts" pairs |
| 48 | 2 | H1 | H2 |
| 49 | 5 | G2, G3 | G1, G4, G5 |

…plus 7 arms in `check_csrf_callers`' own suite, of which **2 flip** and 5 are labelled controls — including the deliberate near-miss: the same TODO sentence three characters *outside* the paren-balanced span the gate actually searches never reached the question, and passes either way.

An arm that passes both before and after is a **control**, not evidence, and each suite says which of its arms is which.

🔑 One rig note worth carrying: `git checkout -- <file>` is **not** a revert once you have committed — it restores from HEAD, fix included. The first run of that last revert had **all seven arms passing**, which reads like seven controls and would have shipped a suite proving nothing. Re-run against `origin/main`, two flip. The tell was that arms I *knew* should flip did not. **When every arm agrees, suspect the rig.**

Existing suites still green: gate-7's 138 → 145 tests, `test_gate7_verb_object_guards.sh` 10/10, and the 45–55 acceptance matrix.

## Two things the survey turned up that are not fixed here

**1. The shared helper already exists — and #420 wrote a fourth dialect.** `lib/source_scope.py` was extracted in #184/#249 for exactly this reason: offset-preserving, knows `#[` is a PHP 8 attribute, knows `//` inside `'https://x'` opens nothing, and exposes the `blank_strings` axis the two kinds of caller need. Three of the four fixes here use it and add no new stripper. #420's `_strip_php_comments` should become a call to `php_mask` once it lands — that is the drift the `exclusion_reason.py` extraction was done to prevent.

**2. `source_scope.markup_mask` is not currently a safe destination.** It has its own hole — `<p>{{ '<!--' }}</p>` … `<img alt="">` … `{{ '-->' }}` blanks the whole span — and that is what makes gates 35 and 36 affected. Six checkers (37, 39, 40, 42, 43, 44) each carry their own copy of `<!--.*?-->`; **routing them into `markup_mask` today would fix their comment half and leave this half armed.** Harden `source_scope` first, then consolidate at one site instead of eight.

## Deliberately not done

- **gate-7's string-literal variant** — see above.
- **gate-48's redundant short-circuit.** The runner's own note argues the caller-STATE question subsumes the diff question, which would make the diff-signal count deletable entirely. That changes verdicts on real PRs and belongs in its own change.
- **The other 43 affected gates.** A wrong recipe repeated at scale is a defect multiplied at scale. Each needs its own anti-widening pair, because for several of them the mask that closes the false negative would delete the evidence.

## Fleet consequence

Every gate-7, gate-25, gate-48 and gate-49 count in the fleet is suspect until a rerun on the fixed package — and for **gate-45** the suspicion is repo-wide, because one comment in one stylesheet sets `HYDRA_RM_GLOBAL_GUARD=1` and silences the gate for every file. `[gate-N] PASS` from before this survey is not necessarily a measurement of the code; it may be a measurement of the comments.

## Also found while building the fixtures

gate-48's `src/**/*.vue` is a **plain** git pathspec, where `*` matches `/` too — so the glob requires a second slash and never matches `src/Del.vue`. Recorded in the suite comment; not fixed here.
