### PR TITLE
fix(gates): gate-3 spares a contract-imposed unused param; gate-53 compares page identity not route spelling

### DIFF
--- a/hydra-gates/scripts/lib/check_caller_identity_exempt.py
+++ b/hydra-gates/scripts/lib/check_caller_identity_exempt.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""check_caller_identity_exempt.py — is a gate-3 caller-identity finding closable?
+
+WHY THIS EXISTS (.github#339)
+-----------------------------
+gate-3's ``caller-identity-ignored`` rule reports any public method under
+``lib/Service`` / ``lib/Controller`` that declares ``$uid`` / ``$callerUid`` /
+``$userId`` / ``$caller`` and never references it in its body.  That is
+decidesk#45's shape: a builder-generated ``authorize*()`` stub that accepts the
+caller and then forgets to check it.
+
+It is ALSO the shape of a correct strategy implementation.  Measured on procest
+(``development`` @ ``792fe1f4b``), all three findings the gate produced were of
+the second kind::
+
+    lib/Service/Transitions/ChecklistGuard.php:64        method=evaluate param=$userId
+    lib/Service/Transitions/RequiredDocumentGuard.php:49 method=evaluate param=$userId
+    lib/Service/Transitions/RequiredFieldGuard.php:47    method=evaluate param=$userId
+
+All three implement ``GuardEvaluatorInterface::evaluate(array, array, string
+$userId)``.  Two of the five implementors (``RoleGuard``, ``MandaatGuard``) use
+the parameter — it is the whole point of those classes.  A guard that asks "is
+this required field filled in?" has no business consulting the caller, so the
+only edits that silence the gate are deleting the parameter (breaking the
+interface and every call site in ``GuardRegistry::evaluateAll()``) or
+referencing it pointlessly to get the grep count to 2.  Both make the code
+worse; the finding had no closing action.
+
+WHAT MAKES A FINDING EXEMPT
+---------------------------
+Two conditions, and BOTH must hold.  Either alone is insufficient, and that is
+deliberate:
+
+1. **The signature is imposed from outside.**  The declaring class names a
+   supertype (``implements`` / ``extends``, transitively) that is resolvable in
+   this repository and declares the same method with the same parameter.  This
+   is fully mechanical: nothing the author asserts, only what the type graph
+   says.  It is what makes the exemption un-sprinklable — a fixer agent cannot
+   escape the rule by adding a docblock line, because an invented service
+   method has no supertype and there is no legitimate reason to keep an unused
+   parameter on one.  You would simply delete it.
+
+2. **The author marked THAT parameter unused.**  The method docblock's
+   ``@param`` line for the flagged parameter carries an explicit
+   unused / ignored marker, e.g.::
+
+       @param string $userId Current user UID (unused)
+
+   Condition 1 alone would exempt a genuinely gutted implementation: if
+   ``RoleGuard`` stopped consulting ``$userId`` tomorrow that is a real defect,
+   and it is contract-imposed too.  The marker is what separates "deliberate"
+   from "forgot", and it is per-parameter, which
+   ``@SuppressWarnings(PHPMD.UnusedFormalParameter)`` is not — that annotation
+   is method-wide and cannot name which parameter it excuses.  #339 offered
+   both and preferred the PHPMD tag; the per-``@param`` marker is the stricter
+   of the two, and procest already carries it on all three findings while
+   ``MandaatGuard`` — which carries the PHPMD tag for a DIFFERENT parameter —
+   does not.  Keying on the PHPMD tag would have exempted MandaatGuard's
+   ``$userId`` for a reason that was never about ``$userId``.
+
+FAIL-CLOSED
+-----------
+Anything unresolvable is NOT an exemption: a supertype that lives outside this
+repository (an OCP interface, a vendored contract) cannot be inspected, so the
+finding stands.  Every error path exits non-zero.  A gate helper that cannot
+read its input must not answer "exempt".
+
+Usage:
+    check_caller_identity_exempt.py --root DIR --file F --line N \\
+        --method NAME --param '$userId'
+
+Exit codes:
+    0 — EXEMPT: contract-imposed AND explicitly marked unused
+    1 — not exempt (report the finding)
+    2 — could not decide (report the finding)
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# `final class X`, `abstract class X`, `readonly final class X`, `interface X`,
+# `trait X` — capture the kind and the name.
+TYPE_DECL = re.compile(
+    r'^\s*(?:(?:final|abstract|readonly)\s+)*(class|interface|trait)\s+(\w+)\b'
+)
+UNUSED_MARKER = re.compile(r'\b(?:unused|ignored|not\s+used|no[t]?\s+consulted)\b', re.I)
+
+MAX_DEPTH = 6  # supertype BFS bound; a cycle guard already prevents loops.
+
+
+def read_lines(path):
+    with open(path, 'r', encoding='utf-8', errors='replace') as fh:
+        return fh.read().split('\n')
+
+
+def docblock_above(lines, idx):
+    """Return the docblock lines immediately preceding 0-based line `idx`.
+
+    Skips blank lines and PHP 8 attribute lines (`#[NoAdminRequired]`), which
+    legitimately sit between a docblock and its signature. Returns [] when the
+    preceding non-skippable line is not a docblock terminator.
+    """
+    i = idx - 1
+    while i >= 0 and (lines[i].strip() == '' or lines[i].strip().startswith('#[')):
+        i -= 1
+    if i < 0 or not lines[i].strip().endswith('*/'):
+        return []
+    end = i
+    while i >= 0 and '/**' not in lines[i]:
+        i -= 1
+    if i < 0:
+        return []
+    return lines[i:end + 1]
+
+
+def param_marked_unused(doc, param):
+    """True when the @param line for `param` carries an explicit unused marker."""
+    # `@param string $userId ...`, `@param $userId ...`, `@param string|null $userId ...`
+    pat = re.compile(r'@param\b[^$]*' + re.escape(param) + r'\b(.*)$')
+    for line in doc:
+        m = pat.search(line)
+        if m and UNUSED_MARKER.search(m.group(1)):
+            return True
+    return False
+
+
+def enclosing_type(lines, idx):
+    """Nearest type declaration at or above 0-based `idx`.
+
+    Returns (name, supertypes) or (None, []).
+    """
+    for i in range(idx, -1, -1):
+        m = TYPE_DECL.match(lines[i])
+        if not m:
+            continue
+        # The header may wrap across lines; read on until `{` or a blank line.
+        header = []
+        j = i
+        while j < len(lines) and j < i + 12:
+            header.append(lines[j])
+            if '{' in lines[j]:
+                break
+            j += 1
+        return m.group(2), parse_supertypes(' '.join(header))
+    return None, []
+
+
+def parse_supertypes(header):
+    """Short names from `extends A` / `implements B, C` in a type header."""
+    names = []
+    for kw in ('extends', 'implements'):
+        m = re.search(kw + r'\s+([\w\\\s,]+?)(?:\s*\{|\s+implements\b|$)', header)
+        if not m:
+            continue
+        for raw in m.group(1).split(','):
+            short = raw.strip().split('\\')[-1].strip()
+            if short and short not in names:
+                names.append(short)
+    return names
+
+
+def index_types(root):
+    """Map short type name -> [file paths] for every PHP type declared under lib/."""
+    index = {}
+    lib = os.path.join(root, 'lib')
+    if not os.path.isdir(lib):
+        return index
+    for dirpath, _dirnames, filenames in os.walk(lib):
+        for fn in filenames:
+            if not fn.endswith('.php'):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                lines = read_lines(path)
+            except OSError:
+                continue
+            for line in lines:
+                m = TYPE_DECL.match(line)
+                if m:
+                    index.setdefault(m.group(2), []).append(path)
+    return index
+
+
+def declares(path, method, param):
+    """True when `path` declares `method` with `param` in its signature.
+
+    Reads the signature region — from `function <method>(` to the first `;` or
+    `{` — which is the only place a parameter can appear. `;` = an interface or
+    abstract declaration, `{` = a body; both count as declaring the contract.
+    """
+    try:
+        lines = read_lines(path)
+    except OSError:
+        return False
+    start = re.compile(r'\bfunction\s+' + re.escape(method) + r'\s*\(')
+    for i, line in enumerate(lines):
+        if not start.search(line):
+            continue
+        sig = []
+        for j in range(i, min(i + 20, len(lines))):
+            sig.append(lines[j])
+            if ';' in lines[j] or '{' in lines[j]:
+                break
+        if re.search(re.escape(param) + r'\b', ' '.join(sig)):
+            return True
+    return False
+
+
+def contract_imposed(root, lines, idx, method, param):
+    """True when a resolvable supertype declares `method` with `param`."""
+    _name, supers = enclosing_type(lines, idx)
+    if not supers:
+        return False
+    index = index_types(root)
+    seen = set()
+    frontier = [(s, 0) for s in supers]
+    while frontier:
+        name, depth = frontier.pop(0)
+        if name in seen or depth > MAX_DEPTH:
+            continue
+        seen.add(name)
+        for path in index.get(name, []):
+            if declares(path, method, param):
+                return True
+            # Not here — follow this type's own parents.
+            try:
+                plines = read_lines(path)
+            except OSError:
+                continue
+            for i, line in enumerate(plines):
+                m = TYPE_DECL.match(line)
+                if m and m.group(2) == name:
+                    header = ' '.join(plines[i:i + 12])
+                    for s in parse_supertypes(header):
+                        frontier.append((s, depth + 1))
+                    break
+    return False
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument('--root', required=True)
+    ap.add_argument('--file', required=True)
+    ap.add_argument('--line', required=True, type=int, help='1-based signature line')
+    ap.add_argument('--method', required=True)
+    ap.add_argument('--param', required=True, help='e.g. $userId')
+    args = ap.parse_args()
+
+    path = args.file if os.path.isabs(args.file) else os.path.join(args.root, args.file)
+    try:
+        lines = read_lines(path)
+    except OSError as exc:
+        print(f'check_caller_identity_exempt: cannot read {path}: {exc}', file=sys.stderr)
+        return 2
+    idx = args.line - 1
+    if idx < 0 or idx >= len(lines):
+        print(f'check_caller_identity_exempt: line {args.line} out of range in {path}',
+              file=sys.stderr)
+        return 2
+
+    if not param_marked_unused(docblock_above(lines, idx), args.param):
+        return 1
+    if not contract_imposed(args.root, lines, idx, args.method, args.param):
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hydra-gates/scripts/lib/check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/check_manifest_crossref.js
@@ -541,8 +541,33 @@ function main() {
 				}
 				return null
 			}
+			// COMPARE PAGE IDENTITY, NOT THE ROUTE SPELLING (.github#340).
+			//
+			// A `menu[].route` may hold EITHER a pages[].id or a pages[].route —
+			// check (a) above accepts both and every app uses both spellings.
+			// This invariant used to compare the raw strings, so two menu
+			// entries reaching the SAME page by different spellings did not
+			// count as reaching each other. Retiring one of them is precisely
+			// the "duplicate navigation entry whose page is still reachable"
+			// that ADR-044 §5 sanctions, and it was reported as an orphan.
+			//
+			// Measured on a two-entry manifest (`route: "ItemsPage"` and
+			// `route: "/items"`, one page `{id: ItemsPage, route: /items}`):
+			// removing the path-spelled entry FAILED removals-invariant.
+			//
+			// Resolve both sides to the page id before comparing. A reference
+			// that resolves to no page is left as-is: check (a) already fails
+			// it, and collapsing unresolvable references onto one another here
+			// would let two broken entries vouch for each other.
+			const pageIdByRoute = new Map()
+			for (const p of pages) {
+				if (!p || typeof p.route !== 'string' || typeof p.id !== 'string') continue
+				if (!pageIdByRoute.has(p.route)) pageIdByRoute.set(p.route, p.id)
+			}
+			const pageKey = (ref) => (pageIds.has(ref) ? ref : (pageIdByRoute.get(ref) || ref))
 			const effectiveRoutes = []
 			collectMenuRoutes(manifest.menu, '/menu', effectiveRoutes)
+			const effectiveKeys = new Set(effectiveRoutes.map((m) => pageKey(m.route)))
 			removals.forEach((id, i) => {
 				const entry = findEntry(preRemoval, id)
 				if (!entry) {
@@ -550,7 +575,7 @@ function main() {
 					return
 				}
 				if (typeof entry.route !== 'string' || entry.route === '') return // nothing routable retired
-				if (!effectiveRoutes.some((m) => m.route === entry.route)) {
+				if (!effectiveKeys.has(pageKey(entry.route))) {
 					fail('removals-invariant', `/menu-layout/removals/${i}`, `removal '${id}' orphans route '${entry.route}' — no surviving menu entry reaches it (ADR-044 no-functionality-loss)`)
 				}
 			})

--- a/hydra-gates/scripts/lib/test_check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/test_check_manifest_crossref.js
@@ -178,6 +178,62 @@ function parseReport(stdout) {
 	fs.rmSync(path.dirname(tmp), { recursive: true, force: true })
 }
 
+// --- removals-invariant compares PAGE IDENTITY, not route spelling (#340) ----
+//
+// `menu[].route` may hold EITHER a pages[].id or a pages[].route — check (a)
+// accepts both. Until 2026-08-13 this invariant compared the raw strings, so
+// two menu entries reaching the SAME page by different spellings did not count
+// as reaching each other, and retiring one of them — exactly the "duplicate
+// navigation entry whose page is still reachable" ADR-044 §5 sanctions — was
+// reported as an orphaned route.
+//
+// Both arms run off ONE fixture pair that differs only in whether a second
+// menu entry survives. Arm B is the control: if the normalisation were written
+// as "any removal whose page exists is fine", arm B would fall silent too.
+{
+	const mkApp = (menu) => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate30-idroute-'))
+		fs.mkdirSync(path.join(dir, 'src'), { recursive: true })
+		fs.writeFileSync(path.join(dir, 'src', 'manifest.json'), JSON.stringify({
+			manifestVersion: '2.0',
+			app: { id: 'demo', name: 'Demo' },
+			menu,
+			pages: [{
+				id: 'ItemsPage', route: '/items', type: 'index', title: 'Items',
+				config: { register: 'demo', schema: 'item' },
+			}],
+		}))
+		fs.writeFileSync(path.join(dir, 'src', 'menu-layout.json'), JSON.stringify({
+			relocations: {}, removals: ['items-by-path'], settingsSection: [],
+		}))
+		return dir
+	}
+	const orphans = (dir) => {
+		const rep = parseReport(run([CHECKER, '--app-dir', dir]).stdout)
+		return rep.findings.filter((f) => f.check === 'removals-invariant' && f.severity === 'error')
+	}
+
+	// ARM A — the duplicate survives, spelled as the page ID. Reachable.
+	const dup = mkApp([
+		{ id: 'items-by-id', label: 'Items', route: 'ItemsPage' },
+		{ id: 'items-by-path', label: 'Items again', route: '/items' },
+	])
+	assert(orphans(dup).length === 0,
+		'removals-invariant: an id-spelled survivor covers a path-spelled removal (#340)')
+
+	// ARM B — CONTROL. Same removal, but nothing else reaches the page. The
+	// route is genuinely orphaned and MUST still be reported.
+	const solo = mkApp([
+		{ id: 'items-by-path', label: 'Items', route: '/items' },
+	])
+	const soloFindings = orphans(solo)
+	assert(soloFindings.length === 1 && soloFindings[0].message.includes("'items-by-path'"),
+		`removals-invariant CONTROL: the sole entry's removal is STILL an orphan (got ${soloFindings.length})`)
+
+	fs.rmSync(dup, { recursive: true, force: true })
+	fs.rmSync(solo, { recursive: true, force: true })
+}
+
 // --- structural stage on the ASSEMBLED broken manifest (Ajv path) ---------------
 // The fragment-introduced `layout[]` page property is invisible to the base
 // gate-22 run and to the crossref checker; it must fail check_manifest.js on

--- a/hydra-gates/scripts/lib/test_gate_3_contract_param.sh
+++ b/hydra-gates/scripts/lib/test_gate_3_contract_param.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_3_contract_param.sh — gate-3's `caller-identity-ignored` rule must
+# not judge a parameter the class did not choose (.github#339).
+#
+# WHAT WENT WRONG
+# ---------------
+# The rule reports any public method under lib/Service / lib/Controller that
+# declares a caller-identity parameter and never references it in its body.
+# That is decidesk#45's shape — a builder-generated authorize*() stub that
+# accepts the caller and forgets to check it.
+#
+# It is also the shape of a correct strategy implementation. Measured on procest
+# (development @ 792fe1f4b), gate-3's three findings were all of the second kind:
+#
+#   lib/Service/Transitions/ChecklistGuard.php:64        method=evaluate
+#   lib/Service/Transitions/RequiredDocumentGuard.php:49 method=evaluate
+#   lib/Service/Transitions/RequiredFieldGuard.php:47    method=evaluate
+#
+# All three implement GuardEvaluatorInterface::evaluate(array, array, string
+# $userId). Two of the five implementors (RoleGuard, MandaatGuard) genuinely use
+# it. A guard answering "is this required field filled in?" has no business
+# consulting the caller, so the only edits that silenced the gate were deleting
+# the parameter — breaking the interface and every call site in
+# GuardRegistry::evaluateAll() — or referencing it pointlessly to push the grep
+# count to 2. The finding had no closing action.
+#
+# THE EXEMPTION HAS TWO HALVES AND EACH ARM BELOW REMOVES ONE
+# -----------------------------------------------------------
+# A finding is exempt only when a resolvable supertype declares the same method
+# with the same parameter AND the docblock's @param line for THAT parameter is
+# explicitly marked unused. Arms 2-5 each delete exactly one of those halves and
+# require the finding to come back. An exemption that cannot fail is worth less
+# than the finding it removes.
+#
+# Run: bash scripts/lib/test_gate_3_contract_param.sh
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+RUNNER="${LIB_DIR}/../run-hydra-gates.sh"
+
+_fail_count=0
+_pass_count=0
+_ok()  { echo "  PASS — $1"; _pass_count=$((_pass_count + 1)); }
+_bad() { echo "  FAIL — $1"; _fail_count=$((_fail_count + 1)); }
+
+[ -f "${RUNNER}" ] || { echo "FAIL — runner not found at ${RUNNER}"; exit 1; }
+
+# Run gate-3 over a repo built from `path=content` pairs; echo the
+# caller-identity findings, one per line.
+_run_gate3_multi() {
+	local root logdir out pair rel content
+	root="$(mktemp -d "${TMPDIR:-/tmp}/g3contract.XXXXXX")" || return 1
+	for pair in "$@"; do
+		rel="${pair%%=*}"
+		content="${pair#*=}"
+		mkdir -p "${root}/$(dirname "${rel}")"
+		printf '%s' "${content}" > "${root}/${rel}"
+	done
+	(
+		cd "${root}" || exit 1
+		git init -q .
+		git config user.email t@example.com
+		git config user.name t
+		git config commit.gpgsign false
+		git add -A && git commit -qm base
+	) >/dev/null 2>&1
+	logdir="$(mktemp -d "${TMPDIR:-/tmp}/g3clogs.XXXXXX")"
+	# The runner's exit status is DELIBERATELY not captured: it aggregates 60+
+	# gates and says nothing about gate-3. The verdict is the log.
+	out="$(cd "${root}" && HYDRA_GATE_LOG_DIR="${logdir}" bash "${RUNNER}" . 2>&1)"
+	grep 'caller-identity-ignored' "${logdir}/hydra-gate-stub-scan.log" 2>/dev/null
+	# Surface gate-3's own verdict on stderr — an unrun gate and a clean one
+	# look identical in an empty result otherwise.
+	printf '%s\n' "${out}" | grep -E '\[gate-3\]' >&2
+	rm -rf "${root}" "${logdir}"
+	return 0
+}
+
+# procest's GuardEvaluatorInterface, trimmed to the one method that matters.
+# shellcheck disable=SC2016  # $userId is PHP source — single quotes are REQUIRED
+_INTERFACE='<?php
+
+namespace OCA\Procest\Service\Transitions;
+
+interface GuardEvaluatorInterface
+{
+    /**
+     * Evaluate one guard configuration against a case.
+     *
+     * @param array  $guardConfig Guard configuration.
+     * @param array  $case        The case object.
+     * @param string $userId      Current user UID.
+     *
+     * @return GuardResult
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult;
+}
+'
+
+# ChecklistGuard's shape: contract-imposed AND marked unused on the @param line.
+# shellcheck disable=SC2016  # $userId is PHP source — single quotes are REQUIRED
+_GUARD_MARKED='<?php
+
+namespace OCA\Procest\Service\Transitions;
+
+class RequiredFieldGuard implements GuardEvaluatorInterface
+{
+    /**
+     * Evaluate the required-field guard.
+     *
+     * @param array  $guardConfig Guard configuration.
+     * @param array  $case        Case object.
+     * @param string $userId      Current user UID (unused)
+     *
+     * @return GuardResult
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $field = (string)($guardConfig["field"] ?? "");
+        if ($field === "") {
+            return new GuardResult(false, "missing field");
+        }
+        return new GuardResult(($case[$field] ?? "") !== "", "field empty");
+    }
+}
+'
+
+# Same class, marker deleted from the @param line. Everything else identical.
+# shellcheck disable=SC2016  # $userId is PHP source — single quotes are REQUIRED
+_GUARD_UNMARKED='<?php
+
+namespace OCA\Procest\Service\Transitions;
+
+class RequiredFieldGuard implements GuardEvaluatorInterface
+{
+    /**
+     * Evaluate the required-field guard.
+     *
+     * @param array  $guardConfig Guard configuration.
+     * @param array  $case        Case object.
+     * @param string $userId      Current user UID.
+     *
+     * @return GuardResult
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $field = (string)($guardConfig["field"] ?? "");
+        if ($field === "") {
+            return new GuardResult(false, "missing field");
+        }
+        return new GuardResult(($case[$field] ?? "") !== "", "field empty");
+    }
+}
+'
+
+# The marker, on a class that implements nothing — decidesk#45 with a docblock.
+# shellcheck disable=SC2016  # $userId is PHP source — single quotes are REQUIRED
+_FREESTANDING_MARKED='<?php
+
+namespace OCA\Procest\Service;
+
+class PermissionService
+{
+    /**
+     * Authorize a case transition.
+     *
+     * @param array  $case   Case object.
+     * @param string $userId Current user UID (unused)
+     *
+     * @return bool
+     */
+    public function authorizeTransition(array $case, string $userId): bool
+    {
+        $this->logger->info("authorizing");
+        $this->bus->dispatch(new Authorized($case));
+        return true;
+    }
+}
+'
+
+echo "== gate-3: a contract-imposed param the author marked unused is not a stub (#339) =="
+echo
+
+# ARM 1 — the false positive is GONE. procest's shape, both halves present.
+_out="$(_run_gate3_multi \
+	"lib/Service/Transitions/GuardEvaluatorInterface.php=${_INTERFACE}" \
+	"lib/Service/Transitions/RequiredFieldGuard.php=${_GUARD_MARKED}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 0 ]; then
+	_ok "arm 1: contract-imposed AND marked unused is not reported (procest's shape)"
+else
+	_bad "arm 1: expected 0 findings, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 2 — CONTROL. Same interface, same class, marker deleted. A contract does
+# not by itself excuse an ignored caller: a gutted RoleGuard is contract-imposed
+# too, and that IS the defect gate-3 exists for.
+_out="$(_run_gate3_multi \
+	"lib/Service/Transitions/GuardEvaluatorInterface.php=${_INTERFACE}" \
+	"lib/Service/Transitions/RequiredFieldGuard.php=${_GUARD_UNMARKED}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'method=evaluate'; then
+	_ok "arm 2 CONTROL: contract WITHOUT the unused marker is STILL reported"
+else
+	_bad "arm 2 CONTROL: expected exactly 1 finding for evaluate, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 3 — CONTROL. The marker WITHOUT a contract. This is the abuse path: if a
+# docblock word alone could silence the rule, a fixer agent would learn to write
+# it and decidesk#45 would ship again with better documentation.
+_out="$(_run_gate3_multi \
+	"lib/Service/PermissionService.php=${_FREESTANDING_MARKED}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'method=authorizeTransition'; then
+	_ok "arm 3 CONTROL: the unused marker WITHOUT a contract is STILL reported"
+else
+	_bad "arm 3 CONTROL: expected exactly 1 finding for authorizeTransition, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 4 — CONTROL, FAIL-CLOSED. Both halves LOOK present, but the interface file
+# is absent from the repo, so the supertype cannot be inspected. An unresolvable
+# claim is not an exemption.
+_out="$(_run_gate3_multi \
+	"lib/Service/Transitions/RequiredFieldGuard.php=${_GUARD_MARKED}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'method=evaluate'; then
+	_ok "arm 4 CONTROL: an UNRESOLVABLE supertype is not an exemption (fail-closed)"
+else
+	_bad "arm 4 CONTROL: expected exactly 1 finding for evaluate, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+# ARM 5 — CONTROL. The interface is present and names the method, but with a
+# DIFFERENT parameter list — the class added $userId on its own. The join is on
+# the parameter, not on the method name.
+# shellcheck disable=SC2016  # $userId is PHP source — single quotes are REQUIRED
+_out="$(_run_gate3_multi \
+	"lib/Service/Transitions/GuardEvaluatorInterface.php=$(printf '%s' '<?php
+
+namespace OCA\Procest\Service\Transitions;
+
+interface GuardEvaluatorInterface
+{
+    public function evaluate(array $guardConfig, array $case): GuardResult;
+}
+')" \
+	"lib/Service/Transitions/RequiredFieldGuard.php=${_GUARD_MARKED}" 2>/dev/null)"
+_n="$(printf '%s' "${_out}" | grep -c . || true)"
+if [ "${_n}" -eq 1 ] && printf '%s' "${_out}" | grep -q 'method=evaluate'; then
+	_ok "arm 5 CONTROL: a supertype that does NOT declare the param is not an exemption"
+else
+	_bad "arm 5 CONTROL: expected exactly 1 finding for evaluate, got ${_n}:"
+	printf '%s\n' "${_out}" | sed 's/^/         /'
+fi
+
+echo
+echo "== summary: ${_pass_count} passed, ${_fail_count} failed =="
+[ "${_fail_count}" -eq 0 ] || exit 1
+exit 0

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1998,7 +1998,38 @@ while IFS= read -r f; do
             # so <2 means body never references it.
             _count=$(echo "${_body}" | grep -cF "${_param}")
             if [ "${_count}" -lt 2 ]; then
-                echo "${f}:${_line_no} method=${_method} rule=caller-identity-ignored param=${_param}" >> "${_stub_log}"
+                # A CONTRACT-IMPOSED PARAMETER THE AUTHOR MARKED UNUSED IS NOT A
+                # STUB (.github#339).
+                #
+                # An unused caller identity is a defect when the author chose the
+                # signature and forgot the check (decidesk#45). It is NOT a defect
+                # when a supertype chose the signature and this implementor has no
+                # business consulting the caller — a strategy/guard/handler
+                # interface that passes the caller to implementors that do not all
+                # need it is a normal shape. Measured on procest: all 3 findings
+                # implement GuardEvaluatorInterface::evaluate(..., string $userId),
+                # which RoleGuard and MandaatGuard genuinely use. Deleting the
+                # parameter breaks the interface and every call site; referencing
+                # it pointlessly is dead code written to satisfy a stub detector.
+                # Neither is a fix, so the finding had no closing action.
+                #
+                # The helper exempts ONLY when BOTH hold: a supertype resolvable
+                # in this repo declares the same method with the same parameter
+                # (mechanical — an invented method cannot acquire one from a
+                # docblock), AND the method docblock's @param line for THAT
+                # parameter carries an explicit unused marker. Either alone still
+                # reports. Fail-closed: a missing helper, an unreadable file or an
+                # unresolvable supertype all leave the finding standing.
+                _ci_exempt=1
+                _ci_helper="${SCRIPT_DIR}/lib/check_caller_identity_exempt.py"
+                if [ -f "${_ci_helper}" ]; then
+                    python3 "${_ci_helper}" --root . --file "$f" --line "${_line_no}" \
+                        --method "${_method}" --param "${_param}" 2>>"${HYDRA_GATE_LOG_DIR}/hydra-gate-stub-scan.err"
+                    _ci_exempt=$?
+                fi
+                if [ "${_ci_exempt}" -ne 0 ]; then
+                    echo "${f}:${_line_no} method=${_method} rule=caller-identity-ignored param=${_param}" >> "${_stub_log}"
+                fi
             fi
         done
 done < <(_enum_tracked '\.php$' lib/Service lib/Controller)


### PR DESCRIPTION
Closes #339. Partially addresses #340 — see "What #340 actually is" below; that issue needs a decision, not just this patch.

Both issues were filed with the observation that **no app-side fix exists**. Rule 1 was to test that claim before writing anything, so both were reproduced first, on a fresh `development` checkout of six fleet apps.

## Reproduction — both still live

Full 60-gate run, `hydra-gates@c26f9a3`, apps at `development`:

| app | gate-3 `caller-identity-ignored` | gate-53 `removals-invariant` |
|---|---|---|
| procest `792fe1f4b` | **3** | **8** |
| opencatalogi | 0 | 0 |
| openregister | 0 | 0 |
| softwarecatalog | 0 | 0 |
| docudesk | 0 | 0 |
| larpingapp | 0 | 0 |

Both reproduce exactly as filed, at the same three files and the same eight removals. Both live populations are **procest only**. `menu-layout.json#removals` is non-empty in **1 of the 18 core apps** (surveyed via the API on `development`; the probe's positive control is that it returned procest's 8).

## gate-3 — outcome: the question is right, the detection is incomplete. Fixed.

The rule exists for decidesk#45: a builder-generated `authorize*()` stub that accepts the caller and forgets to check it. That is a real defect and the rule should keep finding it.

It cannot currently tell that shape apart from a correct strategy implementation. All three procest findings implement `GuardEvaluatorInterface::evaluate(array, array, string $userId)`; two of the five implementors use the parameter, which is the whole point of those classes. A guard answering "is this required field filled in?" has no business consulting the caller. Deleting the parameter breaks the interface and every call site; referencing it pointlessly is dead code written to satisfy a stub detector. **Neither edit is a fix**, which is why procest reported instead of closing.

New helper `check_caller_identity_exempt.py`. A finding is exempt only when **both** hold:

1. **The signature is imposed from outside** — a supertype resolvable *in this repository* (`implements`/`extends`, transitively) declares the same method with the same parameter. Fully mechanical; nothing the author asserts. This is what makes the exemption un-sprinklable: an invented service method has no supertype, so a fixer agent cannot escape the rule by adding a docblock line.
2. **The author marked that parameter unused** — the docblock's `@param` line for the flagged parameter carries an explicit unused marker.

Condition 1 alone would exempt a genuinely gutted implementation (a `RoleGuard` that stopped consulting `$userId` is contract-imposed too, and that *is* the defect). Condition 2 alone is a one-word escape hatch.

#339 suggested keying on `@SuppressWarnings(PHPMD.UnusedFormalParameter)` and preferred it. I took the stricter of the two options it offered: that annotation is **method-wide and cannot name which parameter it excuses**. procest's `MandaatGuard` carries it — for a different parameter — while genuinely using `$userId`. Keying on it would have pre-authorised MandaatGuard's `$userId` for a reason that was never about `$userId`. The per-`@param` marker is per-parameter, and all three findings already carry it, so no app edit is needed.

Fail-closed throughout: a missing helper, an unreadable file, or a supertype outside this repository all leave the finding standing.

### Acceptance — `test_gate_3_contract_param.sh`, 5 arms, 4 of them controls

| arm | fixture | expected |
|---|---|---|
| 1 | contract + marker (procest's shape) | 0 findings |
| 2 **control** | contract, marker deleted | still reported |
| 3 **control** | marker, no contract (decidesk#45 with a docblock) | still reported |
| 4 **control** | both look present, interface file absent from the repo | still reported (fail-closed) |
| 5 **control** | supertype declares the method **without** the parameter | still reported |

Arms 2–5 each delete exactly one half of the exemption. **Revert test**: the same suite run against `origin/main`'s unmodified runner — arm 1 goes red (`RequiredFieldGuard.php:16 method=evaluate rule=caller-identity-ignored param=$userId`), all four controls stay green, i.e. the controls were never depending on the fix.

**Effect**: procest 3 → 0 across a full 60-gate run, and gate-3 is the **only** verdict that moved (runner exit 8 → 7). 0 → 0 on the other five apps.

## gate-53 — outcome: mixed. One real detection defect fixed here; the issue's own premise does not hold.

### The detection defect (fixed)

`menu[].route` may hold **either** a `pages[].id` **or** a `pages[].route` — check (a) in the same file accepts both, and apps use both spellings. `removals-invariant` compared the raw strings, so two menu entries reaching the *same page* by different spellings did not count as reaching each other. Demonstrated on a two-entry manifest:

```
menu:  {id: items-by-id,   route: "ItemsPage"}
       {id: items-by-path, route: "/items"}
pages: {id: "ItemsPage", route: "/items"}
removals: ["items-by-path"]
```

→ `removal 'items-by-path' orphans route '/items' — no surviving menu entry reaches it`

That is precisely the "duplicate navigation entry whose page is still reachable" ADR-044 §5 sanctions, reported as a loss. Both sides now resolve to the page id before comparison. An unresolvable reference is left as-is, so two broken entries cannot vouch for each other (check (a) already fails those).

Two arms added to `test_check_manifest_crossref.js`, off one fixture pair differing only in whether the second entry survives:
- id-spelled survivor covers a path-spelled removal → 0 errors
- **control**: sole entry removed, nothing else reaches the page → still exactly 1 error

Existing `broken/` fixture arm (`cases-index`) unchanged and still red. Whole suite green (28 assertions).

**Fleet A/B**, crossref findings before → after: procest 9→9, opencatalogi 0→0, openregister 0→0, softwarecatalog 1→1, docudesk 0→0, larpingapp 1→1. **Nothing moved** — this is a latent defect, not a live one, because only procest uses `removals` at all and its eight are not this shape.

### What #340 actually is — flagged for a decision, not patched

procest's 8 are **not** closable by this fix and I did not implement the enhancement #340 proposes, for three measured reasons. Detail in the issue comment; summary:

1. **A correct app-side fix does exist**, and #340 missed it. All eight ids are declared in procest's *own* `manifest.json` / `manifest.d/` fragments. Deleting the eight **menu** nodes at source (keeping the **pages** entries, which is what makes the routes routable) and emptying `removals` produces a **byte-identical effective manifest** — measured — and takes gate-53 from 8 errors to 0. So the finding is closable, behaviour-neutrally, without restoring the anti-pattern or retiring any route.
2. **That reveals the gate's real defect**: `removals-invariant` polices the *key*, not the *invariant*. The same menu outcome reached by editing a fragment is completely unchecked — I just did it eight times and got a PASS. The gate penalises the honest, centrally-documented authoring path and ignores the silent one, which is the opposite of what ADR-044 says it is guarding ("the hard risk … is **silently** losing a page").
3. **The enhancement #340 proposes would close at most 3 of the 8.** The `folderSidebar` join is genuinely mechanical; `viewMode` is a name heuristic, not a join; and the sidebar-tab arm is **not resolvable in principle** — `BesluitvormingLeafTab` resolves *another app's* component from the runtime `window.OCA.OpenRegister.integrations` registry, and nothing static links it to `Voorstellen`/`Advice`/`AgendaCompiler`. Implementing it would add PASSes for 3 and leave 5 red, which is the failure mode #340 itself asks to avoid.

Also worth recording: ADR-044 §5 says `removals` may retire **only** a duplicate navigation entry whose page is still reachable. The gate implements that faithfully. procest's eight are *supersessions*, not duplicates — so what #340 is really asking for is an amendment to ADR-044, which is an architecture call, not a gate call.

## Files

- `hydra-gates/scripts/lib/check_caller_identity_exempt.py` (new)
- `hydra-gates/scripts/lib/test_gate_3_contract_param.sh` (new)
- `hydra-gates/scripts/run-hydra-gates.sh` (gate-3 call site, fail-closed)
- `hydra-gates/scripts/lib/check_manifest_crossref.js` (removals-invariant normalisation)
- `hydra-gates/scripts/lib/test_check_manifest_crossref.js` (2 arms)

`source_scope.py` untouched. No app repository is changed by this PR.
