### PR TITLE
fix(gates 9, 27, 28, 46, 47, 61, 62): a comment must not manufacture a finding (#415 class, #423)

### DIFF
--- a/hydra-gates/scripts/lib/check_license_triangle.py
+++ b/hydra-gates/scripts/lib/check_license_triangle.py
@@ -67,8 +67,47 @@ import sys
 DECL = re.compile(
     r'^[\s]*(?:/\*+|\*+/?|//+|#+|<!--)?[\s]*'
     r'(?:@license|SPDX-License-Identifier:)[\s]+'
-    r'([^\s*\'"`;,)\]]+)',
+    r'([^\s*\'"`;,)\]]+)'
+    r'(?P<rest>[^\n]*)',
     re.MULTILINE,
+)
+
+# A SENTENCE THAT BEGINS WITH THE TAG IS NOT A SECOND DECLARATION (#415/#423).
+#
+# The anchor above was already right about position — a quote before the tag
+# means test data, not a claim — but it said nothing about what FOLLOWS the
+# identifier. So a docblock line explaining a licence the file does NOT use:
+#
+#     * @license EUPL-1.2
+#     * @license MIT was never used here — see the note above.
+#
+# read as a file declaring two licences, and produced BOTH
+# `license-internal-conflict` and `license-triangle-drift`. The note about
+# the licence that was ruled out scored as the licence.
+#
+# THE REMAINDER MAY NOT BE EMPTY, because the fleet's own header is not.
+# Measured over every tracked `lib/**/*.php` in openregister, opencatalogi,
+# procest, docudesk, larpingapp and softwarecatalog — 2,394 files, every
+# distinct declaration form:
+#
+#     2724  @license EUPL-1.2 https://joinup.ec.europa.eu/…/eupl-text-eupl-12
+#     2095  @license EUPL-1.2   (and `SPDX-License-Identifier: EUPL-1.2`)
+#       11  @license https://www.gnu.org/licenses/agpl-3.0.html GNU AGPL v3 or later
+#        8  @license AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.en.html
+#
+# A rule of "nothing may follow the identifier" would have deleted the FIRST
+# and most common form — 2,724 real declarations, in the fleet's own house
+# style — and the gate would have gone quiet on exactly the files it exists
+# to compare. So the remainder is allowed to be a URL, a comment terminator
+# or trailing punctuation, and nothing else: those are what a header carries
+# and prose is what it does not.
+#
+# The URL-FIRST form (11 files) is deliberately left alone: its identifier is
+# a URL, `_looks_like_a_path` already reports it as a parser malfunction, and
+# that diagnostic is not this change's to silence. The rule below therefore
+# only applies to a value that is not itself path-shaped.
+_DECL_TAIL_OK = re.compile(
+    r'^(?:\s|https?://\S+|\*/|--!?>|[.,;:)\]]|\(\s*\)|\s*\Z)*$'
 )
 # `/` is deliberately ALLOWED in the captured value. Excluding it (to stop
 # `@license EUPL-1.2*/` capturing the comment terminator) also truncated a
@@ -99,6 +138,12 @@ def declarations(src: str) -> list[str]:
     for m in DECL.finditer(src):
         v = _TRAILING_COMMENT.sub('', m.group(1).strip()).strip().rstrip('.,;')
         if not v or v in seen:
+            continue
+        # See _DECL_TAIL_OK: a header carries an identifier and at most a URL;
+        # prose after the identifier means the line is a SENTENCE about a
+        # licence, not a declaration of one. Path-shaped values keep their
+        # existing "parser malfunction" report regardless of what follows.
+        if not _looks_like_a_path(v) and not _DECL_TAIL_OK.match(m.group('rest')):
             continue
         seen.append(v)
     return seen

--- a/hydra-gates/scripts/lib/check_license_triangle.py
+++ b/hydra-gates/scripts/lib/check_license_triangle.py
@@ -106,9 +106,53 @@ DECL = re.compile(
 # a URL, `_looks_like_a_path` already reports it as a parser malfunction, and
 # that diagnostic is not this change's to silence. The rule below therefore
 # only applies to a value that is not itself path-shaped.
-_DECL_TAIL_OK = re.compile(
-    r'^(?:\s|https?://\S+|\*/|--!?>|[.,;:)\]]|\(\s*\)|\s*\Z)*$'
-)
+# ⚠️ THIS WAS A REGEX AND THE REGEX WAS A ReDoS (CodeQL `py/redos`, HIGH).
+# The first cut read
+#
+#     ^(?:\s|https?://\S+|\*/|--!?>|[.,;:)\]]|\(\s*\)|\s*\Z)*$
+#
+# `\S+` inside a STARRED alternation is ambiguous with itself: `https://ab`
+# can be consumed by one iteration or by several, so a subject that never
+# reaches `$` has exponentially many splits to try.
+#
+# MEASURED, because the alert's own witness string did NOT reproduce here.
+# CodeQL named `'http://' + '!http://' * n`; in CPython that is 0.000s even
+# at n=32,000, because `\s*\Z` can match empty and the engine's empty-repeat
+# guard cuts the search short. The alert is still right — the ambiguity is
+# real — it just names the wrong subject. The one that fires is a repeated
+# URL with one trailing byte that cannot match:
+#
+#     'https://a' * n + ' \x01'      OLD          NEW
+#       n=18  len=164                 0.0949s      0.0000s
+#       n=22  len=200                 1.5284s      0.0000s
+#       n=24  len=218                 6.6797s      0.0000s
+#       n=26  len=236                26.1822s      0.0000s
+#       n=28  len=254                  >60s        0.0000s
+#
+# Every +2 multiplies the old time by ~4. A 254-character line — shorter
+# than plenty of real headers — hangs the gate, and gate-28 runs over every
+# tracked lib/**/*.php in the repo.
+#
+# Rewritten as a linear scan rather than tightened, so the ambiguity cannot
+# exist rather than being harder to reach: split the remainder on whitespace
+# and ask of each token whether a header could carry it. No quantifier, no
+# backtracking. Flat on the adversarial input above, and still flat at
+# 256 KB (0.0103s, linear in length).
+def _decl_tail_ok(rest: str) -> bool:
+    """Is what follows the identifier header FURNITURE rather than prose?
+
+    A header carries the identifier and at most a URL, a comment terminator
+    and punctuation. A sentence carries words. See the measurement above the
+    caller for why "nothing may follow" was not an option.
+    """
+    for token in rest.split():
+        token = _TRAILING_COMMENT.sub('', token).strip('.,;:()[]')
+        if not token:
+            continue
+        if token.startswith(('http://', 'https://')):
+            continue
+        return False
+    return True
 # `/` is deliberately ALLOWED in the captured value. Excluding it (to stop
 # `@license EUPL-1.2*/` capturing the comment terminator) also truncated a
 # path-shaped value to its first segment, so `lib/Service/Thing.php` arrived
@@ -139,11 +183,11 @@ def declarations(src: str) -> list[str]:
         v = _TRAILING_COMMENT.sub('', m.group(1).strip()).strip().rstrip('.,;')
         if not v or v in seen:
             continue
-        # See _DECL_TAIL_OK: a header carries an identifier and at most a URL;
+        # See _decl_tail_ok: a header carries an identifier and at most a URL;
         # prose after the identifier means the line is a SENTENCE about a
         # licence, not a declaration of one. Path-shaped values keep their
         # existing "parser malfunction" report regardless of what follows.
-        if not _looks_like_a_path(v) and not _DECL_TAIL_OK.match(m.group('rest')):
+        if not _looks_like_a_path(v) and not _decl_tail_ok(m.group('rest')):
             continue
         seen.append(v)
     return seen

--- a/hydra-gates/scripts/lib/check_listener_placement.py
+++ b/hydra-gates/scripts/lib/check_listener_placement.py
@@ -81,6 +81,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
+
 GATE_NUM = 61
 
 # The three POST events. A listener on one of these cannot influence the write,
@@ -293,9 +296,28 @@ def parse_registrations(path: Path) -> list[dict]:
     Each entry: {'event', 'listener', 'start_line', 'end_line'}.
     """
     try:
-        text = path.read_text(encoding='utf-8', errors='replace')
+        raw = path.read_text(encoding='utf-8', errors='replace')
     except OSError:
         return []
+
+    # A COMMENT MUST NOT MANUFACTURE A FINDING (#415/#423).
+    #
+    # This function read the RAW file, so a registration that exists ONLY as
+    # a commented-out line was parsed as a live one:
+    #
+    #     // Removed 2026-08: SyncListener did its HTTP work inline, so the
+    #     // listener and its registration both went:
+    #     // $context->registerEventListener(ObjectCreatedEvent::class,
+    #     //                                 SyncListener::class);
+    #
+    # produced `FAIL … ObjectCreatedEvent -> SyncListener — no class file
+    # found under lib/`. Nothing is wired; the listener was DELETED, and the
+    # gate reported the deletion as a broken registration. The author's
+    # cheapest fix is to delete the explanation of the deletion.
+    #
+    # `_strip_comments` is offset-preserving, so `text.count('\\n', 0, …)`
+    # below still yields the line number the finding reports.
+    text = _strip_comments(raw)
 
     # Post events named anywhere in the file — used to attribute a registration
     # whose event argument is a variable (see the foreach case below).
@@ -470,11 +492,28 @@ def classify_annotation(block: list[str]) -> tuple[str, str | None]:
 
 
 def _strip_comments(text: str) -> str:
-    """Blank out comments so a signal named only in prose is not a finding."""
-    text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
-    text = re.sub(r'(?m)//.*$', '', text)
-    text = re.sub(r'(?m)^\s*#(?!\[).*$', '', text)
-    return text
+    """Blank out comments so a signal named only in prose is not a finding.
+
+    Delegates to ``source_scope.php_mask`` (#415/#423) instead of the three
+    regexes that used to live here. Three concrete differences, each of which
+    was a defect:
+
+      * it is OFFSET-PRESERVING — comments are blanked, not deleted — so the
+        result can be searched interchangeably with the raw text and a line
+        number computed on it still names the right line. The old version
+        shortened the string, which is why it could not be used by
+        :func:`parse_registrations`, which needs line numbers;
+      * it is STRING-AWARE, so a `//` inside `'https://example.org/hook'`
+        does not truncate the line and delete the very call the gate is
+        looking for;
+      * it knows a TRAILING `#` opens a comment (the old `^\\s*#` only saw
+        one at the start of a line) and that `#[` opens a PHP 8 attribute.
+
+    String CONTENTS are kept (``blank_strings`` at its default): the URL in
+    an inline `->post('https://…')` and the class name in a `class_exists()`
+    are evidence about code, and blanking them would delete it.
+    """
+    return php_mask(text)
 
 
 def scan_body(text: str) -> list[tuple[str, str]]:

--- a/hydra-gates/scripts/lib/check_phantom_cross_app_rpc.py
+++ b/hydra-gates/scripts/lib/check_phantom_cross_app_rpc.py
@@ -113,6 +113,58 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import js_comment_mask, php_mask  # noqa: E402
+
+# A COMMENT MUST NOT MANUFACTURE A FINDING (#415/#423).
+#
+# The comment test used to be `stripped.startswith(("//", "*", "/*", "#"))`
+# applied per LINE, which only recognises a comment-OPENING line. One clean
+# fixture produced THREE findings:
+#
+#   * an interior line of an unindented `/* … */` block, describing the
+#     phantom call that was REMOVED;
+#   * a TRAILING `// never do $reg->getLeaf($id) here`;
+#   * a string literal warning against the same call.
+#
+# The first two are closed here by masking the file with the shared,
+# offset-preserving strippers before any rule runs. Line numbering survives
+# because the masks blank text without removing lines, and every finding
+# reports a line number.
+#
+# STRINGS ARE KEPT ON PURPOSE (`blank_strings` left at its default). Rule B
+# is `->call('<fleetAppId>', …)` — the evidence IS a string literal, and the
+# rule's own docstring records that requiring a quoted app id is what makes
+# it zero-false-positive. Blanking literals to close the third finding would
+# delete Rule B entirely: a false positive traded for a false negative in
+# the gate that exists because a phantom call only ever dies at runtime.
+# The literal axis is tracked as #424, not smuggled in here.
+#
+# ⚠️ `.vue` IS DELIBERATELY NOT MASKED. The mask for an SFC is
+# `source_scope.script_mask`, which routes through the `<!-- … -->` handling
+# that #424 is currently repairing (a `<!--` inside a string literal blanks
+# live code, i.e. it can silence the gate). Adopting it today would inherit
+# that hole into a gate whose findings are runtime fatals. The `.vue`
+# false positive therefore STANDS, and is blocked on #424 — stated rather
+# than papered over, because a partially-masked checker looks exactly like a
+# fully-masked one from the outside.
+_MASKERS = {
+    ".php": php_mask,
+    ".js": js_comment_mask,
+    ".ts": js_comment_mask,
+    ".mjs": js_comment_mask,
+    ".cjs": js_comment_mask,
+    ".jsx": js_comment_mask,
+    ".tsx": js_comment_mask,
+}
+
+
+def _code_text(path: str, text: str) -> str:
+    """*text* with comments blanked, offsets and line numbers preserved."""
+    masker = _MASKERS.get(os.path.splitext(path)[1].lower())
+    return masker(text) if masker else text
+
+
 # Known fleet app ids. A ->call('<id>', ...) with one of these as the
 # first string-literal argument is a phantom cross-app RPC (Rule B).
 FLEET_APP_IDS = {
@@ -249,14 +301,15 @@ def scan_file(path: str) -> int:
     except OSError:
         return 0
 
-    lines = text.split("\n")
+    lines = _code_text(path, text).split("\n")
     violations = 0
 
     for idx, line in enumerate(lines, start=1):
-        # Skip obvious comment-only lines (PHP // / * / # and JS //) so a
-        # documented example or a forbidden-pattern note never trips the
-        # gate. We keep it simple: a line whose first non-space char starts
-        # a comment is ignored for the literal-call rules.
+        # Retained for the file types `_code_text` does not mask (`.vue`,
+        # blocked on #424): a line whose first non-space char opens a comment
+        # is ignored for the literal-call rules. On a masked file every
+        # comment line is already blank, so this costs nothing and the two
+        # never disagree.
         stripped = line.lstrip()
         is_comment = (
             stripped.startswith("//")
@@ -376,7 +429,7 @@ def check_against_or_contract(path: str, contract: dict) -> None:
 
     try:
         with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            lines = fh.read().split("\n")
+            lines = _code_text(path, fh.read()).split("\n")
     except OSError:
         return
 

--- a/hydra-gates/scripts/lib/check_security_cochange.py
+++ b/hydra-gates/scripts/lib/check_security_cochange.py
@@ -59,6 +59,9 @@ import re
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import js_comment_mask, php_mask  # noqa: E402
+
 # Security code identified by LOCATION. Any change to such a file qualifies —
 # there is no "incidental" edit to lib/Service/Auth/TokenVerifier.php.
 _PATH_PATTERNS = (
@@ -139,7 +142,51 @@ _TEST_PATH_RE = re.compile(
 _CANDIDATE_RE = re.compile(r"^(lib/.*\.php|src/.*\.(vue|js|ts))$")
 
 # Comment shapes, per line, after leading whitespace.
-_COMMENT_LINE_RE = re.compile(r"^\s*(?:\*|//|/\*|\#(?!\[))")
+#
+# `<!--` was missing from this vocabulary entirely while `src/**/*.vue` has
+# always been a candidate path (#415/#423), so
+#
+#     <!-- IUserSession is resolved server-side, see ADR-005 -->
+#
+# was read as a security-relevant change and demanded a test co-change.
+_COMMENT_LINE_RE = re.compile(r"^\s*(?:\*|//|/\*|<!--|\#(?!\[))")
+
+# A TRAILING COMMENT IS A COMMENT TOO (#415/#423).
+#
+# The test above is `match`, i.e. it only ever recognised a line that STARTS
+# with a comment. The module's own docstring promises the opposite —
+# *"Prose that merely mentions `IUserSession` is not — it is a sentence"* —
+# and the annotation arm implements it, but a sentence written after code on
+# the same line was still read as code:
+#
+#     return $this->render();   // resolved via IUserSession elsewhere
+#
+# One reworded end-of-line comment therefore turned gate-47 red and demanded
+# a test for a change containing none. That is #191's shape one level up: the
+# cheapest way to clear the finding is to reword the prose again, so the gate
+# manufactures the appearance of a security review.
+#
+# Masked with the shared, offset-preserving strippers, dispatched on the
+# file's own extension. STRING CONTENTS ARE KEPT (`js_comment_mask`, and
+# `php_mask`'s default): `requesttoken` reaches this gate as the KEY of a
+# header object and `'IUserSession'` as a DI id, so blanking literals would
+# delete real evidence — the axis tracked as #424.
+#
+# ⚠️ A `<!--` appearing MID-LINE in an SFC template is not handled here: that
+# needs `source_scope.markup_mask`, whose delimiter handling is under repair
+# in #424. Line-START is what the fixture in #423 shows and what is closed.
+_LINE_MASKERS = {
+    ".php": php_mask,
+    ".js": js_comment_mask,
+    ".ts": js_comment_mask,
+    ".vue": js_comment_mask,
+}
+
+
+def _line_code(line: str, path: str) -> str:
+    """*line* with any trailing comment blanked, same length."""
+    masker = _LINE_MASKERS.get(os.path.splitext(path)[1].lower())
+    return masker(line) if masker else line
 
 
 def is_test_path(path: str) -> bool:
@@ -150,7 +197,7 @@ def is_security_path(path: str) -> bool:
     return any(p.match(path) for p in _PATH_PATTERNS)
 
 
-def line_is_security_relevant(line: str) -> bool:
+def line_is_security_relevant(line: str, path: str = "") -> bool:
     """Is this ONE changed line a security change?
 
     A comment line qualifies only via ``_ANNOTATION_RE``, and only when the
@@ -162,12 +209,17 @@ def line_is_security_relevant(line: str) -> bool:
     ``match`` rather than ``search``: ``_ANNOTATION_RE`` is anchored with
     ``^`` on both branches, so the two are equivalent here, but ``match``
     states the intent — position is the whole point of this regex.
+
+    *path* names the file the line came from, so the trailing-comment mask
+    can be chosen by extension (see ``_LINE_MASKERS``). It defaults to empty,
+    in which case the line is judged unmasked — the pre-#423 behaviour, and
+    the reason no caller is obliged to know about it.
     """
     if _ANNOTATION_RE.match(line):
         return True
     if _COMMENT_LINE_RE.match(line):
         return False
-    return bool(_CODE_TOKEN_RE.search(line))
+    return bool(_CODE_TOKEN_RE.search(_line_code(line, path)))
 
 
 def changed_lines(base_ref: str, path: str, cwd: str,
@@ -276,7 +328,7 @@ def scan(base_ref: str, cwd: str = ".") -> tuple[list[str], bool]:
         if not _CANDIDATE_RE.match(f):
             continue
         for line in changed_lines(base_ref, f, cwd, renames.get(f)):
-            if line_is_security_relevant(line):
+            if line_is_security_relevant(line, f):
                 security.append(f)
                 break
     return security, has_test

--- a/hydra-gates/scripts/lib/check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/check_semantic_auth.py
@@ -40,8 +40,12 @@ Exits 0 always; the bash gate counts the printed lines.
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
 
 
 _METHOD_RE = re.compile(
@@ -625,12 +629,42 @@ def scan_file(path: str) -> int:
     except OSError:
         return 0
     violations = 0
+    # A COMMENT MUST NOT MANUFACTURE A FINDING (#415/#423).
+    #
+    # Every body question below is a question about CODE, and the bodies were
+    # sliced from the RAW source. A method whose only mention of a guard is a
+    # note about the guard that was REMOVED —
+    #
+    #     // We used to $this->requireAdmin(); here. Now anyone may read.
+    #
+    # — reported `no-admin-required-annotation-with-admin-body`, i.e. the gate
+    # named a contradiction that the code does not contain, and the author's
+    # cheapest fix is to delete the sentence explaining the change. That is
+    # the corrosive direction: it trains explanations out of the codebase and
+    # leaves the gate with nothing a human can check.
+    #
+    # `php_mask` (offset-preserving, `#[` opens an ATTRIBUTE and not a
+    # comment, `//` inside `'https://x'` opens nothing) rather than this
+    # file's local `_strip_comments`, which does not know `#` opens a PHP
+    # comment at all — the hash form reproduced identically.
+    #
+    # STRINGS ARE KEPT (`blank_strings` left at its default). The self-auth
+    # idioms this gate must still see live inside literals by nature —
+    # `'Bearer '`, `'HTTP_AUTHORIZATION'`, the header name passed to
+    # getHeader() — and `_strip_comments`' own docstring records that
+    # blanking them turns correct code into findings. The string-literal
+    # axis is #424's, deliberately not smuggled in here.
+    #
+    # The HEAD is still read from the ORIGINAL text: `@NoAdminRequired` and
+    # `@PublicPage` are docblock annotations, so they live in a comment BY
+    # DESIGN and masking the head would switch the whole gate off.
+    code = php_mask(src)
     # Computed once per file, not per method: the unsourced-denial rule needs
     # the bodies of the private helpers a public action delegates to.
     all_bodies = _all_method_bodies(src)
     for name, head_start, body_start, body_end, line_no in _find_method_bodies(src):
         head = src[head_start:body_start]
-        body = src[body_start:body_end]
+        body = code[body_start:body_end]
         if _NO_ADMIN_HEAD_RE.search(head):
             if _ADMIN_GATE_BODY_RE.search(body) or _has_admin_if_with_throw(body):
                 print(

--- a/hydra-gates/scripts/lib/check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/check_spec_anchors.py
@@ -87,8 +87,17 @@ import sys
 #
 # What is excluded is the tag appearing PART-WAY THROUGH a line, which is
 # the only shape prose and string literals take.
+#
+# ⚠️ EACH OPTIONAL GROUP SWALLOWS ITS OWN TRAILING WHITESPACE, and that is
+# not a style choice. Written the obvious way —
+# `[^\S\n]*(?:lead-in)?[^\S\n]*` — the two whitespace runs are adjacent
+# whenever the lead-in matches empty, and a line of N spaces that never
+# reaches `@spec` costs O(N²): 64,000 spaces took >20s on this machine while
+# the shape below is 0.0000s. Same family as the `py/redos` CodeQL raised on
+# gate-28's tail rule in this change; found by sweeping the other regexes it
+# adds rather than by waiting for the alert.
 TAG = re.compile(
-    r'^[^\S\n]*(?:\*+/?|//+|\#(?!\[)|/\*+|<!--|[-+]|\d+\.)?[^\S\n]*'
+    r'^[^\S\n]*(?:(?:\*+/?|//+|\#(?!\[)|/\*+|<!--|[-+]|\d+\.)[^\S\n]*)?'
     r'(?:\[[ xX~\-]\][^\S\n]*)?'
     r'@spec\s+(openspec/[^\s`\'"]+)',
     re.MULTILINE,

--- a/hydra-gates/scripts/lib/check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/check_spec_anchors.py
@@ -62,7 +62,37 @@ import re
 import sys
 
 # Match `@spec openspec/...` but NOT `@spec exclude ...`
-TAG = re.compile(r'@spec\s+(openspec/[^\s`\'"]+)')
+#
+# POSITION-ANCHORED (#415/#423). Gates 47 and 48 were given exactly this
+# treatment for exactly this reason; gate-46 never was, and it is the gate
+# with no false-NEGATIVE direction at all — every defect it can have is a
+# finding it manufactures.
+#
+#   const spec = '@spec openspec/specs/imaginary/spec.md'     -> FAIL
+#   // See @spec openspec/specs/gone/spec.md#missing for why. -> FAIL
+#
+# Neither is an annotation. The first is a string literal (test data, or the
+# name of a tag being discussed); the second is a sentence. Both reported a
+# dangling spec reference against code that annotates nothing, and the
+# author's cheapest fix is to delete the sentence — on a gate whose whole
+# job is to keep references honest.
+#
+# THE RULE, borrowed verbatim in shape from `check_security_cochange.
+# _ANNOTATION_RE`: an optional comment lead-in (`*`, `//`, `#`, `/*`,
+# `<!--`) and then the tag AT THE START of the content. That is the only
+# position a docblock parser accepts a tag in, and it is not a position
+# prose reaches. The lead-in is permissive on purpose — `// @spec …` is
+# still a declaration-shaped line — and markdown's list markers are included
+# because `openspec/**/tasks.md` writes its tags as list items.
+#
+# What is excluded is the tag appearing PART-WAY THROUGH a line, which is
+# the only shape prose and string literals take.
+TAG = re.compile(
+    r'^[^\S\n]*(?:\*+/?|//+|\#(?!\[)|/\*+|<!--|[-+]|\d+\.)?[^\S\n]*'
+    r'(?:\[[ xX~\-]\][^\S\n]*)?'
+    r'@spec\s+(openspec/[^\s`\'"]+)',
+    re.MULTILINE,
+)
 DATE = re.compile(r'\b\d{4}-\d{2}-\d{2}\b')
 HEADING = re.compile(r'^\s*#{1,6}\s+(.+?)\s*$')
 

--- a/hydra-gates/scripts/lib/check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/check_store_and_settings_surface.py
@@ -19,9 +19,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # AN EXIT CODE IS A STATUS (.github#240 / #242)
@@ -245,8 +249,27 @@ def check_store(root: Path, manifests, findings, changed: set[str] | None = None
                 text = php.read_text(encoding="utf-8", errors="ignore")
             except OSError:
                 continue
-            if "/apps/openregister/api/objects/" in text and (
-                "IClientService" in text or "newClient()" in text
+            # A COMMENT MUST NOT MANUFACTURE A FINDING (#415/#423).
+            #
+            # This was a substring test over the RAW file, so the docblock
+            #
+            #     We deliberately do NOT hit /apps/openregister/api/objects/
+            #     with an IClientService here — GenericStoreService owns
+            #     store discovery (ADR-080 D2/D3).
+            #
+            # produced a finding IDENTICAL to the real violation's, naming a
+            # file that does exactly what the gate wants. The author's
+            # cheapest fix is to delete the paragraph recording the decision
+            # — which is the same shape gate-64 was already repaired for
+            # (doriath's `loadApp`), one gate over.
+            #
+            # STRING CONTENTS ARE KEPT (`blank_strings` at its default): the
+            # URL this rule exists to find is a string literal in every real
+            # violation, so blanking literals would delete the evidence and
+            # turn the false positive into a false negative.
+            code = php_mask(text)
+            if "/apps/openregister/api/objects/" in code and (
+                "IClientService" in code or "newClient()" in code
             ):
                 findings.append(
                     f"FAIL {php.relative_to(root)}: builds and fetches an OpenRegister objects-API URL "

--- a/hydra-gates/scripts/lib/test_check_license_triangle.py
+++ b/hydra-gates/scripts/lib/test_check_license_triangle.py
@@ -197,6 +197,83 @@ class LicenceIdentifiersAsTestData(unittest.TestCase):
                          ["license-triangle-drift"])
 
 
+class ASentenceThatBeginsWithTheTagIsNotADeclaration(unittest.TestCase):
+    """#415/#423 — the anchor knew what may PRECEDE the tag, not what follows.
+
+    So a docblock line explaining a licence the file does NOT use scored as a
+    second declaration, and one clean header produced both
+    `license-internal-conflict` and `license-triangle-drift`.
+
+    T1, T5 and T6 are CONTROLS and pass both before and after. T5 is the one
+    that matters: the fleet's own header is `@license EUPL-1.2 <url>`, 2,724
+    files of it, so "nothing may follow the identifier" would have been a fix
+    that silenced the gate on its main subject.
+    """
+
+    HEADER = "<?php\n/**\n * Thing service.\n *\n * @license EUPL-1.2\n%s */\nclass Thing {}\n"
+
+    def test_T1_control_a_real_second_licence_is_still_a_conflict(self):
+        rules = _rules(_scan(self.HEADER % " * @license MIT\n"))
+        self.assertIn("license-internal-conflict", rules)
+        self.assertIn("license-triangle-drift", rules)
+
+    def test_T2_a_sentence_beginning_with_the_tag_is_not_a_declaration(self):
+        body = self.HEADER % (
+            " * @license MIT was never used here — see the note above.\n")
+        self.assertEqual(_scan(body), [])
+
+    def test_T3_the_prose_line_alone_declares_nothing(self):
+        self.assertEqual(
+            clt.declarations(
+                "<?php\n// @license Apache-2.0 was considered and rejected.\n"),
+            [],
+        )
+
+    def test_T4_mid_sentence_mentions_were_already_clean(self):
+        # A CONTROL for the anchor that already existed — it passes both ways
+        # and is here so a later widening of the tail rule cannot be mistaken
+        # for this one working.
+        self.assertEqual(
+            _scan(self.HEADER % (
+                " * We were asked whether the @license MIT applies. It does not.\n")),
+            [],
+        )
+
+    def test_T5_control_the_fleet_header_carries_a_url_and_still_declares(self):
+        body = (
+            "<?php\n/**\n"
+            " * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12\n"
+            " */\nclass Thing {}\n"
+        )
+        self.assertEqual(clt.declarations(body), ["EUPL-1.2"])
+        self.assertEqual(_scan(body), [])
+        self.assertEqual(clt.declared_file_count.__name__, "declared_file_count")
+
+    def test_T6_control_a_drifted_header_with_a_url_still_drifts(self):
+        body = (
+            "<?php\n/**\n"
+            " * @license MIT https://opensource.org/licenses/MIT\n"
+            " */\nclass Thing {}\n"
+        )
+        self.assertEqual(_rules(_scan(body)), ["license-triangle-drift"])
+
+    def test_T7_control_a_trailing_comment_terminator_still_declares(self):
+        self.assertEqual(
+            clt.declarations("<?php\n/** @license EUPL-1.2 */\n"), ["EUPL-1.2"])
+
+    def test_T8_control_a_url_first_header_keeps_its_malfunction_report(self):
+        # 11 files in the fleet write `@license <url> GNU AGPL v3 or later`.
+        # Their identifier is path-shaped, so `_looks_like_a_path` reports a
+        # PARSER MALFUNCTION — a diagnostic this change must not silence, and
+        # the reason the tail rule is skipped for path-shaped values.
+        body = (
+            "<?php\n/**\n"
+            " * @license https://www.gnu.org/licenses/agpl-3.0.html GNU AGPL v3 or later\n"
+            " */\nclass Thing {}\n"
+        )
+        self.assertIn("license-value-is-a-path", _rules(_scan(body)))
+
+
 class GateIsNotBlind(unittest.TestCase):
     """A direct floor. If `declarations()` ever returns nothing — a regex
     that stops matching, a read that silently fails — every `assertEqual([])`

--- a/hydra-gates/scripts/lib/test_check_license_triangle.py
+++ b/hydra-gates/scripts/lib/test_check_license_triangle.py
@@ -261,6 +261,26 @@ class ASentenceThatBeginsWithTheTagIsNotADeclaration(unittest.TestCase):
         self.assertEqual(
             clt.declarations("<?php\n/** @license EUPL-1.2 */\n"), ["EUPL-1.2"])
 
+    def test_T9_the_tail_rule_is_linear_not_exponential(self):
+        """The first cut of the tail rule was a ReDoS (CodeQL py/redos, HIGH).
+
+        `\\S+` inside a starred alternation is ambiguous with itself, so a
+        repeated URL followed by one byte that cannot match had exponentially
+        many splits to try. Measured on the old pattern: n=24 -> 6.7s,
+        n=26 -> 26.2s, n=28 -> over 60s, on a 254-CHARACTER line. gate-28
+        reads every tracked lib/**/*.php, so that is CI hanging on a header.
+
+        The bound is 5s against a true cost of ~0.00003s — three orders of
+        magnitude of headroom, so this is a shape assertion and not a
+        benchmark that a loaded runner can flake.
+        """
+        import time
+
+        subject = "https://a" * 60 + " \x01"
+        start = time.monotonic()
+        self.assertFalse(clt._decl_tail_ok(subject))
+        self.assertLess(time.monotonic() - start, 5.0)
+
     def test_T8_control_a_url_first_header_keeps_its_malfunction_report(self):
         # 11 files in the fleet write `@license <url> GNU AGPL v3 or later`.
         # Their identifier is path-shaped, so `_looks_like_a_path` reports a

--- a/hydra-gates/scripts/lib/test_check_listener_placement.py
+++ b/hydra-gates/scripts/lib/test_check_listener_placement.py
@@ -610,5 +610,96 @@ class PreEventTest(unittest.TestCase):
         )
 
 
+class ACommentDoesNotManufactureAFinding(unittest.TestCase):
+    """#415/#423 — `parse_registrations` read the RAW Application.php.
+
+    A registration that exists only as a commented-out line was parsed as a
+    live one, so the note explaining that a listener had been DELETED became
+    `FAIL … no class file found under lib/`. Nothing is wired. The cheapest
+    fix available to the author is to delete the explanation.
+
+    L1 and L5 are CONTROLS: they pass before and after, and exist so the
+    negatives below cannot be had by making the parser see nothing.
+    """
+
+    def _parse(self, php: str) -> list[tuple[str, str]]:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(Path(tmp), 'lib/AppInfo/Application.php', php)
+            return [(r['event'], r['listener']) for r in clp.parse_registrations(path)]
+
+    def test_L1_control_a_live_registration_is_still_parsed(self):
+        self.assertEqual(
+            self._parse(
+                '<?php\n'
+                '$context->registerEventListener(ObjectCreatedEvent::class, FooListener::class);\n'
+            ),
+            [('ObjectCreatedEvent', 'FooListener')],
+        )
+
+    def test_L2_a_commented_out_registration_is_not_a_registration(self):
+        self.assertEqual(
+            self._parse(
+                '<?php\n'
+                '// Removed 2026-08: SyncListener did its HTTP work inline, so the\n'
+                '// listener and its registration both went:\n'
+                '// $context->registerEventListener(ObjectCreatedEvent::class, SyncListener::class);\n'
+                '$context->registerEventListener(SomeOtherEvent::class, OtherListener::class);\n'
+            ),
+            # The LIVE registration below the comment is still parsed — this
+            # arm asserts the ghost is gone, not that the parser went blind.
+            [('SomeOtherEvent', 'OtherListener')],
+        )
+
+    def test_L3_a_block_comment_example_is_not_a_registration(self):
+        self.assertEqual(
+            self._parse(
+                '<?php\n'
+                '/**\n'
+                ' * Listeners are registered here, e.g.\n'
+                ' *   $context->registerEventListener(ObjectUpdatedEvent::class, FooListener::class);\n'
+                ' */\n'
+            ),
+            [],
+        )
+
+    def test_L4_the_line_number_still_names_the_live_registration(self):
+        # The mask BLANKS, it does not delete: a finding reports a line
+        # number, and a stripper that removed the comment lines would shift
+        # every registration below it onto the wrong line.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(
+                Path(tmp), 'lib/AppInfo/Application.php',
+                '<?php\n'
+                '// $context->registerEventListener(ObjectCreatedEvent::class, Ghost::class);\n'
+                '// two lines of prose\n'
+                '$context->registerEventListener(ObjectCreatedEvent::class, FooListener::class);\n'
+            )
+            found = clp.parse_registrations(path)
+            self.assertEqual([r['start_line'] for r in found], [4])
+
+    def test_L5_control_a_url_in_a_string_does_not_truncate_the_line(self):
+        # The old stripper was three regexes and not string-aware; `//` in a
+        # URL cut the rest of the line. This is the anti-over-application
+        # control: the registration on the same line must survive.
+        self.assertEqual(
+            self._parse(
+                '<?php\n'
+                "$this->url = 'https://example.org/hook'; "
+                '$context->registerEventListener(ObjectCreatedEvent::class, FooListener::class);\n'
+            ),
+            [('ObjectCreatedEvent', 'FooListener')],
+        )
+
+    def test_L6_control_an_inline_http_call_is_still_seen_in_a_body(self):
+        # scan_body routes through the same helper. Its evidence — the URL —
+        # is a string literal, so this arm goes red if anyone closes the
+        # remaining literal axis (#424) by blanking string contents here.
+        self.assertTrue(clp.scan_body(
+            'public function handle($e): void {\n'
+            "    $this->clients->newClient()->post('https://example.org/hook', []);\n"
+            '}\n'
+        ))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_phantom_cross_app_rpc.py
+++ b/hydra-gates/scripts/lib/test_check_phantom_cross_app_rpc.py
@@ -135,5 +135,96 @@ class RulesABCDStillFireTest(unittest.TestCase):
         self.assertEqual(_scan(src), [])
 
 
+def _scan_ext(src: str, suffix: str) -> list[str]:
+    """As :func:`_scan`, for a file type other than ``.php``."""
+    with tempfile.NamedTemporaryFile(
+        suffix=suffix, mode="w", encoding="utf-8", delete=False
+    ) as fh:
+        fh.write(src)
+        fh_name = fh.name
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            pcar.scan_file(fh_name)
+    finally:
+        os.unlink(fh_name)
+    return [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+
+
+class ACommentDoesNotManufactureAFinding(unittest.TestCase):
+    """#415/#423 — the comment test was ``startswith`` applied per LINE.
+
+    It therefore recognised only a comment-OPENING line. One clean fixture
+    produced THREE findings: an interior line of an unindented ``/* */``
+    block, a TRAILING ``//`` comment, and a string literal. The first two are
+    closed by masking; the third is #424 and is asserted here as it STANDS,
+    so that a later change to string handling cannot pass silently.
+
+    R1, R4, R5, R6 are CONTROLS — they pass both before and after — and exist
+    so the negatives cannot be had by switching a rule off.
+    """
+
+    def test_R1_control_a_live_getLeaf_call_still_fires(self):
+        src = "<?php\nreturn $this->registry->getLeaf($id);\n"
+        self.assertTrue(any("phantom-getleaf" in ln for ln in _scan(src)))
+
+    def test_R2_an_interior_block_comment_line_is_not_a_call(self):
+        src = (
+            "<?php\n"
+            "class Reader {\n"
+            "    /*\n"
+            "    Before ADR-041 this called\n"
+            "    $registry->getLeaf('zaak') to reach the other app. Removed.\n"
+            "    */\n"
+            "    public function read($id) { return $this->store->find($id); }\n"
+            "}\n"
+        )
+        self.assertEqual(_scan(src), [])
+
+    def test_R3_a_trailing_comment_is_not_a_call(self):
+        src = (
+            "<?php\n"
+            "return $this->store->find($id); // never do $reg->getLeaf($id) here\n"
+        )
+        self.assertEqual(_scan(src), [])
+
+    def test_R4_control_a_string_literal_still_counts_it_is_424(self):
+        # NOT a fix. Rule B's evidence — ->call('decidesk', …) — IS a string
+        # literal, so blanking literals here would delete the rule. This arm
+        # records the remaining false positive rather than hiding it, and it
+        # is the anti-widening pair for R2/R3: if someone closes it by
+        # blanking strings, R6 goes red.
+        src = "<?php\nreturn 'do not call $registry->getLeaf( on the registry';\n"
+        self.assertTrue(any("phantom-getleaf" in ln for ln in _scan(src)))
+
+    def test_R5_a_commented_out_js_call_is_not_a_call(self):
+        src = (
+            "export function read(id) {\n"
+            "\t/*\n"
+            "\tBefore ADR-041 this called registry.getLeaf(id); it no longer does.\n"
+            "\t*/\n"
+            "\treturn store.find(id) // never registry.getLeaf(id)\n"
+            "}\n"
+        )
+        self.assertEqual(_scan_ext(src, ".js"), [])
+
+    def test_R6_control_rule_B_still_reads_its_string_literal_argument(self):
+        src = "<?php\n$registry->call('decidesk', 'createDecision', []);\n"
+        self.assertTrue(any("phantom-registry-call" in ln for ln in _scan(src)))
+
+    def test_R7_control_a_live_getLeaf_in_a_js_file_still_fires(self):
+        src = "export const go = (id) => registry.getLeaf(id)\n"
+        self.assertTrue(
+            any("phantom-getleaf" in ln for ln in _scan_ext(src, ".js"))
+        )
+
+    def test_R8_the_mask_is_actually_wired_into_scan_file(self):
+        # An unapplied change looks exactly like a passing test.
+        import inspect
+
+        src = inspect.getsource(pcar.scan_file)
+        self.assertIn("_code_text(path, text)", src)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_security_cochange.py
+++ b/hydra-gates/scripts/lib/test_check_security_cochange.py
@@ -445,6 +445,86 @@ export default {
 """
 
 
+class ATrailingCommentIsACommentToo(unittest.TestCase):
+    """#415/#423 — `_COMMENT_LINE_RE` is a ``match``, so it only ever saw a
+    line that STARTS with a comment.
+
+    The module's own docstring promises the opposite — *"Prose that merely
+    mentions IUserSession is not — it is a sentence"* — and the annotation arm
+    implements it, but a sentence written AFTER code on the same line was
+    still read as code. And `<!--` was not in the vocabulary at all, while
+    `src/**/*.vue` has always been a candidate path.
+
+    C1, C4, C5, C6, C7 are CONTROLS: they pass before and after. They are
+    deliberately called with ONE argument — none of them contains a comment,
+    so the path cannot matter, and calling them the old way keeps them
+    runnable against the pre-fix helper. A control that raises TypeError on
+    the reverted code is not a control, it is a signature check.
+    """
+
+    def test_C1_control_a_real_IUserSession_declaration_still_counts(self):
+        self.assertTrue(csc.line_is_security_relevant(
+            "    private IUserSession $userSession;"))
+
+    def test_C2_a_trailing_comment_naming_the_token_is_a_sentence(self):
+        self.assertFalse(csc.line_is_security_relevant(
+            "        return $this->render();   // resolved via IUserSession elsewhere",
+            "lib/Controller/A.php"))
+
+    def test_C3_an_html_comment_in_an_sfc_is_a_comment(self):
+        # One argument on purpose: this half is `_COMMENT_LINE_RE` gaining
+        # `<!--`, nothing to do with the path, so the arm FLIPS on the
+        # reverted helper rather than raising TypeError at it.
+        self.assertFalse(csc.line_is_security_relevant(
+            "    <!-- IUserSession is resolved server-side, see ADR-005 -->"))
+
+    def test_C4_control_a_string_literal_still_counts_it_is_424(self):
+        # NOT a fix. `requesttoken` arrives as a header KEY and DI ids arrive
+        # as strings, so blanking literals would delete real evidence. This
+        # arm records the remaining false positive rather than hiding it, and
+        # goes red if anyone closes it by blanking string contents.
+        self.assertTrue(csc.line_is_security_relevant(
+            "        $id = 'IUserSession';"))
+
+    def test_C5_control_a_requesttoken_header_key_still_counts(self):
+        self.assertTrue(csc.line_is_security_relevant(
+            "    headers: { requesttoken: OC.requestToken },"))
+
+    def test_C6_control_the_annotation_arm_is_untouched(self):
+        for line in ("    #[NoAdminRequired]",
+                     "     * @PublicPage",
+                     "    #[\\OCP\\AppFramework\\Http\\Attribute\\NoCSRFRequired]"):
+            with self.subTest(line=line):
+                self.assertTrue(
+                    csc.line_is_security_relevant(line))
+
+    def test_C7_control_an_unknown_extension_is_judged_unmasked(self):
+        # The default keeps every existing caller's behaviour, which is what
+        # lets the 23 pre-existing assertions in this suite stand unchanged.
+        self.assertTrue(csc.line_is_security_relevant(
+            "        return $x; // IUserSession"))
+
+    def test_C8_the_path_is_actually_passed_by_the_scanner(self):
+        # An unapplied change looks exactly like a passing test.
+        import inspect
+        self.assertIn("line_is_security_relevant(line, f)",
+                      inspect.getsource(csc.scan))
+
+    def test_C9_end_to_end_a_reworded_trailing_comment_is_not_a_change(self):
+        repo = _Repo()
+        self.addCleanup(repo.close)
+        repo.write("lib/Controller/A.php",
+                   "<?php\nclass A {\n"
+                   "    public function index() { return 1; } // uses IUserSession\n}\n")
+        base = repo.commit("baseline")
+        repo.write("lib/Controller/A.php",
+                   "<?php\nclass A {\n"
+                   "    public function index() { return 1; } // resolved via IUserSession elsewhere\n}\n")
+        repo.commit("reword the comment")
+        security, _ = csc.scan(base, str(repo.root))
+        self.assertEqual(security, [])
+
+
 class RenamesAreNotContentChanges(unittest.TestCase):
     """A pathspec is applied BEFORE rename detection.
 

--- a/hydra-gates/scripts/lib/test_check_semantic_auth.py
+++ b/hydra-gates/scripts/lib/test_check_semantic_auth.py
@@ -826,5 +826,101 @@ class AdminEscalationBranchIsNotAnAdminRequirement(unittest.TestCase):
         self.assertIn("_unconditional_part(body[body_start:i])", src)
 
 
+class ACommentDoesNotManufactureAFinding(unittest.TestCase):
+    """#415/#423 — the body questions were asked of the RAW method body.
+
+    A note about the guard that was REMOVED scored as the guard, so the gate
+    reported a contradiction the code does not contain and the author's
+    cheapest fix was to delete the sentence explaining the change. That is
+    the direction that trains explanations out of a codebase.
+
+    P1 is the POSITIVE CONTROL and passes both before and after: it exists so
+    the two negatives below cannot be had by switching the rule off.
+    """
+
+    def test_P1_control_a_real_requireAdmin_call_still_fires(self):
+        php = CLASS % """
+    #[NoAdminRequired]
+    public function purge(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse([]);
+    }
+"""
+        self.assertEqual(
+            _rules(_scan(php)), ["no-admin-required-annotation-with-admin-body"]
+        )
+
+    def test_P2_a_note_about_the_removed_guard_is_not_an_admin_body(self):
+        php = CLASS % """
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        // We used to $this->requireAdmin(); here. Now anyone may read.
+        return new JSONResponse($this->service->all());
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), [])
+
+    def test_P3_a_hash_comment_is_a_comment_too(self):
+        # This file's local _strip_comments does not know `#` opens a PHP
+        # comment, which is why the body now goes through source_scope's
+        # php_mask instead. Reproduced identically before the fix.
+        php = CLASS % """
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        # Historically this called $this->requireAdmin(); it no longer does.
+        return new JSONResponse([]);
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), [])
+
+    def test_P4_a_docblock_naming_the_removed_isAdmin_denial_is_not_one(self):
+        php = CLASS % """
+    /**
+     * List things.
+     *
+     * Until 2.3 this read:
+     *   if (!$this->groupManager->isAdmin($this->userId)) {
+     *       throw new OCSForbiddenException();
+     *   }
+     * Removed when the register grew its own per-object ACL.
+     */
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        return new JSONResponse($this->service->all());
+    }
+"""
+        self.assertEqual(_rules(_scan(php)), [])
+
+    def test_P5_control_the_head_is_still_read_from_the_original_text(self):
+        # `@NoAdminRequired` lives in a docblock BY DESIGN. If the mask were
+        # applied to the head as well, this whole gate would go silent — so
+        # this arm is the anti-over-application control and must FAIL the
+        # method, not exempt it.
+        php = CLASS % """
+    /**
+     * @NoAdminRequired
+     */
+    public function purge(): JSONResponse
+    {
+        $this->requireAdmin();
+        return new JSONResponse([]);
+    }
+"""
+        self.assertEqual(
+            _rules(_scan(php)), ["no-admin-required-annotation-with-admin-body"]
+        )
+
+    def test_P6_the_mask_is_actually_wired_into_the_body_slice(self):
+        # An unapplied change looks exactly like a passing test.
+        src = Path(csa.__file__).read_text(encoding="utf-8")
+        self.assertIn("code = php_mask(src)", src)
+        self.assertIn("body = code[body_start:body_end]", src)
+        self.assertIn("head = src[head_start:body_start]", src)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/test_check_spec_anchors.py
@@ -720,6 +720,23 @@ class ATagMustBeAtTagPosition(unittest.TestCase):
                     "export default {}\n")
         self.assertEqual(len(out), 1, out)
 
+    def test_A8_the_anchor_is_linear_in_the_line_length(self):
+        """Written the obvious way the anchor was QUADRATIC.
+
+        `[^\\S\\n]*(?:lead-in)?[^\\S\\n]*` puts two whitespace runs next to
+        each other whenever the lead-in matches empty, and a line of N spaces
+        that never reaches the tag costs O(N²) — 64,000 spaces took over 20s
+        before each optional group was made to swallow its own trailing
+        whitespace. Same family as the ReDoS CodeQL raised on gate-28's tail
+        rule in this change; found by sweeping rather than by waiting for the
+        alert. Bound is 5s against a true cost of ~0.007s.
+        """
+        import time
+
+        start = time.monotonic()
+        self.assertIsNone(csa.TAG.match(" " * 64000 + "x"))
+        self.assertLess(time.monotonic() - start, 5.0)
+
     def test_A7_control_a_markdown_task_item_tag_is_still_read(self):
         # openspec/**/tasks.md writes its tags as list items, and `.md` is in
         # this gate's scope. Anchoring must not drop the list marker forms.

--- a/hydra-gates/scripts/lib/test_check_spec_anchors.py
+++ b/hydra-gates/scripts/lib/test_check_spec_anchors.py
@@ -642,5 +642,95 @@ class CapabilityResolutionSurvivesArchiving(unittest.TestCase):
             csa.capability_of("openspec/changes/foo/specs/bar/spec.md"), "bar")
 
 
+class ATagMustBeAtTagPosition(unittest.TestCase):
+    """#415/#423 — `TAG` was unanchored, so prose and string literals matched.
+
+    Gates 47 and 48 were position-anchored for exactly this reason; gate-46
+    never was, and it is the gate with NO false-negative direction — every
+    defect it can have is a finding it manufactures.
+
+    A1, A5, A6, A7 are CONTROLS: they pass before and after, and they are
+    what stops "anchor the tag" from becoming "see no tags".
+
+    Fleet measurement behind the shape of the anchor: over every lib/, src/
+    and tests/ file of openregister, opencatalogi, procest, docudesk,
+    larpingapp and softwarecatalog — 5,684 files, 17,408 tags — the anchored
+    regex sees 17,406, and the finding SETS are identical (25 = 25, no
+    additions, no removals). The two tags it stops seeing are:
+
+      lib/Db/MultiTenancyTrait.php   `// Per @spec openspec/…/spec.md ("the
+                                      system MUST …` — a sentence;
+      src/views/dso/VthDashboard.vue `NOTE: this used to read
+                                      `@spec openspec/…#T07`.` — a note about
+                                      a tag that was REMOVED, in backticks.
+
+    which is this defect class verbatim, twice.
+    """
+
+    TREE = {
+        "openspec/specs/real/spec.md":
+            "# Spec\n\n## Requirement: Real Thing\n\ntext\n",
+    }
+
+    def test_A1_control_a_real_dangling_annotation_still_fails(self):
+        out = _scan(self.TREE, "lib/Thing.php",
+                    "<?php\n/**\n * @spec openspec/specs/absent/spec.md\n */\n"
+                    "class Thing {}\n")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("absent", out[0])
+
+    def test_A2_a_tag_inside_a_string_literal_is_not_an_annotation(self):
+        out = _scan(self.TREE, "lib/Thing.php",
+                    "<?php\n$spec = '@spec openspec/specs/imaginary/spec.md';\n")
+        self.assertEqual(out, [])
+
+    def test_A3_a_tag_part_way_through_a_sentence_is_not_an_annotation(self):
+        out = _scan(
+            self.TREE, "lib/Thing.php",
+            "<?php\n"
+            "// See @spec openspec/specs/gone/spec.md#missing for why this went.\n")
+        self.assertEqual(out, [])
+
+    def test_A4_a_note_about_a_tag_that_was_removed_is_not_the_tag(self):
+        # The procest/VthDashboard.vue shape, verbatim in structure.
+        out = _scan(
+            self.TREE, "src/views/Dash.vue",
+            "<template><div /></template>\n<script>\n"
+            "// NOTE: this used to read `@spec openspec/specs/gone/spec.md`.\n"
+            "export default {}\n</script>\n")
+        self.assertEqual(out, [])
+
+    def test_A5_control_a_docblock_tag_still_resolves_and_is_still_read(self):
+        out = _scan(
+            self.TREE, "lib/Thing.php",
+            "<?php\n/**\n * @spec openspec/specs/real/spec.md#requirement-real-thing\n */\n"
+            "class Thing {}\n")
+        self.assertEqual(out, [])
+        # …and the same tag with a broken fragment must still be reported, or
+        # the arm above proves only that the gate stopped looking.
+        bad = _scan(
+            self.TREE, "lib/Thing.php",
+            "<?php\n/**\n * @spec openspec/specs/real/spec.md#requirement-imaginary\n */\n"
+            "class Thing {}\n")
+        self.assertEqual(len(bad), 1, bad)
+
+    def test_A6_control_a_line_comment_tag_is_still_a_declaration(self):
+        out = _scan(self.TREE, "src/store/thing.js",
+                    "// @spec openspec/specs/nowhere/spec.md\n"
+                    "export default {}\n")
+        self.assertEqual(len(out), 1, out)
+
+    def test_A7_control_a_markdown_task_item_tag_is_still_read(self):
+        # openspec/**/tasks.md writes its tags as list items, and `.md` is in
+        # this gate's scope. Anchoring must not drop the list marker forms.
+        for line in ("- @spec openspec/specs/nowhere/spec.md",
+                     "- [ ] @spec openspec/specs/nowhere/spec.md",
+                     "* @spec openspec/specs/nowhere/spec.md",
+                     "1. @spec openspec/specs/nowhere/spec.md"):
+            with self.subTest(line=line):
+                out = _scan(self.TREE, "lib/notes.md", line + "\n")
+                self.assertEqual(len(out), 1, out)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
+++ b/hydra-gates/scripts/lib/test_check_store_and_settings_surface.py
@@ -142,6 +142,89 @@ class LibScanIsDiffScoped(unittest.TestCase):
         self.assertEqual(rc, 1)
 
 
+class ACommentDoesNotManufactureAFinding(unittest.TestCase):
+    """#415/#423 — the store-discovery rule was a substring test over RAW text.
+
+    A docblock recording that the class deliberately does NOT do the thing
+    produced a finding INDISTINGUISHABLE from the real violation's. The
+    author's cheapest fix is to delete the paragraph, which is how a gate
+    teaches a codebase to stop explaining itself.
+
+    S1 is the POSITIVE CONTROL and passes both before and after — without it
+    S2/S3 could be had by deleting the rule.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        (self.root / "lib" / "Service").mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _scan(self, php_src: str) -> list[str]:
+        (self.root / "lib" / "Service" / "Subject.php").write_text(
+            php_src, encoding="utf-8")
+        findings: list[str] = []
+        css.check_store(self.root, [], findings)
+        return [f for f in findings if "Subject.php" in f]
+
+    def test_S1_control_a_real_objects_api_fetch_still_fires(self):
+        self.assertEqual(len(self._scan(LEGACY_STORE_PHP.replace(
+            "LegacyStoreService", "Subject"))), 1)
+
+    def test_S2_a_docblock_saying_it_does_NOT_is_not_a_violation(self):
+        php = """<?php
+namespace OCA\\Test\\Service;
+
+class Subject
+{
+    /**
+     * Load the catalogue.
+     *
+     * We deliberately do NOT hit /apps/openregister/api/objects/ with an
+     * IClientService here — GenericStoreService owns store discovery
+     * (ADR-080 D2/D3). Two earlier attempts did; this is the note that
+     * stops a third.
+     */
+    public function load(): array
+    {
+        return $this->store->all();
+    }
+}
+"""
+        self.assertEqual(self._scan(php), [])
+
+    def test_S3_a_line_comment_and_a_hash_comment_are_comments_too(self):
+        php = """<?php
+class Subject
+{
+    public function load(): array
+    {
+        // was: $client->get('/apps/openregister/api/objects/' . $reg)
+        # IClientService was injected here until 2.4.
+        return $this->store->all();
+    }
+}
+"""
+        self.assertEqual(self._scan(php), [])
+
+    def test_S4_control_the_url_is_a_string_literal_and_must_survive(self):
+        # The anti-widening pair for S2/S3. The evidence this rule looks for
+        # lives inside a quoted literal in every real violation, so a mask
+        # that blanked string CONTENTS would turn this false positive into a
+        # false negative. If someone sets blank_strings=True, this goes red.
+        php = """<?php
+class Subject
+{
+    public function fetch(IClientService $client)
+    {
+        return $client->newClient()->get('/apps/openregister/api/objects/x');
+    }
+}
+"""
+        self.assertEqual(len(self._scan(php)), 1)
+
+
 class GateIsNotBlind(unittest.TestCase):
     """If `check_store` ever stops producing findings entirely, the scoping
     assertions above still pass. This asserts the floor directly."""


### PR DESCRIPTION
Closes part of #423 — the false-positive half of the #415 comment class, checker side. Companion PR for the runner side: gates 5, 23, 24.

## What was wrong

Seven checkers asked a question about CODE and answered it by matching bytes of a FILE, so a sentence about code that was **removed** scored as that code. Every one of these was reproduced on this package before being touched, with its positive control run first.

| gate | the input | before | after |
|---|---|---|---|
| 9 semantic-auth | a body whose only mention is `// We used to $this->requireAdmin(); here.` | FAIL — 1 | 0 (a real call still FAILs) |
| 27 phantom-rpc | ONE clean file: interior block-comment line, trailing comment, string literal | FAIL — 3 (JS twin: 2) | 1 (the literal, #424); JS 0 |
| 28 license-triangle | `* @license MIT was never used here — see the note above.` under a real EUPL header | FAIL — 2 | 0 (a real second licence still FAILs) |
| 46 spec-anchors | a tag inside a string literal, and a tag mid-sentence | FAIL — 3 | 1 — the real dangling annotation |
| 47 security-cochange | a TRAILING comment naming a token, and an HTML comment | both "security-relevant" | neither; real declarations unchanged |
| 61 listener-placement | a listener existing only as commented-out registration lines | FAIL, "no class file found" | nothing is wired, so nothing is reported |
| 62 store-plane | a docblock saying the class deliberately does NOT do it | FAIL — 1, identical to the real violation | 0 (the real violation still 1) |

This is the corrosive direction: in every case the author's cheapest fix is to **delete the explanation**, and the gate then loses the only thing that would let a human check it.

## How

Six route through `lib/source_scope.py` (`php_mask`, `js_comment_mask`) — offset-preserving, because findings report a line number. gate-61's local three-regex stripper becomes a call to `php_mask` rather than a fourth dialect: it was not offset-preserving, not string-aware, and saw `#` only at the start of a line.

Two are position-anchored instead of masked, because their tag lives in a comment **by design**: gate-46's tag must start the line's content (gates 47 and 48 were given exactly this treatment; 46 never was), and gate-28's licence identifier may be followed only by a URL or a comment terminator.

**String contents are kept everywhere**, and that is a judgement per gate rather than an omission — gate-27's Rule B evidence *is* a string literal, gate-62's URL is a string in every real violation, gate-47 reads a header key. Each suite carries that pairing as an explicit control, so #424 cannot change it silently.

## Measured, not assumed

Six fleet repos (openregister, opencatalogi, procest, docudesk, larpingapp, softwarecatalog), finding **sets** diffed rather than counted:

* gate-28 — 2,394 tracked `lib/**/*.php`: declaration counts identical, finding sets identical, larpingapp's 19 drift findings all survive. The fleet's own header carries a URL after the identifier, **2,724 files of it**, so the obvious rule ("nothing may follow") would have silenced the gate on its main subject. The corpus decided the rule.
* gate-46 — 5,684 files, 17,408 tags → 17,406, finding sets identical (25 = 25). The two tags it stops seeing are a sentence beginning "Per @spec …" and a note reading "this used to read `@spec …`" — this defect class verbatim, twice.
* gates 9 / 47 / 61 / 62 — sets identical, each with a liveness witness so the zero is not a dead rig: 12 surviving findings, 460 classified files, 69 parsed registrations, 1 finding.

The shapes are **latent** in these repos; the evidence is the fixture, and that is stated rather than dressed up as a fleet win.

## Arms

+45 assertions across the seven suites. Reverted against `origin/main`, exactly the evidence arms flip and the labelled controls do not: 9 → P2/P3/P6, 27 → R2/R3/R5/R8, 28 → T2/T3, 46 → A2/A3/A4, 47 → C3/C8/C9, 61 → L2/L3/L4, 62 → S2/S3.

`tests/run-helper-suites.sh`: **83 passed, 0 failed, 2 quarantined** (both pre-existing and documented).

## Deliberately not done

`.vue` is not masked in gates 27 and 47 — the mask for an SFC routes through the `<!-- … -->` handling under repair in #424, and a hole there would let a comment *silence* a gate whose findings are runtime fatals. Those two false positives stand and are named in the code. Gate 15 is blocked on the same thing; gate 21 is declined with the trade measured — see the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
