### PR TITLE
fix(gate-7): Pattern 8 is keyed on the signature, so a SOAP endpoint is invisible to it (#413)

### DIFF
--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -1829,11 +1829,22 @@ _OR_RBAC_ACCESS_RE = re.compile(
 # Anything that pulls caller-controlled input in through the request object.
 # Presence of ANY of these disqualifies the pattern: the method then has an
 # attacker-influenceable value, which is exactly what IDOR manipulates.
+#
+# ⚠️ `IRequest::getContent()` WAS MISSING, and it is the same read as
+# `php://input` — which this list has always carried (`#413`). Without it, a
+# parameterless `#[PublicPage]` handler that reads its envelope with
+# `$this->request->getContent()` was cleared by Pattern 3b as a "zero-input
+# READ", one branch AFTER Pattern 8b had correctly put it in scope. Two clauses
+# disagreeing about whether the same line is caller input is how a widening
+# quietly buys nothing. The alternative is anchored on the REQUEST receiver so
+# that `$file->getContent()` and `$response->getContent()` — neither of which
+# is caller input — are untouched.
 _REQUEST_INPUT_RE = re.compile(
     r"->\s*getParams?\s*\("
     r"|->\s*getQueryParam"
     r"|->\s*getUploadedFile\s*\("
     r"|->\s*getBody\s*\("
+    r"|(?:\$this\s*->\s*request|\$request)\s*->\s*getContent\s*\("
     r"|\$_(?:GET|POST|REQUEST|COOKIE|FILES)\b"
     r"|php://input"
 )
@@ -2504,6 +2515,176 @@ def _public_selection_scope(body: str, params, delegate_probe=None):
     return (selects, validated)
 
 
+# ---------------------------------------------------------------------------
+# Pattern 8b — the RAW REQUEST BODY (`ConductionNL/.github#413`)
+# ---------------------------------------------------------------------------
+#
+# 🔴 PATTERN 8 IS KEYED ON THE METHOD SIGNATURE, SO A SOAP ENDPOINT IS
+# STRUCTURALLY INVISIBLE TO IT.
+#
+# Everything above decides scope by asking whether a caller-supplied SCALAR
+# reaches a selection call, and every source of such a scalar it knows about is
+# either a declared parameter or a `->getParam()`-family read. That is right for
+# REST and it has no opinion at all about the shape where the method takes NO
+# PARAMETERS and the selector arrives inside the request body.
+#
+# MEASURED, three arms in one file varying only the selector's SOURCE:
+#
+#     armVisible(string $id)  -> $this->dispatcher->find($id)        1 finding
+#     armRawBody()            -> $this->dispatcher->dispatch(
+#                                    rawBody: file_get_contents('php://input'))
+#                                                                    0 findings
+#     armRawBodyVerified()    -> ->dispatchVerified(rawBody: …)      0 findings
+#
+# The middle arm is the defect: the same delegate, the same unscoped
+# resolution, and the gate cannot see it. The live instance is procest's
+# `StufController::zaken()` / `::personen()` — `#[PublicPage]` +
+# `#[NoCSRFRequired]`, reaching a responder that dispatches `zakLk01` (case
+# create/update), `zakLv01` (case query), `npsLv01` (PERSON QUERY BY BSN) and
+# `edcLk01` (document create/update) with no authentication of any kind.
+# gate-7 reported ZERO findings on that app's 79 public methods.
+#
+# 🔑 THE SILENCE WAS RIGHT 77 TIMES AND WRONG TWICE, which is precisely the
+# ratio that makes a silence persuasive — the failure mode Pattern 8's own
+# commentary warns about, one level up.
+#
+# THE PREDICATE.
+#
+#   in scope   a `#[PublicPage]` method reads the RAW REQUEST BODY and hands a
+#              value derived from it to a `->` / `::` method call. The raw body
+#              is not `array $data`: a payload is bound by the route to one
+#              resource, whereas an envelope handed to a collaborator names its
+#              own OPERATION as well as its subject, so the caller chose both.
+#              A raw body that is only decoded, measured or logged reaches no
+#              collaborator and is not in scope — PSR-3 diagnostics are
+#              excluded by the same receiver/level test Pattern 6 uses.
+#
+#   cleared    NOTHING NEW. This clause widens the SCOPE ONLY; every clear that
+#              already exists then applies unchanged — the whole-body publicness
+#              and scope-predicate refusals here, and after this returns, the
+#              401/403 body guard, Pattern 7's ownership comparison, Pattern 1's
+#              same-class guard helper and Pattern 4's RESOLVED collaborator
+#              guard in scan_file. That is deliberate: inventing a second
+#              vocabulary for "this webhook authenticated its sender" is how a
+#              gate acquires a clear nobody can audit. All five fleet apps that
+#              get this right are cleared by machinery that was already here —
+#              `checkSignature()` and `verifyWsse()` by Pattern 1/4's name
+#              rules, `validateSignature()` by the inline 401 it answers with,
+#              and procest's repaired `dispatch()` by Pattern 4 reading
+#              `authenticateSender()`'s `STATUS_UNAUTHORIZED` out of the
+#              collaborator's own file.
+
+_PUBLIC_RAW_BODY_RE = re.compile(
+    r"php://input"
+    r"|(?:\$this\s*->\s*request|\$request)\s*->\s*getContent\s*\(",
+)
+
+
+def _public_raw_body_names(body: str) -> set:
+    """Locals carrying a value derived from the raw request body.
+
+    Propagation stops at a `->method()` call for the same reason
+    `_public_tainted_names` stops there — past that hop the value is the
+    server's answer, and that hop is itself judged. Plain FUNCTION calls
+    (`json_decode`, `simplexml_load_string`, `trim`) are not method calls and
+    do propagate: decoding a body does not make it the server's.
+    """
+    names: set = set()
+    for _ in range(4):  # bounded fixpoint
+        grew = False
+        for m in _PUBLIC_ASSIGN_RE.finditer(body):
+            name, rhs = m.group(1), m.group(2)
+            if name in names:
+                continue
+            if _PUBLIC_RAW_BODY_RE.search(rhs):
+                names.add(name)
+                grew = True
+                continue
+            if _PUBLIC_CALL_RE.search(rhs):
+                continue
+            if any(re.search(r"\$" + re.escape(t) + r"\b", rhs) for t in names):
+                names.add(name)
+                grew = True
+        if not grew:
+            break
+    return names
+
+
+def _public_argument_is_capability(arg: str) -> bool:
+    """True when *arg* carries an unguessable credential.
+
+    Both spellings count, because both were MEASURED. `handle($rawBody,
+    $signature)` names it in the VARIABLE (pipelinq's
+    `BrpController::mutationWebhook`) and `handleWebhook(rawBody: $rawBody,
+    signature: $signatureArg)` names it in the NAMED-ARGUMENT LABEL
+    (`CtiController::webhook`) — the same idiom, and reading only one of them
+    would report one of those two while clearing the other.
+    """
+    named = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?!:)", arg)
+    if named is not None and _PUBLIC_CAPABILITY_RE.search(named.group(1)):
+        return True
+    return any(_PUBLIC_CAPABILITY_RE.search(v)
+               for v in re.findall(r"\$([A-Za-z_][A-Za-z0-9_]*)", arg))
+
+
+def _public_raw_body_reaches_collaborator(body: str) -> bool:
+    """True when the raw body — or a value derived from it — is handed on
+    WITHOUT the sender's credential travelling with it.
+
+    ⚠️ THE CREDENTIAL CLEAR IS NOT A NEW IDEA, it is Pattern 8's own. The
+    scalar-selector half already holds that "a `$token` / `$secret` IS the
+    authorisation — Nextcloud's own public-share convention", and clears a
+    lookup that carries one. A webhook signature is the same object: an
+    unguessable value the caller cannot forge, collected from the request and
+    handed to the verifier alongside the bytes it authenticates.
+
+    MEASURED before this clear existed: the widening produced exactly two new
+    findings across the eighteen core apps, and BOTH were this shape —
+    pipelinq's BRP and CTI webhooks, each reading an `X-…-Signature` header and
+    forwarding it. Neither was reachable by the existing clears (the CTI one
+    refuses on `$result['valid'] === false`, a bare field comparison that
+    `_public_refuses_on_scope_predicate` deliberately does not read), so both
+    would have been false positives whose only remedy was an exempt tag.
+
+    The residual risk is stated rather than hidden: an app that collects a
+    signature and never verifies it clears here. That is precisely the risk
+    Pattern 8 already accepts for `$token`, and it is a smaller one than the
+    raw-body blindness this pattern exists to close.
+    """
+    names = _public_raw_body_names(body)
+    for m in _PUBLIC_CALL_RE.finditer(body):
+        op = body.find("(", m.start())
+        cl = _matching_close(body, op)
+        if cl == -1:
+            continue
+        args = _split_arguments(body[op + 1:cl])
+        if not args:
+            continue
+        carries = any(_PUBLIC_RAW_BODY_RE.search(a) for a in args) or any(
+            re.search(r"\$" + re.escape(n) + r"\b", a) for a in args for n in names)
+        if not carries:
+            continue
+        receiver = body[max(0, m.start() - 60):m.start()]
+        if (_PSR3_LOG_RECEIVER_RE.search(receiver)
+                and m.group(1).lower() in _PSR3_LOG_LEVELS):
+            continue  # diagnostics: returns void, resolves nothing
+        if any(_public_argument_is_capability(a) for a in args):
+            continue  # the sender's proof travels with the envelope
+        return True
+    return False
+
+
+def _public_raw_body_is_unjudged(body: str) -> bool:
+    """Pattern 8b entry point — see the commentary above."""
+    if not _PUBLIC_RAW_BODY_RE.search(body):
+        return False
+    if _public_refuses_on_publicness(body):
+        return False
+    if _public_refuses_on_scope_predicate(body):
+        return False
+    return _public_raw_body_reaches_collaborator(body)
+
+
 def _public_page_lookup_is_unscoped(cleaned: str, path: str, sig_start: int,
                                     body: str) -> bool:
     """Pattern 8 entry point — see the commentary above."""
@@ -2518,7 +2699,10 @@ def _public_page_lookup_is_unscoped(cleaned: str, path: str, sig_start: int,
             files = _public_collaborator_files(cleaned, path)
         return _public_delegate_scopes(prop, method, files.get(prop))
 
-    return bool(_public_unscoped_selectors(body, params, probe))
+    if _public_unscoped_selectors(body, params, probe):
+        return True
+    # `#413`: the selector that never appears in a signature.
+    return _public_raw_body_is_unjudged(body)
 
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -2628,6 +2628,134 @@ class PublicPageScopeTest(unittest.TestCase):
         self.assertEqual(len(out), 1, out)
 
 
+class PublicPageRawBodyTest(unittest.TestCase):
+    """Pattern 8b — `ConductionNL/.github#413`.
+
+    Pattern 8 decides scope from the PARAMETER LIST, so a SOAP / webhook
+    handler whose selector arrives in the request body was structurally
+    invisible to it. Measured on procest's `StufController::{zaken,personen}`:
+    `#[PublicPage]` + `#[NoCSRFRequired]`, no authentication of any kind, and
+    gate-7 reported ZERO findings on that app's 79 public methods.
+    """
+
+    def test_raw_body_handed_to_a_collaborator_is_reported(self):
+        """The shipped shape: no parameters, `php://input`, one hop."""
+        out = _scan(_public(
+            "        return new DataDisplayResponse($this->dispatcher->dispatch(\n"
+            "            rawBody: file_get_contents('php://input'),\n"
+            "            service: 'zaken'\n"
+            "        ));\n",
+            sig="", ret="DataDisplayResponse"))
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=publicpage-unscoped-object-lookup", out[0])
+
+    def test_request_get_content_is_the_same_read(self):
+        """`IRequest::getContent()` is the other spelling of the same source."""
+        out = _scan(_public(
+            "        $raw = $this->request->getContent();\n"
+            "        return new JSONResponse($this->dispatcher->dispatch($raw));\n",
+            sig=""))
+        self.assertEqual(len(out), 1, out)
+
+    def test_raw_body_reaches_the_call_through_a_decoder(self):
+        """A plain FUNCTION call does not launder the caller's bytes.
+        `json_decode` is not a `->` hop, so taint survives it — this is
+        openregister's `GraphQLController::execute()` shape."""
+        out = _scan(_public(
+            "        $body = file_get_contents('php://input');\n"
+            "        $data = json_decode($body, true);\n"
+            "        $query = $data['query'];\n"
+            "        return new JSONResponse($this->svc->run($query));\n",
+            sig=""))
+        self.assertEqual(len(out), 1, out)
+
+    def test_raw_body_only_logged_is_not_in_scope(self):
+        """PSR-3 diagnostics return void and resolve nothing — the same
+        exclusion Pattern 6 already makes."""
+        out = _scan(_public(
+            "        $raw = file_get_contents('php://input');\n"
+            "        $this->logger->warning('inbound', ['body' => $raw]);\n"
+            "        return new JSONResponse(['status' => 'ok']);\n",
+            sig=""))
+        self.assertEqual(out, [], out)
+
+    def test_a_public_page_without_a_raw_body_read_is_untouched(self):
+        """The abuse control on the widening itself: `#[PublicPage]` plus a
+        parameterless body that reads nothing must stay silent, or the repair
+        would be 'flag every public method'."""
+        out = _scan(_public(
+            "        return new JSONResponse($this->svc->listPublished());\n",
+            sig=""))
+        self.assertEqual(out, [], out)
+
+    def test_raw_body_with_a_refusing_signature_check_clears(self):
+        """NO NEW CLEAR WAS INVENTED. `checkSignature()` is recognised by the
+        SAME `_GUARD_HELPER_NAME_RE` Pattern 1 has always used — procest's
+        `DSOIntakeController::intake()`."""
+        src = _PUBLIC_TPL % (
+            "    #[PublicPage]\n"
+            "    public function intake(): JSONResponse\n    {\n"
+            "        $raw = (string)file_get_contents('php://input');\n"
+            "        if ($this->checkSignature(body: $raw) === false) {\n"
+            "            return new JSONResponse(['message' => 'bad signature'], 400);\n"
+            "        }\n"
+            "        return new JSONResponse($this->svc->process($raw));\n"
+            "    }\n"
+            "    private function checkSignature(string $body): bool\n    {\n"
+            "        return $body !== '';\n"
+            "    }\n")
+        self.assertEqual(_scan(src), [])
+
+    def test_forwarded_signature_variable_clears(self):
+        """pipelinq's `BrpController::mutationWebhook()`: the HMAC is verified
+        one hop down, and what the controller shows is the credential
+        travelling with the bytes it authenticates. Same rule Pattern 8 already
+        applies to a `$token` on a scalar lookup."""
+        out = _scan(_public(
+            "        $rawBody = (string)file_get_contents('php://input');\n"
+            "        $signature = (string)$this->request->getHeader('X-Signature');\n"
+            "        return new JSONResponse($this->listener->handle($rawBody, $signature));\n",
+            sig=""))
+        self.assertEqual(out, [], out)
+
+    def test_forwarded_signature_named_argument_clears(self):
+        """The same idiom spelled with a NAMED ARGUMENT — pipelinq's
+        `CtiController::webhook()`, where the variable is `$signatureArg` and
+        only the label says `signature:`. Reading one spelling and not the
+        other would report one of these two apps and clear the other."""
+        out = _scan(_public(
+            "        $rawBody = (string)file_get_contents('php://input');\n"
+            "        $sig = (string)$this->request->getHeader('X-Sig');\n"
+            "        return new JSONResponse($this->svc->handleWebhook("
+            "rawBody: $rawBody, signature: $sig));\n",
+            sig=""))
+        self.assertEqual(out, [], out)
+
+    def test_no_credential_alongside_the_body_is_still_reported(self):
+        """🔑 THE ABUSE CONTROL ON THAT CLEAR. procest's StUF routes forward
+        the envelope and nothing else — the WSSE token is INSIDE the XML, so
+        there is no credential in the argument list — and they were the two
+        real exposures `#413` was filed for. Byte-identical to the arms above
+        apart from the missing signature argument."""
+        out = _scan(_public(
+            "        $rawBody = (string)file_get_contents('php://input');\n"
+            "        return new JSONResponse($this->listener->handle($rawBody, 'zaken'));\n",
+            sig=""))
+        self.assertEqual(len(out), 1, out)
+
+    def test_raw_body_with_an_inline_401_clears(self):
+        """procest's `DwangsomPaymentCallbackController::callback()`: the
+        signature check IS the auth and it answers 401 in the body."""
+        out = _scan(_public(
+            "        $raw = (string)file_get_contents('php://input');\n"
+            "        if ($this->signer->validateSignature(rawBody: $raw) === false) {\n"
+            "            return new JSONResponse(['message' => 'invalid'], 401);\n"
+            "        }\n"
+            "        return new JSONResponse($this->svc->handleCallback($raw));\n",
+            sig=""))
+        self.assertEqual(out, [], out)
+
+
 class HelperGuardEvidenceTest(unittest.TestCase):
     """A gate that can be silenced by a sentence in a comment is not measuring
     the code."""

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/appinfo/routes.php
@@ -9,5 +9,6 @@ return [
 		['name' => 'catalogue#arbitraryId',  'url' => '/api/themes/{id}',              'verb' => 'GET'],
 		['name' => 'catalogue#listing',      'url' => '/api/themes',                   'verb' => 'GET'],
 		['name' => 'catalogue#byToken',      'url' => '/api/shares/{shareToken}',      'verb' => 'GET'],
+		['name' => 'catalogue#rawBodyDispatch', 'url' => '/api/soap/cases',           'verb' => 'POST'],
 	],
 ];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/lib/Controller/CatalogueController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/lib/Controller/CatalogueController.php
@@ -20,10 +20,12 @@
 namespace OCA\PublicPageFixture\Controller;
 
 use OCA\PublicPageFixture\Service\CatalogueService;
+use OCA\PublicPageFixture\Service\EnvelopeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -34,6 +36,7 @@ class CatalogueController extends Controller {
 		string $appName,
 		IRequest $request,
 		private readonly CatalogueService $catalogue,
+		private readonly EnvelopeService $envelopes,
 		private readonly IConfig $config,
 	) {
 		parent::__construct($appName, $request);
@@ -78,6 +81,29 @@ class CatalogueController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 		return new JSONResponse($theme);
+	}
+
+	/**
+	 * The same raw-body handler, AUTHENTICATED — `ConductionNL/.github#413`.
+	 *
+	 * Byte-identical to the planted arm's `rawBodyDispatch()`: same signature,
+	 * same `php://input` read, same collaborator, same call. The only thing
+	 * that differs is that `EnvelopeService::dispatch()` in THIS arm verifies
+	 * the sender before it interprets the envelope.
+	 *
+	 * This arm is the one that stops `#413` being repaired by "flag every
+	 * `#[PublicPage]` method that reads the body". It is procest's
+	 * `StufController::zaken()` as it ships today, cleared by Pattern 4
+	 * reading `authenticateSender()` out of the collaborator's own file — no
+	 * new clear was invented for the raw-body family, and this pins that.
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	public function rawBodyDispatch(): DataDisplayResponse {
+		return new DataDisplayResponse($this->envelopes->dispatch(
+			rawBody: file_get_contents('php://input'),
+			service: 'cases'
+		));
 	}
 
 	/**

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/lib/Service/EnvelopeService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/clean/lib/Service/EnvelopeService.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * CLEAN arm — the same raw-body collaborator, WITH the sender authentication.
+ *
+ * Byte-identical to the planted arm apart from `authenticateSender()` and the
+ * three lines in `dispatch()` that consult it. That is the whole difference
+ * between the two arms of this half of the bundle, and it is what the
+ * `#413` widening must be able to tell apart.
+ *
+ * Nothing new in the checker recognises this: `authenticateSender()` refuses
+ * with `STATUS_UNAUTHORIZED`, which makes it a strict guard, and `dispatch()`
+ * calls it before any data access, which makes `dispatch()` transitively
+ * guard-bearing — Pattern 4, reading this file, not the controller's.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\PublicPageFixture\Service;
+
+use OCP\AppFramework\Http;
+
+class EnvelopeService {
+
+	/**
+	 * Parse an inbound SOAP envelope and run whatever it asks for — once the
+	 * sending system has proved who it is.
+	 */
+	public function dispatch(string|false $rawBody, string $service): string {
+		$refusal = $this->authenticateSender($rawBody);
+		if ($refusal !== null) {
+			return $refusal;
+		}
+		$document = $this->parse($rawBody);
+		return $this->respond($document, $service);
+	}
+
+	/**
+	 * Match the envelope's WSSE UsernameToken against the sending endpoint's
+	 * stored credentials. Fail-closed: an unconfigured endpoint refuses.
+	 */
+	private function authenticateSender(string|false $rawBody): ?string {
+		if ($rawBody === false || str_contains($rawBody, 'wsse:UsernameToken') === false) {
+			return $this->fault('Authentication failed', Http::STATUS_UNAUTHORIZED);
+		}
+		return null;
+	}
+
+	public function fault(string $message, int $statusCode): string {
+		return $message;
+	}
+
+	public function parse(string|false $rawBody): array {
+		return [];
+	}
+
+	public function respond(array $document, string $service): string {
+		return '';
+	}
+}

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/expect.conf
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/expect.conf
@@ -23,4 +23,22 @@
 # resolves it GLOBALLY. Adding a register/schema/catalog argument to that
 # lookup — or renaming the callee to something carrying a `Public` segment —
 # clears the arm and this fixture silently stops proving anything.
-gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=arbitraryId
+#
+# SECOND ARM — `ConductionNL/.github#413`, the RAW-BODY family.
+#
+# `rawBodyDispatch()` takes NO PARAMETERS. Pattern 8 decided scope from the
+# parameter list, so a SOAP / webhook handler whose selector arrives inside the
+# request body was invisible to it — and that is a strictly larger exposure
+# than `arbitraryId()`, because the envelope names the OPERATION too. Measured
+# on procest's `StufController::{zaken,personen}`: gate-7 reported ZERO
+# findings on that app's 79 public methods, these two included.
+#
+# The two arms differ ONLY in whether `EnvelopeService::dispatch()`
+# authenticates the sender, so this row cannot be satisfied by "flag every
+# `#[PublicPage]` method that reads the body" — the clean arm reads it too.
+#
+# Both rows carry the trailing ` rule=…` field for the reason spelled out at
+# length in the authn-vs-authz bundle: a bare `method=x` subject is a prefix of
+# every longer method name, and `grep -qF` cannot tell them apart.
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=arbitraryId rule=publicpage-unscoped-object-lookup
+gate 7 hydra-gate-no-admin-idor.log FAIL PASS method=rawBodyDispatch rule=publicpage-unscoped-object-lookup

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/appinfo/routes.php
@@ -9,5 +9,6 @@ return [
 		['name' => 'catalogue#arbitraryId',  'url' => '/api/themes/{id}',              'verb' => 'GET'],
 		['name' => 'catalogue#listing',      'url' => '/api/themes',                   'verb' => 'GET'],
 		['name' => 'catalogue#byToken',      'url' => '/api/shares/{shareToken}',      'verb' => 'GET'],
+		['name' => 'catalogue#rawBodyDispatch', 'url' => '/api/soap/cases',           'verb' => 'POST'],
 	],
 ];

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/lib/Controller/CatalogueController.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/lib/Controller/CatalogueController.php
@@ -19,10 +19,12 @@
 namespace OCA\PublicPageFixture\Controller;
 
 use OCA\PublicPageFixture\Service\CatalogueService;
+use OCA\PublicPageFixture\Service\EnvelopeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -32,6 +34,7 @@ class CatalogueController extends Controller {
 		string $appName,
 		IRequest $request,
 		private readonly CatalogueService $catalogue,
+		private readonly EnvelopeService $envelopes,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -71,5 +74,34 @@ class CatalogueController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 		return new JSONResponse($theme);
+	}
+
+	/**
+	 * THE SECOND PLANT — `ConductionNL/.github#413`. The selector never
+	 * appears in the signature.
+	 *
+	 * This method takes NO PARAMETERS. Everything the caller chose — the
+	 * operation as well as its subject — arrives inside the request body and
+	 * is handed straight to a collaborator that acts on both. That makes it
+	 * strictly more powerful than `arbitraryId()` above, and until `#413` it
+	 * was invisible to a gate that decides scope from the parameter list.
+	 *
+	 * MEASURED as three arms in one file: `arbitraryId(string $id)` reported,
+	 * this body reported NOTHING, and the WSSE-verified twin reported nothing
+	 * either — the middle arm being the defect.
+	 *
+	 * ⚠️ NOTE FOR WHOEVER TOUCHES THIS: what makes it a plant is that
+	 * `EnvelopeService::dispatch()` in THIS arm authenticates nobody. Adding a
+	 * guard there — or a refusing `if` here — clears it and this half of the
+	 * fixture silently stops proving anything. The clean arm is where the
+	 * guard belongs.
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	public function rawBodyDispatch(): DataDisplayResponse {
+		return new DataDisplayResponse($this->envelopes->dispatch(
+			rawBody: file_get_contents('php://input'),
+			service: 'cases'
+		));
 	}
 }

--- a/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/lib/Service/EnvelopeService.php
+++ b/hydra-gates/scripts/test-fixtures/gate-acceptance/publicpage-scope/planted/lib/Service/EnvelopeService.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PLANTED arm — the raw-body collaborator, UNGUARDED.
+ *
+ * `dispatch()` reads the operation and its subject out of the envelope the
+ * caller composed and acts on both. Nothing here authenticates the sender.
+ * This is procest's `StufSoapRequestDispatcher::dispatch()` as it shipped
+ * before ConductionNL/procest#828.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+namespace OCA\PublicPageFixture\Service;
+
+class EnvelopeService {
+
+	/**
+	 * Parse an inbound SOAP envelope and run whatever it asks for.
+	 */
+	public function dispatch(string|false $rawBody, string $service): string {
+		$document = $this->parse($rawBody);
+		return $this->respond($document, $service);
+	}
+
+	public function parse(string|false $rawBody): array {
+		return [];
+	}
+
+	public function respond(array $document, string $service): string {
+		return '';
+	}
+}


### PR DESCRIPTION
Closes #413.

## Reproduced first

Three arms in one file, varying only the selector's **source**:

| arm | selector | gate-7 |
|---|---|---|
| `armVisible(string $id)` | method parameter → `->find($id)` | **1 finding** |
| `armRawBody()` | `->dispatch(rawBody: file_get_contents('php://input'), service: 'zaken')` | **0 findings** |
| `armRawBodyVerified()` | same, WSSE-verified delegate | 0 findings |

The middle arm is the defect: same delegate, same unscoped resolution, invisible. Pattern 8 decides scope by asking whether a caller-supplied **scalar** reaches a selection call, and every source of such a scalar it knows about is a declared parameter or a `->getParam()`-family read. It has no opinion at all about a method that takes **no parameters** and carries its selector in the body.

The live instance is procest `StufController::{zaken,personen}` — `#[PublicPage]` + `#[NoCSRFRequired]`, reaching a responder that dispatches `zakLk01`, `zakLv01`, `npsLv01` (**person query by BSN**) and `edcLk01` with no authentication of any kind. gate-7 reported **zero** findings on that app's 79 public methods. Right 77 times, wrong twice — the ratio that makes a silence persuasive.

## What changes — scope only, no new clear

Pattern 8b puts a `#[PublicPage]` method in scope when it reads the raw request body and hands a derived value to a `->`/`::` call. Everything that already clears then applies unchanged (401/403 body guard, Pattern 7 ownership, Pattern 1 same-class helper, Pattern 4 **resolved** collaborator guard). Every fleet app that gets this right is cleared by machinery that was already here — `checkSignature()`/`verifyWsse()` by the Pattern 1/4 name rules, `validateSignature()` by its inline 401, and procest's repaired `dispatch()` by Pattern 4 reading `authenticateSender()`'s `STATUS_UNAUTHORIZED` out of the collaborator's own file.

One clear **is** added and it is Pattern 8's own: the scalar half already holds that "a `$token`/`$secret` **is** the authorisation", so a webhook signature travelling with the bytes it authenticates clears the same way. It was added because it was measured to be needed — see below.

`IRequest::getContent()` is added to `_REQUEST_INPUT_RE`, which already carried `php://input`. Without it Pattern 3b cleared the same method as a "zero-input READ" one branch *after* Pattern 8b had put it in scope. Anchored on the request receiver, so `$file->getContent()` is untouched.

## Measured before/after — gate-7 on `lib/Controller`, all 18 core apps

| repo | before | after | Δ |
|---|---|---|---|
| decidesk | 15 | 15 | 0 |
| docudesk | 23 | 23 | 0 |
| doriath | 4 | 4 | 0 |
| hermiq | 17 | 17 | 0 |
| larpingapp | 1 | 1 | 0 |
| launchpad | 1 | 1 | 0 |
| nldesign | 0 | 0 | 0 |
| openbuild | 6 | 6 | 0 |
| opencatalogi | 14 | 14 | 0 |
| openconnector | 80 | 80 | 0 |
| openregister | 95 | 95 | 0 |
| pipelinq | 50 | 50 | 0 |
| portaliq | 1 | 1 | 0 |
| procest | 27 | 27 | 0 |
| scholiq | 4 | 4 | 0 |
| shillinq | 18 | 18 | 0 |
| softwarecatalog | 30 | 30 | 0 |
| zaakafhandelapp | 89 | 89 | 0 |
| **TOTAL** | **475** | **475** | **+0** |

The first draft, **without** the credential clear, produced exactly **two** new findings across those 18 apps, and both were false positives of one shape: pipelinq's BRP and CTI webhooks, each reading an `X-…-Signature` header and forwarding it to the verifier. Neither was reachable by any existing clear (the CTI one refuses on `$result['valid'] === false`, a bare field comparison `_public_refuses_on_scope_predicate` deliberately does not read), so their only remedy would have been an exempt tag. Characterised, then closed properly rather than shipped.

Residual risk, stated rather than hidden: an app that collects a signature and never verifies it clears here. That is the risk Pattern 8 already accepts for `$token`, and it is smaller than the raw-body blindness this closes.

## Two-directional control on the real repo

procest with `authenticateSender()` removed — the state it shipped **before** ConductionNL/procest#828 — reports **27** findings without this change and **29** with it, the two extra being `method=zaken` and `method=personen`. procest as it ships **today** reports 27 either way: the fix does not punish the repair. Same file, same checker, one hop of difference.

## Revert control — which arms are evidence

Suite re-run with the **fixtures kept and the checker reverted**:

- **EVIDENCE** — `publicpage-scope/planted` `rawBodyDispatch()`: `FAIL — gate-7 failed but 'method=rawBodyDispatch rule=publicpage-unscoped-object-lookup' is not in hydra-gate-no-admin-idor.log — it failed for some OTHER reason`. With the fix: PASS.
- **CONTROL** — `publicpage-scope/clean` `rawBodyDispatch()`: byte-identical apart from `EnvelopeService::authenticateSender()`. Silent before **and** after, so "flag every public method that reads the body" is not a passing repair.
- **CONTROL** — `publicpage-scope/planted` `arbitraryId()`: unchanged in both directions.

`test_gate_acceptance_matrix.sh`: **134 passed / 0 failed** on this branch (137/0 with #414 also applied). `test_check_no_admin_idor.py`: **148 pass**. `test_gate_orphaned_capability_fixtures.sh` fails identically on pristine `main` (missing fixture dirs) — pre-existing, not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
