### PR TITLE
fix(gates 3, 14): a comment is not a route, and a TODO is not a use (#422)

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_3_14_comment_evidence.sh
+++ b/hydra-gates/scripts/lib/test_gate_3_14_comment_evidence.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: EUPL-1.2
+#
+# test_gate_3_14_comment_evidence.sh — acceptance arms for the two RUNNER-INLINE
+# false negatives in the #415 class (.github#422).
+#
+# THE CLASS
+# ---------
+# A checker asks a question about CODE and answers it by matching bytes of a
+# FILE. Prose is made of the same bytes. In the false-negative direction the
+# gate looks for a POSITIVE signal — a route, a use of a parameter — and prose
+# containing the words is accepted as the signal.
+#
+#   gate-14  invariant 1 asked "does a route entry for this method exist?" with
+#            `grep -qF "'thing#orphanReport'"` over the RAW appinfo/routes.php.
+#            The note at that grep says comment hits are "vanishingly rare" —
+#            it anticipated the false POSITIVE and missed the false NEGATIVE,
+#            which is the direction that ships a 404.
+#
+#   gate-3   the caller-identity arm counted references to `$uid` with
+#            `grep -cF` over the RAW body. This gate exists BECAUSE the
+#            builder's fix-mode wrote methods that accept a caller identity and
+#            ignore it (decidesk#45) — and a stub that DOCUMENTS what it does
+#            not do was reported finished.
+#
+# EACH ARM IS PAIRED. The mask that closes each false negative keeps STRING
+# CONTENTS, and both gates are why: a route name IS the literal
+# `'thing#index'`, and `"no such user: $uid"` INTERPOLATES $uid, so it is a
+# genuine use. Arms 3 and 6 fail the moment somebody generalises
+# "strings are not evidence" across this file.
+#
+# Reverted against origin/main, arms 2, 4 and 5 FLIP (PASS -> FAIL). Arms 1, 3
+# and 6 pass either way and are labelled CONTROLS.
+#
+# Arm 4 was WRITTEN as a control and the revert says it is evidence: a
+# commented-out `'resources' => [...]` block really did exempt a live
+# controller's whole CRUD quintet from invariant 1 on origin/main. Relabelled
+# rather than left as written — an arm's label is a claim about what it
+# measures, and the revert is what decides it, not the author.
+#
+# Run: bash scripts/lib/test_gate_3_14_comment_evidence.sh   (exit 0 = green)
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+RUNNER="${PKG_ROOT}/scripts/run-hydra-gates.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+_pass_n=0
+_fail_n=0
+_ok()  { _pass_n=$((_pass_n + 1)); printf 'PASS — %s\n' "$1"; }
+_bad() { _fail_n=$((_fail_n + 1)); printf 'FAIL — %s\n' "$1"; }
+
+APP="${WORK}/app"
+
+# --- fixture -----------------------------------------------------------------
+# `orphanReport` returns a Response shape and has NO route entry; `authorize`
+# takes a caller identity and never uses it. Both are real defects, and both
+# are what the arms below try to hide behind a comment.
+_scaffold() {
+    rm -rf "${APP}"
+    mkdir -p "${APP}/lib/Controller" "${APP}/lib/Service" "${APP}/appinfo"
+    cat > "${APP}/appinfo/info.xml" <<'XML'
+<?xml version="1.0"?>
+<info><id>fixture</id></info>
+XML
+    cat > "${APP}/lib/Controller/ThingController.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Controller;
+
+use OCP\AppFramework\Http\JSONResponse;
+
+class ThingController {
+	public function index(): JSONResponse {
+		return new JSONResponse([]);
+	}
+
+	public function orphanReport(): JSONResponse {
+		return new JSONResponse([]);
+	}
+}
+PHP
+    _routes_bare
+    _authz_bare
+    (cd "${APP}" && git init -q . \
+        && git config user.email fixture@example.invalid \
+        && git config user.name fixture \
+        && git add -A && git commit -qm fixture)
+}
+
+_routes_bare() {
+    cat > "${APP}/appinfo/routes.php" <<'PHP'
+<?php
+return ['routes' => [
+    ['name' => 'thing#index', 'url' => '/api/things', 'verb' => 'GET'],
+]];
+PHP
+}
+
+_authz_bare() {
+    cat > "${APP}/lib/Service/AuthzService.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Service;
+
+class AuthzService {
+	public function authorize(string $uid, string $objectId): bool {
+		$this->logger->info('authorize called');
+		return true;
+	}
+}
+PHP
+}
+
+_commit() { (cd "${APP}" && git add -A && git commit -qm arm); }
+
+_OUT=""
+_run() {
+    local _logdir
+    _logdir="$(mktemp -d "${WORK}/logs.XXXXXXXX")"
+    _OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${RUNNER}" "${APP}" 2>&1 || true)"
+    # A run that aborts before its summary leaves the per-gate PASS lines on
+    # stdout and reads exactly like a clean run (.github#374).
+    if ! printf '%s' "${_OUT}" | grep -q '^\[hydra-gates\] COVERAGE:'; then
+        _bad "the run ABORTED before its summary — the verdicts above it are not a result"
+        printf '%s\n' "${_OUT}" | tail -20 | sed 's/^/       /'
+        return 1
+    fi
+    return 0
+}
+
+_expect_gate() {  # <n> <PASS|FAIL> <description>
+    local _n="$1" _want="$2" _desc="$3" _line
+    _line="$(printf '%s' "${_OUT}" | grep -E "^\[gate-${_n}\] " | head -1)"
+    if [ -z "${_line}" ]; then
+        _bad "${_desc} — gate-${_n} emitted NO verdict line at all"
+        return
+    fi
+    case "${_line}" in
+        *": ${_want}"*) _ok "${_desc} — ${_line}" ;;
+        *) _bad "${_desc} — wanted ${_want}, got: ${_line}" ;;
+    esac
+}
+
+echo "== gates 3 + 14: a comment is not the evidence (#422) =="
+echo
+
+# ---------------------------------------------------------------------------
+# 1. THE POSITIVE CONTROL, FIRST. Everything below is only a measurement
+#    because these two fire. (Two of the survey's own fixtures printed the same
+#    verdict on both arms because the control had never failed.)
+# ---------------------------------------------------------------------------
+_scaffold
+if _run; then
+    _expect_gate 14 FAIL "CONTROL 1: a Response-returning method with no route entry is reported"
+    _expect_gate 3 FAIL "CONTROL 1: a method that ignores its caller-identity parameter is reported"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. gate-14 — the route exists only in a comment. ONE ADDED LINE.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/appinfo/routes.php" <<'PHP'
+<?php
+return ['routes' => [
+    ['name' => 'thing#index', 'url' => '/api/things', 'verb' => 'GET'],
+    // TODO: wire up 'thing#orphanReport' once the export lands.
+]];
+PHP
+_commit
+if _run; then
+    _expect_gate 14 FAIL "ARM 2: a route written only in a TODO does not make the endpoint reachable"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. gate-14 — CONTROL (anti-widening). A REAL route entry is a STRING, and it
+#    must still count. Written under a comment so the mask has to end where the
+#    comment ends.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/appinfo/routes.php" <<'PHP'
+<?php
+return ['routes' => [
+    ['name' => 'thing#index', 'url' => '/api/things', 'verb' => 'GET'],
+    // The export endpoint, added 2026-08.
+    ['name' => 'thing#orphanReport', 'url' => '/api/things/orphans', 'verb' => 'GET'],
+]];
+PHP
+_commit
+if _run; then
+    _expect_gate 14 PASS "CONTROL 3: a real route entry — a string literal — still satisfies invariant 1"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. gate-14 — A commented-out `'resources' => [...]` block must not exempt a
+#    live controller's CRUD quintet from invariant 1. Same direction, same
+#    cause, a different reader of the same file. Written as a control; the
+#    revert says it FLIPS, so it is a third false negative, not a control.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/appinfo/routes.php" <<'PHP'
+<?php
+/*
+'resources' => [
+    'Thing' => ['url' => '/api/things'],
+],
+*/
+return ['routes' => [
+    ['name' => 'thing#index', 'url' => '/api/things', 'verb' => 'GET'],
+]];
+PHP
+_commit
+if _run; then
+    _expect_gate 14 FAIL "ARM 4: a commented-out resources block does not auto-route a controller"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. gate-3 — the parameter is "used" only by a TODO. ONE ADDED LINE, and it is
+#    the sentence a diligent author writes about the stub they left.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/lib/Service/AuthzService.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Service;
+
+class AuthzService {
+	public function authorize(string $uid, string $objectId): bool {
+		// TODO: verify $uid actually owns this object before returning true.
+		$this->logger->info('authorize called');
+		return true;
+	}
+}
+PHP
+_commit
+if _run; then
+    _expect_gate 3 FAIL "ARM 5: a TODO naming the parameter is not a use of it"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. gate-3 — CONTROL (anti-widening). `"no such user: $uid"` INTERPOLATES the
+#    parameter: in PHP that is a genuine reference, and blanking string
+#    contents would report a correct method as an unfinished stub.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/lib/Service/AuthzService.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Service;
+
+class AuthzService {
+	public function authorize(string $uid, string $objectId): bool {
+		if (!$this->acl->allowed($objectId)) {
+			throw new \RuntimeException("no such user: $uid");
+		}
+		return true;
+	}
+}
+PHP
+_commit
+if _run; then
+    _expect_gate 3 PASS "CONTROL 6: a parameter interpolated into a string is still a use of it"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. A MASK THAT CANNOT BE PRODUCED IS NOT A LICENCE TO GRADE RAW TEXT.
+#
+#    Both gates now depend on source_scope.py. A silent fallback to the raw
+#    file would be exactly the false negative just closed, and it would leave
+#    no log to notice — the shape this package has found four times (#147,
+#    #245, #276, #374). So the package is copied WITHOUT the mask helper and
+#    both gates must decline rather than report a verdict.
+#
+#    This arm is NOT a control: on origin/main neither gate consults the
+#    helper at all, so removing it changes nothing there. It exists because
+#    the fix creates the dependency.
+# ---------------------------------------------------------------------------
+_scaffold
+_PKG_NOMASK="${WORK}/pkg-nomask"
+rm -rf "${_PKG_NOMASK}"
+mkdir -p "${_PKG_NOMASK}"
+cp -r "${PKG_ROOT}/scripts" "${_PKG_NOMASK}/scripts"
+rm -f "${_PKG_NOMASK}/scripts/lib/source_scope.py"
+_logdir="$(mktemp -d "${WORK}/logs.XXXXXXXX")"
+_OUT="$(HYDRA_GATE_LOG_DIR="${_logdir}" bash "${_PKG_NOMASK}/scripts/run-hydra-gates.sh" "${APP}" 2>&1 || true)"
+for _g in 3 14; do
+    _line="$(printf '%s' "${_OUT}" | grep -E "^\[gate-${_g}\] " | head -1)"
+    case "${_line}" in
+        *SKIPPED*|*skipped*)
+            _ok "ARM 7: with source_scope.py absent, gate-${_g} declines — ${_line}" ;;
+        "")
+            _bad "ARM 7: gate-${_g} emitted NO verdict line at all with the mask absent" ;;
+        *)
+            _bad "ARM 7: gate-${_g} reported a verdict it could not support — ${_line}" ;;
+    esac
+done
+
+echo
+echo "----------------------------------------------------------------"
+printf '%d passed, %d failed\n' "${_pass_n}" "${_fail_n}"
+echo "----------------------------------------------------------------"
+[ "${_fail_n}" -eq 0 ]

--- a/hydra-gates/scripts/run-hydra-gates.sh
+++ b/hydra-gates/scripts/run-hydra-gates.sh
@@ -1375,6 +1375,64 @@ _ctrl_path_from_name() {
 }
 
 # ---------------------------------------------------------------------------
+# _php_code_copy <php-file> — path to a COMMENT-MASKED copy of <php-file>,
+# cached per path. Echoes nothing and returns 1 when the mask is unavailable,
+# so a caller can decline to judge rather than silently grade raw text.
+#
+# WHY (#415 / #422). A gate that answers a question about CODE by grepping the
+# bytes of a FILE answers it about PROSE too, and this runner asked several
+# such questions of raw files. The masked copy is length- and
+# newline-preserving (source_scope.php_mask), so every line number, `sed -n
+# "${n}p"` and awk `NR` computed on it names the same line of the original —
+# which is what lets a gate anchor on the mask and still read a suppression
+# marker out of the ORIGINAL text at that line.
+#
+# STRING CONTENTS SURVIVE, deliberately and per caller: `php_mask` keeps them
+# by default, and the two callers below both need them. A route name IS a
+# string (`'thing#index'`), and `"user $uid not found"` IS a use of $uid —
+# PHP interpolates it. Blanking literals here would not close a false
+# negative, it would manufacture false positives on correct code.
+#
+# NOT A SECOND COPY OF gate-5's `_ra_masked_copy`: that one predates this and
+# is scoped to gate-5's own cache directory and its own wiring guard. This is
+# the shared form; folding gate-5 into it means re-proving gate-5's suite and
+# belongs in its own change.
+# ---------------------------------------------------------------------------
+_HYDRA_MASK_HELPER="${SCRIPT_DIR}/lib/source_scope.py"
+_HYDRA_MASK_DIR="${HYDRA_GATE_LOG_DIR}/php-code-copies"
+
+# POSITIVE CONTROL ON THE MASK ITSELF, once per run. A helper that is missing,
+# or that silently echoes its input back, would put every caller straight into
+# the false negative it is here to close — and a false negative leaves no log
+# to notice. So the mask is asked a question with a known answer before it is
+# trusted: of these two lines, exactly ONE must survive.
+_HYDRA_MASK_OK=1
+if [ ! -f "${_HYDRA_MASK_HELPER}" ]; then
+    _HYDRA_MASK_OK=0
+else
+    _hydra_mask_probe=$(printf '// $uid\n$uid\n' \
+        | python3 "${_HYDRA_MASK_HELPER}" --mask php - 2>/dev/null \
+        | grep -c 'uid')
+    [ "${_hydra_mask_probe}" = "1" ] || _HYDRA_MASK_OK=0
+fi
+
+_php_code_copy() {
+    local _src="$1" _dst
+    [ "${_HYDRA_MASK_OK}" -eq 1 ] || return 1
+    [ -f "${_src}" ] || return 1
+    mkdir -p "${_HYDRA_MASK_DIR}" 2>/dev/null || return 1
+    _dst="${_HYDRA_MASK_DIR}/$(printf '%s' "${_src}" | tr '/' '_')"
+    if [ ! -f "${_dst}" ]; then
+        if ! python3 "${_HYDRA_MASK_HELPER}" --mask php "${_src}" > "${_dst}.tmp" 2>/dev/null; then
+            rm -f "${_dst}.tmp"
+            return 1
+        fi
+        mv "${_dst}.tmp" "${_dst}"
+    fi
+    printf '%s' "${_dst}"
+}
+
+# ---------------------------------------------------------------------------
 # _head_block <php-file> <declaration-line> — the annotation region that
 # belongs to the method declared on <declaration-line>, as text.
 #
@@ -1947,12 +2005,50 @@ fi
 # service/controller that declares a caller-identity parameter
 # ($uid / $callerUid / $userId / $caller) but never references it in
 # its body is an unfinished stub and fails gate-3. See ADR-021.
+#
+# A TODO NAMING THE PARAMETER IS NOT A USE OF IT (#415 / #422).
+# -----------------------------------------------------------
+# The reference count below was `grep -cF "$param"` over the RAW body, so a
+# comment counted as a reference. Measured through this gate, one fixture, ONE
+# ADDED LINE:
+#
+#   public function authorize(string $uid, string $id): bool {
+#       $this->log('checked');
+#       return true;
+#   }                       -> FAIL — rule=caller-identity-ignored   (correct)
+#
+#   the same method with
+#     `// TODO: verify $uid actually owns this object before returning true.`
+#                           -> PASS                                 <- the defect
+#
+# That is the sentence a diligent author writes while acknowledging the stub,
+# and this gate exists BECAUSE the builder's fix-mode wrote exactly such stubs
+# (decidesk#45): methods that accept a caller identity and ignore it, which
+# gate-7 also passed. A stub that documents what it does not do is still a
+# stub.
+#
+# The `;` vs `{` terminator test above has the same exposure and the same
+# repair — a `/* … ; … */` in a signature made a real method read as an
+# abstract DECLARATION and be skipped entirely (gate-57 carried that defect
+# verbatim, #422). Both now read the masked copy.
+#
+# ⚠️ STRING CONTENTS SURVIVE, AND HERE THAT IS THE WHOLE POINT. In PHP,
+# `"user $uid not found"` INTERPOLATES $uid — it is a genuine reference, and
+# `throw new NotFoundException("no such user: $uid")` is a perfectly good use
+# of a caller identity. Blanking literals would report those methods as stubs.
+# The single-quoted `'$uid'` that is NOT a use stays a residual false negative
+# and is #424's; it is the fail-safe direction for a gate that accuses a
+# method of being unfinished.
 while IFS= read -r f; do
     [ -f "$f" ] || continue
     _in_scope "$f" || continue
-    grep -nE '^\s*public\s+function\s+\w+\s*\([^)]*\$(uid|callerUid|userId|caller)\b' "$f" \
+    # Anchor on CODE. A file whose mask cannot be produced is not judged by
+    # this arm — reading the raw text instead is the behaviour being removed.
+    _stub_code=$(_php_code_copy "$f") || continue
+    [ -n "${_stub_code}" ] || continue
+    grep -nE '^\s*public\s+function\s+\w+\s*\([^)]*\$(uid|callerUid|userId|caller)\b' "${_stub_code}" \
         | while IFS=: read -r _line_no _; do
-            _sig=$(sed -n "${_line_no}p" "$f")
+            _sig=$(sed -n "${_line_no}p" "${_stub_code}")
             _method=$(echo "$_sig" | grep -oE 'function\s+\w+' | awk '{print $2}')
             _param=$(echo "$_sig" | grep -oE '\$(uid|callerUid|userId|caller)\b' | head -1)
             [ -z "$_method" ] || [ -z "$_param" ] && continue
@@ -1985,10 +2081,10 @@ while IFS= read -r f; do
             #
             # Decide it on the SIGNATURE's terminator, which is the property that
             # actually distinguishes the two: `;` = declaration, `{` = body.
-            _sig_region=$(awk -v start="${_line_no}" 'NR >= start { printf "%s", $0; if (/[;{]/) exit }' "$f")
+            _sig_region=$(awk -v start="${_line_no}" 'NR >= start { printf "%s", $0; if (/[;{]/) exit }' "${_stub_code}")
             _sig_term=$(printf '%s' "${_sig_region}" | grep -oE '[;{]' | head -1)
             [ "${_sig_term}" = ";" ] && continue
-            _body=$(awk -v start="${_line_no}" 'NR >= start { print; if (NR > start && /^    \}/) exit }' "$f")
+            _body=$(awk -v start="${_line_no}" 'NR >= start { print; if (NR > start && /^    \}/) exit }' "${_stub_code}")
             _body_lines=$(echo "${_body}" | wc -l)
             # A legitimate ≥3-line method that accepts a caller-identity
             # param and never references it is a stub. Skip very short
@@ -2002,6 +2098,14 @@ while IFS= read -r f; do
             fi
         done
 done < <(_enum_tracked '\.php$' lib/Service lib/Controller)
+# AN ARM THAT SILENTLY DID NOT RUN IS NOT A PASS. The caller-identity arm above
+# `continue`s on every file whose comment mask cannot be produced, so without
+# this the gate would print PASS with one of its four arms switched off and no
+# log to notice — the shape this package keeps finding (#147, #245, #374).
+if [ "${_stub_ran}" -eq 1 ] && [ "${_stub_scope}" -gt 0 ] && [ "${_HYDRA_MASK_OK}" -eq 0 ]; then
+    _stub_ran=0
+    _skip 3 "stub-scan" wiring "source_scope.py at ${_HYDRA_MASK_HELPER} could not blank a PHP comment (positive control failed) — ${_stub_scope} file(s) were in scope and the caller-identity arm judged NONE of them. Without the mask a TODO naming \$uid counts as a use of \$uid (#422), so the run declines rather than reporting a pass over an arm that did not execute."
+fi
 if [ "${_stub_ran}" -eq 1 ] && [ "${_stub_scope}" -eq 0 ]; then
     _stub_ran=0
     _skip 3 "stub-scan" na "scope was empty — 0 tracked .php/.vue file(s) under lib/ or src/ in this diff, so NOTHING was inspected; stub code (unfinished run() bodies, 'In a complete implementation' markers, ignored caller-identity parameters) is UNVERIFIED by this run."
@@ -3056,6 +3160,49 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     _rr_routes_touched=0
     _in_scope "appinfo/routes.php" && _rr_routes_touched=1
 
+    # A ROUTE WRITTEN ONLY IN A COMMENT IS NOT A ROUTE (#415 / #422).
+    # ---------------------------------------------------------------
+    # Invariant 1 asks "does a route entry for this method exist?" and answered
+    # it with `grep -qF "'thing#index'"` over the RAW routes.php. The in-code
+    # note at that grep says false positives from comments are "vanishingly
+    # rare" — it anticipated the FALSE POSITIVE and missed the false NEGATIVE,
+    # which is the direction that ships a 404. Measured through this gate, one
+    # fixture, ONE ADDED LINE:
+    #
+    #   ThingController::orphanReport(): JSONResponse, no route entry
+    #     -> FAIL — rule=missing-route                              (correct)
+    #   the same tree with routes.php gaining
+    #     `// TODO: wire up 'thing#orphanReport' once the export lands.`
+    #     -> PASS                                                   <- the defect
+    #
+    # The endpoint 404s at runtime and the gate reports it reachable, on the
+    # strength of the line saying it is not wired up yet.
+    #
+    # ⚠️ STRING CONTENTS SURVIVE, and here they ARE the evidence: a route name
+    # is the literal `'thing#index'` and nothing else. `php_mask` keeps them by
+    # default. This is the gate where blanking literals would not widen the
+    # gate, it would delete every route in the file.
+    #
+    # The masked copy also feeds the auto-resource scan below — a commented-out
+    # `'resources' => [...]` block otherwise exempts a live controller's whole
+    # CRUD quintet from invariant 1, same direction, same cause.
+    #
+    # Invariant 2 still reads the raw file. Its exposure is the OPPOSITE
+    # direction (a commented-out route name manufacturing a phantom route) and
+    # belongs with the false-positive half, #423 — changing both here would put
+    # two independent verdict changes behind one measurement.
+    #
+    # A MASK THAT CANNOT BE PRODUCED IS NOT A LICENCE TO GRADE RAW TEXT. If the
+    # helper is missing or fails its positive control, this gate declines
+    # rather than falling back — a silent fallback is exactly the false
+    # negative being closed, and it would leave no log to notice. Same
+    # decision, and the same wording, as gate-5's (#147, #245).
+    _rr_routes_src=""
+    _rr_routes_code=$(_php_code_copy appinfo/routes.php) && _rr_routes_src="${_rr_routes_code}"
+    if [ -z "${_rr_routes_src}" ]; then
+        _skip 14 "route-reachability" wiring "source_scope.py at ${_HYDRA_MASK_HELPER} could not blank a PHP comment (positive control failed) — appinfo/routes.php was NOT masked, so NO route was judged. Without it a route written only in a comment satisfies invariant 1 and the endpoint 404s at runtime (#422), so the run declines rather than reporting a pass it cannot support."
+    else
+
     # Resource auto-routes (entries inside the top-level `'resources' => [...]`
     # block) generate index/show/create/update/destroy on the named
     # controller; methods on those auto-routes are excluded from invariant 1.
@@ -3069,7 +3216,7 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
             match($0, /[A-Za-z][A-Za-z0-9_]*/); key=substr($0, RSTART, RLENGTH)
             print tolower(substr(key,1,1)) substr(key,2)
         }
-    ' appinfo/routes.php | sort -u)
+    ' "${_rr_routes_src}" | sort -u)
 
     # ---- Invariant 1: every Response-returning controller method has a route
     # Iterate Controller files. For each public method whose return type is
@@ -3173,7 +3320,7 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
             # those apps this grep was asking the wrong file and answering "no"
             # every time, which is why five apps were told their working
             # `dashboard#page` / `settings#index` endpoints 404.
-            if ! grep -qF "'${_ctrl_slug}#${_m}'" appinfo/routes.php \
+            if ! grep -qF "'${_ctrl_slug}#${_m}'" "${_rr_routes_src}" \
                 && ! _apphost_supplies_route "${_ctrl_slug}#${_m}"; then
                 echo "${_ctrl_path} method=${_m} expected_route='${_ctrl_slug}#${_m}' rule=missing-route" >> "${_rr_log}"
             fi
@@ -3283,6 +3430,7 @@ if [ -d lib/Controller ] && [ -f appinfo/routes.php ]; then
     else
         _fail 14 "route-reachability" "${_rr_fail} unrouted method(s) or wrong-target route(s) — see ${_rr_log}"
     fi
+    fi  # mask available
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fix(gates 3, 14): a comment is not a route, and a TODO is not a use (#422)

Two more #415-class false negatives, both in the RUNNER's own inline greps.
Each was reproduced on origin/main before it was touched, through the gate,
with a fixture whose only evidence is a comment.

  gate-14 route-reachability, invariant 1
    ThingController::orphanReport(): JSONResponse, no route entry
      -> FAIL — rule=missing-route                              (correct)
    the same tree with routes.php gaining ONE LINE
      `// TODO: wire up 'thing#orphanReport' once the export lands.`
      -> PASS                                                   <- the defect

  gate-3 stub-scan, caller-identity arm
    public function authorize(string $uid, string $id): bool { … }
    with $uid never referenced
      -> FAIL — rule=caller-identity-ignored                    (correct)
    the same method with ONE LINE
      `// TODO: verify $uid actually owns this object before returning true.`
      -> PASS                                                   <- the defect

gate-14's in-code note at that grep says comment hits are "vanishingly rare".
It anticipated the false POSITIVE and missed the false NEGATIVE — the direction
in which the endpoint 404s at runtime and the gate says the route exists.
gate-3's arm exists BECAUSE the builder's fix-mode wrote methods that accept a
caller identity and ignore it (decidesk#45); a stub that DOCUMENTS what it does
not do was being reported finished.

A THIRD one, found while writing the fixture and not in the survey: a
commented-out `'resources' => [...]` block exempted a live controller's whole
CRUD quintet from invariant 1. Written as a control, the revert says it FLIPS.

MEASURED ON REAL REPOS, BOTH DIRECTIONS.

  Full runs over procest, opencatalogi, openregister, softwarecatalog,
  docudesk and larpingapp, before and after: EVERY COUNT IDENTICAL.

    procest         g3=3  g14=0        docudesk    g3=0  g14=12
    opencatalogi    g3=0  g14=0        larpingapp  g3=0  g14=0
    openregister    g3=0  g14=0        softwarecatalog g3=0 g14=0

  Agreement is what a dead rig looks like, so both gates were given a POSITIVE
  CONTROL on a real repository — a COPY of docudesk, the one repo with a
  non-zero gate-14 baseline, whose 12 genuine findings the copy reproduces:

    gate-14  one comment line added to appinfo/routes.php naming
             'portalSigningReceiver#viewDocument' — one of its three real
             missing-route findings on a live controller
               origin/main   12 findings -> 11        (a real one hidden)
               fixed         12 -> 12

    gate-3   a stub service method taking $uid and ignoring it
               origin/main  FAIL — 1     fixed  FAIL — 1   (both see it)
             + `// TODO: verify $uid actually owns this report…`
               origin/main  PASS                            (blind)
               fixed        FAIL — 1

  ⚠️ The gate-3 control is reported in TWO steps on purpose. Step (a) — both
  arms FAIL — is not the measurement; it is what makes step (b) one. Read
  alone, "1 = 1" looks like "the change did nothing", which is exactly what an
  arm that never tested anything also looks like.

⚠️ STRING CONTENTS SURVIVE IN BOTH, AND IN BOTH THEY ARE THE EVIDENCE.
`php_mask` keeps literals by default and that is not an oversight here:

  gate-14  a route name IS the literal 'thing#index' and nothing else.
           Blanking literals would not widen this gate, it would delete every
           route in the file.
  gate-3   PHP INTERPOLATES `"no such user: $uid"` — that is a genuine use of
           the parameter. Blanking literals would report correct methods as
           unfinished stubs. The single-quoted '$uid' that is NOT a use stays
           a residual false negative and is #424's; it is the fail-safe
           direction for a gate that accuses a method of being unfinished.

Arms 3 and 6 of the new suite go red the moment somebody generalises "strings
are not evidence" across this file.

A MASK THAT CANNOT BE PRODUCED IS NOT A LICENCE TO GRADE RAW TEXT.
Both gates now decline — SKIPPED (wiring) — when source_scope.py is missing or
fails its positive control, rather than falling back to the raw file. A silent
fallback is precisely the false negative being closed and it leaves no log to
notice; this package has found that shape four times (#147, #245, #276, #374).
gate-3's guard fires on the ARM, not the file: without it the gate would print
PASS with one of its four arms switched off. Arm 7 removes source_scope.py from
a copy of the package and asserts both gates decline.

The shared `_php_code_copy` helper carries its own positive control, once per
run: of `// $uid` and `$uid`, exactly ONE must survive. A helper that echoed
its input back would put every caller straight back into the false negative,
which is gate-5's rule (#147, #245) applied to the two gates it had not reached.
It is NOT a second copy of gate-5's `_ra_masked_copy` — folding gate-5 into it
means re-proving gate-5's suite and belongs in its own change.

Invariant 2 still reads routes.php RAW. Its exposure is the OPPOSITE direction
(a commented-out route name manufacturing a phantom route) and belongs with the
false-positive half, #423. Changing both here would put two independent verdict
changes behind one measurement.

🔴 REPORTED, NOT FIXED: the runner's `_php_code_only` (~L919) is a line-PREFIX
filter, so an unprefixed interior line of a `/* */` block survives it.
Reproduced: a removal note reading "this app used to return
\OCA\OpenRegister\AppHost\Routes::standard($extra) … It no longer does" sets
_HYDRA_APPHOST_ROUTE_TABLE=1 and injects ten canonical route names, exempting
all of them from invariant 1. The comment directly above that helper already
records this class — it says the first cut was raw greps and that a fixture
"was EXEMPTED BY ITS OWN EXPLANATION" — and it was then repaired with a filter
that only handles the comment shape that fixture used. It gates exemptions read
by gates 5, 14, 30 and 56, so it needs its own change and its own before/after.

TESTS. New suite test_gate_3_14_comment_evidence.sh, 9 arms; discovered by
tests/run-helper-suites.sh with no workflow edit. Reverted against origin/main
— via a separate `git worktree` of origin/main, so SCRIPT_DIR resolves to that
tree's own lib/ — three FLIP (arms 2, 4, 5) and arms 1, 3 and 6 pass either way
and are labelled CONTROLS. Arm 7 is neither: on origin/main neither gate
consults the helper at all, so it exists because the fix creates the dependency.

Refs #422, #415. Sibling PRs cover the PHP call-site gates and the
registry/config gates; gate-38 is BLOCKED on #424 (its fix needs markup
masking, and routing it into source_scope.markup_mask today would close its
comment half and leave the delimiter half armed). gate-30 and gate-1 are
deliberately NOT in this sweep — see the findings note.
