### PR TITLE
fix(gate-45): a commented-out universal reset silenced the gate for the WHOLE repo (#421)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_stylesheet_scope.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_stylesheet_scope.sh
@@ -222,6 +222,104 @@ export default { name: 'Motion' }
 VUE
 _assert "a <style> block with unguarded motion is still a FAIL" "FAIL" "$(_run45 "${_app}")"
 
+# ---------------------------------------------------------------------------
+# ARM 9 — THE GLOBAL PRE-PASS MUST MASK COMMENTS TOO (.github#421).
+#
+# ARM 6 above gave this gate a repo-wide exemption, and the pre-pass that
+# computes it grepped RAW file text. The per-file checker masks comments
+# (ARM 3/5); the pre-pass did not. So the two halves of one gate disagreed
+# about what a comment is, and the careless half ran FIRST.
+#
+# That is not one missed finding. The flag makes the per-file checker exit 0
+# on EVERY file in the repository, so one comment in one stylesheet anywhere
+# in the tree silenced gate-45 for the whole app — and the comment that did
+# it is the one an author writes while acknowledging the debt.
+#
+# Measured 2026-08-13 on c26f9a3, one fixture, one variable:
+#   comment present          PASS   <- the defect (9a below)
+#   comment deleted          FAIL          (9b, CONTROL — passes both before
+#                                           and after the fix, by design)
+#   a REAL universal reset   PASS          (9c, ANTI-WIDENING CONTROL — also
+#                                           passes before and after; it is
+#                                           what makes 9a mean something,
+#                                           because it shows the pre-pass CAN
+#                                           set the flag on real CSS)
+#
+# 9d is the DRIFT arm: the pre-pass and the per-file `_mask_comments` are two
+# separate `python3` invocations and cannot share a function, so this is the
+# only thing stopping them diverging again. It pins the `(?<!:)` that keeps
+# the `//` of a `url(https://…)` out of the SCSS arm — written on ONE line so
+# that eating it would take the `@media` with it.
+# ---------------------------------------------------------------------------
+_g9_motion() {  # _g9_motion <appdir> — the canary: unguarded motion in css/
+    cat > "$1/css/motion.css" <<'CSS'
+.spinner { animation: spin 1s linear infinite; }
+.btn { transition: background-color 0.3s ease; }
+CSS
+}
+
+# 9a — the defect. A /* */ comment that MENTIONS the reset is not the reset.
+_app="${_tmp}/a9a"
+_mkapp "${_app}"
+_g9_motion "${_app}"
+cat > "${_app}/css/reset.css" <<'CSS'
+/* TODO(a11y): we still need
+     @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none; } }
+   Not done yet — tracked in #999. */
+.page { color: black; }
+CSS
+_assert "a COMMENTED-OUT universal reset does NOT globally guard the repo → FAIL" \
+    "FAIL" "$(_run45 "${_app}")"
+
+# 9b — CONTROL. Same tree, comment deleted. Passed before the fix too.
+_app="${_tmp}/a9b"
+_mkapp "${_app}"
+_g9_motion "${_app}"
+cat > "${_app}/css/reset.css" <<'CSS'
+.page { color: black; }
+CSS
+_assert "control: the same tree with no comment at all → FAIL" \
+    "FAIL" "$(_run45 "${_app}")"
+
+# 9c — ANTI-WIDENING CONTROL. A mask that ate CSS rather than comments would
+# turn this gate from silenceable into always-red. Passed before the fix too.
+_app="${_tmp}/a9c"
+_mkapp "${_app}"
+_g9_motion "${_app}"
+cat > "${_app}/css/reset.css" <<'CSS'
+/* The app-wide reduced-motion reset. */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.01ms !important;
+		transition-duration: 0.01ms !important;
+	}
+}
+CSS
+_assert "anti-widening: a REAL universal reset (with a comment above it) still guards → PASS" \
+    "PASS" "$(_run45 "${_app}")"
+
+# 9d — DRIFT. SCSS `//`, both directions, in the pre-pass this time.
+_app="${_tmp}/a9d1"
+_mkapp "${_app}"
+_g9_motion "${_app}"
+mkdir -p "${_app}/src/styles"
+cat > "${_app}/src/styles/reset.scss" <<'SCSS'
+// @media (prefers-reduced-motion: reduce) { *, *::before { animation: none !important; } }
+.page { color: black; }
+SCSS
+_assert "a // -commented reset in SCSS does NOT globally guard → FAIL" \
+    "FAIL" "$(_run45 "${_app}")"
+
+_app="${_tmp}/a9d2"
+_mkapp "${_app}"
+_g9_motion "${_app}"
+mkdir -p "${_app}/src/styles"
+cat > "${_app}/src/styles/reset.scss" <<'SCSS'
+.y { background: url(https://example.test/y.png); } @media (prefers-reduced-motion: reduce) { *, *::before { animation: none !important; } }
+SCSS
+_assert "the // of a url(https://…) does not eat the reset beside it → PASS" \
+    "PASS" "$(_run45 "${_app}")"
+
 echo ""
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_45_stylesheet_scope.sh: ALL GREEN"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -6853,6 +6853,48 @@ if _a11y_has_style_dir; then
     #
     # Fails CLOSED: any error leaves the flag at 0, i.e. more findings, never
     # fewer. A crashed pre-pass must not manufacture a global exemption.
+    #
+    # A COMMENTED-OUT RESET IS NOT A RESET (.github#421) — AND THIS IS THE
+    # WORST PLACE IN THE PACKAGE TO GET THAT WRONG.
+    #
+    # The per-file checker below already masks comments before it looks for
+    # motion or for a guard (`_mask_comments`, #294). This pre-pass did not:
+    # it grepped `UNIVERSAL` over raw file text. So the two halves of one gate
+    # disagreed about what a comment is, and the careless half ran first.
+    #
+    # The consequence is not one missed finding. The flag it sets makes the
+    # per-file checker `sys.exit(0)` on EVERY file in the repository, so ONE
+    # comment in ONE stylesheet anywhere in the tree silenced gate-45 for the
+    # whole app — and the comment that did it is the one an author writes
+    # while acknowledging the debt:
+    #
+    #     /* TODO(a11y): we still need
+    #          @media (prefers-reduced-motion: reduce) { *, *::before … }
+    #        Not done yet — tracked in #999. */
+    #
+    # Measured 2026-08-13, one fixture, one variable — a css/motion.css with
+    # two real unguarded motion declarations, plus a css/reset.css whose only
+    # universal reset is inside that comment:
+    #
+    #   comment present            PASS                          <- the defect
+    #   the same tree, comment deleted
+    #                              FAIL — 1 stylesheet with motion
+    #   a REAL universal reset in reset.css
+    #                              PASS   <- the positive control: the pre-pass
+    #                                        does set the flag on real CSS, so
+    #                                        the arm above means something
+    #
+    # ⚠️ THE MASK MUST EAT COMMENTS, NOT CSS. A mask that swallowed a rule
+    # would turn this gate from "silenceable" into "always red" — the fix
+    # over-applied — which is why the third arm is pinned in
+    # test_gate_45_stylesheet_scope.sh alongside the first two.
+    #
+    # Character for character the same masking as `_mask_comments` in the
+    # PYRM heredoc below, including the `(?<!:)` that keeps the `//` of a
+    # `url(https://…)` out of the SCSS arm. The two copies are pinned
+    # together by the drift arm in test_gate_45_stylesheet_scope.sh: they are
+    # separate `python3` invocations and cannot share a function, so the test
+    # is what stops them diverging again.
     _rm_global=0
     if [ -n "$(_a11y_style_files)" ]; then
         _rm_global=$(_a11y_style_files | python3 -c '
@@ -6860,16 +6902,24 @@ import re, sys
 UNIVERSAL = re.compile(
     r"@media[^{]*prefers-reduced-motion[^{]*\{(?:[^{}]|\{[^{}]*\})*?(?<![\w.#\[-])\*",
     re.IGNORECASE | re.DOTALL)
+
+def _mask_comments(text, scss):
+    text = re.sub(r"/\*.*?\*/", lambda m: re.sub(r"[^\n]", " ", m.group(0)), text, flags=re.DOTALL)
+    if scss:
+        text = re.sub(r"(?<!:)//[^\n]*", lambda m: " " * len(m.group(0)), text)
+    return text
+
 for line in sys.stdin:
     p = line.strip()
     if not p:
         continue
     try:
-        if UNIVERSAL.search(open(p, encoding="utf-8", errors="replace").read()):
-            print(1)
-            break
+        raw = open(p, encoding="utf-8", errors="replace").read()
     except Exception:
         continue
+    if UNIVERSAL.search(_mask_comments(raw, not p.lower().endswith(".css"))):
+        print(1)
+        break
 else:
     print(0)
 ' 2>>"${_rm_log}.err" || echo 0)


### PR DESCRIPTION
Closes #421.

## The defect

The per-file checker masks comments before it looks for motion or for a guard (`_mask_comments`, #294). The **global pre-pass** that computes `HYDRA_RM_GLOBAL_GUARD` did not — it grepped the `UNIVERSAL` regex over raw file text. Two halves of one gate disagreeing about what a comment is, and the careless half runs first.

That flag makes the per-file checker `sys.exit(0)` on **every file in the repository**. So this is not one missed finding: **one comment, in one stylesheet, anywhere in the tree, silenced gate-45 for the whole app** — and the comment that does it is the one an author writes while acknowledging the a11y debt.

## Reproduced on c26f9a3 — one fixture, one variable

`css/motion.css` with two real unguarded motion declarations, plus a `css/reset.css` whose only universal reset is inside a comment:

| arm | verdict |
|---|---|
| the `/* TODO(a11y): … @media (prefers-reduced-motion: reduce) { *, … } … */` comment present | `PASS` **← the defect** |
| the same tree, comment deleted | `FAIL — 1 stylesheet with motion` |
| a **real** universal reset in `css/reset.css` | `PASS` **← positive control: the pre-pass does set the flag on real CSS** |

The third arm is what makes the first mean anything. It was run before the fix, per the issue's request.

## The fix

Route the pre-pass through the same masking `_mask_comments` already applies, character for character, including the `(?<!:)` that keeps the `//` of a `url(https://…)` out of the SCSS arm.

The two copies are separate `python3` invocations and cannot share a function; arm 9d pins them together so they cannot diverge again.

## Acceptance — 5 new arms in `test_gate_45_stylesheet_scope.sh`

Run against **this branch**: all 13 arms green.
Run against **`origin/main`'s runner** (`HYDRA_GATES_RUNNER_UNDER_TEST=`, i.e. a real revert, not `git checkout --`): **2 failures**, and they are the two evidence arms.

| arm | before | after | role |
|---|---|---|---|
| 9a `/* */`-commented reset does not globally guard | PASS (wrong) | FAIL | **evidence** |
| 9b same tree, no comment | FAIL | FAIL | control |
| 9c a **real** universal reset (with a comment above it) still guards | PASS | PASS | **anti-widening control** |
| 9d1 `//`-commented reset in SCSS does not guard | PASS (wrong) | FAIL | **evidence** |
| 9d2 the `//` of a `url(https://…)` does not eat the reset beside it | PASS | PASS | control |

9c is the arm that would catch a mask that ate CSS instead of comments and turned this gate from *silenceable* into *always red*.

## Fleet numbers — 6 repos, whole-tree scope

`gate-45` is not a delta gate, so a whole-tree run exercises it. Six fresh `development` clones: procest, opencatalogi, openregister, softwarecatalog, docudesk, larpingapp.

**Unplanted: `PASS`, 0 findings, in both arms, all six.** That agreement is explained, not assumed — measured at the pre-pass layer, **no repo in the fleet has a universal reset at all today**, by comment or by real CSS (`RAW=0` and `MASKED=0` in all six), so the flag was `0` in both arms and there was nothing for this change to alter.

**Positive control on the real trees** — plant the #421 shape (`css/_g421_probe.css` with unguarded motion + `css/_g421_reset.css` whose reset is only inside a comment) into each repo and re-run both arms:

| repo | base | this branch |
|---|---|---|
| procest | `PASS` | `FAIL — 1` |
| opencatalogi | `PASS` | `FAIL — 1` |
| openregister | `PASS` | `FAIL — 1` |
| softwarecatalog | `PASS` | `FAIL — 1` |
| docudesk | `PASS` | `FAIL — 1` |
| larpingapp | `PASS` | `FAIL — 1` |

Exactly **one** finding each — the planted probe, named by path — in trees that contain 9–29 files declaring `transition:`/`animation:`. Nothing widened.

## Layer

Verdict layer, via the shipped runner, on real fleet trees. Not a helper-only claim.
