### PR TITLE
fix(gates 5, 23, 24): a comment must not spend a window, or invent a gap (#415 class, #423)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_route_auth.sh
+++ b/hydra-gates/scripts/lib/test_gate_route_auth.sh
@@ -146,6 +146,43 @@ if _run "${FIXTURES}/guarded"; then
 fi
 
 # ---------------------------------------------------------------------------
+# 2b. A COMMENT MUST NOT SPEND THE WINDOW (.github#415/#423).
+#
+# `_head_block` took the union of {the contiguous annotation run, a 20-line
+# slice}. For a MULTI-LINE attribute the run breaks at the `)]` line, so the
+# slice was the only thing reaching the `#[` — and an ordinary docblock
+# between the attribute and the declaration spends that slice.
+#
+# Measured on two fixtures differing in NOTHING but the length of the
+# docblock, both carrying a real `#[AuthorizedAdminSetting(\n …\n)]`:
+#
+#     2 doc lines  -> PASS          30 doc lines -> FAIL — 1 routed method(s)
+#
+# so the author who documents the endpoint goes red and the author who
+# deletes the paragraph goes green, having changed nothing about its auth.
+#
+# The pair below is the whole point: stepping over the attribute by STRUCTURE
+# must not let the NEXT method borrow it. `multiline-attribute-borrow` is the
+# same file plus one unguarded routed method, and it must still fail naming
+# `open` — if the step-over ever runs past the previous member's close, this
+# arm goes green and the suite goes red.
+# ---------------------------------------------------------------------------
+if _run "${FIXTURES}/multiline-attribute"; then
+    _expect_gate 5 PASS \
+        "multiline-attribute fixture: a 29-line docblock does not hide a three-line attribute"
+fi
+
+if _run "${FIXTURES}/multiline-attribute-borrow"; then
+    _expect_gate 5 FAIL \
+        "multiline-attribute-borrow fixture: the method BELOW the attribute may not borrow it"
+    _expect_out 'gate-5\] route-auth: FAIL — 1 routed method' \
+        "multiline-attribute-borrow fixture: exactly ONE finding (save is genuinely guarded)"
+    _RALOG="$(cat "${_LOGDIR}/hydra-gate-route-auth.log" 2>/dev/null || true)"
+    _expect_log "${_RALOG}" 'SettingsController.php:[0-9]+ method=open' \
+        "multiline-attribute-borrow fixture: the finding names open, not save"
+fi
+
+# ---------------------------------------------------------------------------
 # 3. DEFECT (a). scholiq's shape: AppHost generics produce NO finding, and the
 #    fact that they were not judged is STATED rather than silently dropped.
 # ---------------------------------------------------------------------------

--- a/hydra-gates/scripts/lib/test_gates_23_33_never_green_over_nothing.sh
+++ b/hydra-gates/scripts/lib/test_gates_23_33_never_green_over_nothing.sh
@@ -262,6 +262,55 @@ rm -rf "${_DIRECT}"
 
 # ===========================================================================
 echo
+echo "== gate-24: a COMMENT is not a registration (.github#415/#423) =="
+# ===========================================================================
+# The two probes that decide `na` vs `structural` were raw greps, so
+#
+#     // TODO: one day we could do `new LeafDescriptor(...)` here
+#     // We used to call registerIntegration({...}); removed in 2.4
+#
+# made the gate claim the repo has a server↔JS pair nobody correlated. Not a
+# red gate — a FABRICATED GAP, in the arithmetic that decides whether the
+# run's coverage is believed. Measured on this fixture: the COVERAGE line went
+# from "17 of 18 applicable gates ran" to "17 of 17".
+#
+# The paired arm is the one that matters, and it is the arm above plus this
+# one: a real `new LeafDescriptor(` and a real `registerIntegration(` must
+# STILL be structural. A mask that over-blanked would make every repo `na`,
+# which is the same gate switched off from the other side.
+_CMT="$(mktemp -d "${TMPDIR:-/tmp}/hydra-gate-24-comment.XXXXXXXX")"
+cp -r "${FIXTURES}/clean/." "${_CMT}/"
+mkdir -p "${_CMT}/lib/Service" "${_CMT}/src"
+cat > "${_CMT}/lib/Service/LeafNotes.php" <<'PHPEOF'
+<?php
+namespace OCA\Fixture\Service;
+
+class LeafNotes
+{
+    public function run(): void
+    {
+        // TODO: one day we could do `new LeafDescriptor(...)` here so the
+        // files integration can render our objects. Not done yet.
+    }
+}
+PHPEOF
+cat > "${_CMT}/src/integration-notes.js" <<'JSEOF'
+// We used to call registerIntegration({ id: 'fixture-thing' }); it was
+// removed in 2.4 when the leaf moved into openregister.
+export default {}
+JSEOF
+if [ ! -f "${_CMT}/lib/Service/LeafNotes.php" ]; then
+    _bad "the comment-only overlay did not land — the gate-24 comment arm would be vacuous"
+elif _run "${_CMT}"; then
+    _expect 24 "NOT APPLICABLE" \
+        "gate-24: a leaf named only in two comments is not a leaf"
+    _expect 24 "registers no integration leaves at all" \
+        "gate-24 says WHY it is na"
+fi
+rm -rf "${_CMT}"
+
+# ===========================================================================
+echo
 echo "== gate-23 in WARN mode: a finding must still be VISIBLE =="
 # ===========================================================================
 # Before the bake-in epoch the linter exits 0 whatever it found, so the gate

--- a/hydra-gates/scripts/lib/test_or_abstraction_pdok.sh
+++ b/hydra-gates/scripts/lib/test_or_abstraction_pdok.sh
@@ -178,6 +178,62 @@ else
     FAILS=$((FAILS + 1))
 fi
 
+# --- the CAPABILITY table's grep row must read code too (#415/#423) ---------
+#
+# The PDOK rule above has routed through `_code_lines` since it was written.
+# `OR_CAPABILITY_RULES`' one `grep`-kind row — Postgres `search_path` tenant
+# isolation — never did, so a docblock saying the class deliberately does NOT
+# do the thing produced a finding IDENTICAL to a real one. Both halves are
+# asserted here: the documented file goes quiet, the real statement does not.
+#
+# ⚠️ THE CAPABILITY ROWS HAVE THEIR OWN BAKE-IN EPOCH, so `run_gate`'s forced
+# BLOCK mode does NOT reach them: in WARN mode the script exits 0 whether or
+# not a capability rule matched. Written as `assert_rc 0` first, BOTH halves
+# passed — including on the unfixed script, where the "silent" arm was
+# measuring the epoch and not the finding. Assert the FILE LIST instead, and
+# force the capability epoch too so the exit status is a second witness.
+assert_out() {  # <yes|no> <regex> <label>
+    local want="$1" rx="$2" label="$3"
+    HYDRA_OR_CAPABILITY_GATE_BLOCK_AFTER_EPOCH=0 run_gate >/dev/null
+    if grep -qE "${rx}" "${WORK}/.out"; then
+        if [ "${want}" = "yes" ]; then echo "PASS — ${label}"; return; fi
+    elif [ "${want}" = "no" ]; then
+        echo "PASS — ${label}"; return
+    fi
+    echo "FAIL — ${label} (expected the output ${want} to match /${rx}/)"
+    sed 's/^/        /' "${WORK}/.out"
+    FAILS=$((FAILS + 1))
+}
+
+reset_tree
+cat > "${WORK}/lib/Service/RowFetcher.php" <<'PHPEOF'
+<?php
+class RowFetcher {
+    /**
+     * Fetch rows for the caller's organisation.
+     *
+     * We deliberately do NOT set a Postgres search_path here — isolation is
+     * OpenRegister's job (ADR-022), and doing it locally would be an
+     * app-local re-implementation of an OR-owned capability.
+     */
+    public function findAll(): array {
+        return $this->or->objects()->all();
+    }
+}
+PHPEOF
+assert_out no "RowFetcher\.php" "silent: a docblock explaining that search_path is NOT set is not a finding"
+
+reset_tree
+cat > "${WORK}/lib/Service/RealScope.php" <<'PHPEOF'
+<?php
+class RealScope {
+    public function scope(string $t): void {
+        $this->db->executeStatement('SET search_path TO '.$t);
+    }
+}
+PHPEOF
+assert_out yes "RealScope\.php" "fires: a real SET search_path is still OR-owned-capability duplication"
+
 # --- openconnector itself owns the adapter and is exempt --------------------
 reset_tree
 printf '<?xml version="1.0"?>\n<info>\n  <id>openconnector</id>\n</info>\n' > "${WORK}/appinfo/info.xml"

--- a/hydra-gates/scripts/lint-or-abstraction-anti-patterns.sh
+++ b/hydra-gates/scripts/lint-or-abstraction-anti-patterns.sh
@@ -415,7 +415,42 @@ if [ "${IS_OR}" -eq 0 ]; then
         case "${_cap_kind}" in
             path) _cap_matches="$(find "${SEARCH_ROOT}" -type f -path "${_cap_pattern}" 2>/dev/null || true)" ;;
             name) _cap_matches="$(find "${SEARCH_ROOT}" -type f -iname "${_cap_pattern}" 2>/dev/null || true)" ;;
-            grep) _cap_matches="$(grep -rln --include='*.php' -e "${_cap_pattern}" "${SEARCH_ROOT}" 2>/dev/null || true)" ;;
+            grep)
+                # A COMMENT MUST NOT MANUFACTURE A FINDING (#415/#423).
+                #
+                # This row is the only `grep`-kind rule in the table, and it
+                # ran over the RAW file. A docblock reading
+                #
+                #     We deliberately do NOT set a Postgres search_path here
+                #     — tenant isolation is OpenRegister's job (ADR-022).
+                #
+                # produced `[or-capability:tenant-boundary]` against a file
+                # that does exactly what the ADR asks. The cheapest fix
+                # available to the author is to delete the paragraph that
+                # records the decision.
+                #
+                # The PDOK rule in this same file has routed through
+                # `_code_lines` since it was written; the capability rows
+                # never got it. `grep -rln` is kept as the CANDIDATE finder
+                # (it is fast and it opens the whole tree), and each
+                # candidate is then re-asked on its code lines only.
+                #
+                # ⚠️ `_code_lines` strips WHOLE-LINE comments only — its own
+                # docstring says trailing comments are left in place because
+                # keeping them "can only cause the gate to fire, never to
+                # stay silent". So a trailing `// no search_path here` still
+                # produces a finding. Narrowing that is a change to a helper
+                # the PDOK rule shares, and it is not made here.
+                _cap_raw="$(grep -rln --include='*.php' -e "${_cap_pattern}" "${SEARCH_ROOT}" 2>/dev/null || true)"
+                _cap_matches=""
+                while IFS= read -r _cap_cand; do
+                    [ -z "${_cap_cand}" ] && continue
+                    if _code_lines "${_cap_cand}" | grep -q -e "${_cap_pattern}"; then
+                        _cap_matches="${_cap_matches}${_cap_cand}"$'\n'
+                    fi
+                done <<< "${_cap_raw}"
+                _cap_matches="$(printf '%s' "${_cap_matches}")"
+                ;;
             *)    _cap_matches="" ;;
         esac
         [ -z "${_cap_matches}" ] && continue

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1407,10 +1407,46 @@ _ctrl_path_from_name() {
 # than the run alone matters for a multi-line attribute
 # (`#[AuthorizedAdminSetting(\n  Application::APP_ID\n)]`), whose middle lines
 # are ordinary code and would otherwise cut the run short.
+#
+# ⚠️ AND THE UNION WAS NOT ENOUGH: A COMMENT COULD STILL SPEND THE BUDGET
+# (#415/#423). The union only rescues a multi-line attribute while the
+# 20-line SLICE still reaches it, so the explanation between the attribute
+# and the declaration is charged against the attribute's visibility.
+# Measured on two fixtures differing in NOTHING but the length of an
+# ordinary docblock, both carrying a real
+# `#[AuthorizedAdminSetting(\n Application::APP_ID\n)]` above it:
+#
+#     2 doc lines  -> [gate-5] route-auth: PASS
+#    30 doc lines  -> [gate-5] route-auth: FAIL — 1 routed method(s)
+#                       missing auth attribute
+#
+# The attribute is there in both. The run breaks at the `)]` line — which
+# matches none of the five patterns above — so `run` stops BELOW the
+# attribute, and past twenty lines of prose the slice no longer reaches it
+# either. An author who documents the endpoint goes red; the same author who
+# deletes the paragraph goes green having changed nothing about its auth.
+# That is the corrosive direction: it teaches people to delete the
+# explanation, and this is a SECURITY gate whose findings a human has to be
+# able to check.
+#
+# So the walk now STEPS OVER a multi-line attribute by structure rather than
+# by distance — the same repair `check_contract_coverage` documents at its
+# L208 ("WHY THIS IS NOT A LINE WINDOW"). On a line that closes a bracket,
+# it scans up for the `#[` that opens it, requiring the brackets between to
+# BALANCE, and resumes the run from there. It cannot run away: the scan is
+# bounded, it must find a real `#[` at line start, and the previous-member
+# clamp below still cuts the window at the last `}` — so a short guarded
+# method still cannot donate its attribute to the next one.
 # ---------------------------------------------------------------------------
 _head_block() {
     local _file="$1" _def="$2"
     awk -v D="${_def}" '
+        # Net bracket depth of one line: `[` opens, `]` closes.
+        function _brk(s,   t, o, c) {
+            t = s; o = gsub(/\[/, "", t)
+            t = s; c = gsub(/\]/, "", t)
+            return o - c
+        }
         NR <= D { line[NR] = $0 }
         NR > D  { exit }
         END {
@@ -1423,6 +1459,21 @@ _head_block() {
                 if (l ~ /^[[:space:]]*\*/)             { run = i; continue }
                 if (l ~ /^[[:space:]]*\/\//)           { run = i; continue }
                 if (l ~ /^[[:space:]]*#\[/)            { run = i; continue }
+                # A line that closes more brackets than it opens may be the
+                # tail of a multi-line attribute. Walk up while the brackets
+                # stay unbalanced; if the line that balances them opens an
+                # attribute, the whole span belongs to this declaration.
+                if (_brk(l) < 0) {
+                    bal = 0
+                    for (j = i; j >= 1 && i - j <= 40; j--) {
+                        bal += _brk(line[j])
+                        if (bal == 0) {
+                            if (line[j] ~ /^[[:space:]]*#\[/) { run = j; i = j }
+                            break
+                        }
+                    }
+                    if (run == i) { continue }
+                }
                 break
             }
             slice = (D > 20) ? D - 20 : 1
@@ -4459,7 +4510,49 @@ _parity_log=${HYDRA_GATE_LOG_DIR}/hydra-gate-integration-parity.log
 # any leaves at all.
 _parity_has_php=0
 _parity_has_js=0
-if [ -d lib ] && grep -rqE 'new[[:space:]]+LeafDescriptor[[:space:]]*\(' lib/ --include='*.php' 2>/dev/null; then
+# A COMMENT MUST NOT MANUFACTURE A CLASSIFICATION (#415/#423).
+#
+# Both probes below were raw `grep -r`, and their answer decides whether an
+# absent wrapper is reported as `na` (no subject matter, not counted) or as
+# `structural` (a real gap, counted against coverage). Two comments —
+#
+#     // TODO: one day we could do `new LeafDescriptor(...)` here
+#     // We used to call registerIntegration({...}); removed in 2.4
+#
+# flipped `NOT APPLICABLE` to `SKIPPED (structural)`, and the run's
+# `--require-full-coverage` exit went 5 -> 6 on the same tree. Not a red
+# gate; a fabricated gap, in the arithmetic that decides whether the fleet's
+# coverage is believed.
+#
+# `_parity_code` finds candidates with grep (fast, and it opens the whole
+# tree) and then re-asks the question on the file's CODE. The masks are the
+# shared, offset-preserving ones. A file type with no mask is judged RAW —
+# which is the pre-#423 behaviour and errs towards `structural`, the
+# stricter side — and `.vue` is deliberately in that set: masking an SFC
+# routes through the `<!-- … -->` handling #424 is repairing, and a hole
+# there would let a comment REMOVE a real registration from the count. Same
+# for a mask that fails to run: the raw answer stands.
+_parity_code() {  # <file> — the file's code, or its raw text if unmaskable
+    case "$1" in
+        *.php) python3 "${SCRIPT_DIR}/lib/source_scope.py" --mask php "$1" 2>/dev/null || cat "$1" ;;
+        *.js|*.ts|*.mjs|*.cjs|*.jsx|*.tsx)
+               python3 "${SCRIPT_DIR}/lib/source_scope.py" --mask js-comments "$1" 2>/dev/null || cat "$1" ;;
+        *)     cat "$1" ;;
+    esac
+}
+_parity_probe() {  # <dir> <extended-regex> <find-args...> — 0 when a CODE line matches
+    local _dir="$1" _rx="$2"; shift 2
+    local _cand
+    while IFS= read -r _cand; do
+        [ -z "${_cand}" ] && continue
+        [ -f "${_cand}" ] || continue
+        if _parity_code "${_cand}" | grep -qE "${_rx}" 2>/dev/null; then
+            return 0
+        fi
+    done < <(grep -rlE "${_rx}" "${_dir}" "$@" 2>/dev/null)
+    return 1
+}
+if [ -d lib ] && _parity_probe lib/ 'new[[:space:]]+LeafDescriptor[[:space:]]*\(' --include='*.php'; then
     _parity_has_php=1
 fi
 # THE JS PROBE MUST MATCH BOTH SUPPORTED REGISTRATION APIs, NOT ONE.
@@ -4489,7 +4582,7 @@ fi
 #
 # `integrations\.register` cannot collide with `unregister(` (the qualifier is
 # part of the match) nor with `registerIntegrationIcons(` (the `\(` anchors it).
-if [ -d src ] && grep -rqE '\b(registerIntegration|integrations\.register)[[:space:]]*\(' src/ 2>/dev/null; then
+if [ -d src ] && _parity_probe src/ '\b(registerIntegration|integrations\.register)[[:space:]]*\('; then
     _parity_has_js=1
 fi
 if [ ! -f scripts/check-integration-parity.sh ]; then

--- a/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute-borrow/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute-borrow/appinfo/routes.php
@@ -1,0 +1,12 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture: the anti-widening pair for `multiline-attribute`. The same
+// three-line attribute, plus a SECOND routed method below it that carries
+// none. Gate-5 MUST fail and MUST name `open` — stepping over a multi-line
+// attribute may not let the next method borrow it.
+return [
+    'routes' => [
+        ['name' => 'settings#save', 'url' => '/api/settings', 'verb' => 'POST'],
+        ['name' => 'settings#open', 'url' => '/api/settings/{id}', 'verb' => 'GET'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute-borrow/lib/Controller/SettingsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute-borrow/lib/Controller/SettingsController.php
@@ -1,0 +1,65 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCA\Fixture\AppInfo\Application;
+
+/**
+ * Fixture controller — the routed method's auth attribute is REAL, spans
+ * three lines, and sits above twenty-nine lines of ordinary docblock.
+ *
+ * Before ConductionNL/.github#423 the contiguous annotation run broke at the
+ * `)]` line and the 20-line slice no longer reached the `#[`, so this file
+ * FAILED gate-5 while a byte-identical file with a two-line docblock PASSED.
+ * The gate was reading the length of the explanation as the absence of the
+ * attribute.
+ */
+class SettingsController extends Controller
+{
+    #[AuthorizedAdminSetting(
+        Application::APP_ID
+    )]
+    /**
+     * Save the admin settings.
+     *
+     * Line 1 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 2 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 3 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 4 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 5 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 6 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 7 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 8 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 9 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 10 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 11 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 12 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 13 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     */
+    public function save(array $data): JSONResponse
+    {
+        return new JSONResponse($data);
+    }
+
+    public function open(string $id): JSONResponse
+    {
+        return new JSONResponse(['id' => $id]);
+    }
+}

--- a/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute/appinfo/routes.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute/appinfo/routes.php
@@ -1,0 +1,10 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+// Fixture: one routed method whose auth attribute is written across three
+// lines and sits ABOVE a long docblock. Gate-5 MUST pass — the attribute is
+// there, and the length of the explanation between them is not evidence.
+return [
+    'routes' => [
+        ['name' => 'settings#save', 'url' => '/api/settings', 'verb' => 'POST'],
+    ],
+];

--- a/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute/lib/Controller/SettingsController.php
+++ b/hydra-gates/scripts/test-fixtures/route-auth/multiline-attribute/lib/Controller/SettingsController.php
@@ -1,0 +1,60 @@
+<?php
+// SPDX-License-Identifier: EUPL-1.2
+
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCA\Fixture\AppInfo\Application;
+
+/**
+ * Fixture controller — the routed method's auth attribute is REAL, spans
+ * three lines, and sits above twenty-nine lines of ordinary docblock.
+ *
+ * Before ConductionNL/.github#423 the contiguous annotation run broke at the
+ * `)]` line and the 20-line slice no longer reached the `#[`, so this file
+ * FAILED gate-5 while a byte-identical file with a two-line docblock PASSED.
+ * The gate was reading the length of the explanation as the absence of the
+ * attribute.
+ */
+class SettingsController extends Controller
+{
+    #[AuthorizedAdminSetting(
+        Application::APP_ID
+    )]
+    /**
+     * Save the admin settings.
+     *
+     * Line 1 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 2 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 3 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 4 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 5 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 6 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 7 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 8 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 9 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 10 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 11 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 12 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     * Line 13 of an ordinary explanation: what this endpoint validates,
+     * which ADR it implements, and why the register is optional here.
+     */
+    public function save(array $data): JSONResponse
+    {
+        return new JSONResponse($data);
+    }
+}


### PR DESCRIPTION
Closes part of #423 — the false-positive half of the #415 comment class, runner side. Companion PR for the checker side: gates 9, 27, 28, 46, 47, 61, 62.

## gate-5 — a docblock was charged against an attribute's visibility

`_head_block` takes the union of {the contiguous annotation run, a 20-line slice}. For a **multi-line** attribute the run breaks at the closing line, so the slice is the only thing that can reach the opener — and an ordinary docblock between them spends it. Two fixtures differing in **nothing** but the length of that docblock, both carrying a real three-line `#[AuthorizedAdminSetting(...)]`:

```
 2 doc lines -> [gate-5] route-auth: PASS
30 doc lines -> [gate-5] route-auth: FAIL — 1 routed method(s) missing auth attribute
```

The attribute is present in both. A security gate telling an author that documenting the endpoint is what made it unsafe, whose cheapest remedy is to delete the paragraph.

The walk now steps over a multi-line attribute **by structure** — on a line that closes more brackets than it opens it scans up for the opener, requiring the brackets between to balance — rather than by distance. The same repair `check_contract_coverage` documents at its L208, *"WHY THIS IS NOT A LINE WINDOW"*. It is bounded at 40 lines, must land on a real attribute opener at line start, and the previous-member clamp still cuts the window at the last `}`.

**The anti-widening pair caught something.** On `multiline-attribute-borrow` — the same file plus one unguarded routed method below it — the OLD runner reports `FAIL — 2`, flagging the genuinely guarded method as well. The new one reports `FAIL — 1` and names the unguarded one. The change removes exactly the false finding and keeps the real one, in the same fixture.

## gate-23 — the one grep-kind capability row never read code

A docblock recording that the class deliberately does **not** do the thing produced a finding identical to a real one: `or_abstraction_findings=1`, dropping to 0 once the candidate is re-asked on its code lines. A real statement still fires. The PDOK rule in the same file has routed through `_code_lines` since it was written; the capability rows never got it. `grep -rln` stays as the candidate finder.

## gate-24 — a comment invented a coverage gap

Both probes deciding `na` vs `structural` were raw greps, so two comments describing registrations that were **removed** made the gate claim the repo has a server↔JS pair nobody correlated. Not a red gate — a fabricated gap in the arithmetic that decides whether a run's coverage is believed:

```
before  COVERAGE: 17 of 65 … (17 of 18 applicable gates ran)
after   COVERAGE: 17 of 65 … (17 of 17 applicable gates ran)
```

and gate-24 is the **only** verdict that moves in the whole 65-gate run. Real registrations stay structural.

## Masks, not new strippers

gate-24 shells out to `lib/source_scope.py` (`--mask php`, `--mask js-comments`), the same way gate-20 already does; gate-23 reuses its own file's `_code_lines`. A file type with no mask is judged **raw** — the pre-#423 behaviour, erring towards `structural`, the stricter side — and `.vue` is deliberately in that set, because masking an SFC routes through the delimiter handling under repair in #424 and a hole there would let a comment *remove* a real registration from the count. Same for a mask that fails to run: the raw answer stands.

## Arms

gate-5: two new fixtures, four assertions (suite 37 → 41). gate-23: two assertions. gate-24: two assertions (suite 42 → 44). With the runner and the linter restored from `origin/main`, exactly the evidence arms flip and the controls do not.

⚠️ **gate-23's first arms were written as exit-code assertions and BOTH passed on the unfixed script.** The capability rows have their own bake-in epoch, so the suite's forced BLOCK mode never reaches them and WARN mode exits 0 whatever it found — the arm was measuring the epoch, not the finding. They assert the file list now, and force the capability epoch as a second witness. Agreement between the two arms was the tell.

`tests/run-helper-suites.sh`: 83 passed, 0 failed, 2 quarantined (both pre-existing and documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
