### PR TITLE
fix(gates 6, 17, 56, 57): a comment naming the call is not the call (#422)

### DIFF
--- a/hydra-gates/scripts/lib/check_orphan_auth.py
+++ b/hydra-gates/scripts/lib/check_orphan_auth.py
@@ -85,6 +85,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask, script_mask  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Verb tiers (the candidate filter — unchanged from the original gate).
@@ -277,6 +280,42 @@ def _is_access_control(name: str, head: str, params: str, body: str) -> bool:
 # (a public helper called from another method in the same class is legit).
 # ---------------------------------------------------------------------------
 def _build_caller_corpus() -> str:
+    """The CODE of lib/ + src/, comments blanked — never the raw bytes.
+
+    A TODO NAMING THE CALL IS NOT THE CALL (#415 / #422).
+    -----------------------------------------------------
+    This corpus is the entire evidence base for "is this guard ever invoked",
+    and it used to be the raw text of every file. The question is then answered
+    by ``->requiresChairAuthorization\\s*\\(`` appearing ANYWHERE in it, and
+    prose is made of the same bytes. Measured on this checker, one fixture, one
+    variable:
+
+        an unreferenced requiresChairAuthorization()   FAIL — defined-but-never-called
+        + one caller-file line reading                 PASS               <- the defect
+          "// TODO: we should call
+           $this->authz->requiresChairAuthorization($uid)
+           here before advancing. Not done yet."
+
+    This gate's whole framing is "an unwired guard is identical to no guard",
+    so the sentence admitting the guard is not wired is the sentence that
+    reports it wired. gate-7's ``#[NoAdminRequired]`` defect, one gate over.
+
+    STRING CONTENTS STAY. ``->name(`` is PHP call syntax and is not evidence
+    inside a literal — but the ROUTE TABLE is a caller this corpus cannot
+    contain, and it is matched separately by :func:`_build_route_corpus`,
+    which reads ``appinfo/routes.php`` UNMASKED because ``'liveTile#validate'``
+    IS a string and is the only form the router has. Blanking literals here
+    would not touch that; it is left alone because the fail-safe direction for
+    a gate that accuses live code of being dead is to keep more callers, not
+    fewer. The string axis is #424's, and it is reported rather than smuggled
+    in behind this one.
+
+    ``.vue``/``.js``/``.ts`` go through ``script_mask``, which blanks HTML and
+    JS comments. Note that no legitimate ``->method(`` PHP call site can exist
+    in a ``.vue`` at all, so both directions there are inert: over-blanking
+    cannot remove a real caller, and under-blanking is exactly the hole being
+    closed.
+    """
     chunks: list[str] = []
     roots = (
         (Path("lib"), (".php",)),
@@ -289,9 +328,13 @@ def _build_caller_corpus() -> str:
             if not path.is_file() or path.suffix not in exts:
                 continue
             try:
-                chunks.append(path.read_text(encoding="utf-8", errors="ignore"))
+                text = path.read_text(encoding="utf-8", errors="ignore")
             except OSError:
                 continue
+            if path.suffix == ".php":
+                chunks.append(php_mask(text))
+            else:
+                chunks.append(script_mask(text, str(path)))
     return "\n".join(chunks)
 
 

--- a/hydra-gates/scripts/lib/check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/check_orphaned_write_capability.py
@@ -72,6 +72,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+from source_scope import php_mask  # noqa: E402
 
 # Foundation repos: the abstractions every leaf app consumes (ADR-022,
 # apps-consume-or-abstractions). A PUBLIC method here is frequently invoked
@@ -339,7 +340,23 @@ def _declaration_has_body(lines: list[str], method_line_idx: int) -> bool:
 
     An abstract method inside an abstract class has no body, so there is
     nothing that can be dead. Scans forward across a multi-line signature
-    for whichever of `{` / `;` appears first (hydra#106, FP class 3)."""
+    for whichever of `{` / `;` appears first (hydra#106, FP class 3).
+
+    *lines* MUST BE COMMENT-BLANKED (#422). The local `//` strip below handles
+    exactly one comment syntax, and a `;` inside any other one is read as the
+    signature's terminator — so the method is classified as an abstract
+    DECLARATION and skipped entirely, findings and all:
+
+        public function postInvoice(string $id) /* returns true; never throws */ {
+
+        raw lines      the `;` in the note terminates the signature -> SKIPPED
+        blanked lines  the `{` terminates it                        -> judged
+
+    A comment cannot make a method bodiless, and this is the quietest possible
+    false negative: the method is not reported as passing, it is never looked
+    at. The caller passes the same ``blanked_lines`` the MCP-attribute seam
+    already uses; the two local `re.sub`s stay as a belt-and-braces for any
+    future caller that passes raw lines."""
     for line in lines[method_line_idx : method_line_idx + 12]:
         code = re.sub(r"//.*$", "", line)
         # Drop quoted literals so a `;` or `{` inside a default string value
@@ -464,43 +481,18 @@ def _blank_php_comments(text: str) -> str:
     ``#`` opens a line comment in PHP, but ``#[`` opens an ATTRIBUTE. Blanking
     attributes would delete the very thing being looked for, so the two are
     distinguished.
+
+    THIS IS NOW THE SHARED MASK, NOT A LOCAL DIALECT (#422). The body used to
+    be a hand-rolled state machine — the FIFTH copy of this logic in the
+    package — and it agreed with ``source_scope.php_mask`` clause for clause:
+    strings skipped, ``#[`` excluded, ``/* */`` and ``//`` blanked, length and
+    newlines preserved. Two copies that are equal are a maintenance cost; two
+    copies that MIGHT diverge are a defect, and this module has already been
+    bitten once by applying its mask on some read paths and not others (see
+    :func:`_build_caller_index`). The name and the docstring stay because the
+    call sites and the REASON are this module's; only the implementation moves.
     """
-    out = list(text)
-    i = 0
-    n = len(text)
-    while i < n:
-        ch = text[i]
-        if ch in ("'", '"'):
-            quote = ch
-            i += 1
-            while i < n:
-                if text[i] == "\\":
-                    i += 2
-                    continue
-                if text[i] == quote:
-                    i += 1
-                    break
-                i += 1
-            continue
-        if ch == "/" and i + 1 < n and text[i + 1] == "*":
-            j = text.find("*/", i + 2)
-            j = n if j == -1 else j + 2
-            for k in range(i, j):
-                if out[k] != "\n":
-                    out[k] = " "
-            i = j
-            continue
-        if (ch == "/" and i + 1 < n and text[i + 1] == "/") or (
-            ch == "#" and not (i + 1 < n and text[i + 1] == "[")
-        ):
-            j = text.find("\n", i)
-            j = n if j == -1 else j
-            for k in range(i, j):
-                out[k] = " "
-            i = j
-            continue
-        i += 1
-    return "".join(out)
+    return php_mask(text)
 
 
 def _build_mcp_attribute_seam(app_root: str) -> set[str]:
@@ -802,14 +794,40 @@ def _build_caller_index(app_root: str, extra_roots: list[str] | None = None) -> 
     reported dead. The index is keyed on method NAME only (not FQCN), which
     is deliberately over-permissive: a name collision inflates the caller
     count and SUPPRESSES a finding. That is the fail-safe direction — this
-    gate must never manufacture a "dead" verdict for live code."""
+    gate must never manufacture a "dead" verdict for live code.
+
+    A TODO NAMING THE CALL IS NOT THE CALL (#415 / #422).
+    -----------------------------------------------------
+    This index used to be built from each file's RAW bytes, so a comment
+    counted as a caller. Measured on this checker, one fixture, one variable:
+
+        an uncalled InvoiceService::postInvoice()   FAIL — orphaned-write-capability
+        + a docblock in the controller reading      PASS               <- the defect
+          "* TODO: we should call
+           $this->fooService->postInvoice($id) here
+           once the ledger migration lands.
+           Not done yet."
+
+    ⚠️ THIS MODULE ALREADY KNEW. ``_blank_php_comments`` was written for the
+    SEAMS in this same file, and its docstring states this exact class — "a
+    checker that greps text misses every constant AND matches every comment" —
+    yet the caller index, which is the gate's primary evidence, went on reading
+    raw. **Knowing about the class is not the same as having applied the fix on
+    every read path**, and a partially-masked checker looks exactly like a
+    fully-masked one from the outside.
+
+    STRING CONTENTS SURVIVE (``php_mask`` default). The index is deliberately
+    over-permissive because its fail-safe direction is to SUPPRESS a finding:
+    this gate accuses live code of being dead, and a false accusation acted on
+    deletes working code. Blanking literals would remove callers, i.e. push the
+    gate the wrong way; that axis is #424's and is reported, not smuggled in."""
     counts: dict[str, int] = {}
     call_re = re.compile(r"->([A-Za-z_][A-Za-z0-9_]*)\s*\(")
     for root in [app_root, *(extra_roots or [])]:
         for fp in _enumerate_lib_php(root, include_untracked=True):
             try:
                 with open(fp, encoding="utf-8", errors="replace") as fh:
-                    text = fh.read()
+                    text = _blank_php_comments(fh.read())
             except OSError:
                 continue
             for m in call_re.finditer(text):
@@ -850,7 +868,7 @@ def scan_file(file_path: str, app_root: str, seams, caller_counts, findings: lis
         name = m.group("name")
         if not _is_write_method(name):
             continue
-        if not _declaration_has_body(lines, idx):
+        if not _declaration_has_body(blanked_lines, idx):
             # Abstract declaration inside an abstract class — no body.
             continue
         if _preceding_docblock_has_exclude(lines, idx):

--- a/hydra-gates/scripts/lib/check_register_handler_resolution.py
+++ b/hydra-gates/scripts/lib/check_register_handler_resolution.py
@@ -47,6 +47,9 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
+
 # Keys whose STRING (or list-of-string) values are treated as class/method
 # references. Object-shaped values under these keys (the declarative CEL
 # `{"type":"precondition","conditions":[...]}` form) are NOT class
@@ -119,6 +122,47 @@ def _method_def_re(method: str) -> re.Pattern:
     return re.compile(r"function\s+" + re.escape(method) + r"\s*\(")
 
 
+def _php_code(path: str) -> str | None:
+    """The CODE of a PHP file, comments blanked. ``None`` when unreadable.
+
+    A COMMENT DESCRIBING A CLASS IS NOT THE CLASS (#415 / #422).
+    -----------------------------------------------------------
+    Both questions this module asks — "does class X exist" and "does it declare
+    method Y" — used to be put to the file's RAW bytes, and a register entry is
+    resolved by whether a regex matches somewhere in it. Measured on this
+    checker, one fixture, one variable:
+
+        handler -> InvoiceGuard::evaluate, class present, no method
+                                            FAIL — guard-method-not-found
+        + a docblock reading                PASS                  <- the defect
+          "* TODO: implement function evaluate() here"
+
+        the class DELETED entirely, its name and its method quoted inside one
+        UNINDENTED `/* */` block in a surviving file
+                                            PASS                  <- the defect
+
+    The second one is the worse of the two: ``_class_def_re`` anchors on the
+    start of a LINE and assumes a docblock line begins with ``*``, so an
+    unindented block comment — the shape a removal note is actually written in
+    — reads as a class declaration. The gate exists because a handler naming a
+    class that is not there is a runtime resolution failure; a note saying the
+    class was removed is the strongest possible evidence FOR the finding, and
+    it was closing it.
+
+    STRING CONTENTS SURVIVE (``blank_strings`` left at its default). A class or
+    function DECLARATION is never legitimately spelled inside a literal, so
+    blanking them would close nothing this does not already close, and PHP's
+    own ``eval``/heredoc-template corner would start manufacturing
+    ``guard-class-not-found`` on code that resolves at runtime. That axis is
+    #424's.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return php_mask(fh.read())
+    except OSError:
+        return None
+
+
 def resolve_fqcn(fqcn: str, method: str | None, app_root: str):
     """Resolve *fqcn* (optionally ``::method``) against *app_root*.
 
@@ -153,10 +197,8 @@ def resolve_fqcn(fqcn: str, method: str | None, app_root: str):
                     if not fn.endswith(".php"):
                         continue
                     fp = os.path.join(dirpath, fn)
-                    try:
-                        with open(fp, encoding="utf-8", errors="replace") as fh:
-                            content = fh.read()
-                    except OSError:
+                    content = _php_code(fp)
+                    if content is None:
                         continue
                     if class_re.search(content):
                         found_file = fp
@@ -168,10 +210,8 @@ def resolve_fqcn(fqcn: str, method: str | None, app_root: str):
         return "guard-class-not-found"
 
     if method:
-        try:
-            with open(found_file, encoding="utf-8", errors="replace") as fh:
-                content = fh.read()
-        except OSError:
+        content = _php_code(found_file)
+        if content is None:
             return "guard-method-not-found"
         if not _method_def_re(method).search(content):
             return "guard-method-not-found"

--- a/hydra-gates/scripts/lib/detect-redundant-controllers.py
+++ b/hydra-gates/scripts/lib/detect-redundant-controllers.py
@@ -59,6 +59,7 @@ from typing import Iterable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
+from source_scope import php_mask  # noqa: E402
 
 # Methods on OpenRegister's ObjectService that are pure CRUD pass-throughs.
 # A method body that calls ONE of these and nothing else of substance is
@@ -108,6 +109,29 @@ OBJECT_SERVICE_CRUD = (
 
 # Calls / constructs that are considered "wrapper noise" — present in any
 # controller body but do not constitute domain logic.
+#
+# ⚠️ THE FOUR COMMENT ROWS BELOW ARE NOW BELT-AND-BRACES, NOT THE MECHANISM
+# (#422). They recognise a comment by its LINE PREFIX, which covers the three
+# ways a comment line can BEGIN and misses the one way it can continue: an
+# UNPREFIXED interior line of a `/* … */` block. Such a line survived as
+# "significant code", and a one-call pass-through with an explanatory block
+# comment in it therefore read as a method with domain logic:
+#
+#     public function index() {
+#         /*
+#         TODO: this should also apply the tenant filter before delegating.
+#         */
+#         return $this->objectService->findAll('thing');
+#     }
+#
+#     raw body       2 significant lines -> not a pass-through -> PASS
+#     masked body    1 significant line  -> pass-through        -> FAIL
+#
+# Measured on this checker, one fixture, one variable: `# count=1` -> `# count=0`.
+# The body is now comment-masked by `scan_files` before it gets here, so these
+# rows only have to survive; they are kept because they also match the empty
+# residue a masked comment leaves and because a future caller passing raw text
+# should not silently lose them.
 WRAPPER_NOISE_PATTERNS = (
     re.compile(r"^\s*$"),                                             # blank lines
     re.compile(r"^\s*//"),                                            # // comments
@@ -171,8 +195,22 @@ OBJECT_SERVICE_CALL_RE = re.compile(
 
 # Method header — captures the method name. Must match `public function NAME(`
 # with optional return type after the closing paren.
+#
+# ⚠️ `^[ \t]*`, NOT `^\s*`. In MULTILINE mode `^` matches at every line start
+# and `\s` matches `\n`, so `^\s*public` could begin the match at the start of
+# any run of BLANK LINES above the declaration — and `header_match.start()` is
+# what the line number is computed from. A method preceded by one blank line
+# was reported at the blank line, one line early (measured on this checker
+# before this change: true line 4, reported 3). Nothing depended on it until
+# the body was comment-masked, at which point a blanked DOCBLOCK became a run
+# of blank lines and the header slid up to the docblock's first line — where
+# `_method_docblock` then walked up from the wrong place, found no `*/`, and a
+# reason-bearing `@spec exclude` silently stopped exempting. That is the fix
+# over-applied: closing a false negative by breaking an escape hatch. Anchoring
+# to horizontal whitespace makes the reported line the DECLARATION's line
+# whatever sits above it, masked or not.
 METHOD_HEADER_RE = re.compile(
-    r"^\s*public\s+function\s+(?P<name>\w+)\s*\(",
+    r"^[ \t]*public\s+function\s+(?P<name>\w+)\s*\(",
     flags=re.MULTILINE,
 )
 
@@ -444,8 +482,22 @@ def scan_files(
             source = abs_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+        # TWO TEXTS, ONE COORDINATE SYSTEM. `php_mask` is length- and
+        # newline-preserving, so `line_no` computed on the mask names the same
+        # line of the original — which is what lets the docblock below be read
+        # from `src_lines` (the ORIGINAL). That split is deliberate and is the
+        # same one gate-49 makes: `@spec exclude` lives in a comment BY DESIGN
+        # and masking it would trade this false negative for a fleet of false
+        # positives, while the BODY question must never see prose at all.
+        #
+        # String contents are kept (`blank_strings` default). A pass-through's
+        # own evidence is often an argument that IS a string —
+        # `findAll('thing')` — and the noise/rescue rows are matched per LINE,
+        # so blanking a literal could empty a line that carries a real call.
+        # The string axis of this gate is #424's.
+        masked = php_mask(source)
         src_lines = source.splitlines()
-        for method_name, line_no, body in _split_methods(source):
+        for method_name, line_no, body in _split_methods(masked):
             # Only check methods whose name fits a CRUD shape — methods
             # named after a domain action (publishX, transitionY,
             # generateZ) are presumed to be domain logic regardless of

--- a/hydra-gates/scripts/lib/test_check_orphan_auth.py
+++ b/hydra-gates/scripts/lib/test_check_orphan_auth.py
@@ -422,5 +422,139 @@ return ['routes' => [
         self.assertIn("method=validateQuorum", findings[0])
 
 
+# ---------------------------------------------------------------------------
+# The caller corpus is CODE, not bytes (#415 class, #422).
+#
+# Reverted against origin/main, arms 2, 3 and 4 FLIP (finding -> no finding).
+# Arms 1, 5 and 6 pass either way and are CONTROLS: without arm 1 firing the
+# other five measure nothing, and 5/6 are the anti-widening pair — the mask
+# that closes the false negative must not delete a real call site.
+# ---------------------------------------------------------------------------
+_GUARD_SRC = """\
+<?php
+namespace OCA\\Demo\\Service;
+
+class AuthzService {
+    public function requiresChairAuthorization(string $userId, string $meetingId): bool
+    {
+        if (!$this->acl->isAllowed($userId)) {
+            throw new \\OCP\\AppFramework\\OCS\\OCSForbiddenException('not the chair');
+        }
+        return true;
+    }
+}
+"""
+
+
+def _caller_file(body: str) -> str:
+    return (
+        "<?php\n"
+        "namespace OCA\\Demo\\Service;\n"
+        "\n"
+        "class MeetingService {\n"
+        "    public function advance(string $userId, string $meetingId): void\n"
+        "    {\n"
+        f"{body}"
+        "        $this->state = 'advanced';\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+class CommentIsNotACallSite(unittest.TestCase):
+    """A guard is orphaned until CODE calls it — prose naming the call is not
+    a call. Same shape as gate-7's `// TODO: throw new OCSForbiddenException`
+    (#425), in the gate whose entire framing is "an unwired guard is identical
+    to no guard": the sentence admitting it is unwired reported it wired."""
+
+    def _scan(self, caller_body: str) -> list[str]:
+        return _scan_in_repo(
+            "lib/Service/AuthzService.php", _GUARD_SRC,
+            {"lib/Service/MeetingService.php": _caller_file(caller_body)},
+        )
+
+    def test_1_positive_control_no_caller_at_all(self):
+        """CONTROL. Without this firing, nothing below is a measurement."""
+        findings = self._scan("")
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("method=requiresChairAuthorization", findings[0])
+
+    def test_2_line_comment_naming_the_call_is_not_a_call(self):
+        findings = self._scan(
+            "        // TODO: we should call\n"
+            "        // $this->authz->requiresChairAuthorization($userId, $meetingId)\n"
+            "        // here before advancing. Not done yet.\n"
+        )
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_3_block_comment_naming_the_call_is_not_a_call(self):
+        findings = self._scan(
+            "        /*\n"
+            "        Wiring note: the chair check belongs here —\n"
+            "        $this->authz->requiresChairAuthorization($userId, $meetingId)\n"
+            "        */\n"
+        )
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_4_hash_comment_naming_the_call_is_not_a_call(self):
+        """`#` is PHP's other line comment, and a repair that handled only
+        `//` would be one alternative spelling away from being bypassed."""
+        findings = self._scan(
+            "        # TODO: $this->authz->requiresChairAuthorization($userId, $meetingId)\n"
+        )
+        self.assertEqual(len(findings), 1, findings)
+
+    def test_5_a_real_call_still_clears_the_guard(self):
+        """CONTROL (anti-widening). Passes before and after."""
+        findings = self._scan(
+            "        if (!$this->authz->requiresChairAuthorization($userId, $meetingId)) {\n"
+            "            return;\n"
+            "        }\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_6_a_call_under_an_attribute_still_counts(self):
+        """CONTROL (anti-widening). `#[` opens a PHP 8 ATTRIBUTE, not a
+        comment — a mask that ate it would blank the line that follows and
+        could take a real call with it."""
+        findings = self._scan(
+            "        #[Pure]\n"
+            "        $ok = $this->authz->requiresChairAuthorization($userId, $meetingId);\n"
+            "        if (!$ok) { return; }\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_7_the_route_table_is_still_read_UNMASKED(self):
+        """CONTROL (anti-widening), and the reason string contents are kept.
+
+        A routed controller action has no `->method(` anywhere by construction
+        — the router reaches it through the STRING `'meeting#validateQuorum'`.
+        Blanking literals in the caller corpus would not touch routes.php, but
+        an agent generalising "strings are not evidence" across this file
+        would, and every routed action would go back to being reported dead
+        (launchpad, #290). This arm is what makes that regression loud."""
+        src = """\
+<?php
+class MeetingController {
+    public function validateQuorum(string $userId, string $meetingId): bool
+    {
+        if (!$this->acl->isAllowed($userId)) {
+            throw new \\OCP\\AppFramework\\OCS\\OCSForbiddenException('no quorum rights');
+        }
+        return true;
+    }
+}
+"""
+        routes = """\
+<?php
+return ['routes' => [
+    ['name' => 'meeting#validateQuorum', 'url' => '/api/meeting/quorum', 'verb' => 'POST'],
+]];
+"""
+        findings = _scan_in_repo("lib/Controller/MeetingController.php", src,
+                                 {"appinfo/routes.php": routes})
+        self.assertEqual(findings, [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
+++ b/hydra-gates/scripts/lib/test_check_orphaned_write_capability.py
@@ -1273,5 +1273,135 @@ class WriteVerbVocabularyTest(unittest.TestCase):
             self.assertFalse(owc._is_write_method(name), name)
 
 
+# ---------------------------------------------------------------------------
+# The caller index is CODE, and a comment cannot make a method bodiless
+# (#415 class, #422).
+#
+# Reverted against origin/main, arms 2, 3, 4 and 5 FLIP (no finding ->
+# finding). Arms 1, 6, 7 and 8 pass either way and are CONTROLS.
+#
+# ⚠️ THIS MODULE ALREADY KNEW. `_blank_php_comments` was written FOR THIS FILE
+# and its docstring states the class in as many words — it was applied to the
+# four seams and never to the caller index, which is the gate's primary
+# evidence. A partially-masked checker looks exactly like a fully-masked one
+# from outside.
+# ---------------------------------------------------------------------------
+_ORPHAN_SERVICE = (
+    "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+    "class InvoiceService {\n"
+    "    public function postInvoice(string $id): bool\n"
+    "    {\n"
+    "        $this->ledger[$id] = true;\n"
+    "        return true;\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def _controller(body: str) -> str:
+    return (
+        "<?php\nnamespace OCA\\Fixture\\Controller;\n\n"
+        "class InvoiceController {\n"
+        f"{body}"
+        "    public function show(string $id)\n"
+        "    {\n"
+        "        return $this->renderer->toArray($id);\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+class CommentIsNotACaller(unittest.TestCase):
+    def _run(self, service_src: str, controller_body: str) -> list[str]:
+        with _AppFixture() as root:
+            svc = os.path.join(root, "lib", "Service", "InvoiceService.php")
+            ctl = os.path.join(root, "lib", "Controller", "InvoiceController.php")
+            for full, src in ((svc, service_src), (ctl, _controller(controller_body))):
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "w", encoding="utf-8") as fh:
+                    fh.write(src)
+            return _run_main(svc)
+
+    def test_1_positive_control_no_caller_anywhere(self):
+        """CONTROL. Without this firing, arms 2-4 measure nothing."""
+        out = self._run(_ORPHAN_SERVICE, "")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=postInvoice", out[0])
+
+    def test_2_a_docblock_todo_naming_the_call_is_not_a_caller(self):
+        out = self._run(_ORPHAN_SERVICE,
+                        "    /**\n"
+                        "     * TODO: we should call $this->fooService->postInvoice($id)\n"
+                        "     * here once the ledger migration lands. Not done yet.\n"
+                        "     */\n")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=postInvoice", out[0])
+
+    def test_3_a_line_comment_naming_the_call_is_not_a_caller(self):
+        out = self._run(_ORPHAN_SERVICE,
+                        "    // $this->fooService->postInvoice($id);  // disabled 2026-08\n")
+        self.assertEqual(len(out), 1, out)
+
+    def test_4_a_hash_comment_naming_the_call_is_not_a_caller(self):
+        out = self._run(_ORPHAN_SERVICE,
+                        "    # $this->fooService->postInvoice($id);\n")
+        self.assertEqual(len(out), 1, out)
+
+    def test_5_a_block_comment_in_the_signature_cannot_make_it_bodiless(self):
+        """The quietest of the four. `_declaration_has_body` stripped `//` and
+        quotes but not `/* */`, so a `;` in a signature note terminated the
+        signature, the method classified as an abstract DECLARATION, and it was
+        never looked at — not reported as passing, simply never judged."""
+        out = self._run(
+            "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+            "class InvoiceService {\n"
+            "    public function postInvoice(string $id) /* returns true; never throws */\n"
+            "    {\n"
+            "        $this->ledger[$id] = true;\n"
+            "        return true;\n"
+            "    }\n"
+            "}\n",
+            "",
+        )
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=postInvoice", out[0])
+
+    def test_6_a_real_caller_still_suppresses(self):
+        """CONTROL (anti-widening). Passes before and after."""
+        out = self._run(_ORPHAN_SERVICE,
+                        "    public function store(string $id): void\n"
+                        "    {\n"
+                        "        $this->fooService->postInvoice($id);\n"
+                        "    }\n")
+        self.assertEqual(out, [])
+
+    def test_7_a_genuinely_bodiless_declaration_is_still_skipped(self):
+        """CONTROL (anti-widening). hydra#106 FP class 3 must stay closed: an
+        abstract declaration has no body, so there is nothing that can be dead
+        and there is no fix its author could make."""
+        with _AppFixture() as root:
+            full = os.path.join(root, "lib", "Service", "AbstractInvoice.php")
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+                    "abstract class AbstractInvoice {\n"
+                    "    abstract public function postLedger(string $id): bool;\n"
+                    "}\n"
+                )
+            self.assertEqual(_run_main(full), [])
+
+    def test_8_a_caller_inside_a_STRING_still_suppresses(self):
+        """CONTROL, and it states a deliberate limit rather than an oversight.
+
+        String contents are KEPT. This index's fail-safe direction is to
+        SUPPRESS: the gate accuses live code of being dead, and a verdict acted
+        on deletes working code. Blanking literals would push it the other way,
+        so the string axis is left to #424 rather than taken here."""
+        out = self._run(_ORPHAN_SERVICE,
+                        "    public const HINT = 'call $this->x->postInvoice($id) first';\n")
+        self.assertEqual(out, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_check_register_handler_resolution.py
+++ b/hydra-gates/scripts/lib/test_check_register_handler_resolution.py
@@ -425,5 +425,115 @@ class ForeignCwdTest(unittest.TestCase):
                 os.chdir(old)
 
 
+# ---------------------------------------------------------------------------
+# A comment describing a class is not the class (#415 class, #422).
+#
+# Reverted against origin/main, arms 2 and 3 FLIP (finding -> no finding).
+# Arms 1, 4, 5 and 6 pass either way and are CONTROLS.
+# ---------------------------------------------------------------------------
+_REGISTER = {
+    "schemas": {"invoice": {"handler": "OCA\\Fixture\\Service\\InvoiceGuard::evaluate"}}
+}
+
+
+class CommentIsNotADeclaration(unittest.TestCase):
+    """Both of this gate's questions — does the class exist, does it declare
+    the method — used to be put to the file's RAW bytes."""
+
+    def _run(self, files: dict[str, str]) -> list[str]:
+        with _AppFixture() as root:
+            for rel, src in files.items():
+                full = os.path.join(root, *rel.split("/"))
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "w", encoding="utf-8") as fh:
+                    fh.write(src)
+            reg = os.path.join(root, "lib", "Settings", "register.json")
+            os.makedirs(os.path.dirname(reg), exist_ok=True)
+            with open(reg, "w", encoding="utf-8") as fh:
+                json.dump(_REGISTER, fh)
+            return _run_main(reg)
+
+    def test_1_positive_control_class_present_method_absent(self):
+        """CONTROL. Without this firing, arms 2-3 measure nothing."""
+        out = self._run({
+            "lib/Service/InvoiceGuard.php":
+                "<?php\nnamespace OCA\\Fixture\\Service;\n\nclass InvoiceGuard {\n}\n",
+        })
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=guard-method-not-found", out[0])
+
+    def test_2_a_todo_naming_the_method_is_not_the_method(self):
+        out = self._run({
+            "lib/Service/InvoiceGuard.php":
+                "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+                "class InvoiceGuard {\n"
+                "    /**\n"
+                "     * TODO: implement function evaluate() here — the register\n"
+                "     * already points at it. Not written yet.\n"
+                "     */\n"
+                "}\n",
+        })
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=guard-method-not-found", out[0])
+
+    def test_3_a_removal_note_in_an_unindented_block_is_not_the_class(self):
+        """The worse of the two. `_class_def_re` anchors on a line start and
+        assumes a docblock line begins with `*`, so the shape a removal note is
+        actually written in — an unindented `/* */` block — read as a class
+        declaration. The class is GONE and the note saying so closed the gate."""
+        out = self._run({
+            "lib/Service/Notes.php":
+                "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+                "/*\n"
+                "Removed 2026-08:\n"
+                "class InvoiceGuard implements Guard\n"
+                "public function evaluate(array $ctx): bool\n"
+                "*/\n\n"
+                "class Notes {\n}\n",
+        })
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=guard-class-not-found", out[0])
+
+    def test_4_the_real_declaration_still_resolves(self):
+        """CONTROL (anti-widening) — the PSR-4 path branch."""
+        out = self._run({
+            "lib/Service/InvoiceGuard.php":
+                "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+                "class InvoiceGuard {\n"
+                "    /** Evaluate the guard. */\n"
+                "    public function evaluate(array $ctx): bool { return true; }\n"
+                "}\n",
+        })
+        self.assertEqual(out, [])
+
+    def test_5_a_class_found_only_by_the_lib_walk_still_resolves(self):
+        """CONTROL (anti-widening) — the fallback branch, which is the one the
+        mask is applied inside. A class at an unconventional path must still be
+        found, or every cross-app reference becomes guard-class-not-found."""
+        out = self._run({
+            "lib/Odd/Weird.php":
+                "<?php\nnamespace OCA\\Fixture\\Odd;\n\n"
+                "class InvoiceGuard {\n"
+                "    public function evaluate(array $ctx): bool { return true; }\n"
+                "}\n",
+        })
+        self.assertEqual(out, [])
+
+    def test_6_a_class_name_in_a_STRING_still_does_not_resolve_it(self):
+        """CONTROL. String contents are deliberately KEPT by the mask, so this
+        arm states what that does and does not buy: a literal is not a
+        declaration here either, because `_class_def_re` requires the
+        `class <Name>` KEYWORD at a line start, not the bare name."""
+        out = self._run({
+            "lib/Service/Notes.php":
+                "<?php\nnamespace OCA\\Fixture\\Service;\n\n"
+                "class Notes {\n"
+                "    public const HINT = 'see OCA\\\\Fixture\\\\Service\\\\InvoiceGuard::evaluate';\n"
+                "}\n",
+        })
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=guard-class-not-found", out[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hydra-gates/scripts/lib/test_detect_redundant_controllers.py
+++ b/hydra-gates/scripts/lib/test_detect_redundant_controllers.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: EUPL-1.2
+"""Tests for detect-redundant-controllers (gate-17). Run with:
+
+    python3 scripts/lib/test_detect_redundant_controllers.py
+
+or via pytest:
+
+    python3 -m pytest scripts/lib/test_detect_redundant_controllers.py
+
+WHY THIS FILE DID NOT EXIST UNTIL #422
+--------------------------------------
+gate-17 shipped with no suite of its own, so nothing had ever asked it to
+fail. That is the same gap gate-25 was in when it was found carrying gate-19's
+defect verbatim (#425): a gate whose only evidence of correctness is that
+nobody has complained about it has no evidence of correctness.
+
+The module is imported by path because its filename is hyphenated and is
+therefore not a legal Python module name — the gate is invoked as a script.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "detect_redundant_controllers", os.path.join(_HERE, "detect-redundant-controllers.py")
+)
+drc = importlib.util.module_from_spec(_SPEC)
+sys.modules["detect_redundant_controllers"] = drc
+_SPEC.loader.exec_module(drc)
+
+
+def _scan(controller_src: str) -> list[str]:
+    """Materialise a throwaway app root holding one controller, scan it."""
+    with tempfile.TemporaryDirectory() as root:
+        path = Path(root) / "lib" / "Controller" / "ThingController.php"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(controller_src, encoding="utf-8")
+        return drc.scan_files([(path, path.relative_to(root))])
+
+
+_PASS_THROUGH = """\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+%s	public function index() {
+%s		return $this->objectService->findAll('thing');
+	}
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# A comment is not domain logic (#415 class, #422).
+#
+# Reverted against origin/main, arms 2 and 3 FLIP (no finding -> finding), as
+# does the blank-line arm in the class below. Arms 1, 3b, 4, 5, 6 and 7 pass
+# either way and are CONTROLS.
+# ---------------------------------------------------------------------------
+class CommentIsNotDomainLogic(unittest.TestCase):
+    """`WRAPPER_NOISE_PATTERNS` recognised a comment by its LINE PREFIX, which
+    covers the three ways a comment line can BEGIN and misses the one way it
+    can continue. An unprefixed interior line of a `/* … */` block survived as
+    "significant code", and a one-call pass-through carrying an explanatory
+    block comment read as a method with real logic — so the gate went quiet on
+    exactly the wrapper whose author had documented it."""
+
+    def test_1_positive_control_a_bare_pass_through_is_flagged(self):
+        """CONTROL. Without this firing, arms 2-3 measure nothing."""
+        out = _scan(_PASS_THROUGH % ("", ""))
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("rule=pass-through-to-ObjectService", out[0])
+
+    def test_2_an_unprefixed_block_comment_interior_line_is_not_logic(self):
+        out = _scan(_PASS_THROUGH % ("", """\
+		/*
+		TODO: this should also apply the tenant filter before delegating.
+		Not done yet.
+		*/
+"""))
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("method=index", out[0])
+
+    def test_3_a_rescue_phrase_inside_a_block_comment_is_not_a_guard(self):
+        """The second direction of the same hole, and the worse one: an
+        unprefixed block-comment line reaches RESCUE_PATTERNS, so prose saying
+        the authorization happens ELSEWHERE reads as authorization happening
+        HERE and the method escapes the gate entirely."""
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	public function index() {
+		/*
+		requireAdmin() is handled by the middleware, not by this method.
+		*/
+		return $this->objectService->findAll('thing');
+	}
+}
+""")
+        self.assertEqual(len(out), 1, out)
+
+    def test_3b_CONTROL_a_trailing_comment_on_the_call_statement(self):
+        """CONTROL — the near-miss, and saying so is the point. The same
+        sentence three characters further along never reaches the question:
+        `_is_redundant_body` tests for the ObjectService call FIRST and
+        `continue`s, so a rescue phrase trailing the call statement is skipped
+        before RESCUE_PATTERNS is consulted. This arm passes before and after.
+        An arm that cannot fail is not proof that the gate cannot."""
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	public function index() {
+		return $this->objectService->findAll('thing'); // requireAdmin() is middleware's
+	}
+}
+""")
+        self.assertEqual(len(out), 1, out)
+
+    def test_4_real_domain_logic_is_still_not_a_pass_through(self):
+        """CONTROL (anti-widening). Passes before and after — the mask must
+        not turn a method that does something into a wrapper."""
+        out = _scan(_PASS_THROUGH % ("", "		$this->tenantService->scope($this->userId);\n"))
+        self.assertEqual(out, [])
+
+    def test_5_a_reason_bearing_spec_exclude_still_exempts(self):
+        """CONTROL (anti-widening), AND THE ARM THAT CAUGHT THE FIX
+        OVER-APPLYING. The docblock is read from the ORIGINAL text — `@spec
+        exclude` lives in a comment BY DESIGN — but the first cut of this
+        change also let `METHOD_HEADER_RE`'s `^\\s*` slide the reported line up
+        through the blanked docblock's now-blank lines, so `_method_docblock`
+        walked from the wrong place, found no `*/`, and this escape hatch
+        silently stopped working. Closing a false negative by breaking an
+        author's only correct remedy is worse than the false negative."""
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	/**
+	 * @spec exclude deliberate ObjectServiceMapperAdapter facade, ADR-022
+	 */
+	public function index() {
+		return $this->objectService->findAll('thing');
+	}
+}
+""")
+        self.assertEqual(out, [])
+
+    def test_6_a_bare_spec_exclude_still_does_NOT_exempt(self):
+        """CONTROL. `#412`: a marker with no usable reason must not waive a
+        gate that gate-16 would refuse for the identical keystrokes."""
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	/**
+	 * @spec exclude
+	 */
+	public function index() {
+		return $this->objectService->findAll('thing');
+	}
+}
+""")
+        self.assertEqual(len(out), 1, out)
+
+    def test_7_a_non_CRUD_method_name_is_still_never_flagged(self):
+        """CONTROL. The name filter is the gate's main defence against
+        flagging domain actions, and the mask must not reach past it."""
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	public function publishThing() {
+		return $this->objectService->saveObject('thing', []);
+	}
+}
+""")
+        self.assertEqual(out, [])
+
+
+class ReportedLineIsTheDeclarationLine(unittest.TestCase):
+    """`METHOD_HEADER_RE` used `^\\s*`, and in MULTILINE mode `\\s` matches
+    `\\n` — so the match could begin at the start of any run of BLANK LINES
+    above the declaration and the reported line number was the blank line.
+    Pre-existing (measured on origin/main: true line 6, reported 5); it became
+    load-bearing once the body was comment-masked, because a blanked docblock
+    IS a run of blank lines."""
+
+    def test_a_method_preceded_by_a_blank_line_reports_its_own_line(self):
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+
+	public function index() {
+		return $this->objectService->findAll('thing');
+	}
+}
+""")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn(":6 ", out[0] + " ")
+
+    def test_a_method_preceded_by_a_docblock_reports_its_own_line(self):
+        out = _scan("""\
+<?php
+namespace OCA\\Fixture\\Controller;
+
+class ThingController {
+	/**
+	 * Lists things.
+	 */
+	public function index() {
+		return $this->objectService->findAll('thing');
+	}
+}
+""")
+        self.assertEqual(len(out), 1, out)
+        self.assertIn(":8 ", out[0] + " ")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
fix(gates 6, 17, 56, 57): a comment naming the call is not the call (#422)

Four more instances of the #415 class, all in the FALSE-NEGATIVE direction:
the gate looks for a positive signal — a call, a class, a method, a line of
logic — and prose containing the words is accepted as the signal. Every one
was reproduced first, with a fixture whose only "evidence" lives in a comment.

  gate-6  orphan-auth
    an unreferenced requiresChairAuthorization()  FAIL — defined-but-never-called
    + "// TODO: we should call
       $this->authz->requiresChairAuthorization($uid)
       here before advancing. Not done yet."      PASS            <- the defect

  gate-56 register-handler-resolution
    handler -> InvoiceGuard::evaluate, no method  FAIL — guard-method-not-found
    + "* TODO: implement function evaluate() here"  PASS          <- the defect
    class DELETED, class and method quoted in one
    UNINDENTED /* */ removal note                 PASS            <- the defect

  gate-57 orphaned-write-capability
    an uncalled postInvoice()                     FAIL — orphaned-write-capability
    + "* TODO: we should call
       $this->fooService->postInvoice($id) here"  PASS            <- the defect
    + "/* returns true; never throws */" in the
      SIGNATURE -> reads as abstract, never judged PASS            <- the defect

  gate-17 redundant-controller
    a one-call pass-through                       FAIL — pass-through
    + an UNPREFIXED interior line of a /* */ block
      survives as "significant code"              PASS            <- the defect
    + a rescue phrase in that block ("requireAdmin()
      is handled by middleware") reads as a guard PASS            <- the defect

THE SENTENCE THAT SWITCHES EACH GATE OFF IS THE SENTENCE ADMITTING THE DEBT.
gate-6's whole framing is "an unwired guard is identical to no guard", and the
note saying the guard is not wired reported it wired. gate-56's is "a handler
naming a class that is not there fails at runtime", and the note saying the
class was removed closed it.

MEASURED IN THE FLEET, AND IT IS NOT HYPOTHETICAL. Across procest,
opencatalogi, openregister, softwarecatalog, docudesk and larpingapp the
counts move by exactly one — openregister gate-57 7 -> 8:

    lib/Service/File/FileOwnershipHandler.php:262
      method=transferFolderOwnershipIfNeeded rule=orphaned-write-capability

Every "caller" of that method in the repository is a comment. Four of them:

    FolderManagementHandler.php:221  // TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($folderNode)
    FolderManagementHandler.php:312  // TODO: Call ...($objectFolder)
    FolderManagementHandler.php:490  // TODO: Call ...($objectFolder)
    FolderManagementHandler.php:562  // TODO: Call ...($node)

Folder ownership is not transferred to the OpenRegister system user at any of
the four sites that say it should be, and the gate that exists to find exactly
that reported it reachable BECAUSE the four TODOs named it. Verified by hand;
it is a real finding, not a new false positive.

WHAT THE MASK DOES NOT DO, PER GATE. A wrong recipe repeated at scale is a
defect multiplied at scale, so each gate carries its own anti-widening arms
and each keeps string literals for its own stated reason:

  gate-6   routes.php is still read UNMASKED. A routed controller action has
           no `->method(` anywhere, ever — the router reaches it through the
           STRING 'liveTile#validateSource'. Blanking literals in the caller
           corpus does not touch that file, but generalising "strings are not
           evidence" across this module would put every routed action back to
           being reported dead (#290). Arm 7 is what makes that loud.
  gate-17  the docblock is still read from the ORIGINAL text: `@spec exclude`
           lives in a comment BY DESIGN and is the author's only correct
           remedy.
  gate-57  the caller index is deliberately over-permissive because its
           fail-safe direction is to SUPPRESS — this gate accuses live code of
           being dead, and a verdict acted on deletes working code.
  gate-56  a class or function DECLARATION is never spelled inside a literal,
           so blanking them would close nothing that is not already closed.

NOT A SIXTH HAND-ROLLED STRIPPER. All four route through
source_scope.php_mask, which already knows `#[` opens a PHP 8 ATTRIBUTE and
that `//` inside 'https://x' opens nothing. gate-57's local
`_blank_php_comments` — clause-for-clause identical to php_mask — becomes a
call to it, so the fifth dialect in this package is gone rather than joined.

⚠️ FOUND WHILE BUILDING THE FIXTURE, AND IT IS THE FIX OVER-APPLYING.
gate-17's METHOD_HEADER_RE used `^\s*public`, and in MULTILINE mode `\s`
matches `\n` — so the match could begin at the start of any run of BLANK
LINES above the declaration. Pre-existing and inert (true line 4, reported 3),
until the body was comment-masked: a blanked DOCBLOCK is a run of blank lines,
the reported line slid up into it, `_method_docblock` walked from the wrong
place, found no `*/`, and a reason-bearing `@spec exclude` SILENTLY STOPPED
EXEMPTING. Closing a false negative by breaking an author's only correct
remedy is worse than the false negative. Anchored to `^[ \t]*`; arm 5 of the
new suite is the arm that caught it.

TESTS. 23 new arms. Reverted against origin/main — not `git checkout --`,
which restores the COMMITTED file — eleven FLIP:

  gate-6   arms 2, 3, 4          (//, /* */, #)
  gate-56  arms 2, 3
  gate-57  arms 2, 3, 4, 5
  gate-17  arms 2, 3 + the blank-line line-number arm

and twelve pass either way and are labelled CONTROLS in their own docstrings,
including the near-miss (gate-17 arm 3b: the same sentence three characters
along never reaches the question, because the ObjectService test short-circuits
before RESCUE_PATTERNS). Saying so is the point — an arm that cannot fail is
not proof that the gate cannot.

gate-17 had NO suite at all before this; test_detect_redundant_controllers.py
is new and tests/run-helper-suites.sh discovers it with no workflow edit.

Refs #422, #415. Sibling PRs cover the runner-inline gates and the
registry/config gates; gate-38 is BLOCKED on #424 (its fix needs markup
masking, and routing it into source_scope.markup_mask today would fix its
comment half and leave the delimiter half armed).
