### PR TITLE
fix(gate-7): a leaf app may delegate per-object authz to OpenRegister

### DIFF
--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -60,8 +60,24 @@ authorisation one call-hop away from the routed method:
     multitenancy layer, which is enforced on every fetch/save.  This pattern
     is deliberately scoped to the ``OCA\\OpenRegister`` namespace: consumer
     apps (decidesk, pipelinq, …) that merely *call* ObjectService still need
-    an explicit controller-level guard (or a Pattern-1 helper), so a real
-    IDOR in a leaf app is never masked.  See "Pattern 2 boundary" below.
+    an explicit controller-level guard for their OWN data layer.  See
+    "Pattern 2 boundary" below, and Pattern 2b for OR delegation from a leaf.
+
+  Pattern 2b — OpenRegister RBAC delegation from a LEAF app (ADR-022).
+    A consumer app that reaches its objects through OpenRegister's
+    ``ObjectService`` facade has delegated per-object authorisation to OR's
+    register RBAC, and is guarded.  ADR-022 requires apps to consume OR's
+    abstractions *including RBAC on data*; before this pattern the gate failed
+    them for doing exactly that (measured 2026-08-14: openbuild 6, pipelinq
+    50).  Narrower than Pattern 2 on three axes, so a leaf app's own storage
+    is still held to an explicit guard:
+
+      * the OR **facade only** — a leaf app's ``*Mapper`` is its own storage
+        and delegates no authorisation, so it clears nothing;
+      * the file must **import** ``OCA\\OpenRegister\\…\\ObjectService`` — a
+        local class of that name clears nothing;
+      * an explicit ``_rbac: false`` **withdraws** the clear, because that is
+        the app declaring in code that OR is not authorising this fetch.
 
   Pattern 4 — delegated guard reached through a chain and/or a collaborator.
     Patterns 1–3 all require the guard to be *one* call-hop away and on
@@ -1837,10 +1853,57 @@ def _delegated_guard_methods(cleaned: str, src: str, guard_map: dict) -> set:
 # Pattern 2 — OpenRegister data-layer RBAC delegation (ADR-022)
 # ---------------------------------------------------------------------------
 
-# Scoped strictly to the OpenRegister app: only there does data-layer access
-# equate to per-object authorisation.  Consumer apps keep the explicit-guard
-# requirement so a real IDOR in a leaf app is never masked.
+# Inside the OpenRegister app, ANY data-layer access (ObjectService or any
+# ``*Mapper``) equates to per-object authorisation, because every one of those
+# fetches runs OR's own RBAC.
 _OR_NAMESPACE_RE = re.compile(r"\bnamespace\s+OCA\\OpenRegister\b")
+
+# ---------------------------------------------------------------------------
+# Pattern 2b — OpenRegister RBAC delegation FROM A LEAF APP (ADR-022)
+# ---------------------------------------------------------------------------
+#
+# Pattern 2 used to be scoped to ``OCA\OpenRegister`` on the reasoning that a
+# consumer app "merely calling" ObjectService should still guard for itself.
+# That contradicted ADR-022, which is explicit that apps consume OpenRegister's
+# abstractions *including RBAC on data* — so the fleet was told to delegate and
+# then failed a gate for delegating. Measured 2026-08-14: 6 findings on
+# openbuild and 50 on pipelinq, and every openbuild one resolved through
+# ``searchObjectsBySlug(..., _rbac: true)``, with RuleEngineService's own
+# docblock reading "@throws … not found / NOT OWNED".
+#
+# So a leaf app MAY rely on OpenRegister for per-object authorisation. The
+# clear is deliberately narrower than Pattern 2's, on two axes, because the
+# thing that must not be masked is a leaf app's own unguarded data layer:
+#
+#   1. It matches the OpenRegister FACADE ONLY — ``objectService`` /
+#      ``ObjectService``. A bare ``*Mapper`` does NOT clear a leaf app: in
+#      OpenRegister a mapper IS the RBAC-enforcing layer, but in a leaf app
+#      ``$this->invoiceMapper->`` is that app's own storage and carries no
+#      OR authorisation whatsoever. This is the "with the exception of when
+#      they have their own services" half of the rule.
+#   2. It requires the file to actually IMPORT OpenRegister's ObjectService.
+#      A local class that happens to be named ObjectService clears nothing.
+#
+# And it is withdrawn when the call turns RBAC OFF: ``_rbac: false`` is the
+# app saying, in code, that OR is not authorising this fetch — at which point
+# the delegation the clear rests on does not exist.
+_OR_IMPORT_RE = re.compile(
+    r"\buse\s+OCA\\OpenRegister\\[A-Za-z0-9_\\]*ObjectService\b"
+)
+
+# The OR facade only. Note the absence of a ``*Mapper`` alternative: that is
+# the whole point of this pattern versus Pattern 2.
+_OR_FACADE_CALL_RE = re.compile(
+    r"->\s*objectService\s*->"
+    r"|\$objectService\s*->"
+)
+
+# ``_rbac: false`` (or ``_rbac : FALSE``) anywhere in the call — the app has
+# explicitly opted out of the authorisation it would otherwise be delegating.
+# ``_multitenancy: false`` is deliberately NOT disqualifying: a system-wide
+# register is a legitimate shape (openbuild's rules register is one) and it is
+# RBAC, not multitenancy, that answers "may this caller have this object".
+_RBAC_DISABLED_RE = re.compile(r"_rbac\s*:\s*false\b", re.IGNORECASE)
 
 # Data access routed through OR's RBAC-enforcing layer: the ObjectService
 # facade or any ``*Mapper``.  Every fetch/save on these enforces register
@@ -2823,7 +2886,8 @@ def _is_preflight_cors_method(name: str) -> bool:
     return name.lower().startswith("preflightedcors")
 
 
-def _collect_guard_helpers(cleaned: str, src: str, is_or_repo: bool) -> set:
+def _collect_guard_helpers(cleaned: str, src: str, is_or_repo: bool,
+                           leaf_or_delegation: bool = False) -> set:
     """Return the set of same-class method names that carry an auth guard.
 
     A method is guard-bearing when its name reads like an authorisation
@@ -2876,6 +2940,46 @@ def _collect_guard_helpers(cleaned: str, src: str, is_or_repo: bool) -> set:
             continue
         if is_or_repo and _OR_RBAC_ACCESS_RE.search(body):
             helpers.add(name)
+            continue
+        # Pattern 2b, one hop away. A leaf app almost never calls OR's facade
+        # from the routed method itself — openbuild's RulesController routes
+        # evaluate/schema/testAll through a private `query()` that wraps
+        # `searchObjectsBySlug(..., _rbac: true)`. Marking that wrapper
+        # guard-bearing lets the existing Pattern-1 closure carry the clear
+        # up the chain, instead of Pattern 2b only ever seeing the wrong body.
+        if (
+            leaf_or_delegation
+            and _OR_FACADE_CALL_RE.search(body)
+            and not _RBAC_DISABLED_RE.search(body)
+        ):
+            helpers.add(name)
+
+    # Transitive closure, leaf-delegation mode only.
+    #
+    # Real controllers wrap the OR facade more than one hop down: openbuild's
+    # `schema()` calls `findRuleSet()` calls `query()` calls
+    # `searchObjectsBySlug(..., _rbac: true)`. Marking only `query()` leaves
+    # the chain broken one link above it, so the routed method still reports.
+    # A same-class method that reaches a guard-bearing helper before its first
+    # mutation is itself guard-bearing — the same rule Pattern 4 already
+    # applies to its own graph, iterated here to a fixpoint.
+    #
+    # Gated on leaf_or_delegation so no existing verdict moves: with the flag
+    # off this loop does not run and the returned set is byte-identical to
+    # what it was before Pattern 2b existed.
+    if leaf_or_delegation:
+        spans = list(_all_method_spans(cleaned))
+        changed = True
+        while changed:
+            changed = False
+            for name, body_start, body_end in spans:
+                if name in helpers:
+                    continue
+                if _calls_guard_helper_before_mutation(
+                    guard_text[body_start:body_end], helpers
+                ):
+                    helpers.add(name)
+                    changed = True
     return helpers
 
 
@@ -2934,7 +3038,13 @@ def scan_file(path: str) -> int:
     # reported, so findings name real lines.
     gsrc = _blank_authentication_only_guards(cleaned, src)
     is_or_repo = bool(_OR_NAMESPACE_RE.search(cleaned))
-    guard_helpers = _collect_guard_helpers(cleaned, gsrc, is_or_repo)
+    # Pattern 2b context: does this leaf-app file actually import OpenRegister's
+    # ObjectService? A local class of the same name must clear nothing.
+    imports_or_object_service = bool(_OR_IMPORT_RE.search(cleaned))
+    guard_helpers = _collect_guard_helpers(
+        cleaned, gsrc, is_or_repo,
+        leaf_or_delegation=(imports_or_object_service and not is_or_repo),
+    )
     # Pattern 4 context: resolve this class's typed collaborators to real files
     # and read their guard-bearing methods out of their own source, then close
     # the same-class delegation graph over that. Both are lazy/cached; a file
@@ -3053,9 +3163,26 @@ def scan_file(path: str) -> int:
         # ---- Pattern 2: OpenRegister data-layer RBAC delegation ---------
         # Inside the OpenRegister app, data access through ObjectService or a
         # *Mapper delegates per-object authz to OR's register RBAC +
-        # multitenancy (ADR-022). Scoped to OCA\OpenRegister so leaf-app
-        # IDORs are never masked.
+        # multitenancy (ADR-022).
         if is_or_repo and _OR_RBAC_ACCESS_RE.search(body):
+            continue
+
+        # ---- Pattern 2b: a LEAF APP delegating to OpenRegister ----------
+        # ADR-022 says apps consume OR's abstractions including RBAC, so a
+        # leaf app that reaches its objects through OR's ObjectService has
+        # delegated per-object authorisation and is guarded.
+        #
+        # Narrower than Pattern 2 on purpose: the facade only (a leaf app's
+        # own *Mapper is its OWN storage and guards nothing), the import must
+        # be OpenRegister's, and an explicit `_rbac: false` withdraws it —
+        # that is the app declaring in code that OR is not authorising this
+        # fetch, which is exactly when the leaf app must guard for itself.
+        if (
+            not is_or_repo
+            and imports_or_object_service
+            and _OR_FACADE_CALL_RE.search(body)
+            and not _RBAC_DISABLED_RE.search(body)
+        ):
             continue
 
         # ---- Pattern 3: session-scoped, no caller-supplied reference ----

--- a/hydra-gates/scripts/lib/check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/check_no_admin_idor.py
@@ -1699,6 +1699,41 @@ def _strict_guard_methods(cleaned: str, src: str) -> set:
     return known
 
 
+def _or_delegating_methods(cleaned: str, guard_text: str) -> set:
+    """Methods in this file that resolve their objects through OpenRegister.
+
+    Pattern 2b's engine, shared by the same-class pass and the collaborator
+    pass so both answer the question identically.
+
+    Seeds on a body that calls the OR **facade** with RBAC left on, then closes
+    transitively over same-class calls, because the facade is routinely wrapped
+    several hops down — openbuild's ``schema()`` reaches it as
+    ``findRuleSet() -> query() -> searchObjectsBySlug(..., _rbac: true)``.
+
+    The caller is responsible for establishing that this file actually imports
+    ``OCA\\OpenRegister\\…\\ObjectService``; without that check a local class
+    named ObjectService would qualify.
+    """
+    seeds: set = set()
+    spans = list(_all_method_spans(cleaned))
+    for name, body_start, body_end in spans:
+        body = guard_text[body_start:body_end]
+        if _OR_FACADE_CALL_RE.search(body) and not _RBAC_DISABLED_RE.search(body):
+            seeds.add(name)
+    changed = True
+    while changed:
+        changed = False
+        for name, body_start, body_end in spans:
+            if name in seeds:
+                continue
+            if _calls_guard_helper_before_mutation(
+                guard_text[body_start:body_end], seeds
+            ):
+                seeds.add(name)
+                changed = True
+    return seeds
+
+
 def _collaborator_guard_methods(class_file: str) -> set:
     """Strict guard-bearing method names declared by the class in *class_file*."""
     cached = _COLLABORATOR_GUARD_CACHE.get(class_file)
@@ -1714,7 +1749,20 @@ def _collaborator_guard_methods(class_file: str) -> set:
     # `.github#365`: a collaborator whose only "guard" is a `no user -> 401`
     # preamble (decidesk's `citizenAction()` is the measured example) must not
     # seed a delegation chain either — the defect is the same one call-hop away.
-    result = _strict_guard_methods(cleaned, _guard_source(src, cleaned))
+    gsrc = _guard_source(src, cleaned)
+    result = _strict_guard_methods(cleaned, gsrc)
+    # Pattern 2b, one class out. A controller routinely reaches OpenRegister
+    # through an injected service rather than calling the facade itself —
+    # openbuild's `RulesController::evaluate` delegates to
+    # `RuleEngineService::evaluate`, whose own docblock reads "@throws ... not
+    # found / NOT OWNED" and which resolves via `searchObjectsBySlug(...,
+    # _rbac: true)`. Without this the same delegation clears from a private
+    # helper but not from a collaborator, which is an arbitrary distinction.
+    #
+    # Gated on the collaborator's OWN file importing OpenRegister's
+    # ObjectService, so a same-named local class contributes nothing.
+    if _OR_IMPORT_RE.search(cleaned):
+        result = result | _or_delegating_methods(cleaned, gsrc)
     _COLLABORATOR_GUARD_CACHE[class_file] = result
     return result
 
@@ -2947,39 +2995,13 @@ def _collect_guard_helpers(cleaned: str, src: str, is_or_repo: bool,
         # `searchObjectsBySlug(..., _rbac: true)`. Marking that wrapper
         # guard-bearing lets the existing Pattern-1 closure carry the clear
         # up the chain, instead of Pattern 2b only ever seeing the wrong body.
-        if (
-            leaf_or_delegation
-            and _OR_FACADE_CALL_RE.search(body)
-            and not _RBAC_DISABLED_RE.search(body)
-        ):
-            helpers.add(name)
-
-    # Transitive closure, leaf-delegation mode only.
-    #
-    # Real controllers wrap the OR facade more than one hop down: openbuild's
-    # `schema()` calls `findRuleSet()` calls `query()` calls
-    # `searchObjectsBySlug(..., _rbac: true)`. Marking only `query()` leaves
-    # the chain broken one link above it, so the routed method still reports.
-    # A same-class method that reaches a guard-bearing helper before its first
-    # mutation is itself guard-bearing — the same rule Pattern 4 already
-    # applies to its own graph, iterated here to a fixpoint.
-    #
-    # Gated on leaf_or_delegation so no existing verdict moves: with the flag
-    # off this loop does not run and the returned set is byte-identical to
-    # what it was before Pattern 2b existed.
+    # Pattern 2b, same class. Delegated to the shared engine so this pass and
+    # the collaborator pass cannot drift apart — two copies of an
+    # authorisation rule that disagree is the failure the gates exist to
+    # catch. Gated on leaf_or_delegation, so with the flag off the returned
+    # set is byte-identical to what it was before Pattern 2b existed.
     if leaf_or_delegation:
-        spans = list(_all_method_spans(cleaned))
-        changed = True
-        while changed:
-            changed = False
-            for name, body_start, body_end in spans:
-                if name in helpers:
-                    continue
-                if _calls_guard_helper_before_mutation(
-                    guard_text[body_start:body_end], helpers
-                ):
-                    helpers.add(name)
-                    changed = True
+        helpers |= _or_delegating_methods(cleaned, guard_text)
     return helpers
 
 

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -845,11 +845,13 @@ class DeckLinksController {
         self.assertEqual(_scan(src), [])
 
     def test_same_objectservice_access_OUTSIDE_or_namespace_still_flags(self):
-        """The delegation is OR-scoped: an identical leaf-app method still flags.
+        """A leaf app whose `$this->objectService` is NOT OpenRegister's still flags.
 
-        This is the decidesk#44 safety proof — a consumer app that fetches via
-        ObjectService without an explicit controller guard is a real IDOR and
-        must NOT be masked by Pattern 2.
+        This is the decidesk#44 safety proof. Pattern 2b (2026-08-14) lets a
+        leaf app delegate authorisation to OpenRegister, but only when the file
+        actually imports `OCA\\OpenRegister\\…\\ObjectService`. This fixture
+        does not, so `$this->objectService` is an unresolved local collaborator
+        and clears nothing — a real IDOR is still reported.
         """
         src = """\
 <?php
@@ -868,6 +870,88 @@ class MinutesController {
         findings = _scan(src)
         self.assertEqual(len(findings), 1)
         self.assertIn("generateALVDraft", findings[0])
+
+    def test_leaf_app_delegating_to_openregister_objectservice_cleared(self):
+        """ADR-022: a leaf app reaching objects through OR's ObjectService is guarded.
+
+        Measured on openbuild 2026-08-14: RulesController::evaluate resolved via
+        `searchObjectsBySlug(..., _rbac: true)` and was reported as an IDOR, in
+        direct contradiction of ADR-022, which requires apps to consume OR's
+        abstractions including RBAC on data.
+        """
+        src = """\
+<?php
+namespace OCA\\OpenBuild\\Controller;
+
+use OCA\\OpenRegister\\Service\\ObjectService;
+
+class RulesController {
+    /**
+     * @NoAdminRequired
+     */
+    public function evaluate(string $ruleSetSlug): JSONResponse
+    {
+        $rows = $this->objectService->searchObjectsBySlug(
+            'openbuild', 'rule-set', ['slug' => $ruleSetSlug], _rbac: true, _multitenancy: false
+        );
+        return new JSONResponse($rows);
+    }
+}
+"""
+        self.assertEqual(_scan(src), [])
+
+    def test_leaf_app_openregister_delegation_with_rbac_false_still_flags(self):
+        """`_rbac: false` withdraws the clear — the app said OR is NOT authorising."""
+        src = """\
+<?php
+namespace OCA\\OpenBuild\\Controller;
+
+use OCA\\OpenRegister\\Service\\ObjectService;
+
+class RulesController {
+    /**
+     * @NoAdminRequired
+     */
+    public function evaluate(string $ruleSetSlug): JSONResponse
+    {
+        $rows = $this->objectService->searchObjectsBySlug(
+            'openbuild', 'rule-set', ['slug' => $ruleSetSlug], _rbac: false
+        );
+        return new JSONResponse($rows);
+    }
+}
+"""
+        findings = _scan(src)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("evaluate", findings[0])
+
+    def test_leaf_app_own_mapper_still_flags_even_with_or_import(self):
+        """A leaf app's OWN mapper is its own storage and delegates no authorisation.
+
+        This is the "with the exception of when they have their own services"
+        half of the rule: importing OR's ObjectService must not launder an
+        endpoint that actually reads through the app's own data layer.
+        """
+        src = """\
+<?php
+namespace OCA\\OpenBuild\\Controller;
+
+use OCA\\OpenRegister\\Service\\ObjectService;
+
+class InvoiceController {
+    /**
+     * @NoAdminRequired
+     */
+    public function show(string $invoiceId): JSONResponse
+    {
+        $invoice = $this->invoiceMapper->find($invoiceId);
+        return new JSONResponse($invoice);
+    }
+}
+"""
+        findings = _scan(src)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("show", findings[0])
 
     def test_or_namespace_no_data_access_still_flags(self):
         """An OR method with NO ObjectService/Mapper access and no guard still flags."""

--- a/hydra-gates/scripts/lib/test_check_no_admin_idor.py
+++ b/hydra-gates/scripts/lib/test_check_no_admin_idor.py
@@ -925,6 +925,92 @@ class RulesController {
         self.assertEqual(len(findings), 1)
         self.assertIn("evaluate", findings[0])
 
+    def test_leaf_app_delegating_to_openregister_via_collaborator_cleared(self):
+        """Pattern 2b reaches one class out, as Pattern 4 does for other guards.
+
+        openbuild's `RulesController::evaluate` never touches the facade
+        itself — it calls `RuleEngineService::evaluate`, which resolves via
+        `searchObjectsBySlug(..., _rbac: true)`. Clearing that from a private
+        helper but not from an injected service would be an arbitrary
+        distinction, since both are the same delegation.
+
+        Uses `_scan_app` because collaborator resolution reads the
+        collaborator's own source off disk; an unresolvable type clears nothing.
+        """
+        engine = """\
+<?php
+namespace OCA\\OpenBuild\\Service;
+
+use OCA\\OpenRegister\\Service\\ObjectService;
+
+class RuleEngineService {
+    public function evaluate(string $slug): array
+    {
+        return $this->objectService->searchObjectsBySlug(
+            'openbuild', 'rule-set', ['slug' => $slug], _rbac: true
+        );
+    }
+}
+"""
+        controller = """\
+<?php
+namespace OCA\\OpenBuild\\Controller;
+
+use OCA\\OpenBuild\\Service\\RuleEngineService;
+
+class TestController {
+    public function __construct(
+        private readonly RuleEngineService $ruleEngine,
+    ) {}
+
+    /**
+     * @NoAdminRequired
+     */
+    public function evaluate(string $ruleSetSlug): JSONResponse
+    {
+        return new JSONResponse($this->ruleEngine->evaluate(slug: $ruleSetSlug));
+    }
+}
+"""
+        self.assertEqual(_scan_app(controller, {"RuleEngineService": engine}), [])
+
+    def test_collaborator_without_or_import_does_not_clear(self):
+        """Abuse control: an identical shape whose service does NOT reach OR still flags."""
+        engine = """\
+<?php
+namespace OCA\\OpenBuild\\Service;
+
+class RuleEngineService {
+    public function evaluate(string $slug): array
+    {
+        return $this->ruleSetMapper->findBySlug($slug);
+    }
+}
+"""
+        controller = """\
+<?php
+namespace OCA\\OpenBuild\\Controller;
+
+use OCA\\OpenBuild\\Service\\RuleEngineService;
+
+class TestController {
+    public function __construct(
+        private readonly RuleEngineService $ruleEngine,
+    ) {}
+
+    /**
+     * @NoAdminRequired
+     */
+    public function evaluate(string $ruleSetSlug): JSONResponse
+    {
+        return new JSONResponse($this->ruleEngine->evaluate(slug: $ruleSetSlug));
+    }
+}
+"""
+        findings = _scan_app(controller, {"RuleEngineService": engine})
+        self.assertEqual(len(findings), 1)
+        self.assertIn("evaluate", findings[0])
+
     def test_leaf_app_own_mapper_still_flags_even_with_or_import(self):
         """A leaf app's OWN mapper is its own storage and delegates no authorisation.
 


### PR DESCRIPTION
Gate-7's Pattern 2 cleared `ObjectService` access **only inside `OCA\OpenRegister`**, on the reasoning that a consumer app "merely calling" ObjectService should still guard for itself. That contradicts **ADR-022**, which requires apps to consume OpenRegister's abstractions *including RBAC on data* — the fleet was told to delegate, then failed a security gate for delegating.

Measured 2026-08-14: **6 findings on openbuild, 50 on pipelinq**. Every openbuild one resolved through `searchObjectsBySlug(..., _rbac: true)`, and `RuleEngineService`'s own docblock reads *"@throws … not found / **not owned**"*.

## The rule

A leaf app **may and should** rely on OpenRegister for per-object authorisation — **except** where it has its own services, which must carry their own RBAC.

Pattern 2b implements exactly that. It is narrower than Pattern 2 on three axes:

- **facade only** — a leaf app's `*Mapper` is its own storage and delegates no authorisation, so it clears nothing;
- the file must **import** `OCA\OpenRegister\...\ObjectService` — a local class of that name clears nothing;
- **`_rbac: false` withdraws the clear** — that is the app declaring in code that OR is not authorising this fetch.

Controllers wrap the facade several hops down (`schema` → `findRuleSet` → `query` → `searchObjectsBySlug`) and often reach it through an injected service rather than calling it directly, so the delegation is resolved **transitively and one class out** — the same boundary Pattern 4 already crosses for other guards. The seed-and-close logic lives in one function, `_or_delegating_methods()`, used by both the same-class and collaborator passes so the two cannot drift.

The collaborator pass is gated on the *collaborator's own* file importing OpenRegister's ObjectService. An unresolvable type clears nothing — fail-closed.

## Measured effect

Each figure is the patched checker against the **unmodified** checker on the same files. The control matters: my first attempt at this measurement returned 0 for every repo — wrong CLI, it takes file paths rather than a directory — and a uniform zero looked exactly like a clean pass.

| repo | before | after | |
|---|---|---|---|
| openbuild | 6 | **2** | four cleared, all genuinely OR-delegated |
| pipelinq | 50 | 50 | reaches its **own** `LoyaltyReportingService` |
| decidesk | 15 | 15 | unchanged |
| doriath | 4 | 4 | unchanged |
| shillinq | 18 | 18 | unchanged |
| openregister | 8 | 8 | unchanged |

**pipelinq staying at 50 is the rule working, not a gap.** Its controllers reach data through `OCA\Pipelinq\Service\LoyaltyReportingService` — the app's own service — so those 50 are real work in pipelinq: give those services their RBAC.

openbuild's two remaining findings are also correct. `StoreController::search` and `::install` act on the remote store catalogue over an HTTP client and touch no OpenRegister object, so there is nothing to delegate.

`ShopController::githubInstall` cleared through the collaborator path and was hand-checked rather than assumed: it hands persistence to `ApplicationsController::installFromTemplateArray`, which writes through `$this->objectService->saveObject`.

## Tests

167 pass. Four new cases pin both directions:

- a leaf app delegating to OR clears;
- delegation **via a collaborator** clears;
- an identical shape whose service reads its own mapper **still flags**;
- `_rbac: false` **still flags**;
- an own-mapper read still flags even with the OR import present.

The existing `decidesk#44` safety test still passes. Its fixture has no OR import, which is now *why* it flags, so its docstring states that instead of the old namespace rationale.
