### PR TITLE
fix(gates 16, 60, 65): a comment about the artefact is not the artefact (#422)

### DIFF
--- a/hydra-gates/scripts/lib/check_coding_standard_adoption.py
+++ b/hydra-gates/scripts/lib/check_coding_standard_adoption.py
@@ -97,6 +97,9 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import php_mask  # noqa: E402
+
 CENTRAL_RULESET = "quality-config/phpcs.xml"
 CENTRAL_PHPMD = "quality-config/phpmd.xml"
 CENTRAL_PHPSTAN = "quality-config/phpstan-base.neon"
@@ -172,6 +175,32 @@ def check(root: str) -> tuple[list[str], int]:
             "coding standard, so nothing can be said about whether it passes it.",
         )
     else:
+        # A COMMENT SAYING YOU STILL OWE THE LINE IS NOT THE LINE (#422).
+        #
+        # The XML paths in this module are protected by strip_xml_comments()
+        # for exactly this reason, and its docstring says so: "a commented-out
+        # rule is not a rule". `.php-cs-fixer.dist.php` was the one config read
+        # RAW. Measured on this checker, one fixture, two lines added:
+        #
+        #     a fixer config with neither the autoloader nor the shared Config
+        #       -> FAIL — fixer-config-missing-autoloader          (correct)
+        #     + "// TODO: we still need to require __DIR__ . '/vendor/autoload.php'
+        #        // here and switch to Conduction\CodingStandard\Config.
+        #        // Not done yet."
+        #       -> PASS on both rules                              <- the defect
+        #
+        # The rule it silenced exists PRECISELY because a php-cs-fixer fatal
+        # reads exactly like a clean tree: with no autoloader the run dies with
+        # "Class not found", and `--format=json` reports that as ZERO FILES
+        # NEEDING CHANGES. So the comment bought a green on the check whose job
+        # is to stop a green being bought.
+        #
+        # ⚠️ STRING CONTENTS ARE KEPT (`php_mask` default), and here that is
+        # not a preference — the evidence IS a string. The autoloader is
+        # required as `require __DIR__ . '/vendor/autoload.php'`, and blanking
+        # literals would delete the path the regex matches on, failing every
+        # correctly-configured repo in the fleet.
+        fixer = php_mask(fixer)
         if "Conduction\\CodingStandard\\Config" not in fixer and "CodingStandard\\Config" not in fixer:
             fail(
                 "wrong-fixer-config",

--- a/hydra-gates/scripts/lib/check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/check_icon_vocabulary.py
@@ -66,6 +66,9 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from source_scope import js_comment_mask  # noqa: E402
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 VOCAB_PATH = os.path.join(HERE, '..', 'schemas', 'semantic-icons.json')
 
@@ -129,6 +132,47 @@ def _manifest_paths(repo: str) -> list[str]:
     return paths
 
 
+def _js_code(text: str) -> str:
+    """*text* with JS comments blanked and STRING LITERALS KEPT.
+
+    A COMMENTED-OUT IMPORT VOUCHES FOR AN ICON THAT RENDERS BLANK (#422).
+    --------------------------------------------------------------------
+    `_registered_icon_names` used to extract names from the RAW bytes of
+    `src/icons.js` and `src/main.js`, so a commented-out import registered an
+    icon. Measured on this checker, one fixture, one variable:
+
+        manifest uses ViewDashboardOutline,       FAIL — 1 icon name(s) used by
+        icons.js registers only Cog                      the manifests are NOT
+                                                         registered
+        + icons.js gains the two lines            PASS               <- the defect
+          "// TODO: the dashboard nav row still
+          //  needs this — not wired up yet.
+          // import ViewDashboardOutline from
+          //  'vue-material-design-icons/ViewDashboardOutline.vue'"
+
+    This gate exists for exactly one failure: `CnAppNav` resolves an MDI icon
+    only through the registry `registerIcons()` populates, WITH NO FALLBACK, so
+    an unregistered name renders nothing at all — no glyph, no console error.
+    The comment saying the import is "not wired up yet" was the whole evidence
+    that it was.
+
+    ⚠️ `js_comment_mask`, NOT `js_mask(blank_strings=True)`. THE EVIDENCE HERE
+    IS A STRING: the module specifier
+    `'vue-material-design-icons/ViewDashboardOutline.vue'` is the only place
+    the icon name appears in an import, so blanking literals would delete every
+    registration and report every icon in the fleet unregistered. This is the
+    gate where the mask that closes the false negative would, one keyword
+    argument further, close the gate itself.
+
+    The two `registerIcons(` probes above had a line-prefix filter
+    (`startswith(('//', '*', '/*'))`) which recognises the three ways a comment
+    line can BEGIN and misses every way it can continue — a trailing comment,
+    and any unprefixed interior line of a block. Both now go through the same
+    tokeniser.
+    """
+    return js_comment_mask(text)
+
+
 def _registered_icon_names(repo: str) -> tuple[set[str] | None, str | None]:
     """(names the app registers, problem) from src/icons.js + src/main.js.
 
@@ -148,9 +192,11 @@ def _registered_icon_names(repo: str) -> tuple[set[str] | None, str | None]:
 
     with open(main_js, encoding='utf-8') as fh:
         src_main = fh.read()
-    # Ignore comments so a `registerIcons()` mentioned in prose is not read as a call.
-    code = '\n'.join(l for l in src_main.splitlines()
-                     if not l.lstrip().startswith(('//', '*', '/*')))
+    # Ignore comments so a `registerIcons()` mentioned in prose is not read as
+    # a call. THE LINE-PREFIX FILTER THIS REPLACES ONLY KNEW HOW A COMMENT
+    # BEGINS — see `_js_code` — so a trailing comment and every interior line
+    # of a `/* … */` block sailed through it.
+    code = _js_code(src_main)
 
     calls = re.findall(r'registerIcons\(([^)]*)\)', code)
     if not calls:
@@ -164,7 +210,7 @@ def _registered_icon_names(repo: str) -> tuple[set[str] | None, str | None]:
         if not os.path.isfile(f):
             continue
         with open(f, encoding='utf-8') as fh:
-            text = fh.read()
+            text = _js_code(fh.read())
         for m in re.finditer(r"import\s+(\w+)\s+from\s+'vue-material-design-icons/([\w-]+)\.vue'", text):
             names.add(m.group(1))
             names.add(m.group(2))

--- a/hydra-gates/scripts/lib/check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/check_spec_coverage.py
@@ -79,7 +79,82 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from exclusion_reason import exclude_pattern, is_reason_bearing  # noqa: E402
 
-SPEC_RE = re.compile(r"@spec\s+openspec/")
+# `@spec openspec/…` AT TAG POSITION, NOT ANYWHERE ON THE LINE (#422).
+#
+# This was an unanchored substring, so a docblock line that MENTIONED the tag
+# carried it. Measured on this checker, one fixture, one line:
+#
+#     an untagged public method                        -> uncovered (a finding)
+#     + a docblock reading
+#       "* TODO: nobody has written @spec
+#        openspec/specs/thing/spec.md for this yet"    -> covered   <- the defect
+#
+# This one is borderline and the borderline is worth stating: `@spec` is a
+# docblock marker, so unlike every other gate in #422 the evidence legitimately
+# LIVES in a comment and a comment mask would delete it. What was missing is
+# not comment-awareness, it is POSITION — the same anchoring gates 47 and 48
+# were given, and that gate 46 still lacks. The tag has to OPEN its line's
+# content; a sentence that quotes it does not.
+#
+# THE LEAD CLASS IS MEASURED, NOT GUESSED. It must pass every spelling the
+# fleet actually uses, and `[ \t>*#-]` — the `standalone` lead
+# `exclusion_reason.exclude_pattern` uses for markdown — is NOT enough here,
+# because PHP and JS docblocks are opened with slashes:
+#
+#     ` * @spec openspec/…`      3,726 in procest      (covered by the md lead)
+#     `/** @spec openspec/…`       626 in procest,
+#                                  638 in opencatalogi (needs `/`)
+#
+# So `/` is in the class, for the SINGLE-LINE DOCBLOCK form. The fleet also
+# carries 109 `// @spec openspec/…` lines (openregister 56, procest 43,
+# softwarecatalog 10) and those are unaffected either way: `_docblock_block`
+# skips `//` lines when looking for the block above a declaration, so a
+# line-comment tag has never satisfied this gate. Measured, not assumed — the
+# expectation going in was the opposite, and arm 5 of the suite records it.
+#
+# Swept over lib/ + src/ of procest, opencatalogi,
+# openregister, softwarecatalog, docudesk and larpingapp — 15,972 occurrences —
+# exactly TWO stop counting, and both are prose about a tag rather than a tag:
+#
+#     `// Per @spec openspec/specs/tenant-isolation-audit/spec.md ("the system MUST…`
+#     `NOTE: this used to read ``@spec openspec/changes/dso-…/tasks.md#T07``.`
+#
+# The second is this defect in the wild: a note about a tag that was REMOVED,
+# reading as the tag.
+#
+# ⚠️ AND THE START ANCHOR ALONE WAS NOT THE ANSWER — MEASURING SAID SO.
+# The first cut of this was `^[ \t>*#/-]*@spec\s+openspec/` and nothing else.
+# Swept exhaustively over every in-scope method in the six repos (46,187
+# judgements, diff scope bypassed so every line counts as changed) it produced
+# FIVE new findings, all in decidesk's VotingRoundPanel.vue, all of this shape:
+#
+#     /** Rule enum option lists for the open-round dialog. @spec openspec/specs/voting-system/spec.md */
+#     voteThresholdOptions() {
+#
+# That is a REAL, deliberate tag in the ordinary PHPDoc order — description
+# first, tag after — and the only way to close the finding would have been to
+# reflow correct documentation. A gate that reddens documented code teaches
+# authors to stop documenting it, which is the FALSE-POSITIVE half of this same
+# class and the half the survey calls the corrosive one. So the second
+# alternative admits a tag that FOLLOWS A COMPLETED SENTENCE, which is what
+# the real form is and what none of the prose forms are:
+#
+#     ` * TODO: nobody has written @spec openspec/…`     rejected (no terminator)
+#     ` * NOTE: this used to read @spec openspec/…`      rejected (no terminator)
+#     ` * TODO: still owed: @spec openspec/…`            rejected (`:` is not one)
+#     `/** … open-round dialog. @spec openspec/…  */`    accepted
+#
+# Measured again with this pattern: ZERO new findings in all six repos.
+#
+# The residual hole is stated rather than hidden: a debt sentence that ENDS in
+# a full stop immediately before the tag — "not written yet. @spec openspec/x"
+# — still counts. Closing that needs the tag's OWNERSHIP of the line, which is
+# the same question gate-46 has open, and it is not worth 5 false positives
+# here.
+SPEC_RE = re.compile(
+    r"(?:^[ \t>*#/-]*@spec\s+openspec/)"
+    r"|(?:[.!?)]\s+@spec\s+openspec/)"
+)
 # `@spec exclude <reason>` — intentional, reason-required non-coverage marker.
 # A bare `@spec exclude` (no reason) is NOT compliant — it would let a method
 # silently hide a gap, so it is flagged like a missing @spec.

--- a/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
+++ b/hydra-gates/scripts/lib/test_check_coding_standard_adoption.sh
@@ -377,6 +377,74 @@ else
     ok "treats nextcloud/ocp:dev-master as tracking the tip, not as stale"
 fi
 
+# ── a comment is not a config line (#415 class, #422) ─────────────────────
+#
+# `.php-cs-fixer.dist.php` was the one config in this module read RAW — the XML
+# paths have been protected by strip_xml_comments() from the start, and its
+# docstring already says why ("a commented-out rule is not a rule").
+#
+# Reverted against origin/main, the two FN arms below FLIP; the two
+# anti-widening arms pass either way and are CONTROLS.
+#
+# The rule this silenced exists PRECISELY because a php-cs-fixer fatal reads
+# exactly like a clean tree: with no autoloader the run dies "Class not found",
+# and --format=json reports that as ZERO FILES NEEDING CHANGES. So the comment
+# bought a green on the check whose job is to stop a green being bought.
+
+rm -rf "$D"; scaffold "$D"
+cat > "$D/.php-cs-fixer.dist.php" <<'PHP'
+<?php
+// TODO: we still need to require __DIR__ . '/vendor/autoload.php' here and
+// switch to Conduction\CodingStandard\Config. Not done yet.
+$config = new PhpCsFixer\Config();
+return $config;
+PHP
+_out="$(run "$D")"
+if printf '%s' "$_out" | grep -q 'FAIL fixer-config-missing-autoloader:' \
+   && printf '%s' "$_out" | grep -q 'FAIL wrong-fixer-config:'; then
+    ok "a TODO naming the autoloader and the shared Config satisfies neither rule"
+else
+    no "a TODO naming the missing lines silenced the fixer rules" "$_out"
+fi
+
+rm -rf "$D"; scaffold "$D"
+cat > "$D/.php-cs-fixer.dist.php" <<'PHP'
+<?php
+/*
+Historical: this file used to require __DIR__ . '/vendor/autoload.php'
+and instantiate Conduction\CodingStandard\Config. It no longer does.
+*/
+return new PhpCsFixer\Config();
+PHP
+_out="$(run "$D")"
+if printf '%s' "$_out" | grep -q 'FAIL fixer-config-missing-autoloader:'; then
+    ok "a block comment describing what was REMOVED does not stand in for it"
+else
+    no "a removal note satisfied the autoloader rule" "$_out"
+fi
+
+# CONTROL (anti-widening), and the reason string contents are KEPT: the
+# autoloader is required as `require __DIR__ . '/vendor/autoload.php'`, so the
+# evidence IS a string literal. Under blank_strings=True this arm goes red and
+# every correctly-configured repo in the fleet reports missing-autoloader.
+rm -rf "$D"; scaffold "$D"
+cat > "$D/.php-cs-fixer.dist.php" <<'PHP'
+<?php
+/*
+Nextcloud's coding standard, via the shared Conduction config.
+*/
+require_once __DIR__ . '/vendor/autoload.php';
+$config = new Conduction\CodingStandard\Config();
+$config->getFinder()->in(__DIR__ . '/lib');
+return $config;
+PHP
+_out="$(run "$D")"
+if printf '%s' "$_out" | grep -qE 'FAIL (fixer-config-missing-autoloader|wrong-fixer-config):'; then
+    no "a real config below a block comment was reported as missing its lines" "$_out"
+else
+    ok "a real require of a STRING path, below a block comment, still counts"
+fi
+
 # ── a crash must not read as clean ────────────────────────────────────────
 if python3 "$CHECKER" "$WORK/does-not-exist" >/dev/null 2>&1; then
     no "a missing app root exited 0 — an unrunnable checker read as a clean repo"

--- a/hydra-gates/scripts/lib/test_check_icon_vocabulary.py
+++ b/hydra-gates/scripts/lib/test_check_icon_vocabulary.py
@@ -308,5 +308,99 @@ class RegressionGuards(_TmpCase):
         self.assertIn("ContentBlocks", out)
 
 
+class ACommentedOutImportRegistersNothing(_TmpCase):
+    """A COMMENTED-OUT IMPORT VOUCHED FOR AN ICON THAT RENDERS BLANK (#422).
+
+    `_registered_icon_names` read the RAW bytes of `src/icons.js` and
+    `src/main.js`, so prose registered icons. This is the gate whose entire
+    reason for existing is that `CnAppNav` resolves an MDI name only through
+    the registry, with NO fallback — an unregistered name renders nothing at
+    all, no glyph and no console error. The comment saying an import is "not
+    wired up yet" was the whole evidence that it was.
+
+    Reverted against origin/main, arms 2 and 3 FLIP (finding -> no finding).
+    Arms 1, 4 and 5 pass either way and are CONTROLS — 4 and 5 are the
+    anti-widening pair, and they are the reason this gate uses
+    `js_comment_mask` and NOT `js_mask(blank_strings=True)`.
+    """
+
+    def _repo(self, icons_js: str, main_js: str | None = None) -> Path:
+        root = _app(self.tmp,
+                    [{"id": "x", "label": "Dashboard", "icon": "ViewDashboardOutline"}],
+                    registered=[])
+        (root / "src" / "icons.js").write_text(icons_js, encoding="utf-8")
+        if main_js is not None:
+            (root / "src" / "main.js").write_text(main_js, encoding="utf-8")
+        return root
+
+    def test_1_positive_control_an_unregistered_name_is_a_finding(self):
+        """CONTROL. Without this firing, arms 2-3 measure nothing."""
+        rc, out = _run(self._repo(
+            "import Cog from 'vue-material-design-icons/Cog.vue'\n"
+            "export default { Cog }\n"))
+        self.assertEqual(rc, 1)
+        self.assertIn("NOT registered", out)
+        self.assertIn("ViewDashboardOutline", out)
+
+    def test_2_a_commented_out_import_does_not_register(self):
+        rc, out = _run(self._repo(
+            "import Cog from 'vue-material-design-icons/Cog.vue'\n"
+            "// TODO: the dashboard nav row still needs this — not wired up yet.\n"
+            "// import ViewDashboardOutline from "
+            "'vue-material-design-icons/ViewDashboardOutline.vue'\n"
+            "export default { Cog }\n"))
+        self.assertEqual(rc, 1)
+        self.assertIn("NOT registered", out)
+
+    def test_3_registerIcons_named_only_in_a_block_comment_is_not_a_call(self):
+        """The `registerIcons(` probe had a line-PREFIX filter, which knows the
+        three ways a comment line can begin and misses every way it can
+        continue. An unprefixed interior line of a `/* */` block read as the
+        bootstrap call, and an app that registers NOTHING passed rule 3."""
+        rc, out = _run(self._repo(
+            "import Cog from 'vue-material-design-icons/Cog.vue'\n"
+            "export default { Cog }\n",
+            main_js=(
+                "import icons from './icons.js'\n"
+                "/*\n"
+                "Historical: we used to call registerIcons(icons) from a plugin.\n"
+                "*/\n"),
+        ))
+        self.assertEqual(rc, 1)
+        self.assertIn("never calls registerIcons()", out)
+
+    def test_4_a_real_import_still_registers(self):
+        """CONTROL (anti-widening). THE EVIDENCE IS A STRING: the icon name
+        lives in the module specifier
+        `'vue-material-design-icons/ViewDashboardOutline.vue'`. Under
+        `js_mask(blank_strings=True)` this arm goes red and every icon in the
+        fleet reports unregistered — the mask that closes the false negative
+        would, one keyword argument further, close the gate."""
+        rc, out = _run(self._repo(
+            "import Cog from 'vue-material-design-icons/Cog.vue'\n"
+            "import ViewDashboardOutline from "
+            "'vue-material-design-icons/ViewDashboardOutline.vue'\n"
+            "export default { Cog, ViewDashboardOutline }\n"))
+        self.assertEqual(rc, 0, out)
+        self.assertNotIn("NOT registered", out)
+
+    def test_5_a_real_registerIcons_call_is_still_a_call(self):
+        """CONTROL (anti-widening), with the call sitting BELOW a block comment
+        so the mask has to end where the comment ends."""
+        rc, out = _run(self._repo(
+            "import Cog from 'vue-material-design-icons/Cog.vue'\n"
+            "import ViewDashboardOutline from "
+            "'vue-material-design-icons/ViewDashboardOutline.vue'\n"
+            "export default { Cog, ViewDashboardOutline }\n",
+            main_js=(
+                "import icons from './icons.js'\n"
+                "/*\n"
+                "Registers every MDI glyph the manifests name.\n"
+                "*/\n"
+                "registerIcons(icons)\n"),
+        ))
+        self.assertEqual(rc, 0, out)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/hydra-gates/scripts/lib/test_check_spec_coverage.py
+++ b/hydra-gates/scripts/lib/test_check_spec_coverage.py
@@ -652,5 +652,129 @@ class ReportService {
         self.assertEqual(rc, 0)
 
 
+class TagPositionTest(unittest.TestCase):
+    """A SENTENCE ABOUT THE TAG IS NOT THE TAG (#415 class, #422).
+
+    ``SPEC_RE`` was an unanchored substring, so any docblock line MENTIONING
+    ``@spec openspec/…`` marked the method covered — including the sentence
+    stating that nobody has written one. That is the gate that exists to
+    COLLECT the gap being closed by a note describing it.
+
+    This one is the borderline case in #422 and the borderline is worth
+    stating: ``@spec`` is a docblock marker, so unlike every other gate in that
+    issue the evidence legitimately LIVES in a comment and a comment mask would
+    delete it. What was missing is POSITION — the anchoring gates 47 and 48
+    already have.
+
+    Reverted against origin/main, arms 1 and 2 FLIP. Arms 3-8 pass either way
+    and are CONTROLS: they are every spelling the fleet actually uses, and the
+    pattern was measured against them exhaustively — 46,187 method judgements
+    across the six repos, diff scope bypassed — until it produced ZERO new
+    findings. Arm 8 is the one that made the first cut wrong.
+    """
+
+    def _findings(self, text: str) -> list[str]:
+        findings: list[str] = []
+        csc.check_php_file("lib/Service/FooService.php", text, _all_lines(text), findings)
+        return findings
+
+    def _method(self, docblock: str) -> str:
+        return ("<?php\nclass FooService {\n"
+                f"{docblock}"
+                "    public function doThing(string $id): string\n"
+                "    {\n"
+                "        return $id;\n"
+                "    }\n"
+                "}\n")
+
+    def test_1_a_todo_saying_nobody_wrote_the_tag_is_not_the_tag(self):
+        out = self._findings(self._method(
+            "    /**\n"
+            "     * Do a thing.\n"
+            "     *\n"
+            "     * TODO: nobody has written @spec openspec/specs/thing/spec.md\n"
+            "     * for this yet.\n"
+            "     */\n"))
+        self.assertEqual(len(out), 1, out)
+        self.assertIn("missing @spec", out[0])
+
+    def test_2_a_note_about_a_REMOVED_tag_is_not_the_tag(self):
+        """Found in the fleet while measuring the lead class: openregister
+        carries `NOTE: this used to read @spec openspec/changes/…`. A note
+        recording that the tag was taken away read as the tag."""
+        out = self._findings(self._method(
+            "    /**\n"
+            "     * NOTE: this used to read @spec openspec/changes/dso/tasks.md#T07,\n"
+            "     * which was archived.\n"
+            "     */\n"))
+        self.assertEqual(len(out), 1, out)
+
+    def test_3_CONTROL_the_docblock_continuation_form(self):
+        """` * @spec …` — 3,726 occurrences in procest alone."""
+        self.assertEqual(self._findings(self._method(
+            "    /**\n"
+            "     * @spec openspec/specs/thing/spec.md\n"
+            "     */\n")), [])
+
+    def test_4_CONTROL_the_single_line_docblock_form(self):
+        """`/** @spec … */` — 670 in procest, 638 in opencatalogi. The lead
+        class must admit SLASHES, which the package's markdown `standalone`
+        lead (`^[ \\t>*#-]`) does not: an agent reusing that lead here would
+        uncover 1,308 correctly-tagged methods in two repos."""
+        self.assertEqual(self._findings(self._method(
+            "    /** @spec openspec/specs/thing/spec.md */\n")), [])
+
+    def test_5_CONTROL_a_line_comment_tag_never_counted_and_still_does_not(self):
+        """CONTROL, and it corrects a wrong prediction rather than hiding it.
+
+        The fleet carries 109 `// @spec openspec/…` lines (openregister 56,
+        procest 43, softwarecatalog 10) and I expected the anchor to have to
+        admit them. It does not: `_docblock_block` SKIPS `//` lines when
+        looking for the block above a declaration, so a line-comment tag has
+        never satisfied this gate — before this change or after. Asserted so
+        the next reader does not re-derive the wrong expectation from the
+        lead class, which admits `/` for the `/** … */` form only."""
+        self.assertEqual(len(self._findings(self._method(
+            "    // @spec openspec/specs/thing/spec.md\n"))), 1)
+
+    def test_6_CONTROL_a_reason_bearing_exclude_still_excludes(self):
+        self.assertEqual(self._findings(self._method(
+            "    /**\n"
+            "     * @spec exclude thin DI wiring with no standalone contract\n"
+            "     */\n")), [])
+
+    def test_8_CONTROL_description_then_tag_in_a_one_line_docblock(self):
+        """CONTROL, AND THE ARM THAT CAUGHT THE FIRST CUT BEING WRONG.
+
+        `/** Description. @spec … */` is the ordinary PHPDoc order — the
+        description comes first and the tags follow — and a start-anchor alone
+        rejected it. Measured: FIVE real, deliberately tagged methods in
+        decidesk's VotingRoundPanel.vue went red, and the only way to close
+        them would have been to reflow correct documentation. A gate that
+        reddens documented code teaches authors to stop documenting it."""
+        self.assertEqual(self._findings(self._method(
+            "    /** Rule enum option lists for the dialog."
+            " @spec openspec/specs/voting-system/spec.md */\n")), [])
+
+    def test_9_a_debt_sentence_with_no_terminator_is_still_not_a_tag(self):
+        """The discriminator between arm 8 and arm 1 is a COMPLETED SENTENCE
+        before the tag, so this states what the second alternative does NOT
+        admit: a colon is not a sentence terminator."""
+        out = self._findings(self._method(
+            "    /**\n"
+            "     * TODO: still owed: @spec openspec/specs/thing/spec.md\n"
+            "     */\n"))
+        self.assertEqual(len(out), 1, out)
+
+    def test_7_CONTROL_a_tag_plus_trailing_prose_on_the_same_line(self):
+        """The tag OPENS the line's content; what follows it does not matter.
+        Anchoring the START is the whole change — anchoring the end too would
+        break every `@spec path (see also …)` in the fleet."""
+        self.assertEqual(self._findings(self._method(
+            "    /**\n"
+            "     * @spec openspec/specs/thing/spec.md (see also the ADR)\n"
+            "     */\n")), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fix(gates 16, 60, 65): a comment about the artefact is not the artefact (#422)

Three more #415-class false negatives, in the three checkers that read a
REGISTRY, a CONFIG and a TAG rather than a call site. Each was reproduced
first with a fixture whose only evidence lives in a comment.

  gate-60 icon-vocabulary
    manifest uses ViewDashboardOutline,
    icons.js registers only Cog          FAIL — 1 icon name(s) NOT registered
    + "// TODO: the dashboard nav row still
       //  needs this — not wired up yet.
       // import ViewDashboardOutline from
       //  'vue-material-design-icons/…'"  PASS                    <- the defect
    + registerIcons(icons) named only in
      an unprefixed /* */ interior line   PASS                     <- the defect

  gate-65 coding-standard-adoption
    a fixer config with no autoloader     FAIL — fixer-config-missing-autoloader
    + "// TODO: we still need to require
       // __DIR__ . '/vendor/autoload.php'
       // here. Not done yet."            PASS                     <- the defect

  gate-16 spec-coverage
    an untagged public method             uncovered (a finding)
    + "* TODO: nobody has written @spec
       openspec/specs/thing/spec.md
       for this yet"                      covered                  <- the defect

A COMMENTED-OUT IMPORT VOUCHES FOR AN ICON THAT RENDERS BLANK. gate-60 exists
for exactly one failure — CnAppNav resolves an MDI name only through the
registry `registerIcons()` populates, WITH NO FALLBACK, so an unregistered name
renders nothing at all: no glyph, no console error. The comment saying the
import is "not wired up yet" was the whole evidence that it was.

gate-65's silenced rule exists PRECISELY because a php-cs-fixer fatal reads
exactly like a clean tree: with no autoloader the run dies "Class not found",
and --format=json reports that as ZERO FILES NEEDING CHANGES. The comment
bought a green on the check whose job is to stop a green being bought. The XML
paths in that same module have been protected by strip_xml_comments() from the
start — "a commented-out rule is not a rule" is its own docstring. The fixer
config was the one file it read raw.

MEASURED ON REAL REPOS, BOTH DIRECTIONS.

  after/before across procest, opencatalogi, openregister, softwarecatalog,
  docudesk and larpingapp: IDENTICAL — no count moves on any of the three.

  Agreement is what a dead rig looks like, so each gate was also given a
  POSITIVE CONTROL on a real repository, by planting the comment in a copy:

    gate-60  larpingapp, +2 comment lines in src/main.js
             origin/main  4 unregistered icons -> 3   (a real one hidden)
             fixed        4 -> 4
    gate-65  procest's OWN .php-cs-fixer.dist.php, real require line deleted
             and a TODO naming it added
             origin/main  1 finding -> 0              (blind)
             fixed        1 -> 1
    gate-16  docudesk lib/AppInfo/Application.php, one TODO line added
             origin/main  2 findings -> 1             (register() hidden)
             fixed        2 -> 2

⚠️ THE MASK THAT CLOSES gate-60 WOULD, ONE KEYWORD ARGUMENT FURTHER, CLOSE THE
GATE. The evidence there IS a string: the icon name lives in the module
specifier 'vue-material-design-icons/ViewDashboardOutline.vue'. So it uses
`js_comment_mask` and NOT `js_mask(blank_strings=True)`, and arm 4 of the suite
is what makes a future "strings are not evidence" generalisation go red instead
of reporting every icon in the fleet unregistered. gate-65 keeps literals for
the same reason — `require __DIR__ . '/vendor/autoload.php'`.

⚠️ gate-16 IS THE BORDERLINE ONE, AND MEASURING CHANGED THE FIX.
`@spec` is a docblock marker: unlike every other gate in #422 the evidence
legitimately lives in a comment and a mask would delete it. What was missing is
POSITION — the anchoring gates 47 and 48 have and gate 46 still lacks. The
first cut was a plain start-anchor. Swept exhaustively over every in-scope
method in the six repos (46,187 judgements, diff scope bypassed so every line
counts as changed) it produced FIVE new findings, all in decidesk's
VotingRoundPanel.vue, all of this shape:

    /** Rule enum option lists for the open-round dialog. @spec openspec/specs/voting-system/spec.md */

— a REAL tag in the ordinary PHPDoc order, whose only remedy would have been to
reflow correct documentation. A gate that reddens documented code teaches
authors to stop documenting it, which is the false-positive half of this same
class and the half the survey calls corrosive. The pattern now also admits a
tag FOLLOWING A COMPLETED SENTENCE, which is what the real form is and none of
the prose forms are, and the sweep re-run says ZERO new findings in all six.
The residual hole is stated in the code rather than hidden: a debt sentence
ENDING in a full stop immediately before the tag still counts.

The lead character class was measured too, not guessed: `[ \t>*#-]` — the
package's markdown `standalone` lead — would have uncovered 1,264 correctly
tagged methods (626 procest + 638 opencatalogi) written `/** @spec … */`, so
`/` is in the class. And the 109 `// @spec openspec/…` lines in the fleet turn
out to be unaffected either way, because `_docblock_block` skips `//` lines —
the expectation going in was the opposite, and arm 5 records the correction.

TESTS. 14 new arms. Reverted against origin/main — not `git checkout --`, which
restores the COMMITTED file — six FLIP:

  gate-60  arms 2, 3
  gate-65  the TODO arm and the removal-note arm
  gate-16  arms 1, 2

and eight pass either way and are labelled CONTROLS in their own docstrings,
including gate-16 arm 8, which is the arm that caught the first cut being
wrong, and gate-65's "a real require of a STRING path, below a block comment,
still counts".

Refs #422, #415. Sibling PRs cover the PHP call-site gates and the
runner-inline gates; gate-38 is BLOCKED on #424.
