### PR TITLE
fix(gate-48): the frontend-signal pathspec could not see a file directly under src/ (#428)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -1075,6 +1075,108 @@ _outH2="${_tmp}/h2.txt"
 _run "${_appH}" "${_outH2}" --scope-to-diff --base "${_baseH}"
 _expect "${_outH2}" 48 "PASS" "a real added requesttoken header is still a co-change signal"
 
+# ===========================================================================
+# FAMILY I — gate-48: `src/**/*.js` CANNOT SEE `src/thing.js` (#428).
+#
+# FAMILY H's own header warns about this and works AROUND it ("the fixture
+# file must not sit directly in src/"). The workaround was correct and the
+# blind spot was left in the gate. This family removes it.
+#
+# In a PLAIN git pathspec there is no `**` operator — it is two ordinary
+# `*`s, and a plain `*` matches `/`. `src/**/*.js` therefore REQUIRES a
+# second slash, and every file at `src/foo.js` was invisible to the signal
+# scan. Reproduced 2026-08-13 on c26f9a3:
+#
+#   git diff --name-only HEAD~1...HEAD -- 'src/**/*.js'          -> (empty)
+#   git diff --name-only HEAD~1...HEAD -- ':(glob)src/**/*.js'   -> src/thing.js
+#
+# DIRECTION. A missed signal makes the count 0, which routes to the
+# caller-state check — the conservative branch. So this was never letting a
+# CSRF removal through; it made the count a FLOOR rather than a count, and
+# the NOTE gate-48 prints about the frontend diff could be wrong about what
+# it had read. Fixing it therefore REMOVES a finding in I1, and the arm is
+# built so that the removal is unambiguous: the diff really does add a real
+# `requesttoken` header, which is exactly the co-change this gate asks for.
+#
+# I1 is the evidence arm (FAIL on origin/main, PASS here).
+# I2 and I3 are CONTROLS: they hold the same verdict before and after.
+# ===========================================================================
+_appI="${_tmp}/appI"
+mkdir -p "${_appI}/lib/Controller" "${_appI}/src/components" "${_appI}/src/sub"
+
+cat > "${_appI}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController
+{
+    /**
+     * @NoCSRFRequired
+     */
+    public function create() { return 1; }
+}
+PHP
+# The same unprotected mutating caller FAMILY H uses, and for the same reason:
+# without it the fallback branch has nothing to find and every arm below
+# passes for a legitimate reason, which cannot distinguish a repaired gate
+# from a satisfied one.
+cat > "${_appI}/src/components/Del.vue" <<'VUE'
+<script>
+export default { methods: { async del(id) {
+  await fetch(`/api/things/${id}`, { method: 'DELETE', headers: {} })
+} } }
+</script>
+VUE
+printf '// placeholder\n' > "${_appI}/src/thing.js"
+printf '// placeholder\n' > "${_appI}/src/sub/thing.js"
+git -C "${_appI}" init -q . 2>/dev/null
+_commit "${_appI}" "a controller with @NoCSRFRequired and an unprotected caller"
+_baseI="$(git -C "${_appI}" rev-parse HEAD)"
+
+cat > "${_appI}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class ThingController
+{
+    public function create() { return 1; }
+}
+PHP
+
+# I1 — THE DEFECT. The added signal sits DIRECTLY under src/.
+cat > "${_appI}/src/thing.js" <<'JS'
+import axios from '@nextcloud/axios'
+export const create = (b) => axios.post('/api/things', b, { headers: { requesttoken: OC.requestToken } })
+JS
+_commit "${_appI}" "drop @NoCSRFRequired; add a real requesttoken in src/thing.js"
+_outI1="${_tmp}/i1.txt"
+_run "${_appI}" "${_outI1}" --scope-to-diff --base "${_baseI}"
+_expect "${_outI1}" 48 "PASS" "a CSRF signal added DIRECTLY under src/ is seen (src/thing.js)"
+
+# I2 — CONTROL. The identical signal one directory down. This is the arm the
+# old pathspec could already see, so it holds its verdict across the fix; it
+# is here so that a fix which handled ONLY the top level would be visible.
+git -C "${_appI}" checkout -q "${_baseI}" -- src/thing.js
+cat > "${_appI}/src/sub/thing.js" <<'JS'
+import axios from '@nextcloud/axios'
+export const create = (b) => axios.post('/api/things', b, { headers: { requesttoken: OC.requestToken } })
+JS
+_commit "${_appI}" "the same signal, one directory down"
+_outI2="${_tmp}/i2.txt"
+_run "${_appI}" "${_outI2}" --scope-to-diff --base "${_baseI}"
+_expect "${_outI2}" 48 "PASS" "control: the same signal in src/sub/thing.js is still seen"
+
+# I3 — ANTI-WIDENING CONTROL. A top-level src/ file that is touched but adds
+# NO signal must not satisfy the gate. Without this arm, "make the top level
+# visible" is indistinguishable from "count any top-level edit".
+git -C "${_appI}" checkout -q "${_baseI}" -- src/sub/thing.js
+cat > "${_appI}/src/thing.js" <<'JS'
+// TODO: this call still needs a requesttoken header. Not done yet.
+export const create = (b) => fetch('/api/things', { method: 'POST', body: b, headers: {} })
+JS
+_commit "${_appI}" "drop @NoCSRFRequired; a top-level src/ edit with no signal"
+_outI3="${_tmp}/i3.txt"
+_run "${_appI}" "${_outI3}" --scope-to-diff --base "${_baseI}"
+_expect "${_outI3}" 48 "FAIL" "anti-widening: a top-level src/ edit carrying NO signal is not a co-change"
+
 echo ""
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_45_to_55_acceptance.sh: ALL GREEN"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7364,9 +7364,37 @@ except ImportError:
 base = sys.argv[1]
 SIGNAL = re.compile(r'OCS-APIRequest|requesttoken|@nextcloud/axios|getRequestToken',
                     re.IGNORECASE)
+# `:(glob)` IS LOAD-BEARING — WITHOUT IT `src/**/*.js` CANNOT SEE `src/thing.js`
+# (.github#428).
+#
+# In a PLAIN git pathspec there is no `**` operator: it is two ordinary `*`s,
+# and a plain `*` MATCHES `/`. So `src/**/*.js` reads as "src/, then anything,
+# then /, then anything, then .js" — it REQUIRES at least one directory below
+# src/, and every file sitting at `src/foo.js` was invisible to this scan.
+#
+# Reproduced 2026-08-13, one repo, one commit dropping #[NoCSRFRequired], one
+# JS file, nothing varying but its path:
+#
+#   git diff --name-only HEAD~1...HEAD
+#     lib/Controller/ThingController.php
+#     src/thing.js
+#   git diff --name-only HEAD~1...HEAD -- 'src/**/*.js'            -> (empty)
+#   git diff --name-only HEAD~1...HEAD -- ':(glob)src/**/*.js'     -> src/thing.js
+#
+# With `:(glob)` magic, `**` means "zero or more directory components" and a
+# single `*` no longer crosses `/`, so the glob matches `src/thing.js` AND
+# `src/sub/thing.js` AND `src/a/b/c.js`. It is a strict superset of the old
+# spelling: nothing that matched before stops matching.
+#
+# DIRECTION: this can only ADD signals, i.e. it can only move a run from the
+# conservative caller-state branch to the "a signal was added" branch. It was
+# never letting a CSRF removal through — a missed signal made the count 0,
+# which routes to check_csrf_callers.py — but it made the count a FLOOR rather
+# than a count, and the NOTE this gate prints about the frontend diff could be
+# wrong about what it had read.
 out = subprocess.run(
     ['git', 'diff', '-U0', f'{base}...HEAD', '--',
-     'src/**/*.vue', 'src/**/*.js', 'src/**/*.ts'],
+     ':(glob)src/**/*.vue', ':(glob)src/**/*.js', ':(glob)src/**/*.ts'],
     capture_output=True, text=True, check=False).stdout
 added, path = {}, None
 hunk = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')


### PR DESCRIPTION
Closes #428.

## The defect

In a **plain** git pathspec there is no `**` operator: it is two ordinary `*`s, and a plain `*` **matches `/`**. So `src/**/*.js` reads as "`src/`, then anything, then `/`, then anything, then `.js`" — it **requires at least one directory below `src/`**, and every file sitting at `src/foo.js` was invisible to gate-48's CSRF-signal scan.

## Reproduced on c26f9a3 — one repo, one commit, nothing varying but the path

```
$ git diff --name-only HEAD~1...HEAD
lib/Controller/ThingController.php
src/thing.js

$ git diff --name-only HEAD~1...HEAD -- 'src/**/*.js'          # (empty)
$ git diff --name-only HEAD~1...HEAD -- ':(glob)src/**/*.js'
src/thing.js
```

`src/sub/thing.js` matches under both spellings, so `:(glob)` is a **strict superset** — nothing that matched before stops matching.

## Direction — this REMOVES findings, it does not add them

The task brief expected this to *increase* gate-48's findings. It does the opposite, and the mechanism is one-way: the pathspec feeds **only** `_csrf_fe_signals`, and a signal count of `0` routes to the caller-state check (`check_csrf_callers.py`), the conservative branch. So the blind spot was never letting a CSRF removal through — it made the count a **floor rather than a count**, and the `NOTE` gate-48 prints about the frontend diff could be wrong about what it had read. Un-blinding it moves runs *off* the fallback branch.

## Acceptance — FAMILY I in `test_gate_45_to_55_acceptance.sh`

FAMILY H's own header already **warned** about this pathspec and worked *around* it ("the fixture file must not sit directly in `src/`"). The workaround was correct; the blind spot was left in the gate. FAMILY I removes it.

Against **this branch**: whole suite green. Against **`origin/main`'s runner** (a real revert via `HYDRA_GATES_RUNNER_UNDER_TEST=`, not `git checkout --`): **1 failure**, the evidence arm.

| arm | before | after | role |
|---|---|---|---|
| I1 a real `requesttoken` added in `src/thing.js` is seen | FAIL (wrong — reached via the fallback) | PASS | **evidence** |
| I2 the same signal in `src/sub/thing.js` | PASS | PASS | control (catches a fix that only handled the top level) |
| I3 a top-level `src/` edit carrying **no** signal | FAIL | FAIL | **anti-widening control** |

I3 is what separates "make the top level visible" from "count any top-level edit".

## Fleet numbers, and the layer they come from

⚠️ **gate-48 is a delta gate.** On a `development` HEAD there is no delta base, so it reports `NOT APPLICABLE` — a whole-tree fleet run cannot exercise it and would produce `na` in both arms, which is not a measurement. So the exposure is reported structurally, over six fresh `development` clones:

| repo | `src/*.{js,ts,vue}` (was invisible) | `src/**/*` (was visible) | top-level files carrying a CSRF signal today |
|---|---|---|---|
| procest | **16** | 302 | 1 (`src/customComponents.js`) |
| opencatalogi | **12** | 175 | 0 |
| openregister | **12** | 331 | 0 |
| softwarecatalog | **9** | 113 | 1 (`src/App.vue`) |
| docudesk | **8** | 106 | 1 (`src/setPublicPath.js`) |
| larpingapp | **6** | 9 | 0 |

**63 files across six repos** sat in the blind spot, and they are not obscure ones: `App.vue`, `main.js`, `settings.js`, `registry.js` and every dashboard-widget entry point — exactly the files where `@nextcloud/axios` or a `requesttoken` header gets added. Three of them carry a signal **right now**.

The verdict-layer evidence is FAMILY I above, which is the same shape driven through `bin/hydra-gates`.

## Real-tree delta measurement (verdict layer)

Since a whole-tree run reports `na`, a real diff was built on three real trees: drop `@NoCSRFRequired`/`#[NoCSRFRequired]` from a controller that actually carries one, and add a real `requesttoken` + `@nextcloud/axios` to the repo's existing **top-level** `src/settings.js`.

| repo | controller | base | this branch |
|---|---|---|---|
| procest | `lib/Controller/StufController.php` | `FAIL` | `PASS` |
| docudesk | `lib/Controller/HealthController.php` | `FAIL` | `PASS` |
| larpingapp | `lib/Controller/SettingsController.php` | `PASS` | `PASS` |

**0 new findings. 2 findings removed, and both were false — hand-characterised, not counted:**

- procest, base log: `@NoCSRFRequired removed but no frontend CSRF-signal added in diff`. That sentence is untrue of that diff; the same commit added `requesttoken` in `src/settings.js`. The gate could not see it, fell through to the caller-state check, and blocked on an unrelated pre-existing `src/store/modules/workflow.js:828 — fetch() POST with no CSRF signal`.
- docudesk, same shape, blocking on `src/views/settings/Settings.vue:816/879/943`.

- larpingapp is the arm that does **not** agree with the other two, and it shows the second harm in the issue directly. Base passes via the advisory branch and prints:
  `[gate-48] NOTE: no CSRF signal was ADDED by this diff, and none was needed…` — **wrong about what it read**. On this branch the NOTE is gone, because the signal was seen.

The two removed findings were not "app debt this fix hides": the underlying unprotected callers are still reported by `check_csrf_callers.py` whenever the signal count is genuinely zero. What changed is that the gate no longer says a signal was absent when it was present.
