### PR TITLE
fix(gate-50): the guard window crossed method boundaries (#429)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
+++ b/hydra-gates/scripts/lib/test_gate_45_to_55_acceptance.sh
@@ -1075,6 +1075,203 @@ _outH2="${_tmp}/h2.txt"
 _run "${_appH}" "${_outH2}" --scope-to-diff --base "${_baseH}"
 _expect "${_outH2}" 48 "PASS" "a real added requesttoken header is still a co-change signal"
 
+# ===========================================================================
+# FAMILY J — gate-50: THE GUARD WINDOW MUST NOT CROSS A METHOD BOUNDARY (#429).
+#
+# The window was "eleven lines of code following the read", counted over the
+# FILE, with no notion of where the method ends. A guard belonging to a
+# DIFFERENT method therefore cleared an unguarded read in the method above it.
+#
+# Measured 2026-08-13 on c26f9a3, one file, one variable:
+#   both methods present                 PASS                   <- the defect
+#   delete the next method, nothing else FAIL — 1, naming api_token
+#
+# #420 changed the window's BUDGET (comments no longer spend it) but not its
+# EXTENT, so that fix moved this defect closer rather than away.
+#
+# J1 is the evidence arm (PASS on origin/main, FAIL here). J2–J5 hold their
+# verdict in BOTH arms and are CONTROLS:
+#   J2  the issue's own positive control — the unguarded read on its own
+#   J3  a guard genuinely in the SAME method, inside budget, must still PASS,
+#       or the clip is a new false-positive engine
+#   J4  the SAME method, one code line OUTSIDE budget, must still FAIL — the
+#       clip must not have quietly shrunk the budget it clips
+#   J5  a `}` inside a string literal AND inside a heredoc body must not
+#       truncate the method span. Load-bearing: walking the un-blanked text
+#       computes readToken() as ending on its second line, which clips the
+#       real guard out and invents a finding. (Measured directly on the
+#       helper: spans (4,6) un-blanked vs (4,15) blanked.)
+# ===========================================================================
+_appJ="${_tmp}/appJ"
+mkdir -p "${_appJ}/lib/Controller"
+git -C "${_appJ}" init -q . 2>/dev/null
+
+_write_j() {  # _write_j <heredoc-on-stdin> — writes lib/Controller/JController.php
+    cat > "${_appJ}/lib/Controller/JController.php"
+}
+
+# J1 — THE DEFECT. The guard five code lines below belongs to another method.
+_write_j <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class JController
+{
+    // UNGUARDED: this read has no fail-mode handling of its own.
+    public function readToken()
+    {
+        $tok = $this->config->getValueString($this->appName, 'api_token', '');
+        return $this->render($tok);
+    }
+
+    // A DIFFERENT METHOD. Its guard is 5 code lines below the read above.
+    public function readRegister()
+    {
+        $reg = $this->config->getValueString($this->appName, 'register_key', '');
+        if ($reg === '') {
+            return $this->render('');
+        }
+        return $this->lookup($reg);
+    }
+}
+PHP
+_commit "${_appJ}" "an unguarded read whose only guard lives in the next method"
+_g50j="${_tmp}/g50j"
+mkdir -p "${_g50j}"
+_outJ1="${_tmp}/j1.txt"
+(
+    cd "${_appJ}" || exit 1
+    HYDRA_GATE_LOG_DIR="${_g50j}" bash "${_runner}" . > "${_outJ1}" 2>&1
+)
+_expect "${_outJ1}" 50 "FAIL" "a guard in the NEXT method does not clear a read in this one"
+if grep -q 'readToken()' "${_g50j}/hydra-gate-security-config-fail-mode.log" 2>/dev/null \
+   && grep -q 'api_token' "${_g50j}/hydra-gate-security-config-fail-mode.log" 2>/dev/null; then
+    _ok "gate-50 NAMES the method the window was clipped to (readToken)"
+else
+    _bad "gate-50 finding does not name readToken(): $(cat "${_g50j}/hydra-gate-security-config-fail-mode.log" 2>/dev/null | head -2)"
+fi
+
+# J2 — CONTROL. The issue's positive control: delete readRegister() and
+# nothing else. FAILs before and after.
+_write_j <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class JController
+{
+    // UNGUARDED: this read has no fail-mode handling of its own.
+    public function readToken()
+    {
+        $tok = $this->config->getValueString($this->appName, 'api_token', '');
+        return $this->render($tok);
+    }
+}
+PHP
+_commit "${_appJ}" "control: the unrelated next method deleted"
+_outJ2="${_tmp}/j2.txt"
+_run "${_appJ}" "${_outJ2}"
+_expect "${_outJ2}" 50 "FAIL" "control: the same read alone is still a finding"
+
+# J3 — CONTROL, ANTI-FALSE-POSITIVE. The guard is genuinely in this method,
+# nine code lines of filler below the read (the 11th code line of the window).
+_write_j <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class JController
+{
+    public function readToken()
+    {
+        $tok = $this->config->getValueString($this->appName, 'api_token', '');
+        $v1 = 1;
+        $v2 = 2;
+        $v3 = 3;
+        $v4 = 4;
+        $v5 = 5;
+        $v6 = 6;
+        $v7 = 7;
+        $v8 = 8;
+        $v9 = 9;
+        if ($tok === '') {
+            return $this->render('');
+        }
+        return $this->render($tok);
+    }
+
+    public function unrelated()
+    {
+        return 2;
+    }
+}
+PHP
+_commit "${_appJ}" "the guard is in the same method, inside budget"
+_outJ3="${_tmp}/j3.txt"
+_run "${_appJ}" "${_outJ3}"
+_expect "${_outJ3}" 50 "PASS" "control: a guard in the SAME method inside budget still PASSes"
+
+# J4 — CONTROL, BUDGET. One more filler line and the guard is out of budget.
+# This is what makes J3 mean something: it shows the budget is still being
+# spent, so J3's PASS is "the guard was in range", not "the window is now
+# unbounded inside a method".
+_write_j <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class JController
+{
+    public function readToken()
+    {
+        $tok = $this->config->getValueString($this->appName, 'api_token', '');
+        $v1 = 1;
+        $v2 = 2;
+        $v3 = 3;
+        $v4 = 4;
+        $v5 = 5;
+        $v6 = 6;
+        $v7 = 7;
+        $v8 = 8;
+        $v9 = 9;
+        $v10 = 10;
+        if ($tok === '') {
+            return $this->render('');
+        }
+        return $this->render($tok);
+    }
+}
+PHP
+_commit "${_appJ}" "the guard is in the same method, one code line outside budget"
+_outJ4="${_tmp}/j4.txt"
+_run "${_appJ}" "${_outJ4}"
+_expect "${_outJ4}" 50 "FAIL" "control: the 11-code-line budget is unchanged by the clip"
+
+# J5 — CONTROL, ROBUSTNESS. Braces inside a string literal and inside a
+# heredoc body must not truncate the method span.
+_write_j <<'PHP'
+<?php
+namespace OCA\Fx\Controller;
+class JController
+{
+    public function readToken()
+    {
+        $tok = $this->config->getValueString($this->appName, 'api_token', '');
+        $fmt = '}';
+        $q = <<<SQL
+            SELECT } FROM t
+SQL;
+        $other = "}}}";
+        if ($tok === '') {
+            return $this->render('');
+        }
+        return $this->render($tok);
+    }
+
+    public function unrelated()
+    {
+        return 2;
+    }
+}
+PHP
+_commit "${_appJ}" "braces inside a string literal and a heredoc body"
+_outJ5="${_tmp}/j5.txt"
+_run "${_appJ}" "${_outJ5}"
+_expect "${_outJ5}" 50 "PASS" "control: a } in a string or heredoc does not truncate the method span"
+
 echo ""
 if [ "${_failures}" -eq 0 ]; then
     echo "test_gate_45_to_55_acceptance.sh: ALL GREEN"

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -7963,9 +7963,25 @@ _ARRAY_VALUE = re.compile(
 # and `#[PublicPage]` is a PHP 8 attribute, not a comment. Quote state is
 # reset per line, so an unterminated literal (a heredoc body) can corrupt at
 # most its own line rather than the rest of the file.
-def _strip_php_comments(raw_lines):
-    out, in_block = [], False
+#
+# `for_structure=True` additionally blanks string CONTENTS and heredoc bodies,
+# keeping the quotes and the line count. That copy is only ever brace-walked
+# (see _method_spans), never searched for a guard, so no guard vocabulary
+# changes meaning: `$fmt = '{';` and a `<<<SQL … {$x} … SQL;` body must not
+# mis-balance a walk, but `throw new` inside a heredoc must not stop being
+# whatever it already was to the window search.
+def _strip_php_comments(raw_lines, for_structure=False):
+    out, in_block, heredoc = [], False, None
     for line in raw_lines:
+        if heredoc is not None:
+            # The closing identifier must be the first non-space token on its
+            # own line (PHP 7.3+ allows indentation). Everything up to and
+            # including it is blanked in the structural copy.
+            _m = re.match(r'\s*' + re.escape(heredoc) + r'\b', line)
+            out.append('')
+            if _m:
+                heredoc = None
+            continue
         buf, i, n, quote = [], 0, len(line), None
         while i < n:
             c = line[i]
@@ -7977,13 +7993,16 @@ def _strip_php_comments(raw_lines):
                 i += 1
                 continue
             if quote is not None:
-                buf.append(c)
                 if c == '\\' and i + 1 < n:
-                    buf.append(line[i + 1])
+                    buf.append('  ' if for_structure else line[i:i + 2])
                     i += 2
                     continue
                 if c == quote:
+                    buf.append(c)
                     quote = None
+                    i += 1
+                    continue
+                buf.append(' ' if for_structure else c)
                 i += 1
                 continue
             if c in ('"', "'"):
@@ -7999,10 +8018,97 @@ def _strip_php_comments(raw_lines):
                 continue
             if c == '#' and not (i + 1 < n and line[i + 1] == '['):
                 break
+            if for_structure and c == '<' and line[i:i + 3] == '<<<':
+                _h = re.match(r"<<<[ \t]*(['\"]?)(\w+)\1", line[i:])
+                if _h:
+                    heredoc = _h.group(2)
+                    break
             buf.append(c)
             i += 1
         out.append(''.join(buf).rstrip('\n'))
     return out
+
+
+# THE WINDOW MUST NOT CROSS INTO THE NEXT METHOD (#429).
+#
+# The window is "eleven lines of code following the read", counted over the
+# FILE, with no notion of where the method ends. A guard belonging to a
+# DIFFERENT method therefore cleared an unguarded read in the method above it.
+#
+# Reproduced 2026-08-13 on c26f9a3, one file, one variable — an unguarded
+# `api_token` read in `readToken()` with an ordinary guarded read in the next
+# method five code lines below:
+#
+#   both methods present   PASS                                <- the defect
+#   delete readRegister()
+#   and nothing else       FAIL — 1, naming api_token at :6    <- the control
+#
+# #420 changed the window's BUDGET (comments no longer spend it) but not its
+# EXTENT, so that fix moved this defect closer rather than away: blanking
+# comments means real code lines from the next method arrive inside the
+# window sooner.
+#
+# It is also order-dependent in a way nobody can see while reading — moving a
+# method, or adding one below, changes the verdict for a method whose body did
+# not change.
+#
+# `_method_spans` is the brace walk gate-49's checker already runs over masked
+# text, kept local here so gate-50 gains no new import and no new wiring
+# failure mode. It walks the `for_structure` copy for the reason gate-49 gives:
+# a `{` inside a comment or a string does not mis-balance a walk loudly, it
+# silently attributes the wrong span of code to the method.
+#
+# FAILS IN THE LOOSE DIRECTION. If the walk never balances (an unterminated
+# body, a heredoc shape this stripper does not know) the span runs to EOF and
+# the window is exactly what it was before this change — a false NEGATIVE at
+# worst, never a finding at a line where no guard could be written.
+_METHOD_DECL = re.compile(r'\bfunction\s+(?P<name>\w+)\s*\(')
+
+
+def _method_spans(text):
+    """[(start_line, end_line, name)] for every NAMED function in *text*.
+
+    Anonymous closures (`function ($x) {`) and arrow functions are deliberately
+    not boundaries: they are written INSIDE a method, and treating one as a new
+    method would clip a window in the middle of the body it belongs to.
+    """
+    spans, n = [], len(text)
+    for m in _METHOD_DECL.finditer(text):
+        p = text.find('(', m.start())
+        if p < 0:
+            continue
+        depth, i = 0, p
+        while i < n:
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if i >= n:
+            continue
+        j = i + 1
+        while j < n and text[j] not in '{;':
+            j += 1
+        start_line = text[:m.start()].count('\n') + 1
+        if j >= n or text[j] == ';':
+            # An abstract/interface declaration has no body; its span is the
+            # declaration itself, so nothing is ever clipped INTO it.
+            spans.append((start_line, text[:min(j, n - 1)].count('\n') + 1, m.group('name')))
+            continue
+        depth, k = 0, j
+        while k < n:
+            if text[k] == '{':
+                depth += 1
+            elif text[k] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            k += 1
+        end_line = text[:k].count('\n') + 1 if k < n else text.count('\n') + 1
+        spans.append((start_line, end_line, m.group('name')))
+    return spans
 
 
 notes_path = log_path + '.notes'
@@ -8014,6 +8120,7 @@ for fp in files:
     except OSError:
         continue
     code_lines = _strip_php_comments(lines)
+    _spans = _method_spans('\n'.join(_strip_php_comments(lines, for_structure=True)))
     src = ''.join(lines)
     for m in SEC_KEY.finditer(src):
         # Find the line number of the match
@@ -8066,8 +8173,21 @@ for fp in files:
         # Blank and comment-only lines no longer spend it, and the text
         # searched below is comment-stripped, so a comment can neither push a
         # guard out of range nor stand in for one.
+        #
+        # …AND THE EXTENT IS THE ENCLOSING METHOD, NOT THE FILE (#429).
+        # A guard in the NEXT method is not this read's guard. The innermost
+        # span containing the read wins, so a named function nested inside
+        # another clips to itself rather than to its host. A read that belongs
+        # to no span (a property initialiser, or a walk that never balanced)
+        # keeps the pre-#429 extent — the loose direction.
+        _limit, _encl = len(code_lines), None
+        for _s, _e, _nm in _spans:
+            if _s <= lineno <= _e and (_encl is None or _s > _encl[0]):
+                _encl = (_s, _e, _nm)
+        if _encl is not None:
+            _limit = min(_limit, _encl[1])
         _budget, _win, _i = 11, [], _end_line - 1
-        while _i < len(code_lines) and _budget > 0:
+        while _i < _limit and _budget > 0:
             _win.append(code_lines[_i])
             if code_lines[_i].strip():
                 _budget -= 1
@@ -8123,7 +8243,11 @@ for fp in files:
                             f"consumer of the assembled array.\n")
                 continue
             with open(log_path, 'a', encoding='utf-8') as g:
-                g.write(f"{fp}:{lineno}: security-relevant config read of \"{m.group('key')}\" has no fail-mode guard within 10 lines\n")
+                # NAME THE METHOD THE WINDOW WAS CLIPPED TO (#429). Without it
+                # the reader cannot tell "unguarded" from "the guard is just
+                # out of range", which is the question the clip decides.
+                _where = f" inside {_encl[2]}()" if _encl is not None else ""
+                g.write(f"{fp}:{lineno}: security-relevant config read of \"{m.group('key')}\" has no fail-mode guard within 10 lines{_where}\n")
 PY
     _scfm_rc=$?
 fi


### PR DESCRIPTION
Closes #429.

## The defect

The guard window is eleven lines of **code** following the read, counted over the **file**, with no notion of where the method ends. A guard belonging to a *different method* therefore cleared an unguarded read in the method above it.

#420 changed the window's **budget** (comment lines no longer spend it) but not its **extent**, so that fix moved this defect *closer* rather than away: blanking comments means real code lines from the next method arrive inside the window sooner.

## Reproduced on c26f9a3 — one file, one variable

```
[gate-50] security-config-fail-mode: PASS                        <- the defect
```
Delete `readRegister()` and nothing else:
```
[gate-50] security-config-fail-mode: FAIL — 1 unsafe security-config read(s)
lib/Controller/WindowController.php:6: security-relevant config read of "api_token" has no fail-mode guard within 10 lines
```

## The fix

Clip the window at the enclosing method's closing brace, using the brace walk gate-49's checker already runs over masked text — kept **local** to this checker so gate-50 gains no new import and no new wiring failure mode.

`_strip_php_comments` grows a `for_structure` mode that additionally blanks string **contents** and heredoc bodies. That copy is only ever brace-walked, never searched for a guard, so no guard vocabulary changes meaning.

**Fails in the loose direction.** A walk that never balances yields a span to EOF, i.e. exactly the pre-#429 window — a false negative at worst, never a finding at a line where no guard could be written.

Findings now name the method the window was clipped to; without it the reader cannot tell "unguarded" from "the guard is just out of range", which is the question the clip decides.

## Acceptance — FAMILY J in `test_gate_45_to_55_acceptance.sh`

Against **this branch**: whole suite green. Against **`origin/main`'s runner** (a real revert via `HYDRA_GATES_RUNNER_UNDER_TEST=`, not `git checkout --`): **2 failures**, both belonging to the evidence arm.

| arm | before | after | role |
|---|---|---|---|
| J1 a guard in the NEXT method does not clear this read (+ names `readToken()`) | PASS (wrong) | FAIL | **evidence** |
| J2 the issue's positive control — the read alone | FAIL | FAIL | control |
| J3 guard genuinely in the SAME method, inside budget | PASS | PASS | **anti-false-positive control** |
| J4 same method, one code line **outside** budget | FAIL | FAIL | **budget control** — proves the clip did not shrink the budget it clips |
| J5 a `}` inside a string literal **and** inside a heredoc body | PASS | PASS | **robustness control** |

J5 is load-bearing rather than decorative: measured directly on the helper, walking the *un-blanked* text computes `readToken()` as ending on its **second** line — spans `(4,6)` un-blanked vs `(4,15)` blanked — which would clip the real guard out and invent a finding.

The budget boundary was characterised separately in both arms — guard 9 filler lines down → `PASS`, 10 down → `FAIL`, **identical before and after**. The clip changes the window's extent and not its budget.

## Fleet numbers — 6 repos, whole-tree scope

gate-50 is not a delta gate, so a whole-tree run exercises it. Six fresh `development` clones.

| repo | base | this branch | finding set |
|---|---|---|---|
| procest | `PASS` 0 | `PASS` 0 | identical |
| opencatalogi | `FAIL` **4** | `FAIL` **4** | identical |
| openregister | `PASS` 0 | `PASS` 0 | identical |
| softwarecatalog | `PASS` 0 (47 demoted in `.notes`) | `PASS` 0 (47) | identical |
| docudesk | `PASS` 0 (1 demoted) | `PASS` 0 (1) | identical |
| larpingapp | `PASS` 0 | `PASS` 0 | identical |

**Zero new findings, zero removed.** Six identical verdicts is what a dead rig looks like, so the zero was measured rather than assumed, two ways:

**1. Exposure, at the checker layer** — running this branch's own `_method_spans`/`_strip_php_comments` (extracted from the runner, so it cannot drift) over every `lib/**/*{Controller,Service}.php` in the six trees:

| repo | security-relevant reads | windows that crossed a method boundary | verdict flips |
|---|---|---|---|
| procest | 3 | 0 | 0 |
| opencatalogi | 45 | 2 | 0 |
| openregister | 8 | 4 | 0 |
| softwarecatalog | 59 | 5 | 0 |
| docudesk | 14 | **11** | 0 |
| larpingapp | 1 | 1 | 0 |

**23 of 130 reads** were structurally in the #429 shape — their window did reach past the enclosing method's brace. None flipped, because in every one of the 23 the read either had a guard inside its own method or had none in either window. That harness reports `verdict-flips=1` when handed the issue's fixture, so its zero is a measured zero.

**2. Positive control at the verdict layer, on the real trees** — plant the #429 shape into each repo and re-run both arms through the shipped runner: base `PASS`/`FAIL n` unchanged, this branch `FAIL n+1` naming `readToken()`. (Table in the thread.)

### Positive-control table (verdict layer, real trees)

| repo | base | this branch | probe named |
|---|---|---|---|
| procest | `PASS` | `FAIL — 1` | `readToken()` |
| opencatalogi | `FAIL — 4` | `FAIL — 5` | `readToken()` |
| openregister | `PASS` | `FAIL — 1` | `readToken()` |
| softwarecatalog | `PASS` | `FAIL — 1` | `readToken()` |
| docudesk | `PASS` | `FAIL — 1` | `readToken()` |
| larpingapp | `PASS` | `FAIL — 1` | `readToken()` |

Exactly **+1** each, and opencatalogi's four pre-existing findings are preserved.

⚠️ **The first run of this control fired on nothing** — 0 probe hits in *both* arms — because gate-50's scope comes from `_enum_tracked`, i.e. `git ls-files`, and the planted file was **untracked**. A control that produces no hits in either arm is indistinguishable from a fix that does nothing; the numbers above are from the corrected run, with the probe staged.
