### PR TITLE
test(gate-3): pin the #434 exemption against the #422 mask — the two reads must stay split

### DIFF
--- a/hydra-gates/scripts/lib/test_gate_3_14_comment_evidence.sh
+++ b/hydra-gates/scripts/lib/test_gate_3_14_comment_evidence.sh
@@ -260,6 +260,59 @@ if _run; then
 fi
 
 # ---------------------------------------------------------------------------
+# 6b. CONTROL — #434's EXEMPTION STILL READS THE ORIGINAL TEXT.
+#
+#     #434 (.github#339) exempts a contract-imposed unused parameter when a
+#     supertype declares the same signature AND the docblock's `@param` line
+#     for that parameter carries an explicit unused marker. That marker LIVES
+#     IN A COMMENT BY DESIGN — the exact region this change blanks.
+#
+#     The two reads are deliberately split, and only `php_mask` being line- and
+#     offset-preserving makes the split legal:
+#
+#       the body question   -> the MASK      ("is $uid referenced in code?")
+#       the exemption       -> the ORIGINAL  (`--file "$f" --line "${_line_no}"`)
+#
+#     Point the second one at the mask and the marker vanishes, the exemption
+#     silently stops working, and procest's three GuardEvaluatorInterface
+#     implementors go red with no closing action available — delete the
+#     parameter and the interface breaks, reference it pointlessly and that is
+#     dead code written to satisfy a stub detector. That is gate-17's `@spec
+#     exclude` trap in this PR's other gate, and it is why this arm exists
+#     rather than a sentence in a commit message.
+# ---------------------------------------------------------------------------
+_scaffold
+cat > "${APP}/lib/Service/GuardEvaluatorInterface.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Service;
+
+interface GuardEvaluatorInterface {
+	public function authorize(string $uid, string $objectId): bool;
+}
+PHP
+cat > "${APP}/lib/Service/AuthzService.php" <<'PHP'
+<?php
+namespace OCA\Fixture\Service;
+
+class AuthzService implements GuardEvaluatorInterface {
+	/**
+	 * Always allows: this guard does not consult the caller.
+	 *
+	 * @param string $uid      Current user UID (unused by this implementor).
+	 * @param string $objectId The object under evaluation.
+	 */
+	public function authorize(string $uid, string $objectId): bool {
+		$this->logger->info('authorize called');
+		return true;
+	}
+}
+PHP
+_commit
+if _run; then
+    _expect_gate 3 PASS "CONTROL 6b: a contract-imposed param marked unused is still exempt with the mask in place (#434 + #422)"
+fi
+
+# ---------------------------------------------------------------------------
 # 7. A MASK THAT CANNOT BE PRODUCED IS NOT A LICENCE TO GRADE RAW TEXT.
 #
 #    Both gates now depend on source_scope.py. A silent fallback to the raw


### PR DESCRIPTION
test(gate-3): pin the #434 exemption against the #422 mask — the two reads must stay split

#445 (#422) and #434 (#339) both changed the SAME arm of gate-3, three lines
apart, so they merged cleanly and the interaction never appeared in a diff.
Both are now on main and the behaviour there is CORRECT — but nothing asserts
it, and this is a shape that breaks silently.

The arm reads two texts in one coordinate system, and only `php_mask` being
line- and offset-preserving makes that legal:

    the body questions  -> the MASK      _sig / _sig_region / _body / _count
                                         ("is $uid referenced in CODE?")
    the exemption       -> the ORIGINAL  --file "$f" --line "${_line_no}"
                                         (#434's `@param … (unused)` marker,
                                          which lives in a COMMENT BY DESIGN)

Repoint the exemption at the mask — a one-word edit, and the obvious
"consistency" cleanup for anyone who notices the arm reading two different
files — and the marker vanishes into blanks. The exemption silently stops
working and procest's three GuardEvaluatorInterface implementors go red WITH NO
CLOSING ACTION AVAILABLE: deleting the parameter breaks the interface and every
call site, referencing it pointlessly is dead code written to satisfy a stub
detector. #434's own note says neither is a fix, which is why it added the
exemption in the first place.

That is gate-17's `@spec exclude` trap, which #444 hit for real in the sibling
gate of the same sweep: masking the body slid the reported line into the
blanked docblock, `_method_docblock` walked from the wrong place, and a
reason-bearing exclusion silently stopped exempting. Caught there by an
anti-widening arm. This is the same arm for gate-3.

  CONTROL 6b — a supertype-declared `authorize(string $uid, …)` whose docblock
  reads `@param string $uid Current user UID (unused by this implementor).`
  must still be EXEMPT with the mask in place.

MUTATION-CHECKED, so it is a coupling and not a comment: with `--file` pointed
at `${_stub_code}` the arm reports `FAIL — 1` (9 passed, 1 failed); restored,
10 passed, 0 failed. Measured against main at 43ecb0c.

No production code changes — one arm, in a suite tests/run-helper-suites.sh
already discovers.

Refs #422, #339, #445, #434.
