### PR TITLE
ci(node): default every shared workflow to Node 22

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,10 +13,11 @@ on:
         type: string
         default: "docs"
       node-version:
+        # Kept in step with quality.yml's default (see the rationale there).
         description: "Node.js version for building"
         required: false
         type: string
-        default: "20"
+        default: "22"
       build-image:
         description: >-
           Build and push a self-contained Apache image of the built site to

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -127,10 +127,23 @@ on:
         type: boolean
         default: true
       node-version:
+        # Node 22, because @nextcloud/eslint-config@9 CANNOT run on Node 20:
+        # it declares `engines.node: ^22.14 || ^24 || >=26` and imports
+        # `findPackageJSON` from `node:module`, an API that first exists in
+        # 22.14. On Node 20 the eslint job dies before linting a single file
+        # with `SyntaxError: The requested module 'node:module' does not
+        # provide an export named 'findPackageJSON'` — and npm reports the
+        # mismatch only as an EBADENGINE warning it then continues past, so
+        # the crash is the only signal.
+        #
+        # Node 22 is also what Nextcloud's own apps target, so this keeps the
+        # fleet matching the upstream toolchain rather than moving ahead of it.
+        # Apps still on eslint 8 run fine on 22; nothing pins Node 20 except
+        # `engines` fields, which npm only warns about.
         description: "Node.js version for all frontend/npm steps"
         required: false
         type: string
-        default: "20"
+        default: "22"
       frontend-path:
         description: "Directory containing package.json + package-lock.json for all npm-side jobs (Vue Quality, Frontend Checks, npm security/license legs). Default: repo root. Use for repos where the frontend lives in a subdirectory (e.g. 'pwa')."
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,13 @@ on:
         type: string
         default: "8.3"
       node-version:
+        # Kept in step with quality.yml's default (see the rationale there):
+        # an app whose devDependencies require Node 22 to lint must also be
+        # able to BUILD its release artefact on the same major.
         description: "Node.js version for building"
         required: false
         type: string
-        default: "20"
+        default: "22"
       verify-vendor-deps:
         description: "Enable vendor dependency verification after composer install"
         required: false


### PR DESCRIPTION
Bumps the `node-version` input default from `"20"` to `"22"` in `quality.yml`, `release.yml` and `documentation.yml`.

## Why

`@nextcloud/eslint-config@9` **cannot run on Node 20**: it declares `engines.node: ^22.14 || ^24 || >=26` and imports `findPackageJSON` from `node:module`, an API that first exists in 22.14. On Node 20.20.2 the eslint job dies before linting a single file:

```
SyntaxError: The requested module 'node:module' does not provide an export named 'findPackageJSON'
```

npm reports the mismatch only as an `EBADENGINE` warning it then continues past, so the crash is the only signal.

## Verified at the runner's own layer first

On larpingapp (ConductionNL/larpingapp#325, the first app migrated):

| | result |
|---|---|
| `node:20-alpine npx eslint src` | the identical `SyntaxError` |
| `node:22-alpine npx eslint src` | exit 0 |

## Risk

Apps still on eslint 8 run fine on Node 22 — nothing pins Node 20 except `engines` fields, which npm only warns about. `node-version` stays an input, so any app that must remain behind can say so explicitly. Node 22 is also what Nextcloud's own apps target, so this keeps the fleet matching the upstream toolchain rather than moving ahead of it.