### PR TITLE
fix(gates): harden markup_mask's delimiter scope, then close the string-literal-as-evidence axis in 16 gates (#424)

### DIFF
--- a/hydra-gates/scripts/lib/check_admin_router.py
+++ b/hydra-gates/scripts/lib/check_admin_router.py
@@ -79,10 +79,21 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
-    from source_scope import js_comment_mask, read_text
+    from source_scope import (
+        js_code_mask,
+        js_comment_mask,
+        js_exec_mask,
+        read_text,
+        script_mask,
+        starts_in_code,
+    )
 except Exception:  # pragma: no cover - wiring failure is the caller's problem
+    js_code_mask = None
     js_comment_mask = None
+    js_exec_mask = None
     read_text = None
+    script_mask = None
+    starts_in_code = None
 
 
 # An import whose SPECIFIER names an admin component or the settings view dir.
@@ -99,18 +110,22 @@ _RENDERS_RX = re.compile(r"\bcomponents?\s*:")
 _LEAVES_RX = re.compile(r"\b(?:redirect|beforeEnter)\s*:")
 
 
-def _enclosing_object(masked: str, idx: int) -> str:
-    """Return the balanced `{...}` route object containing offset *idx*.
+def _enclosing_object(anchor: str, idx: int) -> tuple[int, int]:
+    """Span of the balanced `{...}` route object containing offset *idx*.
 
     Walks back to the nearest unmatched `{`, then forward to its partner. Falls
     back to the line itself when the braces do not balance — a malformed router
     must not make the gate throw, and a single line is the conservative scope
     (it can only ever UNDER-report, never invent a finding).
+
+    Walks the ANCHOR (#424), where string contents are blank, so a `{` or `}`
+    written inside a literal is not a block delimiter. Returns a SPAN rather
+    than text because the caller reads the object out of the other mask.
     """
     depth = 0
     start = -1
     for i in range(idx, -1, -1):
-        ch = masked[i]
+        ch = anchor[i]
         if ch == "}":
             depth += 1
         elif ch == "{":
@@ -119,18 +134,20 @@ def _enclosing_object(masked: str, idx: int) -> str:
                 break
             depth -= 1
     if start < 0:
-        return masked[masked.rfind("\n", 0, idx) + 1 : masked.find("\n", idx)]
+        a = anchor.rfind("\n", 0, idx) + 1
+        b = anchor.find("\n", idx)
+        return (a, len(anchor) if b < 0 else b)
 
     depth = 0
-    for j in range(start, len(masked)):
-        ch = masked[j]
+    for j in range(start, len(anchor)):
+        ch = anchor[j]
         if ch == "{":
             depth += 1
         elif ch == "}":
             depth -= 1
             if depth == 0:
-                return masked[start : j + 1]
-    return masked[start:]
+                return (start, j + 1)
+    return (start, len(anchor))
 
 
 def scan_file(path: str) -> list[str]:
@@ -138,10 +155,27 @@ def scan_file(path: str) -> list[str]:
         src = read_text(path)
     except OSError:
         return []
+    # TWO MASKS, ONE COORDINATE SYSTEM (#424). Both rules read their evidence
+    # out of a string literal — `'/settings'` and the import SPECIFIER — so
+    # `masked` keeps string contents. But `from` and `path:` are code, and
+    # reading both questions out of one text made this count:
+    #
+    #     const t = "routes.push({path:'/settings', component: AdminRoot})"
+    #
+    # as a live admin route. `anchor` is the same text with string contents
+    # blanked; `starts_in_code` asks of the match start, which for both
+    # patterns is a word character.
     masked = js_comment_mask(src)
+    if path.endswith(".vue") and script_mask is not None:
+        masked = script_mask(src, path)
+        anchor = js_exec_mask(src, path)
+    else:
+        anchor = js_code_mask(src)
 
     out: list[str] = []
     for m in _IMPORT_RX.finditer(masked):
+        if not starts_in_code(anchor, masked, m.start()):
+            continue
         line = masked.count("\n", 0, m.start()) + 1
         out.append(
             f"{path}:{line}: rule=admin-component-imported-into-router "
@@ -149,8 +183,11 @@ def scan_file(path: str) -> list[str]:
         )
 
     for m in _PATH_RX.finditer(masked):
+        if not starts_in_code(anchor, masked, m.start()):
+            continue
         line = masked.count("\n", 0, m.start()) + 1
-        obj = _enclosing_object(masked, m.start())
+        a, b = _enclosing_object(anchor, m.start())
+        obj = masked[a:b]
         # Anti-widening: only an IN-APP RENDER is the defect. A route that
         # redirects or hands off to the server-authorized settings framework is
         # the remediation, not the bug (ADR-079 / openconnector).
@@ -167,7 +204,7 @@ def scan_file(path: str) -> list[str]:
 
 
 def main(argv: list[str]) -> int:
-    if js_comment_mask is None or read_text is None:
+    if js_comment_mask is None or read_text is None or starts_in_code is None:
         print(
             "check_admin_router: source_scope.py could not be imported; "
             "NOTHING was inspected",

--- a/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/check_apphost_autoload_prelude.py
@@ -87,6 +87,9 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
+
 # The prelude: registerAutoloading(...) whose arguments name 'openregister'.
 # Tolerant of named arguments (app: 'openregister') and of `OC_App::` /
 # `\OC_App::` / an imported alias, because all three appear in this fleet.
@@ -110,6 +113,9 @@ APPID_CONST = re.compile(
 # loadApp('openregister') is a WRONG fix, not a prelude — it boots OpenRegister
 # before its own register() has run. Named so the reader is told why.
 LOAD_APP = re.compile(r"""loadApp\s*\(\s*['"]openregister['"]\s*\)""")
+# The same call with its argument left unread, for matching against the
+# CALL-SITE anchor where string contents are blank. See has_load_app().
+LOAD_APP_CALL = re.compile(r"loadApp\s*\(([^)]*)\)", re.S)
 
 # Rule 1 — any reference to the AppHost Bootstrap entry point. Covers
 # `use OCA\OpenRegister\AppHost\Bootstrap;`, `\OCA\OpenRegister\AppHost\Bootstrap::`
@@ -205,7 +211,7 @@ def _sources(app_dir: str) -> dict[str, str]:
 
 
 def strip_comments(text: str) -> str:
-    """PHP source with comments removed, string literals preserved.
+    """PHP source with comments blanked, string literals preserved.
 
     EVERY pattern below is evidence about CODE. Scanning raw source made
     comments count as source, in both directions:
@@ -218,73 +224,92 @@ def strip_comments(text: str) -> str:
         counted as a prelude that no longer runs — a false GREEN, the more
         dangerous direction.
 
-    Newlines are preserved so any line-based reporting stays aligned.
+    THE FOURTH DIALECT IS GONE (#424). This was a hand-written state machine —
+    #184's original, and the model `source_scope.php_mask` was generalised
+    FROM. Keeping both meant two definitions of "where does a PHP comment
+    start" that could drift, and gate-50 in run-hydra-gates.sh had since added
+    a third. They are now one, and this function is the name gate-64's own
+    tests use for it.
+
+    The one behavioural change is that comments are now BLANKED rather than
+    deleted, so offsets survive — which is what lets `code_and_anchor()` below
+    hand the same coordinates to two masks.
 
     `#[` opens a PHP 8 attribute, not a comment; treating it as one would
     swallow the rest of the line, including `#[NoAdminRequired]`.
     """
-    out: list[str] = []
-    i, n = 0, len(text)
-    state: str | None = None
-    while i < n:
-        c = text[i]
-        nxt = text[i + 1] if i + 1 < n else ""
-        if state is None:
-            if c == "'":
-                state, _ = "sq", out.append(c)
-                i += 1
-            elif c == '"':
-                state, _ = "dq", out.append(c)
-                i += 1
-            elif c == "/" and nxt == "/":
-                state, i = "line", i + 2
-            elif c == "#" and nxt != "[":
-                state, i = "line", i + 1
-            elif c == "/" and nxt == "*":
-                state, i = "block", i + 2
-            else:
-                out.append(c)
-                i += 1
-        elif state in ("sq", "dq"):
-            quote = "'" if state == "sq" else '"'
-            if c == "\\" and i + 1 < n:
-                out.append(c)
-                out.append(text[i + 1])
-                i += 2
-                continue
-            out.append(c)
-            if c == quote:
-                state = None
-            i += 1
-        elif state == "line":
-            if c == "\n":
-                out.append(c)
-                state = None
-            i += 1
-        else:  # block
-            if c == "*" and nxt == "/":
-                state, i = None, i + 2
-            else:
-                if c == "\n":
-                    out.append(c)
-                i += 1
-    return "".join(out)
+    return php_mask(text)
 
 
-def has_prelude(text: str) -> bool:
+def code_and_anchor(text: str) -> tuple[str, str]:
+    """(evidence text, call-site text) — same length, same offsets.
+
+    #424. This gate's evidence is genuinely a string literal much of the time:
+    the app id in `registerAutoloading('openregister', $p)`, the FQCN in
+    `class_exists('OCA\\OpenRegister\\AppHost\\X')`. So the mask cannot blank
+    string contents. But the CALL is never a string, and reading both out of
+    one text let a sentence close the gate:
+
+        $hint = "we call \\OC_App::registerAutoloading('openregister', $p) here";
+
+    satisfied `has_prelude()` and gate-64 reported OK for an app with no
+    prelude at all — a false NEGATIVE on the ADR-040 rule, produced by a
+    developer documenting what the code was supposed to do.
+
+    So the call site is located in the ANCHOR (string contents blanked) and
+    the argument text is read out of the CODE at the same offsets. Same
+    contract as `source_scope.js_exec_mask`: two questions, two sources, one
+    coordinate system.
+    """
+    return php_mask(text), php_mask(text, blank_strings=True)
+
+
+def has_prelude(text: str, anchor: str | None = None) -> bool:
     """True when text registers OpenRegister's autoloader.
 
     Accepts the app id as a quoted literal OR as a constant defined in the
     same composition root to that literal — both are the same prelude.
+
+    *anchor* is the same text with string CONTENTS blanked (see
+    `code_and_anchor`). The CALL is looked for there, so a sentence quoting
+    the prelude is not the prelude; the ARGUMENTS are read out of *text* at
+    the same offsets, because the app id really is a string literal. When it
+    is omitted the two collapse to one and the pre-#424 behaviour returns —
+    which is what the mutant in the suite uses.
     """
-    const_names = set(APPID_CONST.findall(text))
-    for m in PRELUDE.finditer(text):
-        args = m.group(1)
+    if anchor is None:
+        anchor = text
+    # A `const` written inside a string is not a declaration either: the
+    # keyword surviving the anchor is the proof that this one is code.
+    const_names = {
+        m.group(1)
+        for m in APPID_CONST.finditer(text)
+        if anchor.startswith("const", m.start())
+    }
+    for m in PRELUDE.finditer(anchor):
+        args = text[m.start(1):m.end(1)]
         if OPENREGISTER_LITERAL.search(args):
             return True
         for name in const_names:
             if re.search(r"\b" + re.escape(name) + r"\b", args):
                 return True
+    return False
+
+
+def has_load_app(text: str, anchor: str | None = None) -> bool:
+    """True when text calls `IAppManager::loadApp('openregister')`.
+
+    The WRONG fix, reported alongside the finding. Same split as
+    `has_prelude`: the call from *anchor*, the app id from *text*. Without it
+    a comment-shaped sentence in a STRING — `$why = "we do not call
+    loadApp('openregister')"` — added a second, unclosable finding line to
+    every app that already had one.
+    """
+    if anchor is None:
+        anchor = text
+    for m in LOAD_APP_CALL.finditer(anchor):
+        if OPENREGISTER_LITERAL.search(text[m.start(1):m.end(1)]):
+            return True
     return False
 
 
@@ -492,18 +517,22 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
     # source. The SUPPRESSION is the one exception — it is authored AS a
     # comment — so it keeps reading the raw text.
     raw_blob = "\n".join(sources.values())
-    code = {path: strip_comments(text) for path, text in sources.items()}
+    masks = {path: code_and_anchor(text) for path, text in sources.items()}
+    code = {path: pair[0] for path, pair in masks.items()}
+    anchors = {path: pair[1] for path, pair in masks.items()}
 
     # OpenRegister owns AppHost — exempt by namespace, not by directory name,
     # so a checkout under any directory name is still recognised.
-    if any(OWN_NAMESPACE.search(text) for text in code.values()):
+    if any(OWN_NAMESPACE.search(text) for text in anchors.values()):
         return []
 
+    # Joined with the SAME separator so the two blobs stay offset-aligned.
     blob = "\n".join(code.values())
+    anchor_blob = "\n".join(anchors.values())
 
     # The prelude may legitimately live in a sibling composition-root file that
     # register() calls, so look for it across the whole of lib/AppInfo/.
-    if has_prelude(blob):
+    if has_prelude(blob, anchor_blob):
         return []
 
     if suppression_reason(raw_blob):
@@ -526,7 +555,7 @@ def scan_app(app_dir: str) -> list[tuple[str, str]]:
                 (path, "calls class_exists() on an OCA\\OpenRegister\\AppHost\\ class")
             )
 
-    if findings and LOAD_APP.search(blob):
+    if findings and has_load_app(blob, anchor_blob):
         findings.append(
             (
                 os.path.join(app_dir, "lib", "AppInfo"),
@@ -548,10 +577,12 @@ def scan_notes(app_dir: str) -> list[tuple[str, list[str]]]:
     sources = _sources(app_dir)
     if not sources:
         return []
-    code = {path: strip_comments(text) for path, text in sources.items()}
-    if any(OWN_NAMESPACE.search(text) for text in code.values()):
+    masks = {path: code_and_anchor(text) for path, text in sources.items()}
+    code = {path: pair[0] for path, pair in masks.items()}
+    if any(OWN_NAMESPACE.search(text) for _, text in masks.values()):
         return []
-    if has_prelude("\n".join(code.values())):
+    if has_prelude("\n".join(code.values()),
+                   "\n".join(pair[1] for pair in masks.values())):
         return []
     if suppression_reason("\n".join(sources.values())):
         return []

--- a/hydra-gates/scripts/lib/check_aria_hidden_focusable.py
+++ b/hydra-gates/scripts/lib/check_aria_hidden_focusable.py
@@ -52,8 +52,12 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
 
 # Opening tags, quote-aware so a `>` inside an attribute value does not end
 # the tag early (`:title="a > b"`). The old grep used `[^>]*` and did.
@@ -61,7 +65,10 @@ TAG = re.compile(
     r'<([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)/?>',
     re.DOTALL,
 )
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 
 # `aria-hidden` truthy, literal or bound: aria-hidden="true", :aria-hidden="true".
@@ -113,7 +120,7 @@ def is_focusable(name: str, attrs: str) -> bool:
 
 
 def scan_source(fname: str, src: str) -> list[str]:
-    body = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    body = BLOCK.sub(' ', mask_html_comments(src))
     findings: list[str] = []
     for m in TAG.finditer(body):
         name, attrs = m.group(1), m.group(2) or ''

--- a/hydra-gates/scripts/lib/check_autocomplete.py
+++ b/hydra-gates/scripts/lib/check_autocomplete.py
@@ -47,10 +47,17 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
+
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 
 # Quote-aware attribute run: whole quoted values are consumed, so a `>` inside
@@ -145,7 +152,7 @@ def _is_semantic(value: str) -> bool:
 
 
 def scan_source(fname: str, src: str) -> list[str]:
-    txt = BLOCK.sub(' ', COMMENT.sub(' ', src)).replace('\n', ' ')
+    txt = BLOCK.sub(' ', mask_html_comments(src)).replace('\n', ' ')
     findings: list[str] = []
     for m in INPUT.finditer(txt):
         attrs = m.group(1) or ''

--- a/hydra-gates/scripts/lib/check_button_name.py
+++ b/hydra-gates/scripts/lib/check_button_name.py
@@ -49,10 +49,17 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
+
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 
 # THE FIX. The optional bound prefix applies to EVERY name attribute, not just
@@ -89,7 +96,7 @@ def _named(attrs: str, body: str) -> bool:
 
 
 def scan_source(fname: str, src: str) -> list[str]:
-    body_src = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    body_src = BLOCK.sub(' ', mask_html_comments(src))
     findings: list[str] = []
     for pat in BUTTONS:
         for m in pat.finditer(body_src):

--- a/hydra-gates/scripts/lib/check_form_labels.py
+++ b/hydra-gates/scripts/lib/check_form_labels.py
@@ -53,8 +53,12 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
 
 # Native controls that need a name. `select` is deliberately absent: it is
 # gate-12 (nc-input-labels)' subject, and widening this gate's remit while
@@ -128,7 +132,10 @@ TAG = re.compile(
     r'<(/?)([A-Za-z][A-Za-z0-9._:-]*)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(/?)>',
     re.DOTALL,
 )
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 TEMPLATE = re.compile(r'<template\b[^>]*>(.*)</template\s*>', re.DOTALL | re.IGNORECASE)
 
@@ -160,7 +167,7 @@ def _strip_noise(src: str) -> str:
     Order matters: comments first, because a commented-out `</script>`
     would otherwise end the block early.
     """
-    body = COMMENT.sub(' ', src)
+    body = mask_html_comments(src)
     m = TEMPLATE.search(body)
     if m:
         body = m.group(1)

--- a/hydra-gates/scripts/lib/check_initial_state.py
+++ b/hydra-gates/scripts/lib/check_initial_state.py
@@ -84,11 +84,21 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
-    from source_scope import js_comment_mask, read_text, script_mask
+    from source_scope import (
+        js_code_mask,
+        js_comment_mask,
+        js_exec_mask,
+        read_text,
+        script_mask,
+        starts_in_code,
+    )
 except Exception:  # pragma: no cover
+    js_code_mask = None
     js_comment_mask = None
+    js_exec_mask = None
     read_text = None
     script_mask = None
+    starts_in_code = None
 
 # A DOM lookup that yields a server-rendered element.
 _LOOKUP = r"(?:document|window\.document)\s*\.\s*(?:getElementById|querySelector)\s*\("
@@ -156,34 +166,57 @@ def scan_file(path: str) -> list[str]:
         src = read_text(path)
     except OSError:
         return []
+    # TWO MASKS, ONE COORDINATE SYSTEM (#424).
+    #
+    # `masked` keeps string CONTENTS, because the attribute name in
+    # `getAttribute('data-version')` is the evidence and the
+    # `data-requesttoken` exemption is read out of the same literal. That is
+    # why blanking is not the fix here — and why, until #424, this counted:
+    #
+    #     const doc = "document.getElementById('fx-settings').dataset.version"
+    #
+    # as a DOM read. `anchor` is the same text with string contents blanked,
+    # so `starts_in_code` can say whether the EXPRESSION is code. Every
+    # pattern below begins on a word character or `.`, which is the condition
+    # that predicate is exact for.
     if path.endswith(".vue") and script_mask is not None:
         masked = script_mask(src, path)
+        anchor = js_exec_mask(src, path)
     else:
         masked = js_comment_mask(src)
+        anchor = js_code_mask(src)
     lines = src.splitlines()
 
-    written = {m.group(1) for m in _DATASET_WRITE_RX.finditer(masked)}
+    def code_hits(rx, text=None):
+        for m in rx.finditer(text if text is not None else masked):
+            if starts_in_code(anchor, masked, m.start()):
+                yield m
+
+    written = {m.group(1) for m in code_hits(_DATASET_WRITE_RX)}
 
     hits: set[int] = set()
-    for m in _ONE_STEP_RX.finditer(masked):
+    for m in code_hits(_ONE_STEP_RX):
         if _excluded(m, written):
             continue
         hits.add(masked.count("\n", 0, m.start()) + 1)
 
     # Two-step: a name bound to a DOM lookup, then read for server data.
     # Names that are also parameters somewhere are ambiguous — see _PARAM_RX.
-    ambiguous = _ambiguous_names(masked)
-    names = {m.group(1) for m in _ASSIGN_RX.finditer(masked)} - ambiguous
-    this_names = {m.group(1) for m in _THIS_ASSIGN_RX.finditer(masked)} - ambiguous
+    # The ambiguity scan runs on the ANCHOR: a parameter written inside a
+    # string is not a parameter, and letting prose add names there would
+    # silently suppress real findings.
+    ambiguous = _ambiguous_names(anchor)
+    names = {m.group(1) for m in code_hits(_ASSIGN_RX)} - ambiguous
+    this_names = {m.group(1) for m in code_hits(_THIS_ASSIGN_RX)} - ambiguous
     for name in names:
         rx = re.compile(r"(?<![\w.])" + re.escape(name) + r"\s*[!?]?" + _READ)
-        for m in rx.finditer(masked):
+        for m in code_hits(rx):
             if _excluded(m, written):
                 continue
             hits.add(masked.count("\n", 0, m.start()) + 1)
     for name in this_names:
         rx = re.compile(r"this\s*\.\s*" + re.escape(name) + r"\s*[!?]?" + _READ)
-        for m in rx.finditer(masked):
+        for m in code_hits(rx):
             if _excluded(m, written):
                 continue
             hits.add(masked.count("\n", 0, m.start()) + 1)
@@ -196,7 +229,7 @@ def scan_file(path: str) -> list[str]:
 
 
 def main(argv: list[str]) -> int:
-    if read_text is None or js_comment_mask is None:
+    if read_text is None or js_comment_mask is None or starts_in_code is None:
         print(
             "check_initial_state: source_scope.py could not be imported; "
             "NOTHING was inspected",

--- a/hydra-gates/scripts/lib/check_link_text.py
+++ b/hydra-gates/scripts/lib/check_link_text.py
@@ -51,10 +51,17 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
+
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 
 # Quote-aware attribute run — see the docstring. `(?:"[^"]*"|'[^']*'|[^>"'])*?`
@@ -80,7 +87,7 @@ ANY_TAG = re.compile(r'<[^>]*>', re.DOTALL)
 
 
 def scan_source(fname: str, src: str) -> list[str]:
-    txt = BLOCK.sub(' ', COMMENT.sub(' ', src)).replace('\n', ' ')
+    txt = BLOCK.sub(' ', mask_html_comments(src)).replace('\n', ' ')
     findings: list[str] = []
     for pat, tagname in LINKS:
         for m in pat.finditer(txt):

--- a/hydra-gates/scripts/lib/check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/check_manifest_crossref.js
@@ -240,15 +240,20 @@ const REGISTRY_KINDS_REQUIRING_A_POSITION = new Set(['section', 'page', 'widget'
 // in the fleet — the widening that would make this check useless on arrival.
 const LIB_COMPONENT = /^Cn[A-Z]\w*$/
 
-// Strip line and block comments so a commented-out entry is NOT counted as a
+// Blank line and block comments so a commented-out entry is NOT counted as a
 // registration. A commented-out prelude counting as a prelude was a real
 // false-GREEN in gate-64; the same mistake here would let a deleted component
 // vouch for a manifest reference that resolves to nothing at runtime.
-function stripJsComments(src) {
-	return src
-		.replace(/\/\*[\s\S]*?\*\//g, ' ')
-		.replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
-}
+//
+// THE PRIVATE TWO-LINE REGEX IS GONE (#424). It was not string-aware, so the
+// `/*` inside `glob: '/*.vue'` opened a block comment that ran to the next
+// real `*/` — swallowing whole registry entries, and (when the swallowed span
+// was brace-unbalanced) making `parsed: false` skip the cross-reference check
+// altogether. See scripts/lib/js_scope.js for the measured shapes; it is the
+// node port of `source_scope.js_comment_mask` and is asserted byte-identical
+// to it. String CONTENTS survive, because the quoted registry key and
+// `kind: 'page'` are this parser's evidence.
+const { jsCommentMask } = require('./js_scope.js')
 
 // Top-level keys of the `export default { … }` object, with their `kind`.
 // Brace-depth tracking keeps nested object keys (`component:`, `props:`) out.
@@ -260,7 +265,7 @@ function parseRegistry(appDir, rel) {
 	} catch (e) {
 		return null // absent — nothing to add from this source
 	}
-	const src = stripJsComments(raw)
+	const src = jsCommentMask(raw)
 	const start = src.search(/export\s+default\s*\{/)
 	if (start === -1) return { file, entries: new Map(), parsed: false }
 

--- a/hydra-gates/scripts/lib/check_notification_dialect.py
+++ b/hydra-gates/scripts/lib/check_notification_dialect.py
@@ -36,13 +36,61 @@ from __future__ import annotations
 import json
 import sys
 
-# Tokens that may appear anywhere inside a rule's JSON (keys or string values).
-_SUBSTRING_TOKENS = (
+# WHERE EACH TOKEN CAN ACTUALLY LIVE (#424).
+#
+# These four were matched against `json.dumps(rule)` — one flat haystack in
+# which a KEY, a machine value and a sentence of human documentation are the
+# same bytes. So a rule whose own `description` WARNED AGAINST the legacy
+# dialect was reported as the legacy dialect:
+#
+#   "description": "Canonical dialect. Do NOT use the legacy lifecycleEnter
+#                   trigger or alsoDispatchLifecycle; removed in ADR-031."
+#     -> rule=onIntakeClosed token=lifecycleEnter
+#        rule=onIntakeClosed token=alsoDispatchLifecycle
+#
+# The better the register is documented, the redder the repo — the exact shape
+# recorded for gate-58 in source_scope's header, in a file format where the
+# fix is not a mask but reading the STRUCTURE instead of its serialisation.
+#
+# Three of the four are KEY names in the dialect (`trigger.lifecycleEnter`,
+# rule-level `alsoDispatchLifecycle` / `idempotencyKey`); `@self.` is a
+# recipient VALUE. Nothing that was a key-hit or a machine-value hit before is
+# lost — only the prose axis is.
+_KEY_TOKENS = (
     "lifecycleEnter",
     "alsoDispatchLifecycle",
     "idempotencyKey",
+)
+_VALUE_TOKENS = (
     "@self.",
 )
+# Fields whose contents are human text, per ADR-031: `subject` is the
+# per-locale message map the CANONICAL dialect requires, and the rest are
+# documentation. Prose about the dialect is not the dialect.
+_PROSE_FIELDS = frozenset({
+    "description", "title", "subject", "comment", "$comment",
+})
+
+
+def _keys_and_values(node, in_prose=False, keys=None, values=None):
+    """Every KEY name and every machine string VALUE reachable from *node*.
+
+    Anything under a prose field is neither: its keys are locale codes and its
+    values are sentences.
+    """
+    if keys is None:
+        keys, values = [], []
+    if isinstance(node, dict):
+        for key, val in node.items():
+            if not in_prose:
+                keys.append(key)
+            _keys_and_values(val, in_prose or key in _PROSE_FIELDS, keys, values)
+    elif isinstance(node, list):
+        for item in node:
+            _keys_and_values(item, in_prose, keys, values)
+    elif isinstance(node, str) and not in_prose:
+        values.append(node)
+    return keys, values
 
 
 def _iter_notification_blocks(data):
@@ -85,10 +133,14 @@ def _scan_rule(rule_key, rule):
     trig = rule.get("trigger")
     if isinstance(trig, dict) and "calculated" in trig:
         findings.append("trigger.calculated")
-    # Substring tokens anywhere in the serialised rule.
-    blob = json.dumps(rule)
-    for tok in _SUBSTRING_TOKENS:
-        if tok in blob:
+    # Structural tokens — see _KEY_TOKENS / _VALUE_TOKENS for why this is not
+    # a substring search over `json.dumps(rule)` any more.
+    keys, values = _keys_and_values(rule)
+    for tok in _KEY_TOKENS:
+        if any(tok in key for key in keys):
+            findings.append(tok)
+    for tok in _VALUE_TOKENS:
+        if any(tok in val for val in values) or any(tok in key for key in keys):
             findings.append(tok)
     return findings
 

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -72,6 +72,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+from source_scope import mask_html_comments  # noqa: E402
 
 # Foundation repos: the abstractions every leaf app consumes (ADR-022,
 # apps-consume-or-abstractions). A PUBLIC method here is frequently invoked
@@ -645,7 +646,12 @@ def _build_job_class_seam(app_root: str) -> set[str]:
             # `<!-- <job>…</job> -->` is a job that is NOT scheduled. Same
             # false-GREEN shape as the listener seam above: this exempts the
             # whole class. XML comments, not PHP ones, so a separate strip.
-            text = re.sub(r"<!--.*?-->", " ", fh.read(), flags=re.DOTALL)
+            # #424: the private `<!--.*?-->` this replaces called four
+            # characters a comment opener wherever they appeared, including
+            # inside an attribute value — `<job name="<!--">` blanked every
+            # <job> after it, which is the false GREEN this seam exists to
+            # prevent.
+            text = mask_html_comments(fh.read())
     except OSError:
         return seam
     for m in re.finditer(r"<job>\s*([A-Za-z0-9_\\]+)\s*</job>", text):

--- a/hydra-gates/scripts/lib/check_table_headers.py
+++ b/hydra-gates/scripts/lib/check_table_headers.py
@@ -66,10 +66,17 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 
-COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
+
+# Comment scope comes from the shared library (#424). The private
+# `<!--.*?-->` this replaces called four characters a comment opener wherever
+# they appeared, so `{{ '<!--' }}` … `{{ '-->' }}` blanked every element
+# between them and the gate went green over live markup.
 BLOCK = re.compile(r'<(script|style)\b[^>]*>.*?</\1\s*>', re.DOTALL | re.IGNORECASE)
 
 TABLE = re.compile(r'<table\b([^>]*)>(.*?)</table\s*>', re.IGNORECASE | re.DOTALL)
@@ -122,7 +129,7 @@ def _headers(inner: str) -> list[tuple[str, str | None, bool]]:
 
 
 def scan_source(fname: str, src: str) -> list[str]:
-    body = BLOCK.sub(' ', COMMENT.sub(' ', src))
+    body = BLOCK.sub(' ', mask_html_comments(src))
     findings: list[str] = []
     for m in TABLE.finditer(body):
         inner = m.group(2) or ''

--- a/hydra-gates/scripts/lib/check_unclosable_gate.py
+++ b/hydra-gates/scripts/lib/check_unclosable_gate.py
@@ -81,20 +81,40 @@ CONST_DEF = re.compile(
 CONST_REF = re.compile(r"""(?:self|static|parent|[A-Za-z_][A-Za-z0-9_\\]*)\s*::\s*([A-Z][A-Z0-9_]*)\b""")
 
 
-def call_args(src: str, fname: str):
-    """Yield the argument text of every `fname(...)` call in src."""
-    for m in re.finditer(re.escape(fname) + r'\s*\(', src):
+def call_args(blob: str, anchor: str, fname: str):
+    """Yield the argument text of every `fname(...)` CALL SITE.
+
+    TWO SOURCES, ONE COORDINATE SYSTEM (#424)
+    -----------------------------------------
+    This gate's evidence IS a string literal — the config key — so the mask
+    cannot blank string contents. But the CALL is not a string, and scanning
+    the same text for both questions meant a sentence closed the gate:
+
+        $hint = "call setValueString('fixapp','configuration_version','3') next";
+
+    read as a write of `configuration_version`. A gate whose entire subject is
+    "this guard never closes" was closed by a comment saying someone would
+    close it later — the same shape as the commented-out setter this gate
+    already masks for, one quote character away.
+
+    So: the call site is located in *anchor* (`php_mask(..., blank_strings=
+    True)`, where that sentence is blank and its parentheses cannot be walked)
+    and the argument text is read from *blob* (string contents intact) at the
+    SAME offsets, which both masks preserve. This is the anchoring contract
+    `source_scope.js_exec_mask` documents.
+    """
+    for m in re.finditer(re.escape(fname) + r'\s*\(', anchor):
         depth = 0
         i = m.end() - 1
-        while i < len(src):
-            if src[i] == '(':
+        while i < len(anchor):
+            if anchor[i] == '(':
                 depth += 1
-            elif src[i] == ')':
+            elif anchor[i] == ')':
                 depth -= 1
                 if depth == 0:
                     break
             i += 1
-        yield src[m.end():i]
+        yield blob[m.end():i]
 
 
 def suppressed(src: str, key: str) -> bool:
@@ -172,15 +192,25 @@ def scan_app(app_dir: str):
     # The SUPPRESSION is the one thing that must keep reading raw text — it is
     # authored as a comment, which is exactly what this mask removes.
     blob = php_mask(raw)
+    # The CALL-SITE scope: same text, same offsets, string CONTENTS blanked.
+    # See call_args() for why there have to be two of these.
+    anchor = php_mask(raw, blank_strings=True)
 
-    constants = dict(CONST_DEF.findall(blob))
+    # A `const` written inside a string is not a declaration either, and the
+    # `const` keyword surviving in the anchor is the cheap proof that this one
+    # is real code.
+    constants = {
+        m.group(1): m.group(2)
+        for m in CONST_DEF.finditer(blob)
+        if anchor.startswith('const', m.start())
+    }
 
     read, written = set(), set()
     for fname in GETTERS:
-        for arg in call_args(blob, fname):
+        for arg in call_args(blob, anchor, fname):
             read |= keys_in(arg, constants)
     for fname in SETTERS:
-        for arg in call_args(blob, fname):
+        for arg in call_args(blob, anchor, fname):
             written |= keys_in(arg, constants)
 
     out = []

--- a/hydra-gates/scripts/lib/check_unsafe_auth_resolver.py
+++ b/hydra-gates/scripts/lib/check_unsafe_auth_resolver.py
@@ -32,8 +32,25 @@ Measured 2026-08-08 on a tab-indented file:
 
 Braces are the language's own block delimiter, so this walks them, over a
 comment-masked copy (#184) so a docblock DESCRIBING the anti-pattern — as the
-fixed decidesk code now does — is not itself a finding. String contents are
-kept: they are evidence about code, and blanking them would delete it.
+fixed decidesk code now does — is not itself a finding.
+
+STRING CONTENTS ARE BLANKED TOO (#424)
+--------------------------------------
+The mask ran with `blank_strings=False`, so the docblock case was fixed and the
+STRING LITERAL case was not. Measured on main:
+
+    public function getAuthorizationService(): ?IAuth {
+        $doc = 'catch (\\Throwable $e) { return null; }';   // <- prose, in quotes
+        try { return $this->container->get(IAuth::class); }
+        catch (\\Throwable $e) { throw new ServiceUnavailable(...); }
+    }
+      -> FAIL — 1 fail-open pattern(s), on a resolver that correctly RETHROWS.
+
+Nothing this gate matches is ever a string: `function <name>(`, `catch
+(\\Throwable`, `return null;` and the braces are all syntax. So there is no
+evidence to lose — and blanking string contents also repairs the BRACE WALKER,
+which previously counted a `{` or `}` written inside a literal as a real block
+delimiter.
 
 WHAT IS DELIBERATELY UNCHANGED
 ------------------------------
@@ -98,7 +115,7 @@ def scan_file(path: str) -> list[str]:
         src = read_text(path)
     except OSError:
         return []
-    masked = php_mask(src)
+    masked = php_mask(src, blank_strings=True)
 
     out: list[str] = []
     for m in _METHOD_RX.finditer(masked):

--- a/hydra-gates/scripts/lib/js_scope.js
+++ b/hydra-gates/scripts/lib/js_scope.js
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+//
+// Where does CODE live in a JavaScript file, and where does PROSE live?
+//
+// WHY THIS EXISTS
+// ---------------
+// `source_scope.py` answers this for every Python checker in this package.
+// The node checkers had no equivalent, so gate-53 carried a two-line regex:
+//
+//     src.replace(/\/\*[\s\S]*?\*\//g, ' ')
+//        .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+//
+// which is not string-aware. Measured on a registry of the shape this fleet
+// actually writes (#424):
+//
+//     export default {
+//         Reports:  { kind: 'page', component: Reports, glob: '/*.vue' },
+//         Settings: { /* the admin page */ kind: 'page', component: Settings },
+//     }
+//
+// the `/*` INSIDE the glob string opened a block comment that ran to the
+// `*/` of the real comment two lines later. `Settings` vanished from the
+// registry, and a manifest page referencing it was reported as
+// `FAIL — 1 cross-reference failure`: the gate accused the app of not
+// registering a component it registers, and no correct change closes that
+// finding except deleting the glob.
+//
+// The WORSE variant is silent. When the swallowed span is brace-UNBALANCED,
+// `parseRegistry` returns `parsed: false` and the caller skips the whole
+// cross-reference check — a false GREEN, produced by the same two lines.
+//
+// THE CONTRACT — deliberately identical to `source_scope.js_comment_mask`
+// ----------------------------------------------------------------------
+//   * comments and regex literals are BLANKED,
+//   * string and template CONTENTS are KEPT — for gate-53 the quoted registry
+//     key (`'agent-form'`) and `kind: 'page'` ARE the evidence,
+//   * the result is the SAME LENGTH as the input with newlines intact, so an
+//     index computed on the mask addresses the original text.
+//
+// Being byte-identical to the Python is not a comment: `test_js_scope.js`
+// runs `source_scope.py --mask js-comments` over a shared corpus and asserts
+// equality, and that test is mutation-checked. Two copies that are PROVEN
+// equal are a maintenance cost; two copies that MIGHT differ are a defect —
+// the same trade `test_source_scope.py::TestSharedWithGate19` already makes.
+
+'use strict'
+
+// Keywords after which a `/` opens a regular expression rather than dividing.
+const REGEX_KEYWORDS = new Set([
+	'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+	'throw', 'case', 'do', 'else', 'yield', 'await',
+])
+
+const isWordChar = (c) => /[A-Za-z0-9_$]/.test(c)
+
+// Index just past the quoted string whose opening quote is at `i`. An
+// unterminated literal stops at the newline rather than swallowing the rest of
+// the file — a lone apostrophe in a comment must not blank a whole registry.
+function skipString(text, i) {
+	const quote = text[i]
+	const n = text.length
+	let j = i + 1
+	while (j < n) {
+		const c = text[j]
+		if (c === '\\') { j += 2; continue }
+		if (c === quote) return j + 1
+		if (c === '\n') return j
+		j++
+	}
+	return n
+}
+
+// Index just past the template literal whose backtick is at `i`. `${ … }`
+// substitutions are walked because they may contain braces, quotes and
+// further templates.
+function skipTemplate(text, i) {
+	const n = text.length
+	let j = i + 1
+	let depth = 0
+	while (j < n) {
+		const c = text[j]
+		if (c === '\\') { j += 2; continue }
+		if (depth === 0) {
+			if (c === '`') return j + 1
+			if (c === '$' && j + 1 < n && text[j + 1] === '{') { depth++; j += 2; continue }
+			j++
+			continue
+		}
+		if (c === '`') { j = skipTemplate(text, j); continue }
+		if (c === "'" || c === '"') { j = skipString(text, j); continue }
+		if (c === '{') depth++
+		else if (c === '}') depth--
+		j++
+	}
+	return n
+}
+
+// Index just past the regex literal starting at `i`, or -1 if it is not one.
+// A regex literal cannot span a newline, which is the cheap and reliable
+// disambiguator against division.
+function skipRegex(text, i) {
+	const n = text.length
+	let j = i + 1
+	let inClass = false
+	while (j < n) {
+		const c = text[j]
+		if (c === '\\') { j += 2; continue }
+		if (c === '\n') return -1
+		if (inClass) {
+			if (c === ']') inClass = false
+		} else if (c === '[') {
+			inClass = true
+		} else if (c === '/') {
+			j++
+			while (j < n && /[A-Za-z]/.test(text[j])) j++
+			return j
+		}
+		j++
+	}
+	return -1
+}
+
+function regexCanStart(prevChar, prevWord) {
+	if (prevChar === '') return true
+	if (prevChar === ')' || prevChar === ']') return false
+	if (prevChar === "'" || prevChar === '"' || prevChar === '`') return false
+	if (isWordChar(prevChar)) return REGEX_KEYWORDS.has(prevWord)
+	return true
+}
+
+/**
+ * A same-length copy of `text` with comments and regex literals blanked and
+ * string/template CONTENTS left intact.
+ */
+function jsCommentMask(text) {
+	const out = text.split('')
+	const n = text.length
+	const blank = (a, b) => {
+		for (let k = Math.max(a, 0); k < Math.min(b, n); k++) {
+			if (out[k] !== '\n') out[k] = ' '
+		}
+	}
+	let i = 0
+	let prevChar = ''
+	let prevWord = ''
+	while (i < n) {
+		const c = text[i]
+		if (c === '/' && text.startsWith('//', i)) {
+			let j = text.indexOf('\n', i)
+			if (j < 0) j = n
+			blank(i, j)
+			i = j
+			continue
+		}
+		if (c === '/' && text.startsWith('/*', i)) {
+			let j = text.indexOf('*/', i + 2)
+			j = j < 0 ? n : j + 2
+			blank(i, j)
+			i = j
+			continue
+		}
+		if (c === "'" || c === '"') {
+			i = skipString(text, i)
+			prevChar = c
+			prevWord = ''
+			continue
+		}
+		if (c === '`') {
+			i = skipTemplate(text, i)
+			prevChar = '`'
+			prevWord = ''
+			continue
+		}
+		if (c === '/' && regexCanStart(prevChar, prevWord)) {
+			const j = skipRegex(text, i)
+			if (j > 0) {
+				blank(i, j)
+				prevChar = ')'      // a regex literal is a value
+				prevWord = ''
+				i = j
+				continue
+			}
+		}
+		if (isWordChar(c)) {
+			let k = i
+			while (k < n && isWordChar(text[k])) k++
+			prevWord = text.slice(i, k)
+			prevChar = text[k - 1]
+			i = k
+			continue
+		}
+		if (!/\s/.test(c)) { prevChar = c; prevWord = '' }
+		i++
+	}
+	return out.join('')
+}
+
+module.exports = { jsCommentMask }

--- a/hydra-gates/scripts/lib/php_template_scope.py
+++ b/hydra-gates/scripts/lib/php_template_scope.py
@@ -57,15 +57,24 @@ Usage:
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import mask_html_comments  # noqa: E402
 
 # `<?php … ?>` and the short echo form `<?= … ?>`. An unterminated opener runs
 # to end of file, which is the language's own rule and the common shape of a
 # template whose PHP header is followed by nothing but more PHP.
 PHP_BLOCK = re.compile(r'<\?(?:php\b|=)?.*?(?:\?>|\Z)', re.DOTALL | re.IGNORECASE)
-HTML_COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
-
+# Comment scope comes from the shared library (#424). This module kept a
+# private `<!--.*?-->` on purpose — gate-38's wiring guard is written against
+# it — but the private copy carried the delimiter hole: `<!--` inside a quoted
+# attribute value was a comment opener, so `<html lang="en" title="<!--">`
+# could blank the rest of the document. Only the COMMENT definition is shared;
+# the PHP-block rule and the classification stay local, which is what gate-38
+# is written against.
 DOCUMENT_TAG = re.compile(r'<(?:html|body)\b', re.IGNORECASE)
 # The opening `<html>` element and its attribute text. Quote-aware, so a `>`
 # inside an attribute value does not end the tag — the `[^>]*` shape it
@@ -83,7 +92,7 @@ def emitted_markup(src: str) -> str:
     inside an HTML comment really does close the block in PHP, and pretending
     otherwise would swallow markup that does ship.
     """
-    return HTML_COMMENT.sub(' ', PHP_BLOCK.sub(' ', src))
+    return mask_html_comments(PHP_BLOCK.sub(' ', src))
 
 
 def owns_document(src: str) -> bool:

--- a/hydra-gates/scripts/lib/source_scope.py
+++ b/hydra-gates/scripts/lib/source_scope.py
@@ -385,6 +385,9 @@ def php_mask(text: str, *, blank_strings: bool = False) -> str:
 # ---------------------------------------------------------------------------
 
 _HTML_COMMENT = re.compile(r'<!--.*?-->', re.DOTALL)
+# ⚠️ THE REGEX ABOVE IS KEPT ONLY AS THE MUTATION CONTROL for the scanner
+# below (test_source_scope.TestHtmlCommentDelimiterScope). Nothing in this
+# module masks with it any more — see `html_comment_spans`.
 # `<?php … ?>` and the short echo form. An unterminated opener runs to end of
 # file, which is the language's own rule. Same pattern php_template_scope.py
 # uses (#247); the two agree deliberately.
@@ -412,6 +415,142 @@ def _blank_span(buf: list[str], a: int, b: int) -> None:
     for k in range(max(a, 0), min(b, len(buf))):
         if buf[k] != "\n":
             buf[k] = " "
+
+
+# ---------------------------------------------------------------------------
+# WHERE AN HTML COMMENT REALLY STARTS  (#424)
+# ---------------------------------------------------------------------------
+# `_HTML_COMMENT` — `<!--.*?-->` — reads FOUR CHARACTERS and calls them a
+# comment opener wherever they appear. Two places in a template they are not
+# one, and both ship in this fleet:
+#
+#   1. inside a quoted ATTRIBUTE VALUE.  Per the HTML tokeniser, once an
+#      attribute value is open the only thing that ends it is its own quote;
+#      `<img alt="<!--">` contains no comment.
+#   2. inside a Vue `{{ … }}` INTERPOLATION. Vue's tokeniser enters
+#      interpolation state at `{{` and leaves it only at `}}`; the contents
+#      are a JS expression, so `{{ '<!--' }}` is a string literal.
+#
+# Measured on main before this change, and the reason this is one bug rather
+# than sixteen (#424 group 2):
+#
+#   markup_mask("<p>{{ '<!--' }}</p>\n<img alt=\"\" src=\"/a/avatar.png\">\n"
+#               "<p>{{ '-->' }}</p>")
+#     -> "<p>{{ '            \n                                   \n     ' }}</p>"
+#
+# The `<img alt="">` between the two interpolations is blanked and the gate
+# goes green over live markup. A mask that OVER-blanks is a gate that reports
+# nothing, which is the failure mode this whole module exists to remove — the
+# same trap already recorded above for `<template>` nesting.
+#
+# The fix is a scanner rather than a richer regex, because "am I inside an
+# attribute value" is a state, and a regex that tried to carry it would be the
+# `[^>]*` bug of #236 in a new costume.
+#
+# DELIBERATE NON-CHANGES, so the next reader does not think they are holes:
+#   * `<!--` in a TEXT NODE opens a comment even between quotes. Quotes carry
+#     no meaning in text; `<p>'<!--'</p>` really is a comment to a browser.
+#   * `<script>`/`<style>` bodies are RAW TEXT: their content is script data,
+#     not markup, so `const OPEN = '<!--'` opens nothing. Both callers that
+#     see a script body (`html_markup_mask`, `script_mask`) run
+#     `js_comment_mask` over it afterwards, so a real JS comment there is
+#     still blanked — by the tokeniser that knows JS, not by this one.
+#   * an UNTERMINATED `{{`, quote or tag falls back to "this was ordinary
+#     text" instead of swallowing the rest of the file. Swallowing is the
+#     over-blank direction, and over-blanking is the failure mode.
+
+_RAW_TEXT_ELEMENTS = ("script", "style")
+
+
+def _skip_tag(text: str, i: int) -> int:
+    """Index just past the tag whose `<` is at *i*, or -1 if it is not a tag.
+
+    Quoted attribute values are walked whole, so a `>` — or a `<!--` — inside
+    one neither ends the tag nor opens anything.
+    """
+    n = len(text)
+    if i + 1 >= n:
+        return -1
+    c = text[i + 1]
+    if not (c.isalpha() or c in "/!?"):
+        return -1
+    j = i + 1
+    while j < n:
+        ch = text[j]
+        if ch in "\"'":
+            k = j + 1
+            while k < n and text[k] != ch:
+                k += 1
+            if k >= n:
+                return -1           # unterminated value: this was not a tag
+            j = k + 1
+            continue
+        if ch == ">":
+            return j + 1
+        j += 1
+    return -1                       # no `>` before EOF: this was not a tag
+
+
+def _raw_text_element_at(text: str, i: int) -> str:
+    """The raw-text element name opened by the tag at *i*, or ""."""
+    for name in _RAW_TEXT_ELEMENTS:
+        end = i + 1 + len(name)
+        if text[i + 1:end].lower() == name and (end >= len(text) or not (text[end].isalnum() or text[end] in "-_:")):
+            return name
+    return ""
+
+
+def html_comment_spans(text: str) -> list[tuple[int, int]]:
+    """(start, end) of every real HTML comment in *text*.
+
+    An unterminated `<!--` runs to end of file, which is what a browser does.
+    """
+    spans: list[tuple[int, int]] = []
+    n = len(text)
+    i = 0
+    while i < n:
+        c = text[i]
+        if c == "<":
+            if text.startswith("<!--", i):
+                j = text.find("-->", i + 4)
+                j = n if j < 0 else j + 3
+                spans.append((i, j))
+                i = j
+                continue
+            j = _skip_tag(text, i)
+            if j < 0:
+                i += 1
+                continue
+            raw = _raw_text_element_at(text, i)
+            if raw:
+                m = re.compile(r'</' + raw + r'(?:\s[^>]*)?>', re.IGNORECASE).search(text, j)
+                i = m.end() if m else n
+                continue
+            i = j
+            continue
+        if c == "{" and text.startswith("{{", i):
+            j = text.find("}}", i + 2)
+            if j < 0:
+                i += 2              # never closed: it was not an interpolation
+                continue
+            i = j + 2
+            continue
+        i += 1
+    return spans
+
+
+def mask_html_comments(text: str) -> str:
+    """A same-length copy of *text* with every HTML comment blanked.
+
+    The one definition of "this is a comment" for this package. Seven checkers
+    carried a private `<!--.*?-->` before #424 — six a11y gates plus
+    `php_template_scope` — and every one of them had the delimiter hole
+    documented above. Offsets and newlines survive, as everywhere else here.
+    """
+    buf = list(text)
+    for a, b in html_comment_spans(text):
+        _blank_span(buf, a, b)
+    return "".join(buf)
 
 
 def _top_level_template_spans(text: str) -> list[tuple[int, int]]:
@@ -478,10 +617,7 @@ def vue_markup_mask(text: str) -> str:
     masked = "".join(buf)
     # HTML comments last, over the kept regions only (they are all that is
     # left to comment).
-    out = list(masked)
-    for m in _HTML_COMMENT.finditer(masked):
-        _blank_span(out, m.start(), m.end())
-    return "".join(out)
+    return mask_html_comments(masked)
 
 
 def php_markup_mask(text: str) -> str:
@@ -500,20 +636,12 @@ def php_markup_mask(text: str) -> str:
     buf = list(text)
     for m in _PHP_BLOCK.finditer(text):
         _blank_span(buf, m.start(), m.end())
-    masked = "".join(buf)
-    out = list(masked)
-    for m in _HTML_COMMENT.finditer(masked):
-        _blank_span(out, m.start(), m.end())
-    result = "".join(out)
-    return _mask_script_bodies(result)
+    return _mask_script_bodies(mask_html_comments("".join(buf)))
 
 
 def html_markup_mask(text: str) -> str:
     """HTML comments blanked; `<script>` bodies comment-masked."""
-    buf = list(text)
-    for m in _HTML_COMMENT.finditer(text):
-        _blank_span(buf, m.start(), m.end())
-    return _mask_script_bodies("".join(buf))
+    return _mask_script_bodies(mask_html_comments(text))
 
 
 def _mask_script_bodies(text: str) -> str:
@@ -594,10 +722,7 @@ def script_mask(text: str, path: str = "") -> str:
         # Blank HTML comments across the whole file, then comment-mask every
         # <script> and <style> body. What remains is template markup (whose
         # attribute values are live JS) plus script code.
-        buf = list(text)
-        for m in _HTML_COMMENT.finditer(text):
-            _blank_span(buf, m.start(), m.end())
-        step = "".join(buf)
+        step = mask_html_comments(text)
         out = list(_mask_script_bodies(step))
         for m in _STYLE_BLOCK.finditer(step):
             _blank_span(out, m.start(2), m.end(2))
@@ -607,11 +732,7 @@ def script_mask(text: str, path: str = "") -> str:
     if ext == ".php":
         for m in _PHP_BLOCK.finditer(text):
             _blank_span(buf, m.start(), m.end())
-    step = "".join(buf)
-    out = list(step)
-    for m in _HTML_COMMENT.finditer(step):
-        _blank_span(out, m.start(), m.end())
-    return _mask_script_bodies("".join(out))
+    return _mask_script_bodies(mask_html_comments("".join(buf)))
 
 
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/source_scope.py
+++ b/hydra-gates/scripts/lib/source_scope.py
@@ -786,6 +786,36 @@ def iter_open_tags(masked: str, names: set[str] | None = None):
         yield Tag(name, m.group(3) or "", m.start(), m.end(), m.group(0), line)
 
 
+# ---------------------------------------------------------------------------
+# Anchoring: "is this position CODE, or the inside of a string literal?"
+# ---------------------------------------------------------------------------
+
+def starts_in_code(anchor: str, evidence: str, i: int) -> bool:
+    """True when offset *i* is code rather than the CONTENTS of a literal.
+
+    #424. Several gates need both halves at once: `getAttribute('data-x')`
+    and `path: '/settings'` are evidence that lives INSIDE a string, so their
+    mask cannot blank string contents — but the surrounding expression is
+    code, and reading both questions out of one text made a sentence count:
+
+        const doc = "document.getElementById('fx-settings').dataset.version"
+
+    So the caller runs its pattern over *evidence* (contents intact) and asks
+    this of the match start, with *anchor* being the SAME text masked with
+    `blank_strings=True`. Both masks preserve offsets, and blanking only ever
+    turns a character into a space, so a non-space character that survived the
+    anchor is code.
+
+    ⚠️ ONLY VALID FOR A NON-SPACE POSITION. A space inside a literal is a
+    space in both masks, so this would call it code. Every caller anchors on a
+    pattern that begins with a word character or `.`, which is why the
+    predicate is stated as *starts*_in_code rather than `is_code`.
+    """
+    if i < 0 or i >= len(anchor) or i >= len(evidence):
+        return False
+    return anchor[i] == evidence[i]
+
+
 def read_text(path: str) -> str:
     with open(path, encoding="utf-8", errors="replace") as handle:
         return handle.read()

--- a/hydra-gates/scripts/lib/test_check_admin_router.py
+++ b/hydra-gates/scripts/lib/test_check_admin_router.py
@@ -113,6 +113,43 @@ routes.push({ path: '/:pathMatch(.*)*', redirect: '/' })
 f = run(CLEAN)
 check("a manifest-driven router is clean", f == [], repr(f))
 
+# --- #424: a STRING LITERAL is not a route -----------------------------------
+# Both rules read their evidence out of a literal ('/settings', the import
+# specifier), so the mask cannot blank string contents — which is exactly how
+# a quoted sentence became a live admin route. Mutation-checked by dropping
+# the `starts_in_code` guard in scan_file.
+f = run('const t = "routes.push({path:\'/settings\', component: AdminRoot})"\n')
+check("EVIDENCE: a route quoted inside a string is not a route", len(f) == 0, repr(f))
+
+f = run('const t = "import AdminRoot from \'./views/settings/AdminRoot.vue\'"\n')
+check("EVIDENCE: an import quoted inside a string is not an import",
+      len(f) == 0, repr(f))
+
+f = run(
+    'const t = "routes.push({path:\'/settings\', component: AdminRoot})"\n'
+    "const routes = [{ path: '/settings', component: AdminRoot }]\n"
+)
+check("CONTROL: the real route SURVIVES beside that prose",
+      any(":2:" in line for line in f), repr(f))
+check("EVIDENCE: and it is the ONLY finding — the prose line is gone",
+      len(f) == 1, repr(f))
+
+f = run(
+    "const routes = [{ path: '/settings', redirect: '/x' }]\n"
+)
+check("CONTROL: the anti-widening redirect exemption still holds",
+      len(f) == 0, repr(f))
+
+# A `}` inside a literal is not a block delimiter, so it must not truncate the
+# route object the anti-widening guard is read out of. Separate mutation:
+# point `_enclosing_object` back at the string-preserving mask and this goes
+# red while the arms above stay green.
+f = run(
+    "const routes = [{ path: '/settings', title: 'a } b', component: AdminRoot }]\n"
+)
+check("EVIDENCE (brace walk): a `}` inside a literal does not truncate the object",
+      len(f) == 1, repr(f))
+
 # --- MUTATION CHECK: the anti-widening guard must be load-bearing -----------
 # If `_LEAVES_RX` stopped exempting hand-offs, the openconnector fixture would
 # be reported. Assert the guard is present in the source BEFORE claiming the

--- a/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
+++ b/hydra-gates/scripts/lib/test_check_apphost_autoload_prelude.py
@@ -305,6 +305,97 @@ class Application {
         )
 
 
+class StringLiteralsAreNotCodeTest(GateCase):
+    """#424 — a SENTENCE quoting the prelude is not the prelude.
+
+    The comment axis below was closed in #184 and the literal axis was not, so
+    the same false GREEN survived one quote character away — and this is the
+    dangerous direction: a developer documenting what the code is SUPPOSED to
+    do switched the ADR-040 rule off.
+
+    Mutation-checked by calling `has_prelude`/`has_load_app` with no anchor —
+    the pre-#424 behaviour:
+
+      EVIDENCE (red under the mutation)
+        test_a_prelude_quoted_inside_a_string_is_not_a_prelude
+        test_a_const_declared_inside_a_string_does_not_supply_the_app_id
+        test_a_quoted_loadApp_does_not_add_the_wrong_fix_line
+
+      CONTROL (green both ways — the app id and the FQCN really ARE string
+      literals, and a fix that blanked them would break the gate the other way)
+        test_the_real_prelude_still_closes_the_gate
+        test_the_real_const_prelude_still_closes_the_gate
+    """
+
+    BODY = """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    public function register($context): void {
+%s
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+"""
+
+    def test_a_prelude_quoted_inside_a_string_is_not_a_prelude(self):
+        """EVIDENCE. Measured green (rc=0) on main — the gate reported OK for
+        an app with no prelude at all."""
+        self.app("Application.php", self.BODY % (
+            '        $hint = "we call '
+            "\\\\OC_App::registerAutoloading('openregister', $p) before this\";"
+        ))
+        self.assertEqual(
+            _run(self.dir)[0], 1,
+            "a prelude that does not RUN is not a prelude, in quotes as in comments",
+        )
+
+    def test_the_real_prelude_still_closes_the_gate(self):
+        """CONTROL. The app id IS a string literal — the fix must read it."""
+        self.app("Application.php", self.BODY % (
+            "        \\OC_App::registerAutoloading('openregister', $p);"
+        ))
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_a_const_declared_inside_a_string_does_not_supply_the_app_id(self):
+        self.app("Application.php", self.BODY % (
+            '        $doc = "private const OR = \'openregister\';";\n'
+            "        \\OC_App::registerAutoloading(self::OR, $p);"
+        ))
+        self.assertEqual(
+            _run(self.dir)[0], 1,
+            "a constant declared in prose does not resolve",
+        )
+
+    def test_the_real_const_prelude_still_closes_the_gate(self):
+        """CONTROL for the arm above — the #276 constant form must survive."""
+        self.app("Application.php", """<?php
+namespace OCA\\Leaf\\AppInfo;
+use OCA\\OpenRegister\\AppHost\\Bootstrap;
+class Application {
+    private const OPENREGISTER_APP_ID = 'openregister';
+    public function register($context): void {
+        \\OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $p);
+        if (class_exists(Bootstrap::class) === true) {
+            Bootstrap::register($context, 'leaf', []);
+        }
+    }
+}
+""")
+        self.assertEqual(_run(self.dir)[0], 0)
+
+    def test_a_quoted_loadApp_does_not_add_the_wrong_fix_line(self):
+        self.app("Application.php", self.BODY % (
+            '        $why = "we do not call loadApp(\'openregister\') here";'
+        ))
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 1)
+        self.assertNotIn("bootApp()", out,
+                         "a sentence about loadApp is not a call to it")
+
+
 class CommentsAreNotCodeTest(GateCase):
     """Every rule is evidence about code, so comments must not feed it."""
 

--- a/hydra-gates/scripts/lib/test_check_initial_state.py
+++ b/hydra-gates/scripts/lib/test_check_initial_state.py
@@ -94,6 +94,36 @@ check(
     repr(f),
 )
 
+# --- #424: a STRING LITERAL is not an expression -----------------------------
+# The comment axis was closed when this gate moved onto js_comment_mask, and
+# the literal axis was not. Mutation-checked by dropping the `starts_in_code`
+# guard in scan_file: the first two arms go red, the rest are CONTROLS — the
+# attribute name really does live inside a literal, and a fix that blanked
+# string contents would delete the evidence and kill the gate.
+f = run('const doc = "document.getElementById(\'fx-settings\').dataset.version"\n')
+check("EVIDENCE: a DOM read quoted inside a string is not a DOM read",
+      len(f) == 0, repr(f))
+
+f = run('const doc = "el.getAttribute(\'data-version\') is what we replaced"\n'
+        "const el = document.getElementById('fx-settings')\n")
+check("EVIDENCE: a two-step read quoted inside a string is not one",
+      len(f) == 0, repr(f))
+
+f = run('const doc = "document.getElementById(\'fx\').dataset.version"\n'
+        "export const v = document.getElementById('fx').dataset.version\n")
+check("CONTROL: the real read SURVIVES beside that prose",
+      any(":2:" in line for line in f), repr(f))
+check("EVIDENCE: and it is the ONLY finding — the prose line is gone",
+      len(f) == 1, repr(f))
+
+f = run("export const v = document.getElementById('d').getAttribute('data-version')\n")
+check("CONTROL: the attribute name is still read OUT of its literal",
+      len(f) == 1, repr(f))
+
+f = run("export const v = document.getElementById('d').getAttribute('data-requesttoken')\n")
+check("CONTROL: the data-requesttoken exemption still reads that literal",
+      len(f) == 0, repr(f))
+
 # --- MUTATION CHECK ---------------------------------------------------------
 _SRC = open(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "check_initial_state.py")

--- a/hydra-gates/scripts/lib/test_check_manifest_crossref.js
+++ b/hydra-gates/scripts/lib/test_check_manifest_crossref.js
@@ -304,6 +304,18 @@ function parseReport(stdout) {
 			"a double-quoted hyphenated key resolves too — \"agent-skills\"")
 		assert(!msgs.includes("'LegacyOnlyPanel'"),
 			'a component registered ONLY in src/customComponents.js resolves — the second source (9 false FAILs on softwarecatalog)')
+		// #424. `glob: '/*.vue'` opened a block comment in the private
+		// stripper, and everything up to the next real `*/` was deleted from
+		// the registry. Measured on THIS fixture by swapping js_scope back to
+		// the two-line regex: `AfterGlob` disappeared and the error count
+		// below went 1 -> 2.
+		//   CONTROL  — the entry carrying the glob is BEFORE the phantom
+		//              opener, so it resolved either way.
+		assert(!msgs.includes("'GlobPage'"),
+			"a registry entry carrying `glob: '/*.vue'` still resolves (#424)")
+		//   EVIDENCE — the entry after it did not.
+		assert(!msgs.includes("'AfterGlob'"),
+			'the entry AFTER that glob is not swallowed by a comment that never opened (#424)')
 		assert(errs.length === 1 && errs[0].message.includes("'NotAnywherePanel'"),
 			`THE CONTROL: a component in NEITHER file still FAILS (got ${errs.length} error(s))`)
 		assert(check.status === 1,

--- a/hydra-gates/scripts/lib/test_check_notification_dialect.py
+++ b/hydra-gates/scripts/lib/test_check_notification_dialect.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+# SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+"""Tests for check_notification_dialect (gate-18).
+
+WHY THIS FILE DID NOT EXIST UNTIL #424
+--------------------------------------
+Gate-18 shipped with no helper suite. Its only coverage was the acceptance
+bundle under scripts/test-fixtures/gate-acceptance/register-dialect/, whose
+expect.conf pins exactly two rows — one per code path — so three of the four
+substring tokens and the whole prose axis were unexercised.
+
+WHAT WRITING IT FOUND
+---------------------
+The four substring tokens were matched against `json.dumps(rule)`: keys,
+machine values and human documentation flattened into one haystack. A rule
+whose own `description` WARNED AGAINST the legacy dialect was therefore
+reported as the legacy dialect, twice over — the "the better the docs, the
+redder the repo" shape recorded for gate-58 in source_scope's header.
+
+Every arm below is labelled EVIDENCE or CONTROL by MEASUREMENT, against the
+pre-#424 implementation restored as `_blob_scan` at the bottom of this file:
+
+  EVIDENCE (red on the pre-#424 scan)
+    test_a_description_warning_against_the_dialect_is_not_the_dialect
+    test_a_subject_template_mentioning_at_self_is_not_a_recipient
+  CONTROL (green both ways — they prove the fix kept the gate able to fail)
+    every arm in LegacyDialectStillDetectedTest
+
+Run: python3 scripts/lib/test_check_notification_dialect.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_notification_dialect as gate  # noqa: E402
+
+
+def _register(rule: dict) -> dict:
+    return {
+        "components": {
+            "schemas": {
+                "Thing": {
+                    "type": "object",
+                    "x-openregister-notifications": {"onIntakeClosed": rule},
+                }
+            }
+        }
+    }
+
+
+def _scan(rule: dict) -> list[str]:
+    fd, path = tempfile.mkstemp(suffix=".register.json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(_register(rule), fh)
+        return [line.split("token=", 1)[1] for line in gate.scan_file(path)]
+    finally:
+        os.unlink(path)
+
+
+CANONICAL = {
+    "trigger": {"type": "lifecycle", "state": "closed"},
+    "channels": ["mail"],
+    "recipients": ["owner"],
+    "subject": {"en": "Intake closed"},
+}
+
+
+class LegacyDialectStillDetectedTest(unittest.TestCase):
+    """CONTROL. The gate must be able to fail before anything else counts."""
+
+    def test_a_clean_canonical_rule_is_clean(self):
+        self.assertEqual(_scan(dict(CANONICAL)), [])
+
+    def test_legacy_trigger_key_is_reported(self):
+        rule = dict(CANONICAL, trigger={"lifecycleEnter": "closed"})
+        self.assertIn("lifecycleEnter", _scan(rule))
+
+    def test_legacy_side_channel_flag_is_reported(self):
+        self.assertIn("alsoDispatchLifecycle",
+                      _scan(dict(CANONICAL, alsoDispatchLifecycle=True)))
+
+    def test_legacy_dedupe_field_is_reported(self):
+        self.assertIn("idempotencyKey",
+                      _scan(dict(CANONICAL, idempotencyKey="a-b-c")))
+
+    def test_legacy_self_recipient_VALUE_is_reported(self):
+        rule = dict(CANONICAL, recipients=["@self.owner"])
+        self.assertIn("@self.", _scan(rule))
+
+    def test_singular_channel_is_reported(self):
+        rule = {k: v for k, v in CANONICAL.items() if k != "channels"}
+        rule["channel"] = "mail"
+        self.assertIn("channel", _scan(rule))
+
+    def test_singular_recipient_is_reported(self):
+        rule = {k: v for k, v in CANONICAL.items() if k != "recipients"}
+        rule["recipient"] = "owner"
+        self.assertIn("recipient", _scan(rule))
+
+    def test_legacy_calculated_trigger_key_is_reported(self):
+        rule = dict(CANONICAL, trigger={"calculated": "score"})
+        self.assertIn("trigger.calculated", _scan(rule))
+
+
+class ProseIsNotDialectTest(unittest.TestCase):
+    """#424 — documentation ABOUT the dialect is not the dialect."""
+
+    def test_a_description_warning_against_the_dialect_is_not_the_dialect(self):
+        """EVIDENCE."""
+        rule = dict(
+            CANONICAL,
+            description=(
+                "Canonical dialect. Do NOT use the legacy lifecycleEnter "
+                "trigger or alsoDispatchLifecycle; both were removed in "
+                "ADR-031, and idempotencyKey with them."
+            ),
+        )
+        self.assertEqual(_scan(rule), [])
+
+    def test_a_subject_template_mentioning_at_self_is_not_a_recipient(self):
+        """EVIDENCE. `subject` is the CANONICAL per-locale message map."""
+        rule = dict(CANONICAL, subject={"en": "Closed — see @self.owner below"})
+        self.assertEqual(_scan(rule), [])
+
+    def test_documented_AND_defective_is_still_reported(self):
+        """CONTROL, and the one that matters: excusing prose must not excuse
+        the rule the prose sits on."""
+        rule = dict(
+            CANONICAL,
+            description="We must stop using lifecycleEnter.",
+            trigger={"lifecycleEnter": "closed"},
+        )
+        self.assertIn("lifecycleEnter", _scan(rule))
+
+
+class MutationTest(unittest.TestCase):
+    """The pre-#424 scan, restored, so the labels above are measured rather
+    than asserted. If this ever agrees with the current one, the EVIDENCE arms
+    are inert and this suite proves nothing."""
+
+    _SUBSTRING_TOKENS = (
+        "lifecycleEnter", "alsoDispatchLifecycle", "idempotencyKey", "@self.",
+    )
+
+    def _blob_scan(self, rule: dict) -> list[str]:
+        blob = json.dumps(rule)
+        return [t for t in self._SUBSTRING_TOKENS if t in blob]
+
+    def test_the_old_blob_scan_fails_the_description_fixture(self):
+        rule = dict(
+            CANONICAL,
+            description=(
+                "Canonical dialect. Do NOT use the legacy lifecycleEnter "
+                "trigger or alsoDispatchLifecycle; both were removed in "
+                "ADR-031, and idempotencyKey with them."
+            ),
+        )
+        self.assertEqual(
+            self._blob_scan(rule),
+            ["lifecycleEnter", "alsoDispatchLifecycle", "idempotencyKey"],
+        )
+        self.assertEqual(_scan(rule), [])
+
+    def test_the_old_blob_scan_fails_the_subject_fixture(self):
+        rule = dict(CANONICAL, subject={"en": "Closed — see @self.owner below"})
+        self.assertEqual(self._blob_scan(rule), ["@self."])
+        self.assertEqual(_scan(rule), [])
+
+    def test_the_two_scans_AGREE_on_every_real_defect(self):
+        """If they agreed everywhere the fix would be a no-op; if they
+        disagreed everywhere it would be a deletion. They must differ on prose
+        and agree on defects."""
+        for rule in (
+            dict(CANONICAL, trigger={"lifecycleEnter": "closed"}),
+            dict(CANONICAL, alsoDispatchLifecycle=True),
+            dict(CANONICAL, idempotencyKey="a-b-c"),
+            dict(CANONICAL, recipients=["@self.owner"]),
+        ):
+            old = set(self._blob_scan(rule))
+            new = set(_scan(rule))
+            self.assertTrue(old and old.issubset(new), (old, new))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hydra-gates/scripts/lib/test_check_unclosable_gate.py
+++ b/hydra-gates/scripts/lib/test_check_unclosable_gate.py
@@ -183,7 +183,10 @@ class CommentIsNotAWriteTest(GateCase):
             + "\n        // TODO: " + WRITE % ("'leaf'", f"'{KEY}'"),
         )
         try:
-            gate.php_mask = lambda text: text  # the pre-fix behaviour
+            # The pre-fix behaviour. `**_kw` swallows `blank_strings=`, which
+            # scan_app now passes for the CALL-SITE anchor (#424) — the mutant
+            # must disable BOTH masks, or it would only half-mutate.
+            gate.php_mask = lambda text, **_kw: text
             rc, _ = _run(self.dir)
             self.assertEqual(
                 rc, 0,
@@ -289,6 +292,59 @@ class SuppressionTest(GateCase):
             "        " + READ % ("'leaf'", f"'{KEY}'"),
         )
         self.assertFinding("a suppression is per-key, not per-file")
+
+
+class StringLiteralIsNotAWriteTest(GateCase):
+    """#424 — a SENTENCE about a setter is not a setter.
+
+    The comment axis above was fixed in #276 and the literal axis was not, so
+    the same false GREEN survived one quote character away.
+
+    Mutation-checked: point the call-site anchor back at `php_mask(text)`
+    (string contents kept) and three of the four arms below go red. The fourth
+    — `test_the_real_write_beside_that_sentence_still_closes_it` — is green
+    both ways and is therefore the CONTROL: it proves the fix did not blank
+    the key literal this gate reads its evidence out of.
+    """
+
+    SENTENCE = (
+        '$hint = "call ' + (WRITE % ("'leaf'", f"'{KEY}'")).replace('"', "'")
+        + ' next";'
+    )
+
+    def test_a_setter_quoted_inside_a_string_does_not_close_the_gate(self):
+        """EVIDENCE: red before #424, green after."""
+        _app(self.dir, READ % ("'leaf'", f"'{KEY}'") + "\n        " + self.SENTENCE)
+        self.assertFinding("a string literal is prose, not a write")
+
+    def test_the_real_write_beside_that_sentence_still_closes_it(self):
+        """The PAIRED true positive — the fix must not blank the KEY, which
+        this gate reads out of a string literal on purpose."""
+        _app(
+            self.dir,
+            READ % ("'leaf'", f"'{KEY}'")
+            + "\n        " + self.SENTENCE
+            + "\n        " + WRITE % ("'leaf'", f"'{KEY}'"),
+        )
+        self.assertClean("the key must still be read out of the real call's literal")
+
+    def test_a_read_quoted_inside_a_string_is_not_a_read_either(self):
+        """EVIDENCE, the other direction: prose must not CREATE a finding.
+        Measured red before #424 — the pre-fix gate read the sentence as a
+        real read, found no write, and reported an unclosable gate that the
+        app has no code to close."""
+        _app(self.dir, '$hint = "we call ' + (READ % ("'leaf'", f"'{KEY}'")).replace('"', "'") + ' here";')
+        self.assertClean()
+
+    def test_a_const_declared_inside_a_string_is_not_a_declaration(self):
+        _app(
+            self.dir,
+            READ % ("'leaf'", "self::CONFIG_KEY")
+            + "\n        $doc = \"private const CONFIG_KEY = '" + KEY + "';\";",
+        )
+        rc, out = _run(self.dir)
+        self.assertEqual(rc, 0, out)
+        self.assertNotIn(KEY, out, "an unresolvable constant must not resolve via prose")
 
 
 class NoSubjectTest(GateCase):

--- a/hydra-gates/scripts/lib/test_check_unsafe_auth_resolver.py
+++ b/hydra-gates/scripts/lib/test_check_unsafe_auth_resolver.py
@@ -196,6 +196,70 @@ class S {
 f = run(NESTED)
 check("a fail-open NESTED inside an if is reported", len(f) == 1, repr(f))
 
+# --- #424: a STRING LITERAL is not code either ------------------------------
+# The comment axis was fixed in #184 and the literal axis was not, so the same
+# false positive survived one quote character away.
+#
+# Mutation-checked by pointing scan_file's mask back at `php_mask(src)`:
+#   EVIDENCE (red under the mutation)
+#     "a quoted DESCRIPTION of the anti-pattern is not the anti-pattern"
+#     "an unbalanced brace inside a literal does not move a method boundary"
+#   CONTROL (green both ways — it proves the fix did not simply stop the gate)
+#     "the REAL fail-open beside that prose is still reported"
+QUOTED_ANTIPATTERN = """<?php
+class DemoService {
+    /** A resolver that correctly RETHROWS. */
+    public function getAuthorizationService(): ?IAuth {
+        $doc = 'catch (\\Throwable $e) { return null; }';
+        try {
+            return $this->container->get(IAuth::class);
+        } catch (\\Throwable $e) {
+            throw new ServiceUnavailable($e->getMessage());
+        }
+    }
+}
+"""
+f = run(QUOTED_ANTIPATTERN)
+check("a quoted DESCRIPTION of the anti-pattern is not the anti-pattern",
+      len(f) == 0, repr(f))
+
+# The paired true positive, in the same file as the prose, so a fix that
+# blanked the whole method would be caught here rather than looking green.
+QUOTED_PLUS_REAL = """<?php
+class DemoService {
+    public function getAuthorizationService(): ?IAuth {
+        $doc = 'catch (\\Throwable $e) { return null; }';
+        try {
+            return $this->container->get(IAuth::class);
+        } catch (\\Throwable $e) {
+            return null;
+        }
+    }
+}
+"""
+f = run(QUOTED_PLUS_REAL)
+check("the REAL fail-open beside that prose is still reported",
+      len(f) == 1, repr(f))
+
+# A `{` or `}` inside a literal is not a block delimiter. Before #424 the brace
+# walker counted them, so an unbalanced brace in prose shifted every method
+# boundary after it.
+UNBALANCED_BRACE_IN_STRING = """<?php
+class DemoService {
+    public function getRoleGuard(): ?IAuth {
+        $sql = 'SELECT json_extract(x, \\'$.a{\\') FROM t';
+        return $this->guard;
+    }
+    public function getCachedLabel(): ?string {
+        try { return $this->cache->get('k'); }
+        catch (\\Throwable $e) { return null; }
+    }
+}
+"""
+f = run(UNBALANCED_BRACE_IN_STRING)
+check("an unbalanced brace inside a literal does not move a method boundary",
+      len(f) == 0, repr(f))
+
 # --- MUTATION CHECK ---------------------------------------------------------
 _SRC = open(
     os.path.join(

--- a/hydra-gates/scripts/lib/test_js_scope.js
+++ b/hydra-gates/scripts/lib/test_js_scope.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+//
+// Tests for js_scope.jsCommentMask — the node port of
+// source_scope.js_comment_mask (#424).
+//
+// TWO KINDS OF ASSERTION HERE, AND THE SECOND IS THE IMPORTANT ONE
+// ----------------------------------------------------------------
+// 1. BEHAVIOUR: the shapes gate-53 got wrong, each paired with the true
+//    positive it must not swallow.
+// 2. DRIFT: the mask is asserted BYTE-IDENTICAL to the Python original over a
+//    corpus, by shelling out to `source_scope.py --mask js-comments -`. Two
+//    copies of one rule is what #424 is about; the only honest way to ship a
+//    second one is to prove it equal. Mutation-checked: change one branch of
+//    either copy and TestDrift goes red.
+//
+// Run: node scripts/lib/test_js_scope.js   (exit 0 = green)
+
+'use strict'
+
+const { execFileSync } = require('child_process')
+const path = require('path')
+const { jsCommentMask } = require('./js_scope.js')
+
+let failed = 0
+function check(name, cond, detail) {
+	if (cond) {
+		console.log(`PASS — ${name}`)
+	} else {
+		console.log(`FAIL — ${name}${detail ? ': ' + detail : ''}`)
+		failed++
+	}
+}
+
+// --- the #424 shape ---------------------------------------------------------
+const GLOB = `export default {
+	Reports: { kind: 'page', component: Reports, glob: '/*.vue' },
+	Settings: { /* the admin page */ kind: 'page', component: Settings },
+}
+`
+const masked = jsCommentMask(GLOB)
+check('EVIDENCE: `/*` inside a string does not open a block comment',
+	masked.includes('Settings: {'), JSON.stringify(masked))
+check('CONTROL: the real block comment beside it IS blanked',
+	!masked.includes('the admin page'), JSON.stringify(masked))
+check('CONTROL: the quoted registry key survives — it is the evidence',
+	masked.includes("kind: 'page'"), JSON.stringify(masked))
+
+check('EVIDENCE: `//` inside a URL string opens nothing',
+	jsCommentMask("const u = 'https://x/y'\nconst k = 1\n").includes('const k = 1'))
+check('CONTROL: a real line comment is blanked',
+	!jsCommentMask("const u = 1 // note here\n").includes('note here'))
+check('CONTROL: `:` before `//` no longer needs a special case',
+	jsCommentMask("const o = { u: 'https://x' }\n").includes("'https://x'"))
+
+// The offset contract every caller depends on.
+for (const src of [GLOB, "a // b\nc\n", "const r = /a\\/b/g\nlet z = 1\n", '`t${1}`\n']) {
+	const out = jsCommentMask(src)
+	check('offsets survive: same length and same line count',
+		out.length === src.length && out.split('\n').length === src.split('\n').length,
+		JSON.stringify(src))
+}
+
+// --- DRIFT: identical to the Python original over a corpus -------------------
+const PY = path.join(__dirname, 'source_scope.py')
+
+function pythonMask(src) {
+	return execFileSync('python3', [PY, '--mask', 'js-comments', '-'], {
+		input: src,
+		encoding: 'utf8',
+	})
+}
+
+const CORPUS = [
+	GLOB,
+	"const u = 'https://x/y' // trailing\n",
+	"/* block\n   spanning */\nlet q = `t${1 + 2}`\n",
+	"const r = /[a-z]\\/+/g\nreturn 1 / 2\n",
+	"const s = \"it's fine\" // apostrophe in a string\n",
+	"const t = 'unterminated\nconst u = 2 // still a comment\n",
+	"export default {\n\t'agent-form': { kind: 'section' },\n\tSettings,\n}\n",
+	"function f() { return /x/.test('a') }\n",
+	"const n = a /b/ c\n",
+	"`outer ${ `inner ${ 'deep' }` } end` // done\n",
+]
+
+let compared = 0
+for (const src of CORPUS) {
+	const js = jsCommentMask(src)
+	const py = pythonMask(src)
+	check('drift: js_scope agrees with source_scope.js_comment_mask',
+		js === py, `\n  js: ${JSON.stringify(js)}\n  py: ${JSON.stringify(py)}`)
+	compared++
+}
+
+// This package's own .js sources, so the corpus cannot quietly become trivial.
+const fs = require('fs')
+for (const name of fs.readdirSync(__dirname).sort()) {
+	if (!name.endsWith('.js')) continue
+	const src = fs.readFileSync(path.join(__dirname, name), 'utf8')
+	const js = jsCommentMask(src)
+	const py = pythonMask(src)
+	check(`drift over this package's own source: ${name}`, js === py)
+	compared++
+}
+check('the drift test actually compared something', compared > 5, String(compared))
+
+console.log()
+if (failed) {
+	console.log(`FAILED: ${failed}`)
+	process.exit(1)
+}
+console.log('ALL js_scope assertions passed')

--- a/hydra-gates/scripts/lib/test_source_scope.py
+++ b/hydra-gates/scripts/lib/test_source_scope.py
@@ -577,6 +577,42 @@ class TestHtmlCommentDelimiterScope(unittest.TestCase):
         self.assertIn("window.confirm", ss.script_mask(src, "f.vue"))
 
 
+class TestStartsInCode(unittest.TestCase):
+    """The anchoring predicate gates 10 and 11 read (#424)."""
+
+    JS = "const doc = \"document.getElementById('x').dataset.v\"\n" \
+         "const v = document.getElementById('x').dataset.v\n"
+
+    def setUp(self):
+        self.anchor = ss.js_code_mask(self.JS)
+        self.evidence = ss.js_comment_mask(self.JS)
+
+    def test_the_two_masks_stay_aligned(self):
+        self.assertEqual(len(self.anchor), len(self.evidence))
+
+    def test_a_token_inside_a_literal_is_not_code(self):
+        i = self.JS.index("document")           # the one in quotes
+        self.assertFalse(ss.starts_in_code(self.anchor, self.evidence, i))
+
+    def test_the_same_token_outside_a_literal_is_code(self):
+        i = self.JS.index("document", self.JS.index("\n"))
+        self.assertTrue(ss.starts_in_code(self.anchor, self.evidence, i))
+
+    def test_php_masks_align_too(self):
+        src = "<?php\n$doc = 'return null;';\nreturn null;\n"
+        a = ss.php_mask(src, blank_strings=True)
+        e = ss.php_mask(src)
+        self.assertEqual(len(a), len(e))
+        self.assertFalse(ss.starts_in_code(a, e, src.index("return")))
+        self.assertTrue(ss.starts_in_code(a, e, src.rindex("return")))
+
+    def test_an_out_of_range_offset_is_not_code(self):
+        """It must not raise: a caller with a stale offset gets a False, and
+        False can only ever UNDER-report."""
+        self.assertFalse(ss.starts_in_code("a", "a", 99))
+        self.assertFalse(ss.starts_in_code("a", "a", -1))
+
+
 class TestCli(unittest.TestCase):
     """The bash gates call this module as a process; a broken CLI is a dead
     gate, so it is exercised the way they call it."""

--- a/hydra-gates/scripts/lib/test_source_scope.py
+++ b/hydra-gates/scripts/lib/test_source_scope.py
@@ -460,6 +460,123 @@ class TestSharedWithGate19(unittest.TestCase):
         self.assertGreater(seen, 0, "no .js sources found — this test measured nothing")
 
 
+class TestHtmlCommentDelimiterScope(unittest.TestCase):
+    """#424 group 2 — `<!--` is only a comment opener where it can BE one.
+
+    Every relaxation below is paired with the true positive it must not
+    swallow, and the whole class is mutation-checked against the regex it
+    replaces: `_HTML_COMMENT` is still in the module, and
+    `test_the_old_regex_still_fails_this` asserts it disagrees. Flip
+    `html_comment_spans` back to the regex and five arms below go red.
+
+    WHICH ARM IS EVIDENCE AND WHICH IS A CONTROL, measured by running this
+    class against `html_comment_spans = _HTML_COMMENT.finditer`:
+
+      EVIDENCE (red under the mutation, green after the fix)
+        test_interpolated_delimiter_does_not_blank_the_markup_between
+        test_delimiter_in_a_quoted_attribute_value_opens_nothing
+        test_a_string_in_a_script_body_is_script_data_not_a_comment_opener
+        test_script_mask_keeps_a_call_between_two_delimiter_strings
+        test_an_unterminated_comment_still_runs_to_end_of_file
+
+      CONTROL (green BOTH ways — they prove the fix did not over-relax, and
+      they are not evidence that it did anything)
+        test_a_real_comment_is_still_blanked
+        test_a_real_comment_after_an_interpolation_is_still_blanked
+        test_a_real_comment_after_a_tag_with_a_quoted_gt_is_still_blanked
+        test_quotes_in_a_TEXT_node_do_not_protect_the_opener
+        test_a_js_comment_in_that_script_body_is_still_blanked
+        test_an_unterminated_interpolation_does_not_swallow_the_file
+        test_an_unterminated_quote_does_not_swallow_the_file
+        test_offsets_survive_the_scanner
+    """
+
+    # The exact shape measured on main, from the issue.
+    HOLE = (
+        "<p>{{ '<!--' }}</p>\n"
+        '<img alt="" src="/a/avatarUrl.png">\n'
+        "<p>{{ '-->' }}</p>"
+    )
+
+    def test_interpolated_delimiter_does_not_blank_the_markup_between(self):
+        out = ss.markup_mask(self.HOLE, "f.html")
+        self.assertIn('<img alt="" src="/a/avatarUrl.png">', out)
+
+    def test_the_old_regex_still_fails_this(self):
+        """The MUTATION CONTROL. If this ever passes, the arm above is inert."""
+        old = ss._HTML_COMMENT.sub("", self.HOLE)
+        self.assertNotIn("<img", old)
+
+    def test_delimiter_in_a_quoted_attribute_value_opens_nothing(self):
+        src = '<img alt="<!--" src="/a/avatarUrl.png">\n<img alt="" src="/b/-->.png">'
+        out = ss.markup_mask(src, "f.html")
+        self.assertEqual(out, src)
+
+    def test_a_real_comment_is_still_blanked(self):
+        """The paired true positive: relaxing the opener must not stop the
+        gate seeing a commented-out element as commented out."""
+        src = '<!-- <img src="/a/old.png"> -->\n<p>x</p>\n'
+        out = ss.markup_mask(src, "f.html")
+        self.assertNotIn("<img", out)
+        self.assertIn("<p>x</p>", out)
+
+    def test_a_real_comment_after_an_interpolation_is_still_blanked(self):
+        src = '<p>{{ label }}</p>\n<!-- <img src="/a/old.png"> -->\n'
+        self.assertNotIn("<img", ss.markup_mask(src, "f.html"))
+
+    def test_a_real_comment_after_a_tag_with_a_quoted_gt_is_still_blanked(self):
+        src = ('<NcSelect :reduce="option => option.value" />\n'
+               '<!-- <img src="/a/old.png"> -->\n')
+        self.assertNotIn("<img", ss.markup_mask(src, "f.html"))
+
+    def test_quotes_in_a_TEXT_node_do_not_protect_the_opener(self):
+        """A browser has no string literals in text: this really is a comment,
+        and pretending otherwise would be the over-relaxed direction."""
+        src = "<p>'<!--' <img src=\"/a/x.png\"> '-->'</p>"
+        self.assertNotIn("<img", ss.markup_mask(src, "f.html"))
+
+    def test_a_string_in_a_script_body_is_script_data_not_a_comment_opener(self):
+        # The two delimiter strings sit in DIFFERENT script bodies with live
+        # markup between them, so the old regex really does blank the <img>.
+        src = ('<script>\nconst OPEN = "<!--"\n</script>\n'
+               '<img alt="" src="/a/avatarUrl.png">\n'
+               '<script>\nconst CLOSE = "-->"\n</script>\n')
+        self.assertIn('<img alt="" src="/a/avatarUrl.png">',
+                      ss.html_markup_mask(src))
+
+    def test_a_js_comment_in_that_script_body_is_still_blanked(self):
+        """Paired: the script body is handed to the tokeniser that knows JS."""
+        src = '<script>\n// <img src="/a/old.png">\n</script>\n'
+        self.assertNotIn("<img", ss.html_markup_mask(src))
+
+    def test_an_unterminated_interpolation_does_not_swallow_the_file(self):
+        src = '<p>{{ oops</p>\n<!-- <img src="/a/old.png"> -->\n<p>y</p>\n'
+        out = ss.markup_mask(src, "f.html")
+        self.assertNotIn("<img", out)      # the real comment still went
+        self.assertIn("<p>y</p>", out)     # and nothing after it was eaten
+
+    def test_an_unterminated_quote_does_not_swallow_the_file(self):
+        src = '<p title="oops>\n<!-- <img src="/a/old.png"> -->\n<p>y</p>\n'
+        self.assertIn("<p>y</p>", ss.markup_mask(src, "f.html"))
+
+    def test_an_unterminated_comment_still_runs_to_end_of_file(self):
+        src = '<p>a</p>\n<!-- <img src="/a/old.png">\n'
+        self.assertNotIn("<img", ss.markup_mask(src, "f.html"))
+
+    def test_offsets_survive_the_scanner(self):
+        for src in (self.HOLE, '<!-- c -->\n<p>x</p>\n', '<script>"<!--"</script>\n'):
+            out = ss.mask_html_comments(src)
+            self.assertEqual(len(out), len(src))
+            self.assertEqual(out.count("\n"), src.count("\n"))
+
+    def test_script_mask_keeps_a_call_between_two_delimiter_strings(self):
+        """gate-34/58 read `script_mask`; the same hole was armed there."""
+        src = ("<template>\n  <p>{{ '<!--' }}</p>\n"
+               "  <button @click=\"window.confirm('sure?')\">go</button>\n"
+               "  <p>{{ '-->' }}</p>\n</template>\n")
+        self.assertIn("window.confirm", ss.script_mask(src, "f.vue"))
+
+
 class TestCli(unittest.TestCase):
     """The bash gates call this module as a process; a broken CLI is a dead
     gate, so it is exercised the way they call it."""

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -2980,20 +2980,36 @@ if [ -d src ]; then
         # kept and the status is read, so a broken interpreter reports `wiring`
         # rather than leaving an empty log this gate would call clean.
         set +e
-        python3 - "${vue}" <<'PYMI' >> "${_mi_log}" 2>>"${_mi_log}.err"
+        python3 - "${SCRIPT_DIR}/lib" "${vue}" <<'PYMI' >> "${_mi_log}" 2>>"${_mi_log}.err"
 import re, sys
-fname = sys.argv[1]
+sys.path.insert(0, sys.argv[1])
+from source_scope import vue_markup_mask     # a missing lib is a CRASH, not a pass
+fname = sys.argv[2]
 try:
     src = open(fname, encoding='utf-8', errors='replace').read()
 except Exception:
     sys.exit(0)
 
-# HTML comments in the template, block and line comments in <script>.
-# `(?<![:\w])` keeps the `//` of a `https://` URL from blanking the rest of
-# the line — the same trap gate-45 hit on `url(https://…)`.
-src = re.sub(r'<!--.*?-->', lambda m: re.sub(r'[^\n]', ' ', m.group(0)), src, flags=re.DOTALL)
-src = re.sub(r'/\*.*?\*/', lambda m: re.sub(r'[^\n]', ' ', m.group(0)), src, flags=re.DOTALL)
-src = re.sub(r'(?<![:\w])//[^\n]*', lambda m: ' ' * len(m.group(0)), src)
+# THE SCOPE IS THE RENDERED TEMPLATE (#424).
+#
+# This block used to blank three comment classes with its own re.sub calls and
+# then search the WHOLE FILE. Two things were wrong with that:
+#
+#   * a fourth private comment dialect, drifting from source_scope — and its
+#     `<!--.*?-->` carried the delimiter hole #424 group 2 is about, so
+#     `{{ '<!--' }}` … `{{ '-->' }}` blanked the template between them.
+#   * no string awareness at all, so
+#         const help = 'use <NcDialog> for confirmations'
+#     in <script> reported `1 file(s) with inline modal/dialog`. The gate that
+#     asks you to extract a modal was closable — and openable — by prose.
+#
+# `vue_markup_mask` answers exactly the question this rule asks: what does the
+# SFC RENDER? <script> and <style> are blanked whole, so a string or a JSDoc
+# there is out of scope by construction rather than by a third regex; HTML
+# comments inside the template go with them. This does not weaken the rule:
+# an INLINE modal is by definition written in the template, so no real finding
+# lives in the regions now excluded.
+src = vue_markup_mask(src)
 
 # The delimiter set, PLUS end-of-line and any other whitespace. A lookahead
 # rather than a consuming class so the boundary is asserted without being
@@ -7803,10 +7819,12 @@ _scfm_rc=0
 if [ "${#_scfm_files[@]}" -gt 0 ]; then
     # A CRASHED CHECKER MUST NOT REPORT PASS (#147 / #249 / #262).
     set +e
-    python3 - "${_scfm_log}" "${_scfm_files[@]}" 2>>"${_scfm_log}.err" << 'PY'
+    python3 - "${SCRIPT_DIR}/lib" "${_scfm_log}" "${_scfm_files[@]}" 2>>"${_scfm_log}.err" << 'PY'
 import re, sys
-log_path = sys.argv[1]
-files = sys.argv[2:]
+sys.path.insert(0, sys.argv[1])
+from source_scope import php_mask           # a missing lib is a CRASH, not a pass
+log_path = sys.argv[2]
+files = sys.argv[3:]
 SEC_KEY = re.compile(
     # FIRST ARGUMENT: THE APP ID, IN ANY FORM.
     #
@@ -7960,51 +7978,24 @@ _ARRAY_VALUE = re.compile(
 # a line number.
 #
 # STRING-SAFE, not a naive split: `'https://x'` must not truncate the line,
-# and `#[PublicPage]` is a PHP 8 attribute, not a comment. Quote state is
-# reset per line, so an unterminated literal (a heredoc body) can corrupt at
-# most its own line rather than the rest of the file.
-def _strip_php_comments(raw_lines):
-    out, in_block = [], False
-    for line in raw_lines:
-        buf, i, n, quote = [], 0, len(line), None
-        while i < n:
-            c = line[i]
-            if in_block:
-                if c == '*' and i + 1 < n and line[i + 1] == '/':
-                    in_block = False
-                    i += 2
-                    continue
-                i += 1
-                continue
-            if quote is not None:
-                buf.append(c)
-                if c == '\\' and i + 1 < n:
-                    buf.append(line[i + 1])
-                    i += 2
-                    continue
-                if c == quote:
-                    quote = None
-                i += 1
-                continue
-            if c in ('"', "'"):
-                quote = c
-                buf.append(c)
-                i += 1
-                continue
-            if c == '/' and i + 1 < n and line[i + 1] == '/':
-                break
-            if c == '/' and i + 1 < n and line[i + 1] == '*':
-                in_block = True
-                i += 2
-                continue
-            if c == '#' and not (i + 1 < n and line[i + 1] == '['):
-                break
-            buf.append(c)
-            i += 1
-        out.append(''.join(buf).rstrip('\n'))
-    return out
-
-
+# and `#[PublicPage]` is a PHP 8 attribute, not a comment.
+#
+# THE FOURTH DIALECT IS GONE (#424 / #420). Both properties above are exactly
+# what `source_scope.php_mask` already guarantees, and #420 shipped a
+# hand-rolled `_strip_php_comments` beside it anyway — a fourth definition of
+# "where does a PHP comment start" next to `php_mask`,
+# `check_apphost_autoload_prelude.strip_comments` and
+# `check_no_admin_idor._strip_strings_and_comments`. Four copies of one rule
+# is four chances to drift, and every gate in this package that drifted did so
+# in BOTH directions at once. The window below wants blanked-not-deleted text
+# anyway, which is php_mask's contract.
+#
+# ONE BEHAVIOURAL DIFFERENCE, STATED: the private copy reset quote state at
+# every newline, so an unterminated literal could corrupt at most its own
+# line. php_mask does not, because a PHP double-quoted string may legally
+# contain a newline and bounding at one would mis-scope real code. Gates 5, 8,
+# 59 and 64 already read this same PHP corpus through php_mask, so gate-50 is
+# now consistent with them rather than uniquely lenient.
 notes_path = log_path + '.notes'
 open(notes_path, 'w', encoding='utf-8').close()
 for fp in files:
@@ -8013,8 +8004,10 @@ for fp in files:
             lines = f.readlines()
     except OSError:
         continue
-    code_lines = _strip_php_comments(lines)
     src = ''.join(lines)
+    # Offsets and line count survive the mask, so `code_lines[n - 1]` is still
+    # line n of the file — which is what the window below indexes with.
+    code_lines = php_mask(src).split('\n')
     for m in SEC_KEY.finditer(src):
         # Find the line number of the match
         lineno = src[:m.start()].count('\n') + 1

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/manifest.json
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/manifest.json
@@ -4,7 +4,9 @@
 	"menu": [
 		{ "id": "af", "label": "Agent form", "icon": "Robot", "route": "AgentForm" },
 		{ "id": "lop", "label": "Legacy", "icon": "History", "route": "LegacyPage" },
-		{ "id": "nap", "label": "Broken", "icon": "Alert", "route": "BrokenPage" }
+		{ "id": "nap", "label": "Broken", "icon": "Alert", "route": "BrokenPage" },
+		{ "id": "gp", "label": "Glob", "icon": "Star", "route": "GlobPage" },
+		{ "id": "ag", "label": "After glob", "icon": "Star", "route": "AfterGlobPage" }
 	],
 	"pages": [
 		{
@@ -48,6 +50,24 @@
 			"title": "Broken",
 			"component": "NotAnywherePanel",
 			"_note": "Registered in NEITHER file — must still FAIL.",
+			"config": {}
+		},
+		{
+			"id": "GlobPage",
+			"route": "GlobPage",
+			"type": "custom",
+			"title": "Glob",
+			"component": "GlobPage",
+			"_note": "Its registry entry carries glob: '/*.vue' — see #424.",
+			"config": {}
+		},
+		{
+			"id": "AfterGlobPage",
+			"route": "AfterGlobPage",
+			"type": "custom",
+			"title": "After glob",
+			"component": "AfterGlob",
+			"_note": "Registered AFTER the glob; the non-string-aware stripper deleted it.",
 			"config": {}
 		}
 	]

--- a/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/registry.js
+++ b/hydra-gates/scripts/test-fixtures/effective-manifest/registry-dialects/src/registry.js
@@ -22,4 +22,12 @@ export default {
 	'agent-form': { kind: 'page', component: AgentForm },
 	"agent-skills": { kind: 'section', component: AgentSkills },
 	PlainSection: { kind: 'section', component: PlainSection },
+	// 3. A `/*` INSIDE A STRING (#424). The private two-line comment stripper
+	//    was not string-aware, so the `/*` of this glob opened a block comment
+	//    that ran to the `*/` two lines below — deleting `AfterGlob` from the
+	//    registry and reporting the manifest page that references it as
+	//    unresolved. No correct change closes that finding except removing the
+	//    glob, which is the "finding no correct change can close" shape.
+	GlobPage: { kind: 'page', component: PlainSection, glob: '/*.vue' },
+	AfterGlob: { /* the admin page */ kind: 'page', component: PlainSection },
 }


### PR DESCRIPTION
Closes #424.

> **Merged with `main@73d496a` and everything re-measured.** `main` moved four
> times under this branch (#434, #436, #435, #437). A finding count is a
> reading of (tree × package) and the package half moved, so every number below
> was taken again against `73d496a`; the earlier `c26f9a3` figures are not
> comparable and are not reported. The `#437` resolution is in §7.

## Order of operations — harden FIRST, consolidate SECOND

The issue is explicit that the obvious consolidation is currently the wrong
move, and the agent who found it said why: *"Routing the six private
`<!--.*?-->` copies into `markup_mask` today would fix their comment half and
leave the delimiter half armed."*

So, in two separate commits, in this order:

1. **`699b14d`** — harden `source_scope`'s comment scope, prove gates 35 and 36
   flip on the issue's fixture, **then** redirect the seven private copies onto
   the hardened one.
2. **`73f1110`** — close the remaining string-literal axis (gates 10, 11, 13,
   18, 50, 53).

Within commit 1 the hardening lands *above* the redirection in the file, so
there is no state in which a checker calls `mask_html_comments` while
`mask_html_comments` still has the hole.

---

## 1. The delimiter hole, reproduced before it was fixed

Measured on `origin/main@c26f9a3`, the issue's fixture verbatim:

```
markup_mask("<p>{{ '<!--' }}</p>\n<img alt=\"\" src=\"/a/avatarUrl.png\">\n<p>{{ '-->' }}</p>")
  -> "<p>{{ '            \n                                   \n          ' }}</p>"
```

Gates 35 and 36 over a `.vue` carrying that shape around a live
`<img alt="">` and a live `tabindex="3"`:

| | pre-fix library | post-fix library |
|---|---|---|
| **gate-35** img-alt-empty-only | **0 findings** — green over live markup | 1 |
| **gate-36** tabindex-positive | **0 findings** | 1 |

`_HTML_COMMENT` is replaced by `html_comment_spans()`, a scanner that knows a
quoted **attribute value**, a Vue **`{{ … }}` interpolation** and a
`<script>`/`<style>` **raw-text body** are not comment scope.

Deliberately **not** relaxed, and stated in the code so the next reader does
not mistake them for holes:

* `<!--` in a **text node** still opens a comment even between quotes — quotes
  carry no meaning in text and `<p>'<!--'</p>` really is a comment to a browser.
* An unterminated `{{`, quote or tag falls back to "this was ordinary text"
  rather than swallowing the file. Over-blanking is the failure mode this
  module exists to remove; `source_scope`'s header already records one instance
  (the `<template>`-nesting bug that dropped a real `<NcSelect>`).

`_HTML_COMMENT` stays in the module **as the mutation control** and nothing
masks with it.

---

## 2. Every arm labelled EVIDENCE or CONTROL, by measurement

I ran each suite a second time against a mutated library. The labels below are
what came back, not what I intended:

| suite | mutation | EVIDENCE (red) | CONTROL (green both ways) |
|---|---|---|---|
| `test_source_scope.py::TestHtmlCommentDelimiterScope` | `html_comment_spans = _HTML_COMMENT.finditer` | **5** | **8** |
| gate-8 `test_check_unsafe_auth_resolver.py` | `php_mask(src)` without `blank_strings` | 2 | 1 |
| gate-59 `test_check_unclosable_gate.py` | anchor keeps string contents | 3 | 1 |
| gate-64 `test_check_apphost_autoload_prelude.py` | `has_prelude`/`has_load_app` with no anchor | 3 | 2 |
| gate-10 `test_check_initial_state.py` | `starts_in_code -> True` | 3 | 2 |
| gate-11 `test_check_admin_router.py` | `starts_in_code -> True` | 3 | 1 |
| gate-11 (second mutation) | brace walk back on the string-preserving mask | 1 | 4 |
| gate-53 `test_check_manifest_crossref.js` | `js_scope` restored to the two-line regex | 2 | rest |
| gate-18 `test_check_notification_dialect.py` | the `json.dumps` blob scan, kept in-file | 2 | 8 |

**Three arms I had labelled CONTROL and had to relabel after measuring** — the
measurement is the point of doing it:

* gate-59 `test_a_read_quoted_inside_a_string_is_not_a_read_either` went red.
  The pre-fix gate read the *sentence* as a real read, found no write, and
  reported an unclosable gate the app has no code to close.
* gates 10/11 "the real finding beside that prose is still reported" — the
  **count** assertion is evidence, only the **survival** assertion is a
  control. Split into two arms so each label matches its measurement.
* gate-53 `'GlobPage'` resolves — a control, not evidence: that entry sits
  *before* the phantom opener and resolved either way.

---

## 3. Fleet before/after — and why a table of zeroes is not the answer

Six repos, shallow at `development`: procest, opencatalogi, openregister,
softwarecatalog, docudesk, larpingapp.

Package half: `73d496a` vs this branch.

**Real-world delta: zero on every gate.** Two rows are non-zero and unchanged —
gate-11 (5/1/1/3/1/2) and gate-7 (27/10/8/1/17/1, which I do not touch).

⚠️ A table where every cell agrees is what a **dead rig** looks like, so:

* **gate-7's 64 findings** across the six repos are the loudest proof the
  harness is reading real trees rather than empty file lists.
* `markup_mask` over procest's 231 real `.vue` files yields **5,294 open tags**
  and is **byte-identical** before and after.
* **gate-50 is alive**: opencatalogi **4 findings**, softwarecatalog **47
  demotion notes**, docudesk **1**, across 753 `(Controller|Service)*.php`
  files, zero stderr on both arms — and unchanged against a base that now
  includes #437's method-span clip.
* **The heredoc change has a subject**: 5 of 2,481 fleet PHP files contain a
  heredoc, 8 openers in total. A `0 -> 0` over files containing none would have
  been a check with no subject, not a check that passed.

**Two-directional control on a reconstructed pre-fix tree.** Inject the issue's
delimiter pair into the template of every real component, then count the
elements each mask still lets a gate see:

| repo | files | tags (untouched) | tags PRE | tags POST | **PRE lost** | POST lost |
|---|---|---|---|---|---|---|
| procest | 231 | 5294 | 2306 | 5756 | **2988** | -462 |
| opencatalogi | 93 | 3296 | 2174 | 3482 | **1122** | -186 |
| openregister | 205 | 9524 | 7455 | 9934 | **2069** | -410 |
| softwarecatalog | 73 | 2884 | 2266 | 3030 | **618** | -146 |
| docudesk | 72 | 1610 | 1094 | 1754 | **516** | -144 |
| larpingapp | 5 | 73 | 65 | 83 | **8** | -10 |
| | | | | | **7321** | |

**7,321 real elements** would have been invisible to gates 31/32/35/36/37/39/
40/42/43/44 on live fleet markup. The post-fix column loses none: every
negative number is exactly `2 × files` — the two injected `<p>` elements
themselves (231×2=462, 93×2=186, 205×2=410, 73×2=146, 72×2=144, 5×2=10). That
arithmetic identity is itself a check that the harness measured what it claims.

**Where the heredoc port bites.** `php_mask` compared over all 2,481 fleet PHP
files, old vs new: **2** files differ in the default mask, **5** in the
structural one. Both default-mode differences are the same real bug being
fixed — **CSS inside a heredoc, where `#` was read as a PHP comment and blanked
the rest of the line**:

```
openregister/lib/Controller/GraphQLController.php:231     #graphiql { height: 100vh; }
openregister/lib/Service/Reporting/HtmlReportWriter.php:217   color: #1f1f1f;
```

Note the `{` in the first: previously swallowed by a comment that never opened;
now visible in the default mask and correctly blanked in the structural one, so
the brace walk is right either way.

---

## 3b. Three QUADRATIC scans, found only because I timed at three sizes

A sibling PR in this batch shipped a HIGH `py/redos`, so I timed every pattern
I added or grew. **A single measurement would have shown nothing** — all three
look instant at one size:

| scan | before (N = 200 / 600 / 1800) | ratio | after | ratio |
|---|---|---|---|---|
| `_skip_tag` on `'<a b="' * N` | 12.6 / 134 / **1190 ms** | **×94** | 0.45 / 1.30 / 3.20 ms | ×7.1 |
| `html_comment_spans` on `'{{ ' * N` | 0.16 / 0.60 / 3.47 ms | ×22 | 0.09 / 0.35 / 0.97 ms | ×10.6 |
| `has_prelude` on `'registerAutoloading( ' * N` | 41.6 / 388 / **3038 ms** | **×73** | 0.34 / 1.23 / 5.55 ms | ×16.5 |

A 9× input should cost about 9×. The first extrapolates to roughly **three
hours on a 1 MB file**, and a gate that times out is a gate that did not run —
this programme's own failure mode arriving by a new route.

None is exponential backtracking, so `py/redos` would not have flagged any of
them; two are my own new code and one (`[^)]*`) I copied from a shape already
on `main`. All three fixes are "stop rescanning": a tag cannot contain an
unquoted `<` so `_skip_tag` aborts there; one missed `}}` settles the question
for the whole remainder; and the parenthesis walk is a single-pass table
instead of a fresh walk per call site.

**CodeQL: 0 open alerts on this branch.** Positive control on the query — the
same call returns **2** alerts repo-wide on `main`, so the empty list is a real
clean rather than a broken query.

---

## 3c. Default paging really does hide checks

Verified on this PR: `/commits/<sha>/check-runs` reports `total_count=34` and
returns **30** without `?per_page=100`. The four in the dropped tail:

```
Analyze (actions)
Analyze (javascript-typescript)
Analyze (python)
The spec-coverage threshold can fail a run
```

**Three of the four are the CodeQL analyses** — the exact check that caught the
sibling ReDoS. Read properly: 16 success, 17 skipped, **0 failed**.

---

## 4. What each gate now does

| gate | axis | fix |
|---|---|---|
| **8** unsafe-auth-resolver | FP | `php_mask(blank_strings=True)`. Nothing it matches is ever a string, and blanking also repairs the **brace walker**, which previously counted a `{` written inside a literal as a block delimiter. |
| **10** initial-state | FP | Two masks, one coordinate system + `source_scope.starts_in_code()`. The mask cannot blank contents — the name in `getAttribute('data-x')` and the `data-requesttoken` exemption are read out of that literal — so the ANCHOR answers "is the expression code?" instead. |
| **11** admin-router | FP | Same. The route-object **brace walk** moves to the anchor too, so a `}` inside a literal no longer truncates the object the anti-widening guard is read out of. |
| **13** modal-isolation | FP | The runner's inline `PYMI` carried a **fourth** private `<!--.*?-->` and no string awareness. Now scopes to `vue_markup_mask` — the SFC's *rendered* template — which is the question the rule actually asks. Not a weakening: an inline modal is by definition written in the template. |
| **18** notification-dialect | FP | Tokens were matched against `json.dumps(rule)`, so a rule whose own `description` **warned against** the legacy dialect was reported as it, three times. Now walks the structure: three KEY tokens against keys, `@self.` against machine values, per-locale/documentation fields excluded. |
| **35, 36** | FN | the delimiter hole |
| **37, 39, 40, 41, 42, 43, 44** | FN | private `<!--.*?-->` copies → `mask_html_comments` |
| **50** security-config-fail-mode | drift | #420's hand-rolled `_strip_php_comments` deleted; the block calls `php_mask`. |
| **53** effective-manifest-crossref | FP **and silent FN** | `stripJsComments` was two regexes with no string awareness, so the `/*` in `glob: '/*.vue'` opened a block comment that deleted later registry entries — and when the swallowed span was brace-**un**balanced, `parsed: false` made the caller skip the cross-reference check entirely, a false GREEN. New `scripts/lib/js_scope.js` is the node port of `source_scope.js_comment_mask`. |
| **59** unclosable-gate | FN | Anchored call site; the config KEY is still read out of the literal, because that is the evidence. |
| **64** apphost-autoload-prelude | FN | Same split. `strip_comments()` — #184's own state machine — now delegates to `php_mask`, removing a second PHP comment dialect. |

Also consolidated, same class, one line: `check_orphaned_write_capability`'s
`<!--.*?-->` over `info.xml`.

### On the new `js_scope.js`

The node checkers had no shared scope module, so gate-53's fix would have been
a third private copy. Instead it is a **port with a drift test**:
`test_js_scope.js` shells out to `source_scope.py --mask js-comments` and
asserts the two are **byte-identical** over a corpus *and* over this package's
own `.js` sources. That is the trade
`test_source_scope.py::TestSharedWithGate19` already makes — two copies proven
equal are a maintenance cost, two copies that *might* differ are a defect.

`check_notification_dialect` had **no helper suite at all**; this adds one with
14 arms, including the pre-#424 blob scan kept in-file as the mutation control.

---

## 5. Residuals — stated rather than left looking closed

1. **gate-64's `class_exists_targets` / `openregister_probes` are not
   anchored.** `openregister_probes` builds its text by `header + body` string
   concatenation, which destroys offsets, so threading an anchor through it is
   a restructure, not a parameter. The axis #424 names for gate-64 (a quoted
   prelude closing the gate) **is** closed; a quoted
   `class_exists('OCA\OpenRegister\AppHost\X')` inside prose can still produce
   a non-blocking NOTE.
2. **gate-64's `BOOTSTRAP_REF` still matches inside strings, on purpose.** The
   quoted FQCN form is documented evidence, so anchoring it would lose real
   findings. That is #423's axis, not this one.
3. **`check_no_admin_idor._strip_strings_and_comments` (gate-7) is NOT
   consolidated, and this is a trade, not an omission.** It handles
   **heredocs**, which `php_mask` does not. Routing gate-7 onto `php_mask`
   today would drop heredoc handling from the fleet's highest-yield security
   gate to remove a duplicate — the wrong side of that trade. The right fix is
   to teach `php_mask` heredocs and *then* consolidate, which widens the blast
   radius to gates 5, 8, 50, 59 and 64. #425 is also live on gate-7.
4. **gate-53's `kind:` lookup uses a fixed 400-character window.** Comments are
   now blanked in place rather than collapsed to one space, so a long comment
   between a registry key and its `kind:` could push `kind` out of that window.
   No instance in the fleet fixtures; the window was already a heuristic in
   both directions.
---

## 6. Suites — including a false baseline I caught and corrected

🔴 **My first baseline was contaminated by my own edits and I had written it up
as a pre-existing failure.** I started `run-helper-suites.sh` in the background
on a fresh `main` clone and then began editing `source_scope.py` **in that same
working tree**. The run takes ~40 minutes, so
`test_gate_license_triangle_scope.sh` executed *after* my half-finished edits
landed and reported:

```
FAIL — control: --require-full-coverage did NOT fail a run whose only gap is
       gate-28 (status 98) — the coverage requirement is inert here
```

Re-run on a **pristine, untouched `main` clone**: `passed: 11, failed: 0`. Not
pre-existing. Mine.

The tell was in the text and I nearly walked past it: the passing and failing
messages carry the **same status number (98)** and differ only in the verb —
"DID fail" vs "did NOT fail". A matching number is not agreement.

**A background suite run and an edit session cannot share a working tree.** The
run reads each file at the moment it reaches it, not at the moment it starts,
so "I started it before I edited" is no defence.

**So the numbers below are CI's, not my machine's** — the
`hydra-gates package / Package invariants` job runs the same
`run-helper-suites.sh` in a pristine checkout nothing else is writing to, which
is exactly the property my local run lacked:

| ref | run | passed | quarantined | **failed** |
|---|---|---|---|---|
| `main@c26f9a3` | 31673742837 | 83 | 2 | **0** |
| `main@5543c2d` | 31682298199 | 84 | 2 | **0** |
| `main@73d496a` | 31683550349 | — | — | **CANCELLED — no verdict** |
| **this PR, merged head `ebfa5d3`** | 31684671148 | **86** | 2 | **0** |

Every digit accounted for. `73d496a` adds **no new suite file** — it only
modifies `test_gate_45_to_55_acceptance.sh` — so its tally is `5543c2d`'s 84.
This PR adds exactly two files (`test_check_notification_dialect.py`,
`test_js_scope.js`), which the runner auto-discovers. `84 + 2 = 86`, which is
what CI measured. Nothing disappeared in either direction.

⚠️ **`main@73d496a`'s own run was CANCELLED, so it is not usable as the
baseline** — a cancelled job is no verdict. The comparison therefore goes
through `5543c2d` plus a file-level diff rather than through a run that never
finished.

`test_gate_45_to_55_acceptance.sh` (which covers gate-50) is **ALL GREEN** on
the merged head, including #437's own new arms.

Working notes and every number:
`/home/rubenlinde/fleet-board/findings/gates-424-library.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 7. The `#437` merge — what I kept and what I moved

`#437` reworked gate-50's window inside the runner while this branch was
converting the same block off its private `_strip_php_comments`. Both changes
are right, so both survive:

* **`#437`'s `_method_spans` stays.** The guard window is still clipped at the
  enclosing method's brace, and its acceptance arms pass on the merged head —
  including *"a `}` in a string or heredoc does not truncate the method span"*,
  which is the arm that proves the capability moved rather than vanished.
* **`_strip_php_comments` is gone.** The structural copy it fed is now
  `php_mask(src, blank_strings=True)`; the guard-search copy is `php_mask(src)`.

**`php_mask` had to learn heredocs first.** `#437` had added heredoc handling
to the private copy, and the library did not have it. Deleting the copy without
moving that capability would have been a **capability loss dressed as a
cleanup** — precisely the shape this programme exists to stop. So `php_mask`
now understands heredocs and nowdocs, which is a strict correctness gain for
all five of its gates (5, 8, 50, 59, 64): until now a `<<<SQL` body was parsed
as *code*, so a `//` or `#` inside it blanked a line, an apostrophe opened a
literal that ran to the next stray quote, and a `{` mis-balanced every brace
walk built on the mask. Nine new arms, four of them mutation-checked EVIDENCE.

A pleasant side effect: the reason I had recorded for **not** consolidating
gate-7 was that its private stripper handles heredocs and `php_mask` did not.
That objection is now gone, so gate-7 is a clean follow-up rather than a trade.

`test_gate_45_to_55_acceptance.sh` — which covers gate-50 — is **ALL GREEN** on
the merged head.
